### PR TITLE
Exclude unused archives in huge retina archives API endpoint

### DIFF
--- a/app/grandchallenge/retina_api/views.py
+++ b/app/grandchallenge/retina_api/views.py
@@ -77,7 +77,9 @@ class ArchiveView(APIView):
         # Exclude archives to reduce load time
         exclude = ["AREDS - GA selection", "RS1", "RS2", "RS3"]
         archives = Archive.objects.exclude(name__in=exclude)
-        patients = Patient.objects.all().prefetch_related(
+        patients = Patient.objects.exclude(
+            study__image__archive__name__in=exclude
+        ).prefetch_related(
             "study_set",
             "study_set__image_set",
             "study_set__image_set__modality",

--- a/app/grandchallenge/retina_api/views.py
+++ b/app/grandchallenge/retina_api/views.py
@@ -74,7 +74,9 @@ class ArchiveView(APIView):
 
     @staticmethod  # noqa: C901
     def create_response_object():
-        archives = Archive.objects.all()
+        # Exclude archives to reduce load time
+        exclude = ["AREDS - GA selection", "RS1", "RS2", "RS3"]
+        archives = Archive.objects.exclude(name__in=exclude)
         patients = Patient.objects.all().prefetch_related(
             "study_set",
             "study_set__image_set",


### PR DESCRIPTION
This PR makes the endpoint exclude archives that are currently not in use. I'm unsure how big of a performance boost this will result in but I think the request should at least be <30 seconds again.
See #1095 