### PR TITLE
Improve base64 thumbnail endpoint

### DIFF
--- a/app/grandchallenge/cases/permissions.py
+++ b/app/grandchallenge/cases/permissions.py
@@ -1,0 +1,13 @@
+from rest_framework import permissions
+
+from grandchallenge.serving.permissions import user_can_download_image
+
+
+class ImagePermission(permissions.BasePermission):
+    """
+    Permission class for APIViews in retina app.
+    Checks if user is in retina graders or admins group
+    """
+
+    def has_object_permission(self, request, view, obj):
+        return user_can_download_image(user=request.user, image=obj)

--- a/app/grandchallenge/retina_api/renderers.py
+++ b/app/grandchallenge/retina_api/renderers.py
@@ -1,0 +1,13 @@
+import base64
+
+from rest_framework import renderers
+
+
+class Base64Renderer(renderers.BaseRenderer):
+    media_type = "image/png;base64"
+    format = "base64"
+    charset = "utf-8"
+    render_style = "text"
+
+    def render(self, data, media_type=None, renderer_context=None):
+        return base64.b64encode(data)

--- a/app/grandchallenge/retina_api/renderers.py
+++ b/app/grandchallenge/retina_api/renderers.py
@@ -4,10 +4,18 @@ from rest_framework import renderers
 
 
 class Base64Renderer(renderers.BaseRenderer):
+    """
+    Custom renderer that converts a bytes object into a base64 encoded png
+    """
+
     media_type = "image/png;base64"
     format = "base64"
     charset = "utf-8"
     render_style = "text"
 
     def render(self, data, media_type=None, renderer_context=None):
-        return base64.b64encode(data)
+        # Only encode to base64 if data is a bytes object, otherwise an exception
+        # has occured and it returns a dict containing the error.
+        if isinstance(data, bytes):
+            return base64.b64encode(data)
+        return data

--- a/app/grandchallenge/retina_api/serializers.py
+++ b/app/grandchallenge/retina_api/serializers.py
@@ -43,6 +43,8 @@ class PILImageSerializer(serializers.BaseSerializer):
 class BytesImageSerializer(PILImageSerializer):
     """
     Read-only serializer that returns a BytesIO image from an Image instance.
+    Subclasses PILImageSerializer, so the image may be resized and only the central
+    slice of a 3d image will be returned
     """
 
     def to_representation(self, instance):

