### PR TITLE
Delete groups on parent deletion

### DIFF
--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -525,8 +525,11 @@ def delete_challenge_groups_hook(*_, instance: Challenge, using, **__):
     """
     Use a signal rather than delete() override to catch usages of bulk_delete
     """
-    instance.admins_group.delete(using=using)
-    instance.participants_group.delete(using=using)
+    if instance.admins_group:
+        instance.admins_group.delete(using=using)
+
+    if instance.participants_group:
+        instance.participants_group.delete(using=using)
 
 
 class ExternalChallenge(ChallengeBase):

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.postgres.fields import CICharField, ArrayField
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.core.validators import validate_slug
 from django.db import models
 from django.db.models.signals import post_delete
@@ -525,11 +525,15 @@ def delete_challenge_groups_hook(*_, instance: Challenge, using, **__):
     """
     Use a signal rather than delete() override to catch usages of bulk_delete
     """
-    if instance.admins_group:
+    try:
         instance.admins_group.delete(using=using)
+    except ObjectDoesNotExist:
+        pass
 
-    if instance.participants_group:
+    try:
         instance.participants_group.delete(using=using)
+    except ObjectDoesNotExist:
+        pass
 
 
 class ExternalChallenge(ChallengeBase):

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -3,7 +3,7 @@ from collections import Counter
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.contrib.postgres.fields import JSONField
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.db import models
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
@@ -241,11 +241,15 @@ def delete_reader_study_groups_hook(*_, instance: ReaderStudy, using, **__):
     """
     Use a signal rather than delete() override to catch usages of bulk_delete
     """
-    if instance.editors_group:
+    try:
         instance.editors_group.delete(using=using)
+    except ObjectDoesNotExist:
+        pass
 
-    if instance.readers_group:
+    try:
         instance.readers_group.delete(using=using)
