### PR TITLE
Add ability to edit reader study questions

### DIFF
--- a/app/grandchallenge/reader_studies/forms.py
+++ b/app/grandchallenge/reader_studies/forms.py
@@ -88,7 +88,20 @@ class ReaderStudyUpdateForm(ReaderStudyCreateForm, ModelForm):
         }
 
 
-class QuestionCreateForm(SaveFormInitMixin, ModelForm):
+class QuestionForm(SaveFormInitMixin, ModelForm):
+    def full_clean(self):
+        """Override of the form's full_clean method.
+
+        Some fields are made readonly once the question has been answered.
+        Because disabled fields do not get included in the post data, this
+        causes issues with required fields. Therefore we populate them here.
+        """
+        data = self.data.copy()
+        for field in self.instance.read_only_fields:
+            data[field] = getattr(self.instance, field)
+        self.data = data
+        return super().full_clean()
+
     class Meta:
         model = Question
         fields = (

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -475,6 +475,16 @@ class Question(UUIDModel):
             "api:reader-studies-question-detail", kwargs={"pk": self.pk}
         )
 
+    @property
+    def is_fully_editable(self):
+        return self.answer_set.count() == 0
+
+    @property
+    def read_only_fields(self):
+        if not self.is_fully_editable:
+            return ["question_text", "answer_type", "image_port", "required"]
+        return []
+
     def save(self, *args, **kwargs):
         adding = self._state.adding
 

--- a/app/grandchallenge/reader_studies/templates/reader_studies/reader_study_object_form.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/reader_study_object_form.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% load grandchallenge_tags %}
+{% load crispy_forms_tags %}
+{% load static %}
+
+{% block title %}
+    {{ block.super }}
+{% endblock %}
+
+{% block content %}
+    {% block form_heading %}{% endblock %}
+
+    {% crispy form %}
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    <script type="text/javascript"
+            src="{% static "js/unsavedform.js" %}"></script>
+{% endblock %}

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -95,9 +95,17 @@
 
         <h2>Questions</h2>
 
-        <ul>
+        <ul class="list-group list-group-flush">
             {% for question in object.questions.all %}
-                <li>{{ question }}</li>
+                <li class="list-group-item">
+                    <div class="w-100 d-flex justify-content-between">
+                        <div>{{ question }}</div>
+                        <a class="btn btn-primary btn-sm"
+                           href="{% url 'reader-studies:question-update' slug=object.slug pk=question.pk %}">
+                            <i class="fa fa-edit"></i> Edit
+                        </a>
+                    </div>
+                </li>
             {% endfor %}
         </ul>
 

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_update_object.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_update_object.html
@@ -1,9 +1,9 @@
 {% extends "reader_studies/reader_study_object_form.html" %}
 
 {% block title %}
-    Add {{ type_to_add }} to {{ object }} - {{ block.super }}
+    Edit {{ object }} - {{ block.super }}
 {% endblock %}
 
 {% block form_heading %}
-    <h2>Add {{ type_to_add }} to {{ object }}</h2>
+    <h2>Edit {{ object }}</h2>
 {% endblock %}

--- a/app/grandchallenge/reader_studies/urls.py
+++ b/app/grandchallenge/reader_studies/urls.py
@@ -4,6 +4,7 @@ from grandchallenge.reader_studies.views import (
     AddImagesToReaderStudy,
     AddQuestionToReaderStudy,
     EditorsUpdate,
+    QuestionUpdate,
     ReaderStudyCreate,
     ReaderStudyDetail,
     ReaderStudyList,
@@ -33,6 +34,11 @@ urlpatterns = [
         "<slug>/questions/add/",
         AddQuestionToReaderStudy.as_view(),
         name="add-question",
+    ),
+    path(
+        "<slug>/questions/<pk>/update/",
+        QuestionUpdate.as_view(),
+        name="question-update",
     ),
     path(
         "<slug>/editors/update/",

--- a/app/tests/reader_studies_tests/test_models.py
+++ b/app/tests/reader_studies_tests/test_models.py
@@ -2,7 +2,11 @@ import pytest
 from django.core.exceptions import ObjectDoesNotExist
 
 from grandchallenge.reader_studies.models import ReaderStudy
-from tests.reader_studies_tests.factories import ReaderStudyFactory
+from tests.reader_studies_tests.factories import (
+    AnswerFactory,
+    QuestionFactory,
+    ReaderStudyFactory,
+)
 
 
 @pytest.mark.django_db
@@ -43,3 +47,22 @@ def test_group_deletion_reverse(group):
 
     with pytest.raises(ObjectDoesNotExist):
         rs.refresh_from_db()
+
+
+@pytest.mark.django_db
+def test_read_only_fields():
+    rs = ReaderStudyFactory()
+    q = QuestionFactory(reader_study=rs)
+
+    assert q.is_fully_editable is True
+    assert q.read_only_fields == []
+
+    AnswerFactory(question=q, answer="true")
+
+    assert q.is_fully_editable is False
+    assert q.read_only_fields == [
+        "question_text",
+        "answer_type",
+        "image_port",
+        "required",
+    ]


### PR DESCRIPTION
Questions are fully editable as long as no answers have been submitted yet. Once a question has been answered, only the help text, direction and order may be changed