### PR TITLE
Adding exposing enum support for rest_framework.CharField through swagger_schemas_fields

### DIFF
--- a/app/grandchallenge/api/swagger.py
+++ b/app/grandchallenge/api/swagger.py
@@ -1,0 +1,45 @@
+from typing import Dict, List, Tuple, Union
+
+from drf_yasg.inspectors import FieldInspector
+from drf_yasg.openapi import Schema
+
+
+def add_manual_fields(self, serializer_or_field, schema):
+    meta = getattr(serializer_or_field, "Meta", None)
+    swagger_schema_fields = getattr(meta, "swagger_schema_fields", {})
+    if swagger_schema_fields:
+        for attr, val in swagger_schema_fields.items():
+            if isinstance(val, dict) and isinstance(
+                getattr(schema, attr, None), dict
+            ):
+                to_update = dict(
+                    list(getattr(schema, attr).items()) + list(val.items())
+                )
+                setattr(schema, attr, to_update)
+            else:
+                setattr(schema, attr, val)
+
+
+# This overrides the default behavior when the swagger_schema_fields attribute is set
+# in the serializers. Now dictionary attributes are updated instead of overwritten
+# for the swagger_schema_fields - Sil
+FieldInspector.add_manual_fields = add_manual_fields
+
+
+def swagger_schema_fields_for_charfield(
+    field_names: Union[Tuple, List], field_choices: Union[Tuple, List]
+) -> Dict[str, Dict[str, Schema]]:
+    return {
+        "properties": {
+            field_name: Schema(
+                **{
+                    "enum": [c[1] for c in field_choices],
+                    "title": field_name[0].upper()
+                    + field_name[1:].replace("_", " "),
+                    "type": "string",
+                    "minLength": 1,
+                }
+            )
+            for field_name, field_choices in zip(field_names, field_choices)
+        }
+    }

--- a/app/grandchallenge/api/swagger.py
+++ b/app/grandchallenge/api/swagger.py
@@ -4,14 +4,14 @@ from drf_yasg.inspectors import FieldInspector
 from drf_yasg.openapi import Schema
 
 
-def add_manual_fields(self, serializer_or_field, schema):
+def _add_manual_fields(self, serializer_or_field, schema):
     meta = getattr(serializer_or_field, "Meta", None)
     swagger_schema_fields = getattr(meta, "swagger_schema_fields", {})
     if swagger_schema_fields:
