### PR TITLE
Fix make build issue with pipenv env var collision; adds eyra deploy provider for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,11 @@ after_success:
   - codecov
 
 deploy:
-  provider: script
-  script: bash -c "docker login -u grandchallenge -p "$DOCKER_PASSWORD" && make push"
-  on:
-    branch: master
+  - provider: script
+    script: bash -c "docker login -u grandchallenge -p "$DOCKER_PASSWORD" && make push"
+    on:
+      branch: master
+  - provider: script
+    script: bash -c "docker login -u grandchallenge -p "$DOCKER_PASSWORD" && make push"
+    on:
+      branch: eyra-master

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 		-f dockerfiles/web/Dockerfile \
 		.
 	docker build \
-		--build-arg PIPENV_DEV=--dev \
+		--build-arg PIPENV_DEV_FLAG=--dev \
 		-t grandchallenge/web-test:$(TRAVIS_BUILD_NUMBER) \
 		-t grandchallenge/web-test:latest \
 		-f dockerfiles/web/Dockerfile \

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -17,7 +17,7 @@ ENV PYTHONUNBUFFERED 1
 RUN mkdir -p /app /static /dbox/Dropbox/media
 WORKDIR /app
 
-ARG PIPENV_DEV
+ARG PIPENV_DEV_FLAG
 ADD Pipfile /app/
 ADD Pipfile.lock /app/
 RUN python -m pip install -U pip
@@ -35,8 +35,8 @@ ADD --chown=2001:2001 ./app/manage.py /app/
 
 FROM base as test
 USER root
-ARG PIPENV_DEV
-RUN pipenv install --system $PIPENV_DEV
+ARG PIPENV_DEV_FLAG
+RUN pipenv install --system $PIPENV_DEV_FLAG
 USER 2001:2001
 ADD --chown=2001:2001 ./app/tests /app/tests
 ADD --chown=2001:2001 ./app/pytest.ini /app/


### PR DESCRIPTION
Travis build fails on building containers due to env variable collision: the PIPENV_DEV build-arg conflicts with an existing env var used by pipenv of the same name, but it is not compatible with a value of "--dev". Changing the build flag name to PIPENV_DEV_FLAG fixes the issue.

Closes https://github.com/comic/grand-challenge.org/issues/628

We also added a new travis deploy provider for the eyra-master branch.