### PR TITLE
Fix greedy flatpage matching

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -282,6 +282,8 @@ MIDDLEWARE = (
     "grandchallenge.subdomains.middleware.subdomain_middleware",
     "grandchallenge.subdomains.middleware.challenge_subdomain_middleware",
     "grandchallenge.subdomains.middleware.subdomain_urlconf_middleware",
+    # Flatpage fallback almost last
+    "django.contrib.flatpages.middleware.FlatpageFallbackMiddleware",
     # speedinfo at the end but before FetchFromCacheMiddleware
     "speedinfo.middleware.ProfilerMiddleware",
 )

--- a/app/config/urls.py
+++ b/app/config/urls.py
@@ -98,11 +98,6 @@ urlpatterns = [
         "media/",
         include("grandchallenge.serving.urls", namespace="root-serving"),
     ),
-    # ========== catch all ====================
-    # when all other urls have been checked, try to load page from flatpages
-    # keep this url at the bottom of this list, because urls are checked in
-    # order
-    path("", include("django.contrib.flatpages.urls")),
 ]
 if settings.DEBUG and settings.ENABLE_DEBUG_TOOLBAR:
     import debug_toolbar

--- a/app/grandchallenge/core/templates/grandchallenge/partials/footer.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/footer.html
@@ -12,8 +12,9 @@
                     <ul class="list-unstyled">
                         {% for page in flatpages %}
                             <li>
+                                {# Manual construction of url is used here due to flatpage redirect errors #}
                                 <a class="text-muted"
-                                   href="{% url 'django.contrib.flatpages.views.flatpage' url=page.url %}">
+                                   href="{{ request.scheme }}://{{ request.site.domain }}{{ page.url }}">
                                     {{ page.title }}
                                 </a>
                             </li>
@@ -55,10 +56,15 @@
                 <div class="px-3">
                     <ul class="list-unstyled">
                         <li>
-                            <a class="text-muted"
-                               href="https://github.com/comic/grand-challenge.org"
+                            <a class="p-1 text-muted"
+                               href="https://github.com/comic/grand-challenge.org/"
                                title="Join us on Github">
                                 <i class="fab fa-github fa-lg"></i>
+                            </a>
+                            <a class="p-1 text-muted"
+                               href="https://twitter.com/g13e_org/"
+                               title="Follow us on Twitter">
+                                <i class="fab fa-twitter fa-lg"></i>
                             </a>
                         </li>
                     </ul>

--- a/app/grandchallenge/subdomains/utils.py
+++ b/app/grandchallenge/subdomains/utils.py
@@ -24,11 +24,6 @@ def reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None):
     else:
         urlconf = urlconf or settings.ROOT_URLCONF
 
-    if "views.flatpage" in viewname.lower() and "url" in kwargs:
-        # Fix for a long standing bug in django flatpages
-        # https://code.djangoproject.com/ticket/15658
-        kwargs.update({"url": kwargs["url"].lstrip("/")})
-
     path = reverse_org(
         viewname,
         urlconf=urlconf,


### PR DESCRIPTION
The flatpage urls on the top level were not correctly implementing APPEND_SLASH,
it seems that there is a well known bug in django about this. This
commit swaps out the catch all url for the FlatpageFallbackMiddleware
which correctly handles a 404 page with APPEND_SLASH=True.

https://code.djangoproject.com/ticket/6213

As reverse lookups for flatpages no longer work we have to construct
the full url from the request.site, but, we can now remove a workaround
in the url resolver. A side effect of this now is that the flatpages
will appear on the subdomains, but the pages on those domains have
precedence.

Closes #957