### PR TITLE
Allow archive only images in Archive API endpoint

### DIFF
--- a/app/grandchallenge/retina_api/views.py
+++ b/app/grandchallenge/retina_api/views.py
@@ -925,7 +925,8 @@ class ArchiveAPIView(APIView):
                         archive_only_images.append(image)
 
                 images = sorted(
-                    generate_images(archive_only_images), key=lambda x: x["id"]
+                    generate_images(archive_only_images, archive_only=True),
+                    key=lambda x: x["id"],
                 )
                 subfolders = sorted(
                     generate_patients(archive, patients), key=lambda x: x["id"]
@@ -965,17 +966,23 @@ class ArchiveAPIView(APIView):
                     "subfolders": [],
                 }
 
-        def generate_images(image_list):
+        def generate_images(image_list, archive_only=False):
             for image in image_list:
-                yield {
+                yield_obj = {
                     "id": image.id,
                     "name": image.name,
                     "eye": image.eye_choice,
                     "modality": image.modality.modality,
-                    "patient": image.study.patient.name,
-                    "study": image.study.name,
                     "archives": image.archive_set.values(),
                 }
+                if not archive_only:
+                    yield_obj.update(
+                        {
+                            "study": image.study.name,
+                            "patient": image.study.patient.name,
+                        }
+                    )
+                yield yield_obj
 
         return sorted(
             generate_archives(archives, patients), key=lambda x: x["id"]

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -540,7 +540,7 @@ def generate_archive_patient_study_image_set():
     images113 = ImageFactoryWithoutImageFile.create_batch(6, study=study113)
     images121 = ImageFactoryWithoutImageFile.create_batch(2, study=study121)
     images122 = ImageFactoryWithoutImageFile.create_batch(3, study=study122)
-    images211 = ImageFactoryWithoutImageFile.create_batch(4)
+    images211 = ImageFactoryWithoutImageFile.create_batch(4, study=None)
     archive1 = ArchiveFactory.create(
         images=[*images111, *images112, *images113, *images121, *images122]
     )


### PR DESCRIPTION
Resolves https://sentry.io/organizations/grand-challenge/issues/1195527370/?project=303639

I thought I wrote the test for this so that it already tested if archive-only images are allowed. But I did not account for the fact that the ImageFactory will create a Study automatically when it is not specified. I explicitly declared the `study=None` in the fixture, so now it is tested.