### PR TITLE
Code refactor of complex cases image_builders methods

### DIFF
--- a/app/tests/cases_tests/test_mhd.py
+++ b/app/tests/cases_tests/test_mhd.py
@@ -7,7 +7,7 @@ import pytest
 
 from grandchallenge.cases.image_builders.metaio_utils import (
     load_sitk_image,
-    load_sitk_image_with_nd_support_from_headers,
+    load_sitk_image_with_nd_support,
     parse_mh_header,
 )
 from tests.cases_tests import RESOURCE_PATH
@@ -189,7 +189,7 @@ def test_4d_mh_loader_with_more_than_4_dimensions_fails(tmpdir):
 )
 def test_4dloader_reproduces_normal_sitk_loader_results(image: Path):
     img_ref = SimpleITK.ReadImage(str(image))
-    img = load_sitk_image_with_nd_support_from_headers(mhd_file=image)
+    img = load_sitk_image_with_nd_support(mhd_file=image)
     assert_sitk_img_equivalence(img, img_ref)
 
 

--- a/app/tests/cases_tests/test_models.py
+++ b/app/tests/cases_tests/test_models.py
@@ -98,7 +98,6 @@ class TestGetSitkImage:
         image.files.add(too_large_imagefile)
 
         # Try to open and catch expected exception
-        exec_info = None
         with pytest.raises(IOError) as exec_info:
             image.get_sitk_image()
         assert "File exceeds maximum file size." in str(


### PR DESCRIPTION
Closes #973

* Renamed load_sitk_image_with_nd_support_with_header -> load_sitk_image_with_nd_support
* Split load_sitk_image_with_nd_support into 3 helper functions
* Extracted extract_key_value_pairs method for parse_mh_header method