### PR TITLE
Feature/930 more descriptive error

### DIFF
--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -186,7 +186,7 @@ class ReaderStudy(UUIDModel, TitleSlugDescriptionModel):
 
     @property
     def study_image_names(self):
-        return [im.name for im in self.images.all()]
+        return self.images.values_list("name", flat=True)
 
     @property
     def hanging_image_names(self):

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -205,6 +205,15 @@ class ReaderStudy(UUIDModel, TitleSlugDescriptionModel):
         )
 
     @property
+    def hanging_list_diff(self):
+        return {
+            "in_study_list": set(self.study_image_names)
+            - set(self.hanging_image_names),
+            "in_hanging_list": set(self.hanging_image_names)
+            - set(self.study_image_names),
+        }
+
+    @property
     def non_unique_study_image_names(self):
         """
         Get all of the image names that are non-unique for this ReaderStudy

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -21,8 +21,31 @@
 
     {% if not object.is_valid %}
         <div class="alert alert-danger">
-        This reader study is not ready to be used. Please update the configuration. All of the images should be included in the hanging list
-        exactly once.
+            This reader study is not ready to be used. Please update the configuration. All of the images should be included in the hanging list exactly once.
+            {% if object.non_unique_study_image_names|length > 0 %}
+                <hr/>
+                The following image names appear more than once in the study: <br/>
+                <span class="font-weight-bold">
+                    {{ object.non_unique_study_image_names|join:', ' }}
+                </span>
+            {% endif %}
+            {% if not object.hanging_list_valid %}
+                {% if object.hanging_list_diff.in_study_list|length > 0 %}
+                    <hr/>
+                    The following image names appear in the study but not in the hanging list: <br/>
+                    <span class="font-weight-bold">
+                        {{ object.hanging_list_diff.in_study_list|join:', ' }}
+                    </span>
+                {% endif %}
+                {% if object.hanging_list_diff.in_hanging_list|length > 0 %}
+                    <hr/>
+                    The following image names appear in the hanging list but not in the study: <br/>
+                    <span class="font-weight-bold">
+                        {{ object.hanging_list_diff.in_hanging_list|join:', ' }}
+                    </span>
+                {% endif %}
+
+            {% endif %}
         </div>
     {% endif %}
 


### PR DESCRIPTION
This adds more information as to why a reader study is invalid:

![Screenshot from 2019-11-07 15-27-44](https://user-images.githubusercontent.com/57257130/68397925-3aa5cd00-0174-11ea-9b0c-f9571b9aefbc.png)

Closes #930 