### PR TITLE
Fix HTTP 500 error when invalid UUID is passed

### DIFF
--- a/app/grandchallenge/retina_api/views.py
+++ b/app/grandchallenge/retina_api/views.py
@@ -3,7 +3,11 @@ from enum import Enum
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
+from django.core.exceptions import (
+    MultipleObjectsReturned,
+    ObjectDoesNotExist,
+    ValidationError,
+)
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.utils import timezone
@@ -999,7 +1003,11 @@ class LandmarkAnnotationSetViewSet(viewsets.ModelViewSet):
         ).all()
         image_id = self.request.query_params.get("image_id")
         if image_id is not None:
-            image = get_object_or_404(Image.objects.all(), pk=image_id)
+            try:
+                image = get_object_or_404(Image.objects.all(), pk=image_id)
+            except ValidationError:
+                # Invalid uuid passed, return 404
+                raise NotFound()
             queryset = LandmarkAnnotationSet.objects.filter(
                 singlelandmarkannotation__image=image
             )

--- a/app/tests/retina_api_tests/test_viewsets.py
+++ b/app/tests/retina_api_tests/test_viewsets.py
@@ -1884,6 +1884,16 @@ class TestLandmarkAnnotationSetViewSetForImage:
         else:
             assert response.status_code == status.HTTP_200_OK
 
+    def test_invalid_image_uuid(self, rf, user_type):
+        response = self.perform_request(
+            rf, user_type, f"?image_id=invalid_uuid"
+        )
+
+        if user_type in (None, "normal_user"):
+            assert response.status_code == status.HTTP_403_FORBIDDEN
+        else:
+            assert response.status_code == status.HTTP_404_NOT_FOUND
+
     def test_non_existant_image(self, rf, user_type):
         img = ImageFactory()
         pk = img.pk


### PR DESCRIPTION
I just noticed while testing the LandmarkAnnotationSet endpoint that passing an invalid UUID as query parameter (eg. `?image_id=test`) results in an HTTP 500 error.
This changes it to result in a 404 and adds a test for it.