-        update_swagger_schema_fields(schema, swagger_schema_fields)
+        _update_swagger_schema_fields(schema, swagger_schema_fields)
 
 
-def update_swagger_schema_fields(schema, swagger_schema_fields):
+def _update_swagger_schema_fields(schema, swagger_schema_fields):
     for attr, val in swagger_schema_fields.items():
         if isinstance(val, dict) and isinstance(
             getattr(schema, attr, None), dict
@@ -27,7 +27,7 @@ def update_swagger_schema_fields(schema, swagger_schema_fields):
 # This overrides the default behavior when the swagger_schema_fields attribute is set
 # in the serializers. Now dictionary attributes are updated instead of overwritten
 # for the swagger_schema_fields - Sil
-FieldInspector.add_manual_fields = add_manual_fields
+FieldInspector.add_manual_fields = _add_manual_fields
 
 
 def swagger_schema_fields_for_charfield(

--- a/app/grandchallenge/api/swagger.py
+++ b/app/grandchallenge/api/swagger.py
@@ -5,7 +5,7 @@ from drf_yasg.inspectors import FieldInspector
 from drf_yasg.openapi import Schema
 
 
-def _add_manual_fields(self, serializer_or_field, schema):
+def _add_manual_fields(_, serializer_or_field, schema):
     meta = getattr(serializer_or_field, "Meta", None)
     swagger_schema_fields = getattr(meta, "swagger_schema_fields", {})
     if swagger_schema_fields:
@@ -32,7 +32,7 @@ FieldInspector.add_manual_fields = _add_manual_fields
 
 
 def swagger_schema_fields_for_charfield(
-    *_, **kwargs: Dict[str, CharField]
+    *_, **kwargs: CharField
 ) -> Dict[str, Dict[str, Schema]]:
     return {
         "properties": {

--- a/app/grandchallenge/api/swagger.py
+++ b/app/grandchallenge/api/swagger.py
@@ -1,5 +1,6 @@
-from typing import Dict, List, Tuple, Union
+from typing import Dict
 
+from django.db.models import CharField
 from drf_yasg.inspectors import FieldInspector
 from drf_yasg.openapi import Schema
 
@@ -31,19 +32,19 @@ FieldInspector.add_manual_fields = _add_manual_fields
 
 
 def swagger_schema_fields_for_charfield(
-    field_names: Union[Tuple, List], field_choices: Union[Tuple, List]
+    *_, **kwargs: Dict[str, CharField]
 ) -> Dict[str, Dict[str, Schema]]:
     return {
         "properties": {
-            field_name: Schema(
+            char_field_name: Schema(
                 **{
-                    "enum": [c[1] for c in field_choices],
-                    "title": field_name[0].upper()
-                    + field_name[1:].replace("_", " "),
+                    "enum": [c[1] for c in char_field.choices],
+                    "title": char_field_name[0].upper()
+                    + char_field_name[1:].replace("_", " "),
                     "type": "string",
                     "minLength": 1,
                 }
             )
-            for field_name, field_choices in zip(field_names, field_choices)
+            for char_field_name, char_field in kwargs.items()
         }
     }

--- a/app/grandchallenge/api/swagger.py
+++ b/app/grandchallenge/api/swagger.py
@@ -8,16 +8,20 @@ def add_manual_fields(self, serializer_or_field, schema):
     meta = getattr(serializer_or_field, "Meta", None)
     swagger_schema_fields = getattr(meta, "swagger_schema_fields", {})
     if swagger_schema_fields:
-        for attr, val in swagger_schema_fields.items():
-            if isinstance(val, dict) and isinstance(
-                getattr(schema, attr, None), dict
-            ):
-                to_update = dict(
-                    list(getattr(schema, attr).items()) + list(val.items())
-                )
-                setattr(schema, attr, to_update)
-            else:
-                setattr(schema, attr, val)
+        update_swagger_schema_fields(schema, swagger_schema_fields)
+
+
+def update_swagger_schema_fields(schema, swagger_schema_fields):
+    for attr, val in swagger_schema_fields.items():
+        if isinstance(val, dict) and isinstance(
+            getattr(schema, attr, None), dict
+        ):
+            to_update = dict(
+                list(getattr(schema, attr).items()) + list(val.items())
+            )
+            setattr(schema, attr, to_update)
+        else:
+            setattr(schema, attr, val)
 
 
 # This overrides the default behavior when the swagger_schema_fields attribute is set

--- a/app/grandchallenge/reader_studies/serializers.py
+++ b/app/grandchallenge/reader_studies/serializers.py
@@ -6,6 +6,7 @@ from rest_framework.serializers import (
     SerializerMethodField,
 )
 
+from grandchallenge.api.swagger import swagger_schema_fields_for_charfield
 from grandchallenge.cases.models import Image
 from grandchallenge.reader_studies.models import Answer, Question, ReaderStudy
 
@@ -30,6 +31,14 @@ class QuestionSerializer(HyperlinkedModelSerializer):
             "question_text",
             "reader_study",
             "required",
+        )
+        swagger_schema_fields = swagger_schema_fields_for_charfield(
+            ("answer_type", "form_direction", "image_port"),
+            (
+                Question.ANSWER_TYPE_CHOICES,
+                Question.DIRECTION_CHOICES,
+                Question.IMAGE_PORT_CHOICES,
+            ),
         )
 
 

--- a/app/grandchallenge/reader_studies/serializers.py
+++ b/app/grandchallenge/reader_studies/serializers.py
@@ -33,12 +33,9 @@ class QuestionSerializer(HyperlinkedModelSerializer):
             "required",
         )
         swagger_schema_fields = swagger_schema_fields_for_charfield(
-            ("answer_type", "form_direction", "image_port"),
-            (
-                Question.ANSWER_TYPE_CHOICES,
-                Question.DIRECTION_CHOICES,
-                Question.IMAGE_PORT_CHOICES,
-            ),
+            answer_type=model.answer_type,
+            form_direction=model.direction,  # model.direction gets remapped
+            image_port=model.image_port,
         )
 
 

--- a/app/grandchallenge/reader_studies/serializers.py
+++ b/app/grandchallenge/reader_studies/serializers.py
@@ -33,9 +33,11 @@ class QuestionSerializer(HyperlinkedModelSerializer):
             "required",
         )
         swagger_schema_fields = swagger_schema_fields_for_charfield(
-            answer_type=model.answer_type,
-            form_direction=model.direction,  # model.direction gets remapped
-            image_port=model.image_port,
+            answer_type=model._meta.get_field("answer_type"),
+            form_direction=model._meta.get_field(
+                "direction"
+            ),  # model.direction gets remapped
+            image_port=model._meta.get_field("image_port"),
         )
 
 

--- a/app/grandchallenge/workstation_configs/serializers.py
+++ b/app/grandchallenge/workstation_configs/serializers.py
@@ -2,6 +2,7 @@ from rest_framework.fields import CharField, FloatField
 from rest_framework.relations import SlugRelatedField
 from rest_framework.serializers import ModelSerializer
 
+from grandchallenge.api.swagger import swagger_schema_fields_for_charfield
 from grandchallenge.workstation_configs.models import (
     LookUpTable,
     WindowPreset,
@@ -69,3 +70,6 @@ class WorkstationConfigSerializer(ModelSerializer):
             "show_image_info_plugin",
             "show_display_plugin",
         ]
+        swagger_schema_fields = swagger_schema_fields_for_charfield(
+            ("default_orientation",), (WorkstationConfig.ORIENTATION_CHOICES,)
+        )

--- a/app/grandchallenge/workstation_configs/serializers.py
+++ b/app/grandchallenge/workstation_configs/serializers.py
@@ -71,5 +71,11 @@ class WorkstationConfigSerializer(ModelSerializer):
             "show_display_plugin",
         ]
         swagger_schema_fields = swagger_schema_fields_for_charfield(
-            default_orientation=WorkstationConfig.default_orientation
+            default_orientation=model._meta.get_field("default_orientation"),
+            default_slab_render_method=model._meta.get_field(
+                "default_slab_render_method"
+            ),
+            default_overlay_interpolation=model._meta.get_field(
+                "default_overlay_interpolation"
+            ),
         )

--- a/app/grandchallenge/workstation_configs/serializers.py
+++ b/app/grandchallenge/workstation_configs/serializers.py
@@ -71,5 +71,5 @@ class WorkstationConfigSerializer(ModelSerializer):
             "show_display_plugin",
         ]
         swagger_schema_fields = swagger_schema_fields_for_charfield(
-            ("default_orientation",), (WorkstationConfig.ORIENTATION_CHOICES,)
+            default_orientation=WorkstationConfig.default_orientation
         )

