### PR TITLE
Adds a legacy submission form

### DIFF
--- a/app/grandchallenge/evaluation/forms.py
+++ b/app/grandchallenge/evaluation/forms.py
@@ -79,31 +79,51 @@ class SubmissionForm(forms.ModelForm):
         display_comment_field kwarg
         """
         display_comment_field = kwargs.pop('display_comment_field', False)
+
         allow_supplementary_file = kwargs.pop(
             'allow_supplementary_file', False
         )
+
         require_supplementary_file = kwargs.pop(
             'require_supplementary_file', False
         )
+
         supplementary_file_label = kwargs.pop('supplementary_file_label', '')
+
         supplementary_file_help_text = kwargs.pop(
             'supplementary_file_help_text', ''
         )
+
         super(SubmissionForm, self).__init__(*args, **kwargs)
+
         if not display_comment_field:
             del self.fields['comment']
+
         if supplementary_file_label:
             self.fields['supplementary_file'].label = supplementary_file_label
+
         if supplementary_file_help_text:
             self.fields[
                 'supplementary_file'
             ].help_text = supplementary_file_help_text
+
         if require_supplementary_file:
             self.fields['supplementary_file'].required = True
         elif not allow_supplementary_file:
             del self.fields['supplementary_file']
+
         self.helper = FormHelper(self)
 
     class Meta:
         model = Submission
         fields = ('comment', 'supplementary_file', 'chunked_upload')
+
+class LegacySubmissionForm(SubmissionForm):
+    class Meta:
+        model = Submission
+        fields = (
+            'creator',
+            'comment',
+            'supplementary_file',
+            'chunked_upload',
+        )

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
@@ -11,6 +11,13 @@
             </a>
     </p>
 
+    <p>
+    <a class="btn btn-primary"
+       href="{% url 'evaluation:submission-create-legacy' site.short_name %}">
+                <i class="fas fa-plus"></i> Add a legacy submission
+            </a>
+    </p>
+
     <table class="table" id="submissionsTable">
         <thead>
         <tr>

--- a/app/grandchallenge/evaluation/urls.py
+++ b/app/grandchallenge/evaluation/urls.py
@@ -18,6 +18,7 @@ from grandchallenge.evaluation.views import (
     ResultDetail,
     ConfigUpdate,
     ResultUpdate,
+    LegacySubmissionCreate,
 )
 from grandchallenge.jqfileupload.forms import (
     test_upload_widget, test_upload_widget2,
@@ -43,6 +44,16 @@ urlpatterns = [
         r'^submissions/create/$',
         SubmissionCreate.as_view(),
         name='submission-create',
+    ),
+    url(
+        r'^submissions/create-legacy/$',
+        LegacySubmissionCreate.as_view(),
+        name='submission-create-legacy',
+    ),
+    url(
+        f'^submissions/create-legacy/{submission_upload_widget.ajax_target_path}$',
+        submission_upload_widget.handle_ajax,
+        name='submission-upload-legacy-ajax',
     ),
     url(
         f'^submissions/create/{submission_upload_widget.ajax_target_path}$',
@@ -73,6 +84,7 @@ urlpatterns = [
         name='result-update',
     ),
 ]
+
 if settings.DEBUG:
     urlpatterns.append(
         url(

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -169,6 +169,35 @@ def test_submission_create(client, TwoChallengeSets):
         client=client,
     )
 
+    response = get_view_for_user(
+        viewname='evaluation:submission-create',
+        challenge=TwoChallengeSets.ChallengeSet1.challenge,
+        user=TwoChallengeSets.ChallengeSet1.participant,
+        client=client,
+    )
+
+    assert response.status_code == 200
+    assert 'Creator' not in response.rendered_content
+
+
+@pytest.mark.django_db
+def test_legacy_submission_create(client, TwoChallengeSets):
+    validate_admin_only_view(
+        viewname='evaluation:submission-create-legacy',
+        two_challenge_set=TwoChallengeSets,
+        client=client,
+    )
+
+    response = get_view_for_user(
+        viewname='evaluation:submission-create-legacy',
+        challenge=TwoChallengeSets.ChallengeSet1.challenge,
+        user=TwoChallengeSets.admin12,
+        client=client,
+    )
+
+    assert response.status_code == 200
+    assert 'Creator' in response.rendered_content
+
 
 @pytest.mark.django_db
 def test_submission_time_limit(client, TwoChallengeSets):


### PR DESCRIPTION
Allows challenge administrators to port old submissions to the
evaluation framework.

Fix #457 