### PR TITLE
Fix adding ground truth for boolean type questions

### DIFF
--- a/app/grandchallenge/reader_studies/forms.py
+++ b/app/grandchallenge/reader_studies/forms.py
@@ -206,7 +206,8 @@ class GroundTruthForm(SaveFormInitMixin, Form):
         " and the question text for each of the questions in this study."
         " The subsequent rows should then be filled with the image file"
         " names (separated by semicolons) and the answer corresponding to"
-        " the question text provided in the header.",
+        " the question text provided in the header. For Boolean type answers,"
+        " use `0` for False and `1` for True.",
     )
 
     def __init__(self, *args, reader_study, **kwargs):

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -269,6 +269,7 @@ class ReaderStudy(UUIDModel, TitleSlugDescriptionModel):
         return self.answerable_questions.count()
 
     def add_ground_truth(self, *, data, user):
+        answers = []
         for gt in data:
             images = self.images.filter(name__in=gt["images"].split(";"))
             for key in gt.keys():
@@ -290,14 +291,21 @@ class ReaderStudy(UUIDModel, TitleSlugDescriptionModel):
                     answer=_answer,
                     is_ground_truth=True,
                 )
-                answer = Answer.objects.create(
-                    creator=user,
-                    question=question,
-                    answer=_answer,
-                    is_ground_truth=True,
+                answers.append(
+                    {
+                        "answer": Answer(
+                            creator=user,
+                            question=question,
+                            answer=_answer,
+                            is_ground_truth=True,
+                        ),
+                        "images": images,
+                    }
                 )
-                answer.images.set(images)
-                answer.save()
+        for answer in answers:
+            answer["answer"].save()
+            answer["answer"].images.set(answer["images"])
+            answer["answer"].save()
 
     def get_hanging_list_images_for_user(self, *, user):
         """

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -275,17 +275,25 @@ class ReaderStudy(UUIDModel, TitleSlugDescriptionModel):
                 if key == "images":
                     continue
                 question = self.questions.get(question_text=key)
+                if question.answer_type == Question.ANSWER_TYPE_BOOL:
+                    if gt[key] not in ["1", "0"]:
+                        raise ValidationError(
+                            "Expected 1 or 0 for answer type BOOL."
+                        )
+                    _answer = bool(int(gt[key]))
+                else:
+                    _answer = gt[key]
                 Answer.validate(
                     creator=user,
                     question=question,
                     images=images,
-                    answer=gt[key],
+                    answer=_answer,
                     is_ground_truth=True,
                 )
                 answer = Answer.objects.create(
                     creator=user,
                     question=question,
-                    answer=gt[key],
+                    answer=_answer,
                     is_ground_truth=True,
                 )
                 answer.images.set(images)

--- a/app/tests/reader_studies_tests/resources/ground_truth.csv
+++ b/app/tests/reader_studies_tests/resources/ground_truth.csv
@@ -1,4 +1,4 @@
-images,foo
-im1,yes
-im2,no
-im3;im4,yes
+images,foo,bool
+im1,yes,1
+im2,no,0
+im3;im4,yes,1

--- a/app/tests/reader_studies_tests/resources/ground_truth_wrong_boolean.csv
+++ b/app/tests/reader_studies_tests/resources/ground_truth_wrong_boolean.csv
@@ -1,0 +1,4 @@
+images,foo,bool
+im1,yes,true
+im2,no,false
+im3;im4,yes,false

--- a/app/tests/reader_studies_tests/test_forms.py
+++ b/app/tests/reader_studies_tests/test_forms.py
@@ -369,6 +369,11 @@ def test_reader_study_add_ground_truth(client):
         question_text="bar",
         answer_type=Question.ANSWER_TYPE_SINGLE_LINE_TEXT,
     )
+    QuestionFactory(
+        reader_study=rs,
+        question_text="bool",
+        answer_type=Question.ANSWER_TYPE_BOOL,
+    )
     im1, im2, im3, im4 = (
         ImageFactory(name="im1"),
         ImageFactory(name="im2"),
@@ -456,6 +461,19 @@ def test_reader_study_add_ground_truth(client):
     rs.save()
     assert rs.hanging_list_valid
 
+    with open(RESOURCE_PATH / "ground_truth_wrong_boolean.csv") as gt:
+        response = get_view_for_user(
+            viewname="reader-studies:add-ground-truth",
+            client=client,
+            method=client.post,
+            reverse_kwargs={"slug": rs.slug},
+            data={"ground_truth": gt},
+            follow=True,
+            user=editor,
+        )
+    assert response.status_code == 200
+    assert "Expected 1 or 0 for answer type BOOL." in response.rendered_content
+
     with open(RESOURCE_PATH / "ground_truth.csv") as gt:
         response = get_view_for_user(
             viewname="reader-studies:add-ground-truth",
@@ -467,8 +485,8 @@ def test_reader_study_add_ground_truth(client):
             user=editor,
         )
     assert response.status_code == 200
-    assert Answer.objects.all().count() == 3
-    assert Answer.objects.filter(is_ground_truth=True).count() == 3
+    assert Answer.objects.all().count() == 6
+    assert Answer.objects.filter(is_ground_truth=True).count() == 6
 
     with open(RESOURCE_PATH / "ground_truth.csv") as gt:
         response = get_view_for_user(
@@ -485,5 +503,5 @@ def test_reader_study_add_ground_truth(client):
         "Ground truth already added for this question/image combination"
         in response.rendered_content
     )
-    assert Answer.objects.all().count() == 3
-    assert Answer.objects.filter(is_ground_truth=True).count() == 3
+    assert Answer.objects.all().count() == 6
+    assert Answer.objects.filter(is_ground_truth=True).count() == 6


### PR DESCRIPTION
In a later stage, when we add support for more types of answers, we might need a more proper preprocessing step for the csv data, but for now this fixes the issue that adding boolean values was not possible via the csv.