### PR TITLE
Made api::schema-json and api::schema-docs public for safe rest-api methods

### DIFF
--- a/app/grandchallenge/api/urls.py
+++ b/app/grandchallenge/api/urls.py
@@ -68,9 +68,7 @@ router.register(
 
 
 class IsSuperUserOrReadOnly(permissions.BasePermission):
-    """
-    The request is authenticated as an admin, or is a read-only request.
-    """
+    """The request is authenticated as an admin, or is a read-only request."""
 
     def has_permission(self, request, view):
         return bool(

--- a/app/grandchallenge/api/urls.py
+++ b/app/grandchallenge/api/urls.py
@@ -67,17 +67,6 @@ router.register(
 )
 
 
-class IsSuperUserOrReadOnly(permissions.BasePermission):
-    """The request is authenticated as an admin, or is a read-only request."""
-
-    def has_permission(self, request, view):
-        return bool(
-            request.method in permissions.SAFE_METHODS
-            or request.user
-            and request.user.is_superuser
-        )
-
-
 # TODO: add terms_of_service and contact
 schema_view = get_schema_view(
     openapi.Info(
@@ -86,7 +75,7 @@ schema_view = get_schema_view(
         description=f"The API for {settings.SESSION_COOKIE_DOMAIN.lstrip('.')}.",
         license=openapi.License(name="Apache License 2.0"),
     ),
-    permission_classes=(IsSuperUserOrReadOnly,),
+    permission_classes=(permissions.AllowAny,),
     patterns=[path("api/v1/", include(router.urls))],
 )
 

--- a/app/grandchallenge/api/urls.py
+++ b/app/grandchallenge/api/urls.py
@@ -66,7 +66,6 @@ router.register(
     basename="landmark-annotation",
 )
 
-
 # TODO: add terms_of_service and contact
 schema_view = get_schema_view(
     openapi.Info(

--- a/app/grandchallenge/api/urls.py
+++ b/app/grandchallenge/api/urls.py
@@ -66,6 +66,20 @@ router.register(
     basename="landmark-annotation",
 )
 
+
+class IsSuperUserOrReadOnly(permissions.BasePermission):
+    """
+    The request is authenticated as an admin, or is a read-only request.
+    """
+
+    def has_permission(self, request, view):
+        return bool(
+            request.method in permissions.SAFE_METHODS
+            or request.user
+            and request.user.is_superuser
+        )
+
+
 # TODO: add terms_of_service and contact
 schema_view = get_schema_view(
     openapi.Info(
@@ -74,7 +88,7 @@ schema_view = get_schema_view(
         description=f"The API for {settings.SESSION_COOKIE_DOMAIN.lstrip('.')}.",
         license=openapi.License(name="Apache License 2.0"),
     ),
-    permission_classes=(permissions.IsAuthenticated,),
+    permission_classes=(IsSuperUserOrReadOnly,),
     patterns=[path("api/v1/", include(router.urls))],
 )
 

--- a/app/tests/api_tests/test_urls.py
+++ b/app/tests/api_tests/test_urls.py
@@ -1,34 +1,9 @@
-from collections import namedtuple
-
 import pytest
-from django.contrib.auth.models import AnonymousUser
-from rest_framework import permissions
 
 from grandchallenge.subdomains.utils import reverse
-from tests.factories import UserFactory
 from tests.utils import assert_viewname_status
 
 
-@pytest.fixture(name="api_users_set")
-def api_users_set():
-    """Creates four user types with varying permissions."""
-    api_users_sets = namedtuple(
-        "api_users", ["user", "staff", "super_user", "anonymous"]
-    )
-
-    user = UserFactory(is_staff=False, is_superuser=False)
-    staff = UserFactory(is_staff=True, is_superuser=False)
-    super_user = UserFactory(is_staff=True, is_superuser=True)
-    anonymous = AnonymousUser()
-
-    return api_users_sets(user, staff, super_user, anonymous)
-
-
-@pytest.mark.parametrize("user", ["user", "staff", "super_user", "anonymous"])
-@pytest.mark.parametrize(
-    "method",
-    ("POST", "PUT", "DELETE", "TRACE", "PATCH") + permissions.SAFE_METHODS,
-)
 @pytest.mark.parametrize(
     "schema, schema_format",
     [
@@ -38,21 +13,10 @@ def api_users_set():
     ],
 )
 @pytest.mark.django_db
-def test_api_permissions(
-    client, user, method, schema, schema_format, api_users_set
+def test_api_docs_generation(
+    client, schema, schema_format,
 ):
-    if method == "OPTIONS" and schema == "schema-docs":
-        pytest.xfail(
-            reason="These tests are known to fail with with: "
-            "django.core.exceptions.ImproperlyConfigured: "
-            "Returned a template response with no `template_name` "
-            "attribute set on either the view or response"
-        )
     kwargs = dict(format=schema_format) if schema == "schema-json" else None
     assert_viewname_status(
-        code=200 if method in permissions.SAFE_METHODS else 405,
-        url=reverse(f"api:{schema}", kwargs=kwargs),
-        client=client,
-        user=getattr(api_users_set, user),
-        method=getattr(client, method.lower()),
+        code=200, url=reverse(f"api:{schema}", kwargs=kwargs), client=client,
     )

--- a/app/tests/api_tests/test_urls.py
+++ b/app/tests/api_tests/test_urls.py
@@ -43,19 +43,14 @@ def test_api_permissions(
 ):
     if method == "OPTIONS" and schema == "schema-docs":
         pytest.xfail(
-            "These tests are known to fail with with: "
+            reason="These tests are known to fail with with: "
             "django.core.exceptions.ImproperlyConfigured: "
             "Returned a template response with no `template_name` "
             "attribute set on either the view or response"
         )
-    expected_responses_per_user_for_unsafe_methods = dict(
-        user=403, staff=403, super_user=405, anonymous=401
-    )
     kwargs = dict(format=schema_format) if schema == "schema-json" else None
     assert_viewname_status(
-        code=expected_responses_per_user_for_unsafe_methods[user]
-        if method not in permissions.SAFE_METHODS
-        else 200,
+        code=200 if method in permissions.SAFE_METHODS else 405,
         url=reverse(f"api:{schema}", kwargs=kwargs),
         client=client,
         user=getattr(api_users_set, user),

--- a/app/tests/api_tests/test_urls.py
+++ b/app/tests/api_tests/test_urls.py
@@ -1,0 +1,63 @@
+from collections import namedtuple
+
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from rest_framework import permissions
+
+from grandchallenge.subdomains.utils import reverse
+from tests.factories import UserFactory
+from tests.utils import assert_viewname_status
+
+
+@pytest.fixture(name="api_users_set")
+def api_users_set():
+    """Creates four user types with varying permissions."""
+    api_users_sets = namedtuple(
+        "api_users", ["user", "staff", "super_user", "anonymous"]
+    )
+
+    user = UserFactory(is_staff=False, is_superuser=False)
+    staff = UserFactory(is_staff=True, is_superuser=False)
+    super_user = UserFactory(is_staff=True, is_superuser=True)
+    anonymous = AnonymousUser()
+
+    return api_users_sets(user, staff, super_user, anonymous)
+
+
+@pytest.mark.parametrize("user", ["user", "staff", "super_user", "anonymous"])
+@pytest.mark.parametrize(
+    "method",
+    ("POST", "PUT", "DELETE", "TRACE", "PATCH") + permissions.SAFE_METHODS,
+)
+@pytest.mark.parametrize(
+    "schema, schema_format",
+    [
+        ("schema-json", ".json"),
+        ("schema-json", ".yaml"),
+        ("schema-docs", None),
+    ],
+)
+@pytest.mark.django_db
+def test_api_permissions(
+    client, user, method, schema, schema_format, api_users_set
+):
+    if method == "OPTIONS" and schema == "schema-docs":
+        pytest.xfail(
+            "These tests are known to fail with with: "
+            "django.core.exceptions.ImproperlyConfigured: "
+            "Returned a template response with no `template_name` "
+            "attribute set on either the view or response"
+        )
+    expected_responses_per_user_for_unsafe_methods = dict(
+        user=403, staff=403, super_user=405, anonymous=401
+    )
+    kwargs = dict(format=schema_format) if schema == "schema-json" else None
+    assert_viewname_status(
+        code=expected_responses_per_user_for_unsafe_methods[user]
+        if method not in permissions.SAFE_METHODS
+        else 200,
+        url=reverse(f"api:{schema}", kwargs=kwargs),
+        client=client,
+        user=getattr(api_users_set, user),
+        method=getattr(client, method.lower()),
+    )


### PR DESCRIPTION
#1017

* Note several tests with method=OPTIONS and shema="schema-docs" fail and have now been added as expected failures