### PR TITLE
Speed up the container build

### DIFF
--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -1,3 +1,6 @@
+###################
+#  Base Container #
+###################
 FROM python:3.6 as base
 
 RUN apt-get update && \
@@ -14,29 +17,36 @@ RUN apt-get update && \
 
 ENV PYTHONUNBUFFERED 1
 
-RUN mkdir -p /app /static /dbox/Dropbox/media
-WORKDIR /app
-
-ARG PIPENV_DEV_FLAG
-ADD Pipfile /app/
-ADD Pipfile.lock /app/
+RUN mkdir -p /opt/pipenv /app /static /dbox/Dropbox/media
 RUN python -m pip install -U pip
 RUN python -m pip install -U pipenv
+
+# Install base python packages
+WORKDIR /opt/pipenv
+ADD Pipfile /opt/pipenv
+ADD Pipfile.lock /opt/pipenv
 RUN pipenv install --system
 
 RUN chown 2001:2001 /static /dbox/Dropbox/media
 
 USER 2001:2001
+WORKDIR /app
 
 ADD --chown=2001:2001 ./app/config /app/config
 ADD --chown=2001:2001 ./app/grandchallenge /app/grandchallenge
 ADD --chown=2001:2001 ./app/manage.py /app/
 
-
+###################
+#  Test Container #
+###################
 FROM base as test
+
 USER root
+WORKDIR /opt/pipenv
 ARG PIPENV_DEV_FLAG
 RUN pipenv install --system $PIPENV_DEV_FLAG
+
 USER 2001:2001
+WORKDIR /app
 ADD --chown=2001:2001 ./app/tests /app/tests
 ADD --chown=2001:2001 ./app/pytest.ini /app/


### PR DESCRIPTION
This restructures the web docker file so that the build can use more caching. Previously, the permissions of the pipfile and pipfile.lock would change causing a re-build of the installation layer every time.