### PR TITLE
Gitattributes and retina demo user

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Default behavior is to set autocrlf
+* text=auto
+
+# Make file and sh should keep their line endings
+*.sh text eol=lf
+Makefile text eol=lf
+

--- a/app/grandchallenge/core/management/commands/initcomicdemo.py
+++ b/app/grandchallenge/core/management/commands/initcomicdemo.py
@@ -5,6 +5,7 @@ from django.contrib.sites.models import Site
 from django.core.files.base import ContentFile
 from django.core.management import BaseCommand
 from userena.models import UserenaSignup
+from django.contrib.auth.models import Group
 
 from grandchallenge.challenges.models import (
     Challenge,
@@ -32,7 +33,7 @@ class Command(BaseCommand):
             short_name=settings.MAIN_PROJECT_NAME,
             description="main project",
             use_registration_page=False,
-            disclaimer="You <b>must</b> delete the admin, demo, and demop users before deploying to production!",
+            disclaimer="You <b>must</b> delete the admin, demo, demop, and retina_demo users before deploying to production!",
         )
         if created:
             Page.objects.create(
@@ -178,3 +179,12 @@ class Command(BaseCommand):
             mr_modality = ImagingModality.objects.get(modality="MR")
             ex_challenge.modalities.add(mr_modality)
             ex_challenge.save()
+
+            retina_demo = UserenaSignup.objects.create_user(
+                username="retina_demo",
+                email="retina@example.com",
+                password="retina",
+                active=True,
+            )
+            retina_group = Group.objects.get(name=settings.RETINA_GRADERS_GROUP_NAME)
+            retina_demo.groups.add(retina_group)

--- a/app/grandchallenge/core/management/commands/initcomicdemo.py
+++ b/app/grandchallenge/core/management/commands/initcomicdemo.py
@@ -186,5 +186,7 @@ class Command(BaseCommand):
                 password="retina",
                 active=True,
             )
-            retina_group = Group.objects.get(name=settings.RETINA_GRADERS_GROUP_NAME)
+            retina_group = Group.objects.get(
+                name=settings.RETINA_GRADERS_GROUP_NAME
+            )
             retina_demo.groups.add(retina_group)


### PR DESCRIPTION
This PR adds the .gitattributes file that makes sure the line endings in .sh and Makefile are always LF so that the cycle_docker_compose.sh file can be run on windows systems. Also, it adds a retina_demo user that is in the retina_graders group with the initcomicdemo management command. I believe this management command does not have any tests, correct?