### PR TITLE
Change LandmarkAnnotationSet endpoint and add custom action

### DIFF
--- a/app/grandchallenge/api/urls.py
+++ b/app/grandchallenge/api/urls.py
@@ -21,6 +21,7 @@ from grandchallenge.reader_studies.views import (
     QuestionViewSet,
     ReaderStudyViewSet,
 )
+from grandchallenge.retina_api.views import LandmarkAnnotationSetViewSet
 from grandchallenge.workstation_configs.views import WorkstationConfigViewSet
 from grandchallenge.workstations.views import SessionViewSet
 
@@ -59,6 +60,12 @@ router.register(
 router.register(r"reader-studies", ReaderStudyViewSet, basename="reader-study")
 router.register(r"chunked-uploads", StagedFileViewSet, basename="staged-file")
 
+router.register(
+    r"retina/landmark-annotation",
+    LandmarkAnnotationSetViewSet,
+    basename="landmark-annotation",
+)
+
 # TODO: add terms_of_service and contact
 schema_view = get_schema_view(
     openapi.Info(
@@ -81,5 +88,5 @@ urlpatterns = [
     # the serializers
     path("v1/", include(router.urls)),
     path("auth/", include("rest_framework.urls", namespace="rest_framework")),
-    path("", schema_view.with_ui("swagger"), name="schema-docs",),
+    path("", schema_view.with_ui("swagger"), name="schema-docs"),
 ]

--- a/app/grandchallenge/retina_api/filters.py
+++ b/app/grandchallenge/retina_api/filters.py
@@ -1,0 +1,19 @@
+from rest_framework import filters
+
+from grandchallenge.retina_api.mixins import is_in_retina_admins_group
+
+
+class RetinaAnnotationFilter(filters.BaseFilterBackend):
+    """
+    Filter backend that only returns objects that belong to the current user, except
+    if the user is in the `retina_admins` group.
+
+    This filter is created for annotation models and requires that the model has a
+    `grader` field that defines the user that is the owner of the object. As defined
+    in `annotations.AbstractAnnotationModel`.
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        if is_in_retina_admins_group(request.user):
+            return queryset
+        return queryset.filter(grader=request.user)

--- a/app/grandchallenge/retina_api/urls.py
+++ b/app/grandchallenge/retina_api/urls.py
@@ -19,11 +19,6 @@ annotation_router.register(
     basename="polygonannotationset",
 )
 annotation_router.register(
-    "landmarkannotationset",
-    views.LandmarkAnnotationSetViewSet,
-    basename="landmarkannotationset",
-)
-annotation_router.register(
     "etdrsgridannotation",
     views.ETDRSGridAnnotationViewSet,
     basename="etdrsgridannotation",

--- a/app/grandchallenge/retina_api/views.py
+++ b/app/grandchallenge/retina_api/views.py
@@ -976,7 +976,7 @@ class ImageTextAnnotationViewSet(viewsets.ModelViewSet):
 
 
 class LandmarkAnnotationSetViewSet(viewsets.ModelViewSet):
-    permission_classes = (RetinaOwnerAPIPermission,)
+    permission_classes = (RetinaAPIPermission,)
     authentication_classes = (authentication.TokenAuthentication,)
     serializer_class = LandmarkAnnotationSetSerializer
     filter_backends = (filters.ObjectPermissionsFilter,)

--- a/app/tests/annotations_tests/factories.py
+++ b/app/tests/annotations_tests/factories.py
@@ -121,19 +121,6 @@ class SingleLandmarkAnnotationFactory(factory.DjangoModelFactory):
     landmarks = FuzzyFloatCoordinatesList()
 
 
-def create_batch_landmarks():
-    landmark_annotation_set = LandmarkAnnotationSet()
-    landmark_annotations = []
-    for _ in range(3):
-        landmark_annotations.append(
-            SingleLandmarkAnnotationFactory(
-                registration=landmark_annotation_set
-            )
-        )
-
-    return landmark_annotation_set, landmark_annotations
-
-
 class ImageQualityAnnotationFactory(DefaultImageAnnotationModelFactory):
     class Meta:
         model = ImageQualityAnnotation

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -422,16 +422,19 @@ def two_retina_polygon_annotation_sets():
 class MultipleLandmarkAnnotationSets(NamedTuple):
     grader1: UserFactory
     grader2: UserFactory
+    grader3: UserFactory
     landmarkset1: LandmarkAnnotationSetFactory
     landmarkset1images: List
     landmarkset2: LandmarkAnnotationSetFactory
     landmarkset2images: List
     landmarkset3: LandmarkAnnotationSetFactory
     landmarkset3images: List
+    landmarkset4: LandmarkAnnotationSetFactory
+    landmarkset4images: List
 
 
 def generate_multiple_landmark_annotation_sets(retina_grader=False):
-    graders = (UserFactory(), UserFactory())
+    graders = (UserFactory(), UserFactory(), UserFactory())
 
     if retina_grader:
         add_to_graders_group(graders)
@@ -440,6 +443,7 @@ def generate_multiple_landmark_annotation_sets(retina_grader=False):
         LandmarkAnnotationSetFactory(grader=graders[0]),
         LandmarkAnnotationSetFactory(grader=graders[1]),
         LandmarkAnnotationSetFactory(grader=graders[0]),
+        LandmarkAnnotationSetFactory(grader=graders[2]),
     )
 
     # Create child models for landmark annotation set
@@ -451,6 +455,7 @@ def generate_multiple_landmark_annotation_sets(retina_grader=False):
             5, annotation_set=landmarksets[1]
         ),
         [],
+        [],
     )
 
     images = [
@@ -460,6 +465,7 @@ def generate_multiple_landmark_annotation_sets(retina_grader=False):
         Image.objects.filter(
             singlelandmarkannotation__annotation_set=landmarksets[1].id
         ),
+        [],
         [],
     ]
 
@@ -471,6 +477,13 @@ def generate_multiple_landmark_annotation_sets(retina_grader=False):
             )
         )
         images[2].append(image)
+
+        singlelandmarkbatches[3].append(
+            SingleLandmarkAnnotationFactory.create(
+                annotation_set=landmarksets[3], image=image
+            )
+        )
+        images[3].append(image)
     singlelandmarkbatches[2].append(
         SingleLandmarkAnnotationFactory.create(annotation_set=landmarksets[2])
     )
@@ -479,12 +492,15 @@ def generate_multiple_landmark_annotation_sets(retina_grader=False):
     return MultipleLandmarkAnnotationSets(
         grader1=graders[0],
         grader2=graders[1],
+        grader3=graders[2],
         landmarkset1=landmarksets[0],
         landmarkset1images=images[0],
         landmarkset2=landmarksets[1],
         landmarkset2images=images[1],
         landmarkset3=landmarksets[2],
         landmarkset3images=images[2],
+        landmarkset4=landmarksets[3],
+        landmarkset4images=images[3],
     )
 
 

--- a/app/tests/retina_api_tests/test_viewsets.py
+++ b/app/tests/retina_api_tests/test_viewsets.py
@@ -1868,14 +1868,12 @@ class TestLandmarkAnnotationSetViewSetForImage:
 
         user = get_user_from_user_type(user_type, **kwargs)
 
-        url = reverse(f"api:landmark-annotation-for-image") + querystring
+        url = reverse(f"api:landmark-annotation-list") + querystring
 
         request = rf.get(url)
 
         force_authenticate(request, user=user)
-        view = LandmarkAnnotationSetViewSet.as_view(
-            actions={"get": "for_image"}
-        )
+        view = LandmarkAnnotationSetViewSet.as_view(actions={"get": "list"})
         return view(request)
 
     def test_no_query_params(self, rf, user_type):
@@ -1884,7 +1882,7 @@ class TestLandmarkAnnotationSetViewSetForImage:
         if user_type in (None, "normal_user"):
             assert response.status_code == status.HTTP_403_FORBIDDEN
         else:
-            assert response.status_code == status.HTTP_404_NOT_FOUND
+            assert response.status_code == status.HTTP_200_OK
 
     def test_non_existant_image(self, rf, user_type):
         img = ImageFactory()

--- a/app/tests/retina_api_tests/test_viewsets.py
+++ b/app/tests/retina_api_tests/test_viewsets.py
@@ -1316,42 +1316,27 @@ class TestETDRSAnnotationViewSet:
     ],
 )
 @pytest.mark.parametrize(
-    "viewset,factory,serializer,with_image,non_update",
+    "viewset,factory,serializer",
     (
         (
             ImageQualityAnnotationViewSet,
             ImageQualityAnnotationFactory,
             ImageQualityAnnotationSerializer,
-            True,
-            False,
         ),
         (
             ImagePathologyAnnotationViewSet,
             ImagePathologyAnnotationFactory,
             ImagePathologyAnnotationSerializer,
-            True,
-            False,
         ),
         (
             RetinaImagePathologyAnnotationViewSet,
             RetinaImagePathologyAnnotationFactory,
             RetinaImagePathologyAnnotationSerializer,
-            True,
-            False,
         ),
         (
             ImageTextAnnotationViewSet,
             ImageTextAnnotationFactory,
             ImageTextAnnotationSerializer,
-            True,
-            False,
-        ),
-        (
-            LandmarkAnnotationSetViewSet,
-            LandmarkAnnotationSetFactory,
-            LandmarkAnnotationSetSerializer,
-            False,
-            True,
         ),
     ),
 )
@@ -1372,16 +1357,7 @@ class TestAnnotationViewSets:
 
         return models
 
-    def test_list_view(
-        self,
-        rf,
-        user_type,
-        viewset,
-        factory,
-        serializer,
-        with_image,
-        non_update,
-    ):
+    def test_list_view(self, rf, user_type, viewset, factory, serializer):
         models = self.create_models(factory)
         response = view_test(
             "list",
@@ -1404,25 +1380,14 @@ class TestAnnotationViewSets:
             assert len(response.data) == len(serialized_data)
             assert response.data == serialized_data
 
-    def test_create_view(
-        self,
-        rf,
-        user_type,
-        viewset,
-        factory,
-        serializer,
-        with_image,
-        non_update,
-    ):
+    def test_create_view(self, rf, user_type, viewset, factory, serializer):
         models = self.create_models(factory)
         build_kwargs = {"grader": models[0].grader}
-        if with_image:
-            build_kwargs.update({"image": models[0].image})
+        build_kwargs.update({"image": models[0].image})
         model_build = factory.build(**build_kwargs)
         model_serialized = serializer(model_build).data
         model_serialized["grader"] = models[0].grader.id
-        if with_image:
-            model_serialized["image"] = str(model_serialized["image"])
+        model_serialized["image"] = str(model_serialized["image"])
         model_json = json.dumps(model_serialized)
 
         response = view_test(
@@ -1438,29 +1403,19 @@ class TestAnnotationViewSets:
         )
         if user_type in ("retina_grader", "retina_admin"):
             model_serialized["id"] = response.data["id"]
-            if with_image:
-                response.data["image"] = str(response.data["image"])
+            response.data["image"] = str(response.data["image"])
             assert response.data == model_serialized
 
     def test_create_view_wrong_user_id(
-        self,
-        rf,
-        user_type,
-        viewset,
-        factory,
-        serializer,
-        with_image,
-        non_update,
+        self, rf, user_type, viewset, factory, serializer
     ):
         models = self.create_models(factory)
         build_kwargs = {"grader": models[0].grader}
-        if with_image:
-            build_kwargs.update({"image": ImageFactory()})
+        build_kwargs.update({"image": ImageFactory()})
         model_build = factory.build(**build_kwargs)
         model_serialized = serializer(model_build).data
         model_serialized["grader"] = models[2].grader.id
-        if with_image:
-            model_serialized["image"] = str(model_serialized["image"])
+        model_serialized["image"] = str(model_serialized["image"])
         model_json = json.dumps(model_serialized)
 
         response = view_test(
@@ -1477,8 +1432,7 @@ class TestAnnotationViewSets:
         )
         if user_type == "retina_admin":
             model_serialized["id"] = response.data["id"]
-            if with_image:
-                response.data["image"] = str(response.data["image"])
+            response.data["image"] = str(response.data["image"])
             assert response.data == model_serialized
         elif user_type == "retina_grader":
             assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -1489,16 +1443,7 @@ class TestAnnotationViewSets:
         else:
             assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_retrieve_view(
-        self,
-        rf,
-        user_type,
-        viewset,
-        factory,
-        serializer,
-        with_image,
-        non_update,
-    ):
+    def test_retrieve_view(self, rf, user_type, viewset, factory, serializer):
         models = self.create_models(factory)
         response = view_test(
             "retrieve",
@@ -1514,21 +1459,11 @@ class TestAnnotationViewSets:
             model_serialized = serializer(models[0]).data
             assert response.data == model_serialized
 
-    def test_update_view(
-        self,
-        rf,
-        user_type,
-        viewset,
-        factory,
-        serializer,
-        with_image,
-        non_update,
-    ):
+    def test_update_view(self, rf, user_type, viewset, factory, serializer):
         models = self.create_models(factory)
         model_serialized = serializer(models[1]).data
         models[1].delete()
-        if with_image:
-            model_serialized["image"] = str(model_serialized["image"])
+        model_serialized["image"] = str(model_serialized["image"])
         model_serialized["id"] = str(models[0].id)
         model_json = json.dumps(model_serialized)
 
@@ -1545,28 +1480,16 @@ class TestAnnotationViewSets:
         )
 
         if user_type in ("retina_grader", "retina_admin"):
-            if with_image:
-                response.data["image"] = str(response.data["image"])
-            if non_update:
-                assert response.data != model_serialized
-            else:
-                assert response.data == model_serialized
+            response.data["image"] = str(response.data["image"])
+            assert response.data == model_serialized
 
     def test_update_view_wrong_user_id(
-        self,
-        rf,
-        user_type,
-        viewset,
-        factory,
-        serializer,
-        with_image,
-        non_update,
+        self, rf, user_type, viewset, factory, serializer
     ):
         other_user = UserFactory()
         models = self.create_models(factory)
         model_serialized = serializer(models[0]).data
-        if with_image:
-            model_serialized["image"] = str(model_serialized["image"])
+        model_serialized["image"] = str(model_serialized["image"])
         model_serialized["grader"] = other_user.id
         model_json = json.dumps(model_serialized)
 
@@ -1584,12 +1507,8 @@ class TestAnnotationViewSets:
         )
         if user_type == "retina_admin":
             model_serialized["id"] = response.data["id"]
-            if with_image:
-                response.data["image"] = str(response.data["image"])
-            if non_update:
-                assert response.data != model_serialized
-            else:
-                assert response.data == model_serialized
+            response.data["image"] = str(response.data["image"])
+            assert response.data == model_serialized
         elif user_type == "retina_grader":
             assert response.status_code == status.HTTP_400_BAD_REQUEST
             assert (
@@ -1600,20 +1519,12 @@ class TestAnnotationViewSets:
             assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_partial_update_view(
-        self,
-        rf,
-        user_type,
-        viewset,
-        factory,
-        serializer,
-        with_image,
-        non_update,
+        self, rf, user_type, viewset, factory, serializer
     ):
         models = self.create_models(factory)
         model_serialized = serializer(models[0]).data
         partial_model = copy.deepcopy(model_serialized)
-        if with_image:
-            del partial_model["image"]
+        del partial_model["image"]
         del partial_model["id"]
         del partial_model["grader"]
         model_json = json.dumps(partial_model)
@@ -1633,16 +1544,7 @@ class TestAnnotationViewSets:
         if user_type in ("retina_grader", "retina_admin"):
             assert response.data == model_serialized
 
-    def test_destroy_view(
-        self,
-        rf,
-        user_type,
-        viewset,
-        factory,
-        serializer,
-        with_image,
-        non_update,
-    ):
+    def test_destroy_view(self, rf, user_type, viewset, factory, serializer):
         models = self.create_models(factory)
         view_test(
             "destroy",
@@ -1660,14 +1562,7 @@ class TestAnnotationViewSets:
             ).exists()
 
     def test_destroy_view_wrong_user(
-        self,
-        rf,
-        user_type,
-        viewset,
-        factory,
-        serializer,
-        with_image,
-        non_update,
+        self, rf, user_type, viewset, factory, serializer
     ):
         models = self.create_models(factory)
         response = view_test(
@@ -1680,6 +1575,275 @@ class TestAnnotationViewSets:
             rf,
             viewset,
             check_response_status_code=False,
+        )
+        if user_type == "retina_admin":
+            assert not factory._meta.model.objects.filter(
+                id=models[0].id
+            ).exists()
+        elif user_type == "retina_grader":
+            assert response.status_code == status.HTTP_404_NOT_FOUND
+        else:
+            assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_type", [None, "normal_user", "retina_grader", "retina_admin"]
+)
+@pytest.mark.parametrize(
+    "viewset,factory,serializer,basename,",
+    (
+        (
+            LandmarkAnnotationSetViewSet,
+            LandmarkAnnotationSetFactory,
+            LandmarkAnnotationSetSerializer,
+            "landmark-annotation",
+        ),
+    ),
+)
+class TestLandmarkAnnotationSetViewSet:
+    namespace = "api"
+
+    @staticmethod
+    def create_models(factory):
+        graders = [UserFactory(), UserFactory(), UserFactory()]
+        add_to_graders_group(graders)
+        model = factory(grader=graders[0])
+        models = [
+            model,
+            factory(grader=graders[0]),
+            factory(grader=graders[1]),
+            factory(grader=graders[2]),
+        ]
+
+        return models
+
+    def test_list_view(
+        self, rf, user_type, viewset, factory, serializer, basename
+    ):
+        models = self.create_models(factory)
+        response = view_test(
+            "list",
+            user_type,
+            self.namespace,
+            basename,
+            models[0].grader,
+            None,
+            rf,
+            viewset,
+            with_user=False,
+        )
+        if user_type == "retina_grader":
+            serialized_data = serializer(models[0:2], many=True).data
+            assert len(response.data) == len(serialized_data)
+            serialized_data.sort(key=lambda k: k["created"], reverse=True)
+            assert response.data == serialized_data
+        elif user_type == "retina_admin":
+            serialized_data = serializer(models, many=True).data
+            serialized_data.sort(key=lambda k: k["created"], reverse=True)
+            assert len(response.data) == len(serialized_data)
+            assert response.data == serialized_data
+
+    def test_create_view(
+        self, rf, user_type, viewset, factory, serializer, basename
+    ):
+        models = self.create_models(factory)
+        build_kwargs = {"grader": models[0].grader}
+        model_build = factory.build(**build_kwargs)
+        model_serialized = serializer(model_build).data
+        model_serialized["grader"] = models[0].grader.id
+        model_json = json.dumps(model_serialized)
+
+        response = view_test(
+            "create",
+            user_type,
+            self.namespace,
+            basename,
+            models[0].grader,
+            None,
+            rf,
+            viewset,
+            model_json,
+            with_user=False,
+        )
+        if user_type in ("retina_grader", "retina_admin"):
+            model_serialized["id"] = response.data["id"]
+            assert response.data == model_serialized
+
+    def test_create_view_wrong_user_id(
+        self, rf, user_type, viewset, factory, serializer, basename
+    ):
+        models = self.create_models(factory)
+        build_kwargs = {"grader": models[0].grader}
+        model_build = factory.build(**build_kwargs)
+        model_serialized = serializer(model_build).data
+        model_serialized["grader"] = models[2].grader.id
+        model_json = json.dumps(model_serialized)
+
+        response = view_test(
+            "create",
+            user_type,
+            self.namespace,
+            basename,
+            models[0].grader,
+            None,
+            rf,
+            viewset,
+            model_json,
+            check_response_status_code=False,
+            with_user=False,
+        )
+        if user_type == "retina_admin":
+            model_serialized["id"] = response.data["id"]
+            assert response.data == model_serialized
+        elif user_type == "retina_grader":
+            assert response.status_code == status.HTTP_400_BAD_REQUEST
+            assert (
+                str(response.data["grader"][0])
+                == "User is not allowed to create annotation for other grader"
+            )
+        else:
+            assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_retrieve_view(
+        self, rf, user_type, viewset, factory, serializer, basename
+    ):
+        models = self.create_models(factory)
+        response = view_test(
+            "retrieve",
+            user_type,
+            self.namespace,
+            basename,
+            models[0].grader,
+            models[0],
+            rf,
+            viewset,
+            with_user=False,
+        )
+        if user_type == "retina_grader" or user_type == "retina_admin":
+            model_serialized = serializer(models[0]).data
+            assert response.data == model_serialized
+
+    def test_update_view(
+        self, rf, user_type, viewset, factory, serializer, basename
+    ):
+        models = self.create_models(factory)
+        model_serialized = serializer(models[1]).data
+        models[1].delete()
+        model_serialized["id"] = str(models[0].id)
+        model_json = json.dumps(model_serialized)
+
+        response = view_test(
+            "update",
+            user_type,
+            self.namespace,
+            basename,
+            models[0].grader,
+            models[0],
+            rf,
+            viewset,
+            model_json,
+            with_user=False,
+        )
+
+        if user_type in ("retina_grader", "retina_admin"):
+            assert response.data != model_serialized
+
+    def test_update_view_wrong_user_id(
+        self, rf, user_type, viewset, factory, serializer, basename
+    ):
+        other_user = UserFactory()
+        models = self.create_models(factory)
+        model_serialized = serializer(models[0]).data
+        model_serialized["grader"] = other_user.id
+        model_json = json.dumps(model_serialized)
+
+        response = view_test(
+            "update",
+            user_type,
+            self.namespace,
+            basename,
+            models[0].grader,
+            models[0],
+            rf,
+            viewset,
+            model_json,
+            check_response_status_code=False,
+            with_user=False,
+        )
+        if user_type == "retina_admin":
+            model_serialized["id"] = response.data["id"]
+            assert response.data != model_serialized
+        elif user_type == "retina_grader":
+            assert response.status_code == status.HTTP_400_BAD_REQUEST
+            assert (
+                str(response.data["grader"][0])
+                == "User is not allowed to create annotation for other grader"
+            )
+        else:
+            assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_partial_update_view(
+        self, rf, user_type, viewset, factory, serializer, basename
+    ):
+        models = self.create_models(factory)
+        model_serialized = serializer(models[0]).data
+        partial_model = copy.deepcopy(model_serialized)
+        del partial_model["id"]
+        del partial_model["grader"]
+        model_json = json.dumps(partial_model)
+
+        response = view_test(
+            "partial_update",
+            user_type,
+            self.namespace,
+            basename,
+            models[0].grader,
+            models[0],
+            rf,
+            viewset,
+            model_json,
+            with_user=False,
+        )
+
+        if user_type in ("retina_grader", "retina_admin"):
+            assert response.data == model_serialized
+
+    def test_destroy_view(
+        self, rf, user_type, viewset, factory, serializer, basename
+    ):
+        models = self.create_models(factory)
+        view_test(
+            "destroy",
+            user_type,
+            self.namespace,
+            basename,
+            models[0].grader,
+            models[0],
+            rf,
+            viewset,
+            with_user=False,
+        )
+        if user_type in ("retina_grader", "retina_admin"):
+            assert not factory._meta.model.objects.filter(
+                id=models[0].id
+            ).exists()
+
+    def test_destroy_view_wrong_user(
+        self, rf, user_type, viewset, factory, serializer, basename
+    ):
+        models = self.create_models(factory)
+        response = view_test(
+            "destroy",
+            user_type,
+            self.namespace,
+            basename,
+            models[2].grader,
+            models[0],
+            rf,
+            viewset,
+            check_response_status_code=False,
+            with_user=False,
         )
         if user_type == "retina_admin":
             assert not factory._meta.model.objects.filter(

--- a/app/tests/retina_api_tests/test_viewsets.py
+++ b/app/tests/retina_api_tests/test_viewsets.py
@@ -1918,11 +1918,29 @@ class TestLandmarkAnnotationSetViewSetForImage:
             data=multiple_landmark_retina_annotation_sets,
         )
 
-        if user_type in (None, "normal_user"):
-            assert response.status_code == status.HTTP_403_FORBIDDEN
-        elif user_type == "retina_grader":
+        if user_type == "retina_grader":
             assert response.status_code == status.HTTP_200_OK
             assert len(response.data) == 2
+            serialized_data = LandmarkAnnotationSetSerializer(
+                [
+                    multiple_landmark_retina_annotation_sets.landmarkset1,
+                    multiple_landmark_retina_annotation_sets.landmarkset3,
+                ],
+                many=True,
+            ).data
+            serialized_data.sort(key=lambda k: k["created"], reverse=True)
+            assert response.data == serialized_data
         elif user_type == "retina_admin":
             assert response.status_code == status.HTTP_200_OK
             assert len(response.data) == 3
+            serialized_data = LandmarkAnnotationSetSerializer(
+                [
+                    multiple_landmark_retina_annotation_sets.landmarkset1,
+                    multiple_landmark_retina_annotation_sets.landmarkset3,
+                    multiple_landmark_retina_annotation_sets.landmarkset4,
+                ],
+                many=True,
+            ).data
+            serialized_data.sort(key=lambda k: k["created"], reverse=True)
+        else:
+            assert response.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
- Changes endpoint url from `/retina/api/...` to `/api/v1/retina/landmark-annotation/`
- Adds a custom action on the viewset for retrieving all annotations for a specific image provided in the querystring

Closes #1032 