### PR TITLE
Replace '/' with '-' in TRAVIS_BRANCH for docker tagging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   - DOCKER_COMPOSE_VERSION=1.21.2
 
 before_install:
+  - export TRAVIS_BRANCH_SAFE=$(echo $TRAVIS_BRANCH | sed "s/[/]/-/")
   - sudo docker pull crccheck/hello-world
   - sudo rm /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose

--- a/Makefile
+++ b/Makefile
@@ -3,30 +3,30 @@ USER_ID = $(shell id -u)
 build_web:
 	docker build \
 		--target test \
-		-t grandchallenge/web-test:$(TRAVIS_BUILD_NUMBER)-$(TRAVIS_BRANCH) \
+		-t grandchallenge/web-test:$(TRAVIS_BUILD_NUMBER)-$(TRAVIS_BRANCH_SAFE) \
 		-t grandchallenge/web-test:latest \
 		-f dockerfiles/web/Dockerfile \
 		.
 	docker build \
 		--target dist \
-		-t grandchallenge/web:$(TRAVIS_BUILD_NUMBER)-$(TRAVIS_BRANCH) \
+		-t grandchallenge/web:$(TRAVIS_BUILD_NUMBER)-$(TRAVIS_BRANCH_SAFE) \
 		-t grandchallenge/web:latest \
 		-f dockerfiles/web/Dockerfile \
 		.
 
 build_http:
 	docker build \
-		-t grandchallenge/http:$(TRAVIS_BUILD_NUMBER)-$(TRAVIS_BRANCH) \
+		-t grandchallenge/http:$(TRAVIS_BUILD_NUMBER)-$(TRAVIS_BRANCH_SAFE) \
 		-t grandchallenge/http:latest \
 		dockerfiles/http
 
 build: build_web build_http
 
 push_web:
-	docker push grandchallenge/web:$(TRAVIS_BUILD_NUMBER)-$(TRAVIS_BRANCH)
+	docker push grandchallenge/web:$(TRAVIS_BUILD_NUMBER)-$(TRAVIS_BRANCH_SAFE)
 
 push_http:
-	docker push grandchallenge/http:$(TRAVIS_BUILD_NUMBER)-$(TRAVIS_BRANCH)
+	docker push grandchallenge/http:$(TRAVIS_BUILD_NUMBER)-$(TRAVIS_BRANCH_SAFE)
 
 push: push_web push_http
 

--- a/cycle_docker_compose.sh
+++ b/cycle_docker_compose.sh
@@ -5,7 +5,7 @@ echo "Press Ctrl+C (once) to stop"
 sleep 1
 
 export TRAVIS_BUILD_NUMBER=$(git describe --always --dirty)
-export TRAVIS_BRANCH=$(git rev-parse --abbrev-ref HEAD | sed "s/[^[a-zA-Z0-9]]//")
+export TRAVIS_BRANCH_SAFE=$(git rev-parse --abbrev-ref HEAD | sed "s/[^[a-zA-Z0-9]]//" | sed "s/[/]/-/")
 
 make -j2 build
 


### PR DESCRIPTION
Without this change, the travis build fails when a '/' character is included in the branch name, as it is creates an invalid docker tag.