### PR TITLE
Fix incorrect condition

### DIFF
--- a/app/tests/retina_api_tests/test_viewsets.py
+++ b/app/tests/retina_api_tests/test_viewsets.py
@@ -124,11 +124,11 @@ class TestPolygonAnnotationSetViewSet:
             rf,
             PolygonAnnotationSetViewSet,
         )
-        if user_type in ("retina_grader", "retina_admin"):
+        if user_type == "retina_grader":
             serialized_data = PolygonAnnotationSetSerializer(
                 TwoRetinaPolygonAnnotationSets.polygonset1
             ).data
-            assert response.data[0] == serialized_data
+            assert response.data == [serialized_data]
         if user_type == "retina_admin":
             serialized_data = PolygonAnnotationSetSerializer(
                 [


### PR DESCRIPTION
I forgot to remove `"retina_admin"` from the first condition after adding a separate check below it (line 132-143) in #813. The test then fails when `polygonset2.created` is higher than `polygonset1.created`. This should fix it.