--- a/app/grandchallenge/workstations/serializers.py
+++ b/app/grandchallenge/workstations/serializers.py
@@ -12,5 +12,5 @@ class SessionSerializer(ModelSerializer):
         model = Session
         fields = ("pk", "status")
         swagger_schema_fields = swagger_schema_fields_for_charfield(
-            status=Session.status
+            status=model._meta.get_field("status")
         )

--- a/app/grandchallenge/workstations/serializers.py
+++ b/app/grandchallenge/workstations/serializers.py
@@ -12,5 +12,5 @@ class SessionSerializer(ModelSerializer):
         model = Session
         fields = ("pk", "status")
         swagger_schema_fields = swagger_schema_fields_for_charfield(
-            ("status",), (Session.STATUS_CHOICES,)
+            status=Session.status
         )

--- a/app/grandchallenge/workstations/serializers.py
+++ b/app/grandchallenge/workstations/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework.fields import CharField
 from rest_framework.serializers import ModelSerializer
 
+from grandchallenge.api.swagger import swagger_schema_fields_for_charfield
 from grandchallenge.workstations.models import Session
 
 
@@ -10,3 +11,6 @@ class SessionSerializer(ModelSerializer):
     class Meta:
         model = Session
         fields = ("pk", "status")
+        swagger_schema_fields = swagger_schema_fields_for_charfield(
+            ("status",), (Session.STATUS_CHOICES,)
+        )

