### PR TITLE
Sets Proxy SSL Header

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -150,10 +150,10 @@ DEFAULT_SCHEME = os.environ.get("DEFAULT_SCHEME", "https")
 SESSION_COOKIE_DOMAIN = os.environ.get(
     "SESSION_COOKIE_DOMAIN", ".gc.localhost"
 )
-SESSION_COOKIE_SECURE = strtobool(
-    os.environ.get("SESSION_COOKIE_SECURE", "False")
-)
-CSRF_COOKIE_SECURE = strtobool(os.environ.get("CSRF_COOKIE_SECURE", "False"))
+# We're always running behind a proxy so set these to true
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Set the allowed hosts to the cookie domain
 ALLOWED_HOSTS = [SESSION_COOKIE_DOMAIN, "web"]

--- a/dockerfiles/http/nginx.conf.template
+++ b/dockerfiles/http/nginx.conf.template
@@ -137,6 +137,7 @@ http {
       rewrite ^(.*[^/])$ $1/ break;
 
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header Host $host;
       proxy_redirect off;
       proxy_pass http://app_server;


### PR DESCRIPTION
This fixes a problem in the API where the urls are set to http rather than https.