### PR TITLE
Moves the upload session files api endpoint

### DIFF
--- a/app/grandchallenge/api/urls.py
+++ b/app/grandchallenge/api/urls.py
@@ -30,30 +30,34 @@ from grandchallenge.workstations.views import SessionViewSet
 app_name = "api"
 
 router = routers.DefaultRouter()
+
+# Algorithms
 router.register(
-    r"cases/upload-sessions",
-    RawImageUploadSessionViewSet,
-    basename="upload-session",
-)
-router.register(
-    r"cases/image-files", RawImageFileViewSet, basename="image-file"
-)
-router.register(r"cases/images", ImageViewSet, basename="image")
-router.register(r"workstations/sessions", SessionViewSet)
-router.register(
-    r"workstations/configs",
-    WorkstationConfigViewSet,
-    basename="workstations-config",
+    r"algorithms/images", AlgorithmImageViewSet, basename="algorithms-image"
 )
 router.register(r"algorithms/jobs", JobViewSet, basename="algorithms-job")
 router.register(
     r"algorithms/results", ResultViewSet, basename="algorithms-result"
 )
-router.register(
-    r"algorithms/images", AlgorithmImageViewSet, basename="algorithms-image"
-)
 router.register(r"algorithms", AlgorithmViewSet, basename="algorithm")
 
+# Cases
+router.register(r"cases/images", ImageViewSet, basename="image")
+router.register(
+    r"cases/upload-sessions/files",
+    RawImageFileViewSet,
+    basename="upload-session-file",
+)
+router.register(
+    r"cases/upload-sessions",
+    RawImageUploadSessionViewSet,
+    basename="upload-session",
+)
+
+# Chunked uploads
+router.register(r"chunked-uploads", StagedFileViewSet, basename="staged-file")
+
+# Reader studies
 router.register(
     r"reader-studies/answers", AnswerViewSet, basename="reader-studies-answer"
 )
@@ -63,15 +67,23 @@ router.register(
     basename="reader-studies-question",
 )
 router.register(r"reader-studies", ReaderStudyViewSet, basename="reader-study")
-router.register(r"chunked-uploads", StagedFileViewSet, basename="staged-file")
 
+# Retina
 router.register(
     r"retina/landmark-annotation",
     LandmarkAnnotationSetViewSet,
     basename="landmark-annotation",
 )
 
-# TODO: add terms_of_service and contact
+# Workstations
+router.register(
+    r"workstations/configs",
+    WorkstationConfigViewSet,
+    basename="workstations-config",
+)
+router.register(r"workstations/sessions", SessionViewSet)
+
+
 schema_view = get_schema_view(
     openapi.Info(
         title=f"{settings.SESSION_COOKIE_DOMAIN.lstrip('.')} API",

--- a/app/grandchallenge/cases/models.py
+++ b/app/grandchallenge/cases/models.py
@@ -147,7 +147,9 @@ class RawImageFile(UUIDModel):
 
     @property
     def api_url(self):
-        return reverse("api:image-file-detail", kwargs={"pk": self.pk})
+        return reverse(
+            "api:upload-session-file-detail", kwargs={"pk": self.pk}
+        )
 
     def save(self, *args, **kwargs):
         adding = self._state.adding

--- a/app/tests/cases_tests/test_api.py
+++ b/app/tests/cases_tests/test_api.py
@@ -139,7 +139,7 @@ def test_image_file_list(client):
     RawImageFileFactory(upload_session=us1)
 
     response = get_view_for_user(
-        viewname="api:image-file-list",
+        viewname="api:upload-session-file-list",
         client=client,
         user=u1,
         content_type="application/json",
@@ -148,7 +148,7 @@ def test_image_file_list(client):
     assert response.json()["count"] == 1
 
     response = get_view_for_user(
-        viewname="api:image-file-list",
+        viewname="api:upload-session-file-list",
         client=client,
         user=u2,
         content_type="application/json",
@@ -164,7 +164,7 @@ def test_image_file_detail(client):
     rif = RawImageFileFactory(upload_session=us)
 
     response = get_view_for_user(
-        viewname="api:image-file-detail",
+        viewname="api:upload-session-file-detail",
         reverse_kwargs={"pk": rif.pk},
         client=client,
         user=u1,
@@ -172,7 +172,7 @@ def test_image_file_detail(client):
     assert response.status_code == 200
 
     response = get_view_for_user(
-        viewname="api:image-file-detail",
+        viewname="api:upload-session-file-detail",
         reverse_kwargs={"pk": rif.pk},
         client=client,
         user=u2,
@@ -190,7 +190,7 @@ def test_image_file_create(client):
     )
 
     response = get_view_for_user(
-        viewname="api:image-file-list",
+        viewname="api:upload-session-file-list",
         user=user,
         client=client,
         method=client.post,
@@ -208,7 +208,7 @@ def test_image_file_create(client):
     upload_session = RawImageUploadSessionFactory()
 
     response = get_view_for_user(
-        viewname="api:image-file-list",
+        viewname="api:upload-session-file-list",
         user=user,
         client=client,
         method=client.post,
@@ -226,7 +226,7 @@ def test_invalid_image_file_post(client):
     user = UserFactory(is_staff=True)
 
     response = get_view_for_user(
-        viewname="api:image-file-list",
+        viewname="api:upload-session-file-list",
         user=user,
         client=client,
         method=client.post,
@@ -240,7 +240,7 @@ def test_invalid_image_file_post(client):
 
     upload_session = RawImageUploadSessionFactory()
     response = get_view_for_user(
-        viewname="api:image-file-list",
+        viewname="api:upload-session-file-list",
         user=user,
         client=client,
         method=client.post,
@@ -256,7 +256,7 @@ def test_empty_data_image_files(client):
     user = UserFactory(is_staff=True)
 
     response = get_view_for_user(
-        viewname="api:image-file-list",
+        viewname="api:upload-session-file-list",
         user=user,
         client=client,
         method=client.post,
@@ -281,7 +281,7 @@ def test_image_file_post_permissions(client, is_active, expected_response):
         creator=user, algorithm_image=algo
     )
     response = get_view_for_user(
-        viewname="api:image-file-list",
+        viewname="api:upload-session-file-list",
         user=user,
         client=client,
         method=client.post,


### PR DESCRIPTION
Moves the upload session files endpoint to upload-sessions/files/ and tidies up the router definition so that the endpoints are in alphabetical order.

Closes #1137