### PR TITLE
Load archive data as celery task and cache result

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -631,6 +631,10 @@ CELERY_BEAT_SCHEDULE = {
         "options": {"queue": "evaluation"},
         "schedule": timedelta(hours=1),
     },
+    "cache_retina_archive_data": {
+        "task": "grandchallenge.retina_api.tasks.cache_archive_data",
+        "schedule": timedelta(hours=1),
+    },
 }
 
 CELERY_TASK_ROUTES = {
@@ -744,3 +748,5 @@ RETINA_GRADERS_GROUP_NAME = "retina_graders"
 RETINA_ADMINS_GROUP_NAME = "retina_admins"
 RETINA_IMPORT_USER_NAME = "retina_import_user"
 RETINA_EXCEPTION_ARCHIVE = "Australia"
+
+RETINA_ARCHIVE_DATA_CACHE_KEY = "retina_archive_data"

--- a/app/grandchallenge/retina_api/tasks.py
+++ b/app/grandchallenge/retina_api/tasks.py
@@ -1,0 +1,139 @@
+from celery import shared_task
+from django.conf import settings
+from django.core.cache import cache
+from django.core.exceptions import ObjectDoesNotExist
+
+from grandchallenge.archives.models import Archive
+from grandchallenge.patients.models import Patient
+
+
+@shared_task
+def cache_archive_data():
+    def create_archive_data_object():
+        archives = Archive.objects.all()
+        patients = Patient.objects.prefetch_related(
+            "study_set",
+            "study_set__image_set",
+            "study_set__image_set__modality",
+            "study_set__image_set__obs_image",
+            "study_set__image_set__oct_image",
+            "study_set__image_set__archive_set",
+        )
+
+        return {
+            "subfolders": dict(generate_archives(archives, patients)),
+            "info": "level 2",
+            "name": "Archives",
+            "id": "none",
+            "images": {},
+        }
+
+    archive_data = create_archive_data_object()
+    cache.set(settings.RETINA_ARCHIVE_DATA_CACHE_KEY, archive_data, None)
+
+
+def generate_archives(archive_list, patients):
+    for archive in archive_list:
+        if archive.name == "kappadata":
+            subfolders = {}
+            images = dict(generate_images(archive.images))
+        else:
+            subfolders = dict(generate_patients(archive, patients))
+            images = {}
+
+        yield archive.name, {
+            "subfolders": subfolders,
+            "info": "level 3",
+            "name": archive.name,
+            "id": archive.id,
+            "images": images,
+        }
+
+
+def generate_patients(archive, patients):
+    patient_list = patients.filter(study__image__archive=archive).distinct()
+    for patient in patient_list:
+        if archive.name == settings.RETINA_EXCEPTION_ARCHIVE:
+            image_set = {}
+            for study in patient.study_set.all():
+                image_set.update(dict(generate_images(study.image_set)))
+            yield patient.name, {
+                "subfolders": {},
+                "info": "level 4",
+                "name": patient.name,
+                "id": patient.id,
+                "images": image_set,
+            }
+        else:
+            yield patient.name, {
+                "subfolders": dict(generate_studies(patient.study_set)),
+                "info": "level 4",
+                "name": patient.name,
+                "id": patient.id,
+                "images": {},
+            }
+
+
+def generate_studies(study_list):
+    for study in study_list.all():
+        yield study.name, {
+            "info": "level 5",
+            "images": dict(generate_images(study.image_set)),
+            "name": study.name,
+            "id": study.id,
+            "subfolders": {},
+        }
+
+
+def generate_images(image_list):
+    for image in image_list.all():
+        if image.modality.modality == settings.MODALITY_OCT:
+            # oct image add info
+            obs_image_id = "no info"
+            try:
+                oct_obs_registration = image.oct_image.get()
+                obs_image_id = oct_obs_registration.obs_image.id
+                obs_list = oct_obs_registration.registration_values
+                obs_registration_flat = [
+                    val for sublist in obs_list for val in sublist
+                ]
+            except ObjectDoesNotExist:
+                obs_registration_flat = []
+
+            # leave voxel_size always empty because this info is in mhd file
+            voxel_size = [0, 0, 0]
+            study_datetime = "Unknown"
+            if image.study.datetime:
+                study_datetime = image.study.datetime.strftime(
+                    "%Y/%m/%d %H:%M:%S"
+                )
+
+            yield image.name, {
+                "images": {
+                    "trc_000": "no info",
+                    "obs_000": obs_image_id,
+                    "mot_comp": "no info",
+                    "trc_001": "no info",
+                    "oct": image.id,
+                },
+                "info": {
+                    "voxel_size": {
+                        "axial": voxel_size[0],
+                        "lateral": voxel_size[1],
+                        "transversal": voxel_size[2],
+                    },
+                    "date": study_datetime,
+                    "registration": {
+                        "obs": obs_registration_flat,
+                        "trc": [0, 0, 0, 0],
+                    },
+                },
+            }
+        elif (
+            image.modality.modality == settings.MODALITY_CF
+            and image.name.endswith(".fds")
+        ):
+            # OBS image, skip because this is already in fds
+            pass
+        else:
+            yield image.name, image.id

--- a/app/grandchallenge/retina_api/urls.py
+++ b/app/grandchallenge/retina_api/urls.py
@@ -44,13 +44,7 @@ annotation_router.register(
     basename="imagetextannotation",
 )
 urlpatterns = [
-    path(
-        "archives/",
-        cache_page(settings.RETINA_IMAGE_CACHE_TIME)(
-            views.ArchiveView.as_view()
-        ),
-        name="archives-api-view",
-    ),
+    path("archives/", views.ArchiveView.as_view(), name="archives-api-view",),
     path(
         "archive_data/",
         cache_page(settings.RETINA_IMAGE_CACHE_TIME)(

--- a/app/grandchallenge/retina_api/views.py
+++ b/app/grandchallenge/retina_api/views.py
@@ -3,9 +3,9 @@ from enum import Enum
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.core.exceptions import (
     MultipleObjectsReturned,
-    ObjectDoesNotExist,
     ValidationError,
 )
 from django.http import HttpResponse
@@ -63,6 +63,7 @@ from grandchallenge.retina_api.serializers import (
     TreeImageSerializer,
     TreeObjectSerializer,
 )
+from grandchallenge.retina_api.tasks import cache_archive_data
 from grandchallenge.serving.permissions import user_can_download_image
 from grandchallenge.studies.models import Study
 
@@ -72,142 +73,19 @@ class ArchiveView(APIView):
     authentication_classes = (authentication.SessionAuthentication,)
     pagination_class = None
 
-    @staticmethod  # noqa: C901
-    def create_response_object():  # noqa: C901
-        # Exclude archives to reduce load time
-        exclude = ["AREDS - GA selection", "RS1", "RS2", "RS3"]
-        archives = Archive.objects.exclude(name__in=exclude)
-        patients = Patient.objects.exclude(
-            study__image__archive__name__in=exclude
-        ).prefetch_related(
-            "study_set",
-            "study_set__image_set",
-            "study_set__image_set__modality",
-            "study_set__image_set__obs_image",
-            "study_set__image_set__oct_image",
-            "study_set__image_set__archive_set",
-        )
-
-        def generate_archives(archive_list, patients):
-            for archive in archive_list:
-                if archive.name == "kappadata":
-                    subfolders = {}
-                    images = dict(generate_images(archive.images))
-                else:
-                    subfolders = dict(generate_patients(archive, patients))
-                    images = {}
-
-                yield archive.name, {
-                    "subfolders": subfolders,
-                    "info": "level 3",
-                    "name": archive.name,
-                    "id": archive.id,
-                    "images": images,
-                }
-
-        def generate_patients(archive, patients):
-            patient_list = patients.filter(
-                study__image__archive=archive
-            ).distinct()
-            for patient in patient_list:
-                if archive.name == settings.RETINA_EXCEPTION_ARCHIVE:
-                    image_set = {}
-                    for study in patient.study_set.all():
-                        image_set.update(
-                            dict(generate_images(study.image_set))
-                        )
-                    yield patient.name, {
-                        "subfolders": {},
-                        "info": "level 4",
-                        "name": patient.name,
-                        "id": patient.id,
-                        "images": image_set,
-                    }
-                else:
-                    yield patient.name, {
-                        "subfolders": dict(
-                            generate_studies(patient.study_set)
-                        ),
-                        "info": "level 4",
-                        "name": patient.name,
-                        "id": patient.id,
-                        "images": {},
-                    }
-
-        def generate_studies(study_list):
-            for study in study_list.all():
-                yield study.name, {
-                    "info": "level 5",
-                    "images": dict(generate_images(study.image_set)),
-                    "name": study.name,
-                    "id": study.id,
-                    "subfolders": {},
-                }
-
-        def generate_images(image_list):
-            for image in image_list.all():
-                if image.modality.modality == settings.MODALITY_OCT:
-                    # oct image add info
-                    obs_image_id = "no info"
-                    try:
-                        oct_obs_registration = image.oct_image.get()
-                        obs_image_id = oct_obs_registration.obs_image.id
-                        obs_list = oct_obs_registration.registration_values
-                        obs_registration_flat = [
-                            val for sublist in obs_list for val in sublist
-                        ]
-                    except ObjectDoesNotExist:
-                        obs_registration_flat = []
-
-                    # leave voxel_size always empty because this info is in mhd file
-                    voxel_size = [0, 0, 0]
-                    study_datetime = "Unknown"
-                    if image.study.datetime:
-                        study_datetime = image.study.datetime.strftime(
-                            "%Y/%m/%d %H:%M:%S"
-                        )
-
-                    yield image.name, {
-                        "images": {
-                            "trc_000": "no info",
-                            "obs_000": obs_image_id,
-                            "mot_comp": "no info",
-                            "trc_001": "no info",
-                            "oct": image.id,
-                        },
-                        "info": {
-                            "voxel_size": {
-                                "axial": voxel_size[0],
-                                "lateral": voxel_size[1],
-                                "transversal": voxel_size[2],
-                            },
-                            "date": study_datetime,
-                            "registration": {
-                                "obs": obs_registration_flat,
-                                "trc": [0, 0, 0, 0],
-                            },
-                        },
-                    }
-                elif (
-                    image.modality.modality == settings.MODALITY_CF
-                    and image.name.endswith(".fds")
-                ):
-                    # OBS image, skip because this is already in fds
-                    pass
-                else:
-                    yield image.name, image.id
-
-        response = {
-            "subfolders": dict(generate_archives(archives, patients)),
-            "info": "level 2",
-            "name": "Archives",
-            "id": "none",
-            "images": {},
-        }
-        return response
-
     def get(self, request):
-        return Response(self.create_response_object())
+        archive_data = cache.get(settings.RETINA_ARCHIVE_DATA_CACHE_KEY)
+        if archive_data is None:
+            cache_archive_data.delay()
+            return Response(
+                {
+                    "error": [
+                        1,
+                        "Archive data task triggered. Try again in 30 seconds.",
+                    ]
+                }
+            )
+        return Response(archive_data)
 
 
 class ImageView(RetinaAPIPermissionMixin, View):

--- a/app/grandchallenge/retina_api/views.py
+++ b/app/grandchallenge/retina_api/views.py
@@ -81,7 +81,7 @@ class ArchiveView(APIView):
                 {
                     "error": [
                         1,
-                        "Archive data task triggered. Try again in 30 seconds.",
+                        "Archive data task triggered. Try again in 2 minutes.",
                     ]
                 }
             )

--- a/app/tests/retina_api_tests/test_tasks.py
+++ b/app/tests/retina_api_tests/test_tasks.py
@@ -1,0 +1,251 @@
+import pytest
+from django.conf import settings
+from django.core.cache import cache
+
+from grandchallenge.retina_api.tasks import cache_archive_data
+from tests.retina_api_tests.helpers import create_datastructures_data
+
+
+@pytest.mark.django_db
+class TestCacheArchiveDataTaks:
+    def test_caching(self):
+        # Create data
+        (
+            datastructures,
+            datastructures_aus,
+            oct_obs_registration,
+            oct_obs_registration_aus,
+        ) = create_datastructures_data()
+
+        # Run task synchronously
+        cache_archive_data()
+
+        # Check cached data
+        archive_data = cache.get(settings.RETINA_ARCHIVE_DATA_CACHE_KEY)
+
+        expected_archive_data = {
+            "subfolders": {
+                datastructures["archive"].name: {
+                    "subfolders": {
+                        datastructures["patient"].name: {
+                            "subfolders": {
+                                datastructures["study_oct"].name: {
+                                    "info": "level 5",
+                                    "images": {
+                                        datastructures["image_oct"].name: {
+                                            "images": {
+                                                "trc_000": "no info",
+                                                "obs_000": datastructures[
+                                                    "image_obs"
+                                                ].id,
+                                                "mot_comp": "no info",
+                                                "trc_001": "no info",
+                                                "oct": datastructures[
+                                                    "image_oct"
+                                                ].id,
+                                            },
+                                            "info": {
+                                                "voxel_size": {
+                                                    "axial": 0,
+                                                    "lateral": 0,
+                                                    "transversal": 0,
+                                                },
+                                                "date": datastructures[
+                                                    "study_oct"
+                                                ].datetime.strftime(
+                                                    "%Y/%m/%d %H:%M:%S"
+                                                ),
+                                                "registration": {
+                                                    "obs": "Checked separately",
+                                                    "trc": [0, 0, 0, 0],
+                                                },
+                                            },
+                                        }
+                                    },
+                                    "name": datastructures["study_oct"].name,
+                                    "id": datastructures["study_oct"].id,
+                                    "subfolders": {},
+                                },
+                                datastructures["study"].name: {
+                                    "info": "level 5",
+                                    "images": {
+                                        datastructures["image_cf"].name: (
+                                            datastructures["image_cf"].id
+                                        )
+                                    },
+                                    "name": datastructures["study"].name,
+                                    "id": (datastructures["study"].id),
+                                    "subfolders": {},
+                                },
+                            },
+                            "info": "level 4",
+                            "name": datastructures["patient"].name,
+                            "id": (datastructures["patient"].id),
+                            "images": {},
+                        }
+                    },
+                    "info": "level 3",
+                    "name": datastructures["archive"].name,
+                    "id": (datastructures["archive"].id),
+                    "images": {},
+                },
+                datastructures_aus["archive"].name: {
+                    "subfolders": {
+                        datastructures_aus["patient"].name: {
+                            "subfolders": {},
+                            "info": "level 4",
+                            "name": datastructures_aus["patient"].name,
+                            "id": (datastructures_aus["patient"].id),
+                            "images": {
+                                datastructures_aus["image_oct"].name: {
+                                    "images": {
+                                        "trc_000": "no info",
+                                        "obs_000": (
+                                            datastructures_aus["image_obs"].id
+                                        ),
+                                        "mot_comp": "no info",
+                                        "trc_001": "no info",
+                                        "oct": (
+                                            datastructures_aus["image_oct"].id
+                                        ),
+                                    },
+                                    "info": {
+                                        "voxel_size": {
+                                            "axial": 0,
+                                            "lateral": 0,
+                                            "transversal": 0,
+                                        },
+                                        "date": datastructures_aus[
+                                            "study_oct"
+                                        ].datetime.strftime(
+                                            "%Y/%m/%d %H:%M:%S"
+                                        ),
+                                        "registration": {
+                                            "obs": "Checked separately",
+                                            "trc": [0, 0, 0, 0],
+                                        },
+                                    },
+                                },
+                                datastructures_aus["image_cf"].name: (
+                                    datastructures_aus["image_cf"].id
+                                ),
+                            },
+                        }
+                    },
+                    "info": "level 3",
+                    "name": datastructures_aus["archive"].name,
+                    "id": (datastructures_aus["archive"].id),
+                    "images": {},
+                },
+            },
+            "info": "level 2",
+            "name": "Archives",
+            "id": "none",
+            "images": {},
+        }
+
+        # Compare floats separately because of intricacies of floating-point arithmetic in python
+        try:
+            # Get info objects of both archives in response data
+            response_archive_info = (
+                archive_data.get("subfolders")
+                .get(datastructures["archive"].name)
+                .get("subfolders")
+                .get(datastructures["patient"].name)
+                .get("subfolders")
+                .get(datastructures["study_oct"].name)
+                .get("images")
+                .get(datastructures["image_oct"].name)
+                .get("info")
+            )
+            response_archive_australia_info = (
+                archive_data.get("subfolders")
+                .get(datastructures_aus["archive"].name)
+                .get("subfolders")
+                .get(datastructures_aus["patient"].name)
+                .get("images")
+                .get(datastructures_aus["image_oct"].name)
+                .get("info")
+            )
+
+            floats_to_compare = (
+                []
+            )  # list of (response_float, expected_float, name) tuples
+            for archive, response_info, oor in (
+                ("Rotterdam", response_archive_info, oct_obs_registration),
+                (
+                    "Australia",
+                    response_archive_australia_info,
+                    oct_obs_registration_aus,
+                ),
+            ):
+                # oct obs registration
+                response_obs = response_info.get("registration").get("obs")
+                rv = oor.registration_values
+                floats_to_compare.append(
+                    (
+                        response_obs[0],
+                        rv[0][0],
+                        archive + " obs oct registration top left x",
+                    )
+                )
+                floats_to_compare.append(
+                    (
+                        response_obs[1],
+                        rv[0][1],
+                        archive + " obs oct registration top left y",
+                    )
+                )
+                floats_to_compare.append(
+                    (
+                        response_obs[2],
+                        rv[1][0],
+                        archive + " obs oct registration bottom right x",
+                    )
+                )
+                floats_to_compare.append(
+                    (
+                        response_obs[3],
+                        rv[1][1],
+                        archive + " obs oct registration bottom right y",
+                    )
+                )
+
+            # Compare floats
+            for result, expected, name in floats_to_compare:
+                if result != pytest.approx(expected):
+                    pytest.fail(name + " does not equal expected value")
+
+            # Clear voxel and obs registration objects before response object to expected object comparison
+            archive_data["subfolders"][datastructures["archive"].name][
+                "subfolders"
+            ][datastructures["patient"].name]["subfolders"][
+                datastructures["study_oct"].name
+            ][
+                "images"
+            ][
+                datastructures["image_oct"].name
+            ][
+                "info"
+            ][
+                "registration"
+            ][
+                "obs"
+            ] = "Checked separately"
+
+            archive_data["subfolders"][datastructures_aus["archive"].name][
+                "subfolders"
+            ][datastructures_aus["patient"].name]["images"][
+                datastructures_aus["image_oct"].name
+            ][
+                "info"
+            ][
+                "registration"
+            ][
+                "obs"
+            ] = "Checked separately"
+
+        except (AttributeError, KeyError, TypeError):
+            pytest.fail("Response object structure is not correct")
+
+        assert archive_data == expected_archive_data

--- a/app/tests/retina_api_tests/test_views.py
+++ b/app/tests/retina_api_tests/test_views.py
@@ -18,6 +18,7 @@ from grandchallenge.retina_api.serializers import (
     TreeImageSerializer,
     TreeObjectSerializer,
 )
+from grandchallenge.retina_api.tasks import cache_archive_data
 from grandchallenge.subdomains.utils import reverse
 from tests.cases_tests.factories import (
     ImageFactoryWithImageFile,
@@ -66,16 +67,42 @@ class TestArchiveIndexAPIEndpoints:
         response = client.get(url, HTTP_ACCEPT="application/json")
         assert response.status_code == status.HTTP_200_OK
 
-    def test_archive_view_returns_correct_data(self, client):
-        # Clear cache manually (this is not done by pytest-django for some reason...)
+    def test_archive_view_returns_correct_error_on_empty_cache(
+        self, client, monkeypatch
+    ):
+        # Clear cache manually
         cache.clear()
-        # Create data
-        (
-            datastructures,
-            datastructures_aus,
-            oct_obs_registration,
-            oct_obs_registration_aus,
-        ) = create_datastructures_data()
+
+        # Mock celery task
+        is_called = False
+
+        def call_task():
+            nonlocal is_called
+            is_called = True
+
+        monkeypatch.setattr(cache_archive_data, "delay", call_task)
+
+        # login client
+        client, _ = client_login(client, user="retina_user")
+
+        url = reverse("retina:api:archives-api-view")
+        response = client.get(url, HTTP_ACCEPT="application/json")
+        response_data = json.loads(response.content)
+        # check if correct error is sent
+        assert response_data == {
+            "error": [
+                1,
+                "Archive data task triggered. Try again in 30 seconds.",
+            ]
+        }
+        assert is_called
+
+    def test_archive_view_returns_correct_data_from_cache(self, client):
+        # Clear cache manually
+        cache.clear()
+        # Set cached data
+        test_data = {"test": "data", "object": 1}
+        cache.set(settings.RETINA_ARCHIVE_DATA_CACHE_KEY, test_data, 60)
 
         # login client
         client, _ = client_login(client, user="retina_user")
@@ -84,251 +111,7 @@ class TestArchiveIndexAPIEndpoints:
         response = client.get(url, HTTP_ACCEPT="application/json")
         response_data = json.loads(response.content)
         # check if correct data is sent
-        expected_response_data = {
-            "subfolders": {
-                datastructures["archive"].name: {
-                    "subfolders": {
-                        datastructures["patient"].name: {
-                            "subfolders": {
-                                datastructures["study_oct"].name: {
-                                    "info": "level 5",
-                                    "images": {
-                                        datastructures["image_oct"].name: {
-                                            "images": {
-                                                "trc_000": "no info",
-                                                "obs_000": str(
-                                                    datastructures[
-                                                        "image_obs"
-                                                    ].id
-                                                ),
-                                                "mot_comp": "no info",
-                                                "trc_001": "no info",
-                                                "oct": str(
-                                                    datastructures[
-                                                        "image_oct"
-                                                    ].id
-                                                ),
-                                            },
-                                            "info": {
-                                                "voxel_size": {
-                                                    "axial": 0,
-                                                    "lateral": 0,
-                                                    "transversal": 0,
-                                                },
-                                                "date": datastructures[
-                                                    "study_oct"
-                                                ].datetime.strftime(
-                                                    "%Y/%m/%d %H:%M:%S"
-                                                ),
-                                                "registration": {
-                                                    "obs": "Checked separately",
-                                                    "trc": [0, 0, 0, 0],
-                                                },
-                                            },
-                                        }
-                                    },
-                                    "name": datastructures["study_oct"].name,
-                                    "id": str(datastructures["study_oct"].id),
-                                    "subfolders": {},
-                                },
-                                datastructures["study"].name: {
-                                    "info": "level 5",
-                                    "images": {
-                                        datastructures["image_cf"].name: str(
-                                            datastructures["image_cf"].id
-                                        )
-                                    },
-                                    "name": datastructures["study"].name,
-                                    "id": str(datastructures["study"].id),
-                                    "subfolders": {},
-                                },
-                            },
-                            "info": "level 4",
-                            "name": datastructures["patient"].name,
-                            "id": str(datastructures["patient"].id),
-                            "images": {},
-                        }
-                    },
-                    "info": "level 3",
-                    "name": datastructures["archive"].name,
-                    "id": str(datastructures["archive"].id),
-                    "images": {},
-                },
-                datastructures_aus["archive"].name: {
-                    "subfolders": {
-                        datastructures_aus["patient"].name: {
-                            "subfolders": {},
-                            "info": "level 4",
-                            "name": datastructures_aus["patient"].name,
-                            "id": str(datastructures_aus["patient"].id),
-                            "images": {
-                                datastructures_aus["image_oct"].name: {
-                                    "images": {
-                                        "trc_000": "no info",
-                                        "obs_000": str(
-                                            datastructures_aus["image_obs"].id
-                                        ),
-                                        "mot_comp": "no info",
-                                        "trc_001": "no info",
-                                        "oct": str(
-                                            datastructures_aus["image_oct"].id
-                                        ),
-                                    },
-                                    "info": {
-                                        "voxel_size": {
-                                            "axial": 0,
-                                            "lateral": 0,
-                                            "transversal": 0,
-                                        },
-                                        "date": datastructures_aus[
-                                            "study_oct"
-                                        ].datetime.strftime(
-                                            "%Y/%m/%d %H:%M:%S"
-                                        ),
-                                        "registration": {
-                                            "obs": "Checked separately",
-                                            "trc": [0, 0, 0, 0],
-                                        },
-                                    },
-                                },
-                                datastructures_aus["image_cf"].name: str(
-                                    datastructures_aus["image_cf"].id
-                                ),
-                            },
-                        }
-                    },
-                    "info": "level 3",
-                    "name": datastructures_aus["archive"].name,
-                    "id": str(datastructures_aus["archive"].id),
-                    "images": {},
-                },
-            },
-            "info": "level 2",
-            "name": "Archives",
-            "id": "none",
-            "images": {},
-        }
-
-        # Compare floats separately because of intricacies of floating-point arithmetic in python
-        try:
-            # Get info objects of both archives in response data
-            response_archive_info = (
-                response_data.get("subfolders")
-                .get(datastructures["archive"].name)
-                .get("subfolders")
-                .get(datastructures["patient"].name)
-                .get("subfolders")
-                .get(datastructures["study_oct"].name)
-                .get("images")
-                .get(datastructures["image_oct"].name)
-                .get("info")
-            )
-            response_archive_australia_info = (
-                response_data.get("subfolders")
-                .get(datastructures_aus["archive"].name)
-                .get("subfolders")
-                .get(datastructures_aus["patient"].name)
-                .get("images")
-                .get(datastructures_aus["image_oct"].name)
-                .get("info")
-            )
-
-            floats_to_compare = (
-                []
-            )  # list of (response_float, expected_float, name) tuples
-            for archive, response_info, oor in (
-                ("Rotterdam", response_archive_info, oct_obs_registration),
-                (
-                    "Australia",
-                    response_archive_australia_info,
-                    oct_obs_registration_aus,
-                ),
-            ):
-                # oct obs registration
-                response_obs = response_info.get("registration").get("obs")
-                rv = oor.registration_values
-                floats_to_compare.append(
-                    (
-                        response_obs[0],
-                        rv[0][0],
-                        archive + " obs oct registration top left x",
-                    )
-                )
-                floats_to_compare.append(
-                    (
-                        response_obs[1],
-                        rv[0][1],
-                        archive + " obs oct registration top left y",
-                    )
-                )
-                floats_to_compare.append(
-                    (
-                        response_obs[2],
-                        rv[1][0],
-                        archive + " obs oct registration bottom right x",
-                    )
-                )
-                floats_to_compare.append(
-                    (
-                        response_obs[3],
-                        rv[1][1],
-                        archive + " obs oct registration bottom right y",
-                    )
-                )
-
-            # Compare floats
-            for result, expected, name in floats_to_compare:
-                if result != pytest.approx(expected):
-                    pytest.fail(name + " does not equal expected value")
-
-            # Clear voxel and obs registration objects before response object to expected object comparison
-            response_data["subfolders"][datastructures["archive"].name][
-                "subfolders"
-            ][datastructures["patient"].name]["subfolders"][
-                datastructures["study_oct"].name
-            ][
-                "images"
-            ][
-                datastructures["image_oct"].name
-            ][
-                "info"
-            ][
-                "registration"
-            ][
-                "obs"
-            ] = "Checked separately"
-
-            response_data["subfolders"][datastructures_aus["archive"].name][
-                "subfolders"
-            ][datastructures_aus["patient"].name]["images"][
-                datastructures_aus["image_oct"].name
-            ][
-                "info"
-            ][
-                "registration"
-            ][
-                "obs"
-            ] = "Checked separately"
-
-        except (AttributeError, KeyError, TypeError):
-            pytest.fail("Response object structure is not correct")
-
-        assert response_data == expected_response_data
-
-    def test_caching(self, client):
-        # Clear cache manually
-        cache.clear()
-        # Perform normal request
-        datastructures, _, _, _ = create_datastructures_data()
-        client, _ = client_login(client, user="retina_user")
-        url = reverse("retina:api:archives-api-view")
-        response = client.get(url, HTTP_ACCEPT="application/json")
-        response_data = json.loads(response.content)
-        # Remove archive and perform request again
-        datastructures["archive"].delete()
-        response = client.get(url, HTTP_ACCEPT="application/json")
-        # Check that response is cached so it is not changed
-        assert json.loads(response.content) == response_data
+        assert response_data == test_data
 
 
 @pytest.mark.django_db

--- a/app/tests/retina_api_tests/test_views.py
+++ b/app/tests/retina_api_tests/test_views.py
@@ -92,7 +92,7 @@ class TestArchiveIndexAPIEndpoints:
         assert response_data == {
             "error": [
                 1,
-                "Archive data task triggered. Try again in 30 seconds.",
+                "Archive data task triggered. Try again in 2 minutes.",
             ]
         }
         assert is_called


### PR DESCRIPTION
This should solve the `SystemExit` errors that occur on the `/retina/archives/` endpoint. It runs an hourly task that builds the response object and caches it. When requesting the endpoint it will check if the result is cached and return that. If it is not in the cache it will trigger the task and return an error message explaining that the result will be ready after a minute or so.

Closes #1095 