+    except ObjectDoesNotExist:
+        pass
 
 
 ANSWER_TYPE_ANNOTATIONS_SCHEMA = {

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -241,8 +241,11 @@ def delete_reader_study_groups_hook(*_, instance: ReaderStudy, using, **__):
     """
     Use a signal rather than delete() override to catch usages of bulk_delete
     """
-    instance.editors_group.delete(using=using)
-    instance.readers_group.delete(using=using)
+    if instance.editors_group:
+        instance.editors_group.delete(using=using)
+
+    if instance.readers_group:
+        instance.readers_group.delete(using=using)
 
 
 ANSWER_TYPE_ANNOTATIONS_SCHEMA = {

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -5,6 +5,8 @@ from django.contrib.auth.models import Group
 from django.contrib.postgres.fields import JSONField
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
 from django_extensions.db.models import TitleSlugDescriptionModel
 from guardian.shortcuts import assign_perm, get_objects_for_group, remove_perm
 from numpy.random.mtrand import RandomState
@@ -232,6 +234,15 @@ class ReaderStudy(UUIDModel, TitleSlugDescriptionModel):
             RandomState(seed=int(user.pk)).shuffle(hanging_list)
 
         return hanging_list
+
+
+@receiver(post_delete, sender=ReaderStudy)
+def delete_reader_study_groups_hook(*_, instance: ReaderStudy, using, **__):
+    """
+    Use a signal rather than delete() override to catch usages of bulk_delete
+    """
+    instance.editors_group.delete(using=using)
+    instance.readers_group.delete(using=using)
 
 
 ANSWER_TYPE_ANNOTATIONS_SCHEMA = {

--- a/app/grandchallenge/workstations/migrations/0003_group_data_migration.py
+++ b/app/grandchallenge/workstations/migrations/0003_group_data_migration.py
@@ -7,8 +7,8 @@ def delete_workstation_groups(apps, schema_editor):
     Workstation = apps.get_model("workstations", "Workstation")
 
     for ws in Workstation.objects.all():
-        ws.editors_group.delete()
-        ws.users_group.delete()
+        ws.editors_group.delete(keep_parents=True)
+        ws.users_group.delete(keep_parents=True)
 
         ws.editors_group = None
         ws.users_group = None

--- a/app/grandchallenge/workstations/models.py
+++ b/app/grandchallenge/workstations/models.py
@@ -124,8 +124,11 @@ def delete_workstation_groups_hook(*_, instance: Workstation, using, **__):
     """
     Use a signal rather than delete() override to catch usages of bulk_delete
     """
-    instance.editors_group.delete(using=using)
-    instance.users_group.delete(using=using)
+    if instance.editors_group:
+        instance.editors_group.delete(using=using)
+
+    if instance.users_group:
+        instance.users_group.delete(using=using)
 
 
 class WorkstationImage(UUIDModel, ContainerImageModel):

--- a/app/grandchallenge/workstations/models.py
+++ b/app/grandchallenge/workstations/models.py
@@ -3,6 +3,7 @@ from urllib.parse import unquote, urljoin
 
 from django.conf import settings
 from django.contrib.auth.models import Group
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.validators import MaxValueValidator, RegexValidator
 from django.db import models
 from django.db.models.signals import post_delete
@@ -124,11 +125,15 @@ def delete_workstation_groups_hook(*_, instance: Workstation, using, **__):
     """
     Use a signal rather than delete() override to catch usages of bulk_delete
     """
-    if instance.editors_group:
+    try:
         instance.editors_group.delete(using=using)
+    except ObjectDoesNotExist:
+        pass
 
-    if instance.users_group:
+    try:
         instance.users_group.delete(using=using)
+    except ObjectDoesNotExist:
+        pass
 
 
 class WorkstationImage(UUIDModel, ContainerImageModel):

--- a/app/tests/challenges_tests/test_models.py
+++ b/app/tests/challenges_tests/test_models.py
@@ -1,0 +1,23 @@
+import pytest
+from django.core.exceptions import ObjectDoesNotExist
+
+from grandchallenge.challenges.models import Challenge
+from tests.factories import ChallengeFactory
+
+
+@pytest.mark.django_db
+def test_group_deletion():
+    challenge = ChallengeFactory()
+    participants_group = challenge.participants_group
+    admins_group = challenge.admins_group
+
+    assert participants_group
+    assert admins_group
+
+    Challenge.objects.filter(pk__in=[challenge.pk]).delete()
+
+    with pytest.raises(ObjectDoesNotExist):
+        participants_group.refresh_from_db()
+
+    with pytest.raises(ObjectDoesNotExist):
+        admins_group.refresh_from_db()

--- a/app/tests/challenges_tests/test_models.py
+++ b/app/tests/challenges_tests/test_models.py
@@ -21,3 +21,25 @@ def test_group_deletion():
 
     with pytest.raises(ObjectDoesNotExist):
         admins_group.refresh_from_db()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("group", ["participants_group", "admins_group"])
+def test_group_deletion_reverse(group):
+    challenge = ChallengeFactory()
+    participants_group = challenge.participants_group
+    admins_group = challenge.admins_group
+
+    assert participants_group
+    assert admins_group
+
+    getattr(challenge, group).delete()
+
+    with pytest.raises(ObjectDoesNotExist):
+        participants_group.refresh_from_db()
+
+    with pytest.raises(ObjectDoesNotExist):
+        admins_group.refresh_from_db()
+
+    with pytest.raises(ObjectDoesNotExist):
+        challenge.refresh_from_db()

--- a/app/tests/reader_studies_tests/test_models.py
+++ b/app/tests/reader_studies_tests/test_models.py
@@ -21,3 +21,25 @@ def test_group_deletion():
 
     with pytest.raises(ObjectDoesNotExist):
         editors_group.refresh_from_db()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("group", ["readers_group", "editors_group"])
+def test_group_deletion_reverse(group):
+    rs = ReaderStudyFactory()
+    readers_group = rs.readers_group
+    editors_group = rs.editors_group
+
+    assert readers_group
+    assert editors_group
+
+    getattr(rs, group).delete()
+
+    with pytest.raises(ObjectDoesNotExist):
+        readers_group.refresh_from_db()
+
+    with pytest.raises(ObjectDoesNotExist):
+        editors_group.refresh_from_db()
+
+    with pytest.raises(ObjectDoesNotExist):
+        rs.refresh_from_db()

--- a/app/tests/reader_studies_tests/test_models.py
+++ b/app/tests/reader_studies_tests/test_models.py
@@ -1,0 +1,23 @@
+import pytest
+from django.core.exceptions import ObjectDoesNotExist
+
+from grandchallenge.reader_studies.models import ReaderStudy
+from tests.reader_studies_tests.factories import ReaderStudyFactory
+
+
+@pytest.mark.django_db
+def test_group_deletion():
+    rs = ReaderStudyFactory()
+    readers_group = rs.readers_group
+    editors_group = rs.editors_group
+
+    assert readers_group
+    assert editors_group
+
+    ReaderStudy.objects.filter(pk__in=[rs.pk]).delete()
+
+    with pytest.raises(ObjectDoesNotExist):
+        readers_group.refresh_from_db()
+
+    with pytest.raises(ObjectDoesNotExist):
+        editors_group.refresh_from_db()

--- a/app/tests/workstations_tests/test_models.py
+++ b/app/tests/workstations_tests/test_models.py
@@ -214,3 +214,25 @@ def test_group_deletion():
 
     with pytest.raises(ObjectDoesNotExist):
         editors_group.refresh_from_db()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("group", ["users_group", "editors_group"])
+def test_group_deletion_reverse(group):
+    ws = WorkstationFactory()
+    users_group = ws.users_group
+    editors_group = ws.editors_group
+
+    assert users_group
+    assert editors_group
+
+    getattr(ws, group).delete()
+
+    with pytest.raises(ObjectDoesNotExist):
+        users_group.refresh_from_db()
+
+    with pytest.raises(ObjectDoesNotExist):
+        editors_group.refresh_from_db()
+
+    with pytest.raises(ObjectDoesNotExist):
+        ws.refresh_from_db()


### PR DESCRIPTION
This PR moves the deletion of child groups to `post_delete` signals to ensure that the groups are cleaned up when `Foo.objects.filter(...).delete()` is used.

Closes #886