### PR TITLE
Add search field to Token admin

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -360,7 +360,7 @@ LOCAL_APPS = [
     "grandchallenge.workstation_configs",
 ]
 
-INSTALLED_APPS = DJANGO_APPS + LOCAL_APPS + THIRD_PARTY_APPS
+INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
 ADMIN_URL = f'{os.environ.get("DJANGO_ADMIN_URL", "django-admin")}/'
 

--- a/app/grandchallenge/core/admin.py
+++ b/app/grandchallenge/core/admin.py
@@ -2,8 +2,10 @@ from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import GroupAdmin
 from django.contrib.auth.models import Group
+from rest_framework.authtoken.models import Token
 
 admin.site.unregister(Group)
+admin.site.unregister(Token)
 
 
 class ReadOnlyUserInLine(admin.TabularInline):
@@ -21,3 +23,16 @@ class ReadOnlyUserInLine(admin.TabularInline):
 @admin.register(Group)
 class GroupWithUsers(GroupAdmin):
     inlines = [ReadOnlyUserInLine]
+
+
+@admin.register(Token)
+class TokenAdmin(admin.ModelAdmin):
+    list_display = ("key", "user", "created")
+    fields = ("user",)
+    ordering = ("-created",)
+    search_fields = (
+        "user__username",
+        "user__email",
+        "user__first_name",
+        "user__last_name",
+    )


### PR DESCRIPTION
There are currently 15 pages of tokens in production and no way to search through them which is inconvenient. This adds a search field that allows an admin to search for username, email, fist or last name of a user in the admin. 

**WARNING!** This requires a change in the order of the `INSTALLED_APPS` setting for correctly unregistering and registering the admin. I'm not sure if that will break other things.