--- a/app/tests/api_tests/test_urls.py
+++ b/app/tests/api_tests/test_urls.py
@@ -1,5 +1,14 @@
-import pytest
+import importlib
+import inspect
+from typing import Dict, Type
 
+import pytest
+import rest_framework.fields
+from django.db.models import CharField
+from rest_framework.serializers import ModelSerializer
+
+import grandchallenge.api.urls
+from grandchallenge.reader_studies.serializers import QuestionSerializer
 from grandchallenge.subdomains.utils import reverse
 from tests.utils import assert_viewname_status
 
@@ -13,14 +22,92 @@ from tests.utils import assert_viewname_status
     ],
 )
 @pytest.mark.django_db
-def test_api_docs_generation(
-    client, schema, schema_format,
-):
+def test_api_docs_generation(client, schema, schema_format):
     kwargs = dict(format=schema_format) if schema == "schema-json" else None
     response = assert_viewname_status(
         code=200, url=reverse(f"api:{schema}", kwargs=kwargs), client=client
     )
     if schema_format is not None:
         assert len(response.data["paths"]) > 0
+        check_response_schema_formatting(response)
     else:
         assert len(response.content) > 0
+
+
+def check_response_schema_formatting(response):
+    definitions = response.data["definitions"]
+    serializers = extract_all_api_exposed_model_serializers()
+    for serializer in serializers:
+        if hasattr(serializer, "Meta") and hasattr(serializer.Meta, "model"):
+            model_name = serializer.Meta.model.__name__
+            if model_name not in (
+                "ImagingModality",
+                "Patient",
+                "Study",
+                "Archive",
+            ):
+                assert model_name in definitions
+                check_serializer_charfield_schema_formatting(
+                    definitions=definitions, serializer=serializer
+                )
+
+
+def extract_all_api_exposed_model_serializers():
+    serializer_module_names = {
+        klass.__module__.replace(".views", ".serializers")
+        for _, klass, _ in grandchallenge.api.urls.router.registry
+    }
+    serializers = []
+    for module_name in serializer_module_names:
+        module = importlib.import_module(module_name)
+        serializers = serializers + [
+            v
+            for v in module.__dict__.values()
+            if inspect.isclass(v) and issubclass(v, (ModelSerializer,))
+        ]
+    return serializers
+
+
+def check_serializer_charfield_schema_formatting(
+    *, definitions: Dict, serializer: Type[ModelSerializer]
+):
+    model = serializer.Meta.model
+    model_field_names = [f.name for f in model._meta.fields]
+    model_property_definitions = definitions[model.__name__]["properties"]
+    name_remapping = (
+        {"form_direction": "direction"} if model is QuestionSerializer else {}
+    )
+    char_field_names = [
+        field_name
+        for field_name, field in serializer._declared_fields.items()
+        if isinstance(field, rest_framework.fields.CharField)
+    ]
+    for field_name in char_field_names:
+        if field_name in model_field_names:
+            field_name = (
+                field_name
+                if field_name not in name_remapping
+                else name_remapping[field_name]
+            )
+            char_field = model._meta.get_field(field_name)
+            if (
+                isinstance(char_field, CharField)
+                and len(char_field.choices) > 0
+            ):
+                check_charfield_schema_formatting(
+                    definitions=model_property_definitions,
+                    char_field=char_field,
+                )
+
+
+def check_charfield_schema_formatting(
+    *, definitions: Dict, char_field: CharField
+):
+    name = char_field.name
+    assert name in definitions
+    schema = definitions[name]
+    assert schema["type"] == "string"
+    assert schema["minLength"] == 1
+    assert schema["title"] == name[0].upper() + name[1:].replace("_", " ")
+    assert "enum" in schema
+    assert schema["enum"] == [e[1] for e in char_field.choices]


### PR DESCRIPTION
This PR changes the default behavior of swagger_schemas_fields with update instead of overwriting #1017

* Created a swagger utility for creating char field swagger fields
  * This adds additional enum information to the generated schemas
* Added this to the serializers for:
  * reader_studies: answer_type, form_direction, image_port
  * workstation_configs: default_orientation
  * workstations: status