### PR TITLE
Add GitHub actions for static code inspections

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -5,8 +5,14 @@ jobs:
   precommit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v1.1.1
+      - name: Install Python 3.7
+        uses: actions/setup-python@v1.1.1
+        with:
+          python-version: '3.7'
       - uses: actions/checkout@v1
-      - run: python -m pip install pre-commit
-      - run: pre-commit install
-      - run: pre-commit run --all-files
+      - name: Install pre-commit
+        run: |
+          python -m pip install pre-commit
+          pre-commit install
+      - name: Run static code inspections
+        run: pre-commit run --all-files

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,0 +1,13 @@
+name: CI
+on: [push, pull_request]
+jobs:
+
+  precommit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v1.1.1
+      - uses: actions/checkout@v1
+      - run: python -m pip install pre-commit
+      - run: |
+          pre-commit install
+          pre-commit run --all-files

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -8,6 +8,5 @@ jobs:
       - uses: actions/setup-python@v1.1.1
       - uses: actions/checkout@v1
       - run: python -m pip install pre-commit
-      - run: |
-          pre-commit install
-          pre-commit run --all-files
+      - run: pre-commit install
+      - run: pre-commit run --all-files


### PR DESCRIPTION
At the moment developers need to wait a while for the flake8/black checks to pass, this adds a CI step so that we get quick feedback from these tools.