### PR TITLE
Adds keep alive endpoint for workstation sessions

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -640,8 +640,8 @@ WORKSTATIONS_MAXIMUM_SESSIONS = int(
 )
 # The name of the group whose members will be able to create workstations
 WORKSTATIONS_CREATORS_GROUP_NAME = "workstation_creators"
-WORKSTATIONS_MAXIMUM_TIMEOUT = int(
-    os.environ.get("WORKSTATIONS_MAXIMUM_TIMEOUT", "10000")
+WORKSTATIONS_SESSION_DURATION_LIMIT = int(
+    os.environ.get("WORKSTATIONS_SESSION_DURATION_LIMIT", "10000")
 )
 
 # Disallow some challenge names due to subdomain or media folder clashes

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -640,6 +640,9 @@ WORKSTATIONS_MAXIMUM_SESSIONS = int(
 )
 # The name of the group whose members will be able to create workstations
 WORKSTATIONS_CREATORS_GROUP_NAME = "workstation_creators"
+WORKSTATIONS_MAXIMUM_TIMEOUT = int(
+    os.environ.get("WORKSTATIONS_MAXIMUM_TIMEOUT", "10000")
+)
 
 # Disallow some challenge names due to subdomain or media folder clashes
 DISALLOWED_CHALLENGE_NAMES = [

--- a/app/grandchallenge/core/permissions/rest_framework.py
+++ b/app/grandchallenge/core/permissions/rest_framework.py
@@ -1,0 +1,26 @@
+from rest_framework.permissions import DjangoObjectPermissions
+
+
+class DjangoObjectOnlyPermissions(DjangoObjectPermissions):
+    """
+    Workaround for using object permissions without setting model perms,
+    which is required by the implementation in Django Rest Framework. It
+    enforces that the user is logged in so that the permissions can be checked
+    later.
+
+    See similar issue detailed here:
+    https://stackoverflow.com/questions/34371409/
+    """
+
+    def has_permission(self, request, view):
+        # Workaround to ensure DjangoModelPermissions are not applied
+        # to the root view when using DefaultRouter.
+        if getattr(view, "_ignore_model_permissions", False):
+            return True
+
+        if not request.user or (
+            not request.user.is_authenticated and self.authenticated_users_only
+        ):
+            return False
+
+        return True

--- a/app/grandchallenge/workstations/serializers.py
+++ b/app/grandchallenge/workstations/serializers.py
@@ -5,7 +5,7 @@ from grandchallenge.workstations.models import Session
 
 
 class SessionSerializer(ModelSerializer):
-    status = CharField(source="get_status_display")
+    status = CharField(source="get_status_display", read_only=True)
 
     class Meta:
         model = Session

--- a/app/grandchallenge/workstations/urls.py
+++ b/app/grandchallenge/workstations/urls.py
@@ -75,22 +75,22 @@ urlpatterns = [
         name="image-update",
     ),
     path(
-        "<slug>/session/create/",
+        "<slug>/sessions/create/",
         SessionCreate.as_view(),
         name="session-create",
     ),
     path(
-        "<slug>/session/<uuid:pk>/",
+        "<slug>/sessions/<uuid:pk>/",
         SessionDetail.as_view(),
         name="session-detail",
     ),
     path(
-        "<slug>/session/<uuid:pk>/update/",
+        "<slug>/sessions/<uuid:pk>/update/",
         SessionUpdate.as_view(),
         name="session-update",
     ),
     path(
-        "<slug>/session/<uuid:pk>/<path:path>",
+        "<slug>/sessions/<uuid:pk>/<path:path>",
         session_proxy,
         name="session-proxy",
     ),

--- a/app/grandchallenge/workstations/views.py
+++ b/app/grandchallenge/workstations/views.py
@@ -31,10 +31,12 @@ from rest_framework.mixins import (
     UpdateModelMixin,
     ListModelMixin,
 )
-from rest_framework.permissions import DjangoObjectPermissions
 from rest_framework.viewsets import GenericViewSet
 from rest_framework_guardian.filters import DjangoObjectPermissionsFilter
 
+from grandchallenge.core.permissions.rest_framework import (
+    DjangoObjectOnlyPermissions,
+)
 from grandchallenge.workstations.forms import (
     WorkstationForm,
     WorkstationImageForm,
@@ -51,23 +53,6 @@ from grandchallenge.workstations.utils import (
     get_workstation_image_or_404,
     get_or_create_active_session,
 )
-
-
-class DjangoObjectOnlyPermissions(DjangoObjectPermissions):
-    """ Workaround for using object permissions without setting model perms """
-
-    def has_permission(self, request, view):
-        # Workaround to ensure DjangoModelPermissions are not applied
-        # to the root view when using DefaultRouter.
-        if getattr(view, "_ignore_model_permissions", False):
-            return True
-
-        if not request.user or (
-            not request.user.is_authenticated and self.authenticated_users_only
-        ):
-            return False
-
-        return True
 
 
 class SessionViewSet(

--- a/app/tests/workstations_tests/test_permissions.py
+++ b/app/tests/workstations_tests/test_permissions.py
@@ -267,8 +267,7 @@ def test_session_api_permissions(client, two_workstation_sets, viewname):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("method", ["put", "patch"])
-def test_session_api_patch_permissions(client, two_workstation_sets, method):
+def test_session_api_patch_permissions(client, two_workstation_sets):
     tests = (
         (two_workstation_sets.ws1.editor, 200, True),
         (two_workstation_sets.ws1.user, 200, True),
@@ -287,10 +286,9 @@ def test_session_api_patch_permissions(client, two_workstation_sets, method):
         )
 
         response = get_view_for_user(
-            viewname="api:session-detail",
+            viewname="api:session-keep-alive",
             client=client,
-            method=getattr(client, method),
-            data={"pk": s.pk, "status": "Stopped"} if method == "put" else {},
+            method=client.patch,
             user=test[0],
             reverse_kwargs={"pk": s.pk},
             content_type="application/json",


### PR DESCRIPTION
This adds an `workstations/sessions/{pk}/keep_alive/` endpoint for the users workstation session that only does 1 thing - increases the expiration time of the session to now + 5 minutes, up to a maximum duration of 10000 seconds (default, environment variable). This will help us fix an issue where the workstation will shut down after 10 minutes, so long as we periodically call this function from JS. 

Closes #911