--- a/app/grandchallenge/retina_api/serializers.py
+++ b/app/grandchallenge/retina_api/serializers.py
@@ -1,0 +1,54 @@
+from io import BytesIO
+
+import SimpleITK as sitk
+from PIL import Image as PILImage
+
+from django.http import Http404
+from rest_framework import serializers
+
+
+class PILImageSerializer(serializers.BaseSerializer):
+    """
+    Read-only serializer that returns a PIL image from a Image instance.
+    If "width" and "height" are passed as extra serializer content, the
+    PIL image will be resized to those dimensions.
+    """
+
+    def to_representation(self, instance):
+        image_itk = instance.get_sitk_image()
+        if image_itk is None:
+            raise Http404
+        pil_image = self.convert_itk_to_pil(image_itk)
+        try:
+            pil_image.thumbnail(
+                (self.context["width"], self.context["height"]),
+                PILImage.ANTIALIAS,
+            )
+        except KeyError:
+            pass
+        return pil_image
+
+    @staticmethod
+    def convert_itk_to_pil(image_itk):
+        depth = image_itk.GetDepth()
+        image_nparray = sitk.GetArrayFromImage(image_itk)
+        if depth > 0:
+            # Get center slice of image if 3D
+            image_nparray = image_nparray[depth // 2]
+        return PILImage.fromarray(image_nparray)
+
+
+class BytesImageSerializer(PILImageSerializer):
+    """
+    Read-only serializer that returns a BytesIO image from an Image instance.
+    """
+
+    def to_representation(self, instance):
+        image_pil = super().to_representation(instance)
+        return self.create_thumbnail_as_bytes_io(image_pil)
+
+    @staticmethod
+    def create_thumbnail_as_bytes_io(image_pil):
+        buffer = BytesIO()
+        image_pil.save(buffer, format="png")
+        return buffer.getvalue()

--- a/app/grandchallenge/retina_api/serializers.py
+++ b/app/grandchallenge/retina_api/serializers.py
@@ -12,11 +12,13 @@ class PILImageSerializer(serializers.BaseSerializer):
     Read-only serializer that returns a PIL image from a Image instance.
     If "width" and "height" are passed as extra serializer content, the
     PIL image will be resized to those dimensions.
+    If the image is 3D it will return the center slice of the image.
     """
 
     def to_representation(self, instance):
-        image_itk = instance.get_sitk_image()
-        if image_itk is None:
+        try:
+            image_itk = instance.get_sitk_image()
+        except:
             raise Http404
         pil_image = self.convert_itk_to_pil(image_itk)
         try:

--- a/app/grandchallenge/retina_api/urls.py
+++ b/app/grandchallenge/retina_api/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path, include
-from rest_framework.routers import DefaultRouter, SimpleRouter
+from rest_framework.routers import SimpleRouter
 from grandchallenge.retina_api import views
 from django.views.decorators.cache import cache_page
 from django.conf import settings
@@ -96,14 +96,14 @@ urlpatterns = [
     ),
     path("annotation/<int:user_id>/", include(annotation_router.urls)),
     path(
-        "image/thumbnail/<uuid:image_id>/",
+        "image/thumbnail/<uuid:pk>/",
         cache_page(settings.RETINA_IMAGE_CACHE_TIME)(
             views.B64ThumbnailAPIView.as_view()
         ),
         name="image-thumbnail",
     ),
     path(
-        "image/thumbnail/<uuid:image_id>/<int:width>/<int:height>/",
+        "image/thumbnail/<uuid:pk>/<int:width>/<int:height>/",
         cache_page(settings.RETINA_IMAGE_CACHE_TIME)(
             views.B64ThumbnailAPIView.as_view()
         ),

--- a/app/tests/cases_tests/test_permissions.py
+++ b/app/tests/cases_tests/test_permissions.py
@@ -1,0 +1,52 @@
+import pytest
+from django.conf import settings
+from django.contrib.auth.models import AnonymousUser, Group
+
+from grandchallenge.cases.permissions import ImagePermission
+from tests.factories import UserFactory, ImageFactory
+
+
+class Request:
+    """ Mock request class containing only user """
+
+    def __init__(self, user):
+        self.user = user
+
+
+@pytest.mark.django_db
+class TestImagePermission:
+    @pytest.mark.parametrize(
+        "user,access",
+        [
+            (AnonymousUser, False),
+            (UserFactory, False),
+            (UserFactory, True),
+            ("retina_grader_no_access", False),
+            ("retina_admin_no_access", False),
+            ("retina_grader", True),
+            ("retina_admin", True),
+        ],
+    )
+    def test_permissions(self, user, access):
+        image = ImageFactory()
+        if isinstance(user, str):
+            group_name = (
+                settings.RETINA_ADMINS_GROUP_NAME
+                if "admin" in user
+                else settings.RETINA_GRADERS_GROUP_NAME
+            )
+            if "no_access" not in user:
+                image.permit_viewing_by_retina_users()
+
+            user = UserFactory()
+            grader_group, group_created = Group.objects.get_or_create(
+                name=group_name
+            )
+            grader_group.user_set.add(user)
+        elif user == AnonymousUser:
+            user = AnonymousUser()
+        else:
+            user = user(is_staff=access)
+        request = Request(user=user)
+        permission = ImagePermission()
+        assert permission.has_object_permission(request, {}, image) == access

--- a/app/tests/retina_api_tests/test_serializers.py
+++ b/app/tests/retina_api_tests/test_serializers.py
@@ -1,0 +1,83 @@
+import random
+from PIL import Image as PILImage
+import pytest
+from django.conf import settings
+from django.http import Http404
+
+from grandchallenge.retina_api.serializers import (
+    PILImageSerializer,
+    BytesImageSerializer,
+)
+from tests.cases_tests.factories import (
+    ImageFactoryWithImageFile,
+    ImageFactoryWithoutImageFile,
+    ImageFactoryWithImageFile3D,
+    ImageFactoryWithImageFile2DLarge,
+    ImageFactoryWithImageFile3DLarge3Slices,
+    ImageFactoryWithImageFile3DLarge4Slices,
+)
+
+
+@pytest.mark.django_db
+class TestPILImageSerializer:
+    def test_non_existant_image_files(self):
+        image = ImageFactoryWithoutImageFile()
+        serializer = PILImageSerializer(image)
+        with pytest.raises(Http404):
+            assert serializer.data
+
+    @pytest.mark.parametrize(
+        "factory", [ImageFactoryWithImageFile, ImageFactoryWithImageFile3D]
+    )
+    def test_image_no_parameters(self, factory):
+        image = factory()
+        serializer = PILImageSerializer(image)
+        image_itk = image.get_sitk_image()
+        image_pil = PILImageSerializer.convert_itk_to_pil(image_itk)
+        assert serializer.data == image_pil
+
+    @pytest.mark.parametrize(
+        "factory",
+        [
+            ImageFactoryWithImageFile2DLarge,
+            ImageFactoryWithImageFile3DLarge3Slices,
+            ImageFactoryWithImageFile3DLarge4Slices,
+        ],
+    )
+    @pytest.mark.parametrize("max_dimension", ["default", "random"])
+    def test_image_resizes(self, factory, max_dimension):
+        if max_dimension == "random":
+            max_dimension = random.randint(1, 255)
+        else:
+            max_dimension = settings.RETINA_DEFAULT_THUMBNAIL_SIZE
+        image = factory()
+        serializer_context = {"width": max_dimension, "height": max_dimension}
+        serializer = PILImageSerializer(image, context=serializer_context)
+        image_itk = image.get_sitk_image()
+        image_pil = PILImageSerializer.convert_itk_to_pil(image_itk)
+        image_pil.thumbnail((max_dimension, max_dimension), PILImage.ANTIALIAS)
+        assert serializer.data == image_pil
+        assert serializer.data.size == image_pil.size
+        assert max(serializer.data.size) == max_dimension
+
+
+@pytest.mark.django_db
+class TestBytesImageSerializer:
+    def test_non_existant_image_files(self):
+        image = ImageFactoryWithoutImageFile()
+        serializer = BytesImageSerializer(image)
+        with pytest.raises(Http404):
+            assert serializer.data
+
+    @pytest.mark.parametrize(
+        "factory", [ImageFactoryWithImageFile, ImageFactoryWithImageFile3D]
+    )
+    def test_image_no_parameters(self, factory):
+        image = factory()
+        serializer = BytesImageSerializer(image)
+        image_itk = image.get_sitk_image()
+        image_pil = PILImageSerializer.convert_itk_to_pil(image_itk)
+        image_bytes = BytesImageSerializer.create_thumbnail_as_bytes_io(
+            image_pil
+        )
+        assert serializer.data == image_bytes

--- a/app/tests/retina_api_tests/test_views.py
+++ b/app/tests/retina_api_tests/test_views.py
@@ -471,10 +471,10 @@ class TestBase64ThumbnailView:
             ("retina_user", status.HTTP_200_OK),
         ],
     )
-    def test_access(self, client, user, expected_status):
+    def test_access_and_defaults(self, client, user, expected_status):
         image = ImageFactoryWithImageFile()
         image.permit_viewing_by_retina_users()
-        url = reverse("retina:api:image-thumbnail", args=[image.pk])
+        url = reverse("retina:api:image-thumbnail", kwargs={"pk": image.pk})
         client, user_model = client_force_login(client, user=user)
         token = ""
         if user_model is not None and not isinstance(user_model, str):
@@ -485,10 +485,10 @@ class TestBase64ThumbnailView:
     @staticmethod
     def perform_thumbnail_request(client, image, max_dimension):
         image.permit_viewing_by_retina_users()
-        args = [image.id]
+        kwargs = {"pk": image.id}
         if max_dimension != settings.RETINA_DEFAULT_THUMBNAIL_SIZE:
-            args = [image.id, max_dimension, max_dimension]
-        url = reverse("retina:api:image-thumbnail", args=args)
+            kwargs.update({"width": max_dimension, "height": max_dimension})
+        url = reverse("retina:api:image-thumbnail", kwargs=kwargs)
         client, user_model = client_force_login(client, user="retina_user")
         token = f"Token {Token.objects.create(user=user_model).key}"
         response = client.get(url, HTTP_AUTHORIZATION=token)

--- a/app/tests/retina_api_tests/test_views.py
+++ b/app/tests/retina_api_tests/test_views.py
@@ -29,6 +29,7 @@ from tests.retina_api_tests.helpers import (
     batch_test_data_endpoints,
     client_login,
     client_force_login,
+    get_user_from_str,
 )
 
 
@@ -475,11 +476,12 @@ class TestBase64ThumbnailView:
         image = ImageFactoryWithImageFile()
         image.permit_viewing_by_retina_users()
         url = reverse("retina:api:image-thumbnail", kwargs={"pk": image.pk})
-        client, user_model = client_force_login(client, user=user)
-        token = ""
+        user_model = get_user_from_str(user)
+        kwargs = {}
         if user_model is not None and not isinstance(user_model, str):
-            token = f"Token {Token.objects.create(user=user_model).key}"
-        response = client.get(url, HTTP_AUTHORIZATION=token)
+            token_object, _ = Token.objects.get_or_create(user=user_model)
+            kwargs.update({"HTTP_AUTHORIZATION": f"Token {token_object.key}"})
+        response = client.get(url, **kwargs)
         assert response.status_code == expected_status
 
     @staticmethod


### PR DESCRIPTION
Improves the endpoint so that it complies with changes in https://github.com/DIAGNijmegen/rse-cirrus-core/pull/232. Also splits up some of the functionality so it can be reused easier and makes the endpoint behave more in line with a normal DRF endpoint