### PR TITLE
Updates the algorithm results page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install pre-commit
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pre-commit
+          python -m pip install pre-commit virtualenv!=20.0.6
           pre-commit install
       - name: Run static code inspections
         run: pre-commit run --all-files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install pre-commit
         run: |
+          python -m pip install --upgrade pip
           python -m pip install pre-commit
           pre-commit install
       - name: Run static code inspections

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -660,7 +660,7 @@ CELERY_BEAT_SCHEDULE = {
         "kwargs": {
             "app_label": "algorithms",
             "model_name": "job",
-            "extra_filters": {"requires_gpu": True},
+            "extra_filters": {"algorithm_image__requires_gpu": True},
         },
         "options": {"queue": "gpu"},
         "schedule": timedelta(hours=1),
@@ -670,7 +670,7 @@ CELERY_BEAT_SCHEDULE = {
         "kwargs": {
             "app_label": "algorithms",
             "model_name": "job",
-            "extra_filters": {"requires_gpu": False},
+            "extra_filters": {"algorithm_image__requires_gpu": False},
         },
         "options": {"queue": "evaluation"},
         "schedule": timedelta(hours=1),

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -660,7 +660,7 @@ CELERY_BEAT_SCHEDULE = {
         "kwargs": {
             "app_label": "algorithms",
             "model_name": "job",
-            "exclude": {"requires_gpu": False},
+            "extra_filters": {"requires_gpu": True},
         },
         "options": {"queue": "gpu"},
         "schedule": timedelta(hours=1),
@@ -670,7 +670,7 @@ CELERY_BEAT_SCHEDULE = {
         "kwargs": {
             "app_label": "algorithms",
             "model_name": "job",
-            "exclude": {"requires_gpu": True},
+            "extra_filters": {"requires_gpu": False},
         },
         "options": {"queue": "evaluation"},
         "schedule": timedelta(hours=1),

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
@@ -60,18 +60,19 @@
                 </a>
             {% endif %}
 
-            {% if "execute_algorithm" in algorithm_perms %}
-                {% if object.latest_ready_image %}
-                    <a class="nav-link"
-                       href="{% url 'algorithms:execution-session-create' slug=object.slug %}">
-                        <i class="fa fa-flask fa-fw"></i>&nbsp;Run Algorithm
-                    </a>
-                {% endif %}
+            {% if "execute_algorithm" in algorithm_perms and object.latest_ready_image %}
                 <a class="nav-link"
-                   href="{% url 'algorithms:results-list' slug=object.slug %}">
-                    <i class="fa fa-cogs fa-fw"></i>&nbsp;Results
+                   href="{% url 'algorithms:execution-session-create' slug=object.slug %}">
+                    <i class="fa fa-flask fa-fw"></i>&nbsp;Run Algorithm
                 </a>
-            {% else %}
+            {% endif %}
+
+            <a class="nav-link"
+               href="{% url 'algorithms:results-list' slug=object.slug %}">
+                <i class="fa fa-cogs fa-fw"></i>&nbsp;Results
+            </a>
+
+            {% if "execute_algorithm" not in algorithm_perms %}
                 <a class="nav-link"
                    href="{% url 'algorithms:permission-request-create' slug=object.slug %}">
                     <i class="fa fa-question fa-fw"></i>&nbsp;Request Access

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
@@ -68,7 +68,7 @@
                     </a>
                 {% endif %}
                 <a class="nav-link"
-                   href="{% url 'algorithms:jobs-list' slug=object.slug %}">
+                   href="{% url 'algorithms:results-list' slug=object.slug %}">
                     <i class="fa fa-cogs fa-fw"></i>&nbsp;Results
                 </a>
             {% else %}

--- a/app/grandchallenge/algorithms/templates/algorithms/executionsession_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/executionsession_detail.html
@@ -63,7 +63,7 @@
                     <div class="text-center p-3 statusSymbol">
                     </div>
                     <p class="card-text">
-                        <a href="{% url 'algorithms:jobs-list' slug=algorithm.slug %}"
+                        <a href="{% url 'algorithms:results-list' slug=algorithm.slug %}"
                            class="stretched-link statusMessage"></a>
                     </p>
                 </div>
@@ -77,7 +77,7 @@
                     <div class="text-center p-3 statusSymbol">
                     </div>
                     <p class="card-text">
-                        <a href="{% url 'algorithms:jobs-list' slug=algorithm.slug %}"
+                        <a href="{% url 'algorithms:results-list' slug=algorithm.slug %}"
                            class="stretched-link statusMessage"></a>
                     </p>
                 </div>

--- a/app/grandchallenge/algorithms/templates/algorithms/result_form.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/result_form.html
@@ -17,7 +17,7 @@
                 href="{{ object.job.algorithm_image.algorithm.get_absolute_url }}">{{ object.job.algorithm_image.algorithm.title }}
         </a>
         <li class="breadcrumb-item"><a
-                href="{% url 'algorithms:jobs-list' slug=object.job.algorithm_image.algorithm.slug %}">Results</a>
+                href="{% url 'algorithms:results-list' slug=object.job.algorithm_image.algorithm.slug %}">Results</a>
         <li class="breadcrumb-item"><a href="">{{ object.pk }}</a></li>
         <li class="breadcrumb-item active"
             aria-current="page">Update

--- a/app/grandchallenge/algorithms/templates/algorithms/result_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/result_list.html
@@ -83,26 +83,24 @@
                     </td>
                     <td>
                         <ul class="list-unstyled">
-                            {% if result.images.all %}
-                                {% for image in result.images.all %}
-                                    <li>
-                                        <a href="{% url 'workstations:workstation-session-redirect' slug=algorithm.workstation.slug %}?{% workstation_query image=result.job.image overlay=image config=algorithm.workstation_config %}">
+                            {% for image in result.images.all %}
+                                <li>
+                                    <a href="{% url 'workstations:workstation-session-redirect' slug=algorithm.workstation.slug %}?{% workstation_query image=result.job.image overlay=image config=algorithm.workstation_config %}">
                                             <span class="badge badge-primary">
                                                 <i class="fa fa-eye"></i> View Input &amp; Output
                                             </span>
-                                        </a>
-                                    </li>
-                                    {% for file in image.files.all %}
-                                        <li>
-                                            <a href="{{ file.file.url }}">
+                                    </a>
+                                </li>
+                                {% for file in image.files.all %}
+                                    <li>
+                                        <a href="{{ file.file.url }}">
                                             <span class="badge badge-primary">
                                                 <i class="fa fa-download"></i> Output ({{ file.file|suffix }})
                                             </span>
-                                            </a>
-                                        </li>
-                                    {% endfor %}
+                                        </a>
+                                    </li>
                                 {% endfor %}
-                            {% else %}
+                            {% empty %}
                                 <li>
                                     <span class="badge badge-warning"
                                           title="No output images were found">
@@ -116,7 +114,7 @@
                                         </span>
                                     </a>
                                 </li>
-                            {% endif %}
+                            {% endfor %}
                             {% for file in result.job.image.files.all %}
                                 <li>
                                     <a href="{{ file.file.url }}">

--- a/app/grandchallenge/algorithms/templates/algorithms/result_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/result_list.html
@@ -141,8 +141,7 @@
                                 <i class="fa fa-file"></i>
                             </a>
                         {% endif %}
-                        {# TODO: This should be change_result but is expensive to lookup here, do this when moving to results list #}
-                        {% if "change_algorithm" in algorithm_perms and result %}
+                        {% if change_result|get_jsonpath:result.pk %}
                             <a href="{% url 'algorithms:result-update' slug=algorithm.slug pk=result.pk %}">
                                 <span class="badge badge-primary" title="Edit result">
                                     <i class="fa fa-edit"></i>

--- a/app/grandchallenge/algorithms/templates/algorithms/result_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/result_list.html
@@ -47,69 +47,24 @@
             <tr>
                 <th>Created</th>
                 <th>Creator</th>
-                <th>Input Image</th>
-                <th>Status</th>
                 <th>Result</th>
                 <th>Visibility</th>
-                <th>Output Images</th>
+                <th>Output</th>
                 <th>Comment</th>
             </tr>
             </thead>
             <tbody>
             {% for result in object_list %}
                 <tr>
-                    {# pk included for test support #}
-                    <!-- {{ result.job.pk }} -->
                     <td data-order="{{ result.job.created|date:"U" }}">{{ result.job.created|naturaltime }}</td>
                     <td>
                         {{ result.job.creator|user_profile_link }}
                     </td>
                     <td>
-                        <ul class="list-unstyled">
-                            <li>
-                                <a href="{% url 'workstations:workstation-session-redirect' slug=algorithm.workstation.slug %}?{% workstation_query image=result.job.image config=algorithm.workstation_config %}">
-                                    <span class="badge badge-primary">
-                                        <i class="fa fa-eye"></i> View Input
-                                    </span>
-                                </a>
-                            </li>
-                            {% for file in result.job.image.files.all %}
-                                <li>
-                                    <a href="{{ file.file.url }}">
-                                        <span class="badge badge-primary">
-                                            <i class="fa fa-download"></i> Input ({{ file.file|suffix }})
-                                        </span>
-                                    </a>
-                                </li>
-                            {% endfor %}
-                        </ul>
-                    </td>
-                    <td>
-                        <a href="#jobInfoModal"
-                           class="badge
-                            {% if result.job.status == result.job.FAILURE or result.job.status == result.job.CANCELLED %}
-                                badge-danger
-                            {% elif result.job.status == result.job.RETRY %}
-                                badge-warning
-                            {% elif result.job.status == result.job.SUCCESS %}
-                                badge-success
-                            {% else %}
-                                badge-info
-                            {% endif %}"
-                           data-toggle="modal"
-                           data-target="#jobInfoModal"
-                           data-title="Job Info"
-                           data-output="{% firstof result.job.output|user_error result.job.get_status_display %}"
-                           data-pk="{{ result.job.pk }}"
-                           title="Job Info">
-                            {{ result.job.get_status_display }}
-                        </a>
-                    </td>
-                    <td>
-                        <a href="#jobInfoModal"
+                        <a href="#resultInfoModal"
                            class="badge badge-primary"
                            data-toggle="modal"
-                           data-target="#jobInfoModal"
+                           data-target="#resultInfoModal"
                            data-title="Result Info"
                            data-output="{% firstof result.output 'No output produced.' %}"
                            data-pk="{{ result.pk }}"
@@ -127,8 +82,8 @@
                         {% endif %}
                     </td>
                     <td>
-                        {% if result.images.all %}
-                            <ul class="list-unstyled">
+                        <ul class="list-unstyled">
+                            {% if result.images.all %}
                                 {% for image in result.images.all %}
                                     <li>
                                         <a href="{% url 'workstations:workstation-session-redirect' slug=algorithm.workstation.slug %}?{% workstation_query image=result.job.image overlay=image config=algorithm.workstation_config %}">
@@ -147,20 +102,38 @@
                                         </li>
                                     {% endfor %}
                                 {% endfor %}
-                            </ul>
-                        {% elif result.job.status == result.job.SUCCESS %}
-                            <span class="badge badge-warning"
-                                  title="No output images were found">
-                               <i class="fa fa-eye-slash"></i>
-                           </span>
-                        {% endif %}
+                            {% else %}
+                                <li>
+                                    <span class="badge badge-warning"
+                                          title="No output images were found">
+                                        <i class="fa fa-eye-slash"></i>
+                                    </span>
+                                </li>
+                                <li>
+                                    <a href="{% url 'workstations:workstation-session-redirect' slug=algorithm.workstation.slug %}?{% workstation_query image=result.job.image config=algorithm.workstation_config %}">
+                                        <span class="badge badge-primary">
+                                            <i class="fa fa-eye"></i> View Input
+                                        </span>
+                                    </a>
+                                </li>
+                            {% endif %}
+                            {% for file in result.job.image.files.all %}
+                                <li>
+                                    <a href="{{ file.file.url }}">
+                                        <span class="badge badge-primary">
+                                            <i class="fa fa-download"></i> Input ({{ file.file|suffix }})
+                                        </span>
+                                    </a>
+                                </li>
+                            {% endfor %}
+                        </ul>
                     </td>
                     <td>
                         {% if result.comment %}
-                            <a href="#jobInfoModal"
+                            <a href="#resultInfoModal"
                                class="badge badge-primary"
                                data-toggle="modal"
-                               data-target="#jobInfoModal"
+                               data-target="#resultInfoModal"
                                data-title="Result Comment"
                                data-output="{{ result.comment }}"
                                data-pk="{{ result.pk }}"
@@ -183,9 +156,8 @@
         </table>
     </div>
 
-
-    <div class="modal fade" id="jobInfoModal" tabindex="-1" role="dialog"
-         aria-labelledby="jobInfoModalTitle" aria-hidden="true">
+    <div class="modal fade" id="resultInfoModal" tabindex="-1" role="dialog"
+         aria-labelledby="resultInfoModalTitle" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered" role="document">
             <div class="modal-content">
                 <div class="modal-header">
@@ -219,9 +191,9 @@
     </script>
 
     <script type="text/javascript">
-        $('#jobInfoModal').on('show.bs.modal', function (event) {
-            var button = $(event.relatedTarget);
-            var modal = $(this);
+        $('#resultInfoModal').on('show.bs.modal', function (event) {
+            let button = $(event.relatedTarget);
+            let modal = $(this);
             modal.find('.modal-title').text(button.data('title'));
             modal.find('.modal-job-output').text(button.data('output'));
             modal.find('#footerText').text("ID: " + button.data('pk'));

--- a/app/grandchallenge/algorithms/templates/algorithms/result_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/result_list.html
@@ -1,14 +1,14 @@
 {% extends "base.html" %}
 {% load url %}
-{% load user_profile_link from profiles %}
+{% load profiles %}
 {% load workstations %}
 {% load guardian_tags %}
-{% load suffix from pathlib %}
+{% load pathlib %}
 {% load humanize %}
-{% load user_error from evaluation_extras %}
+{% load evaluation_extras %}
 
 {% block title %}
-    Algorithm Jobs - {{ block.super }}
+    Algorithm Results - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}
@@ -56,26 +56,24 @@
             </tr>
             </thead>
             <tbody>
-            {% for job in object_list %}
+            {% for result in object_list %}
                 <tr>
                     {# pk included for test support #}
-                    <!-- {{ job.pk }} -->
-                    <td data-order="{{ job.created|date:"U" }}">{{ job.created|naturaltime }}</td>
+                    <!-- {{ result.job.pk }} -->
+                    <td data-order="{{ result.job.created|date:"U" }}">{{ result.job.created|naturaltime }}</td>
                     <td>
-                        {% if job.creator %}
-                            {{ job.creator|user_profile_link }}
-                        {% endif %}
+                        {{ result.job.creator|user_profile_link }}
                     </td>
                     <td>
                         <ul class="list-unstyled">
                             <li>
-                                <a href="{% url 'workstations:workstation-session-redirect' slug=job.algorithm_image.algorithm.workstation.slug %}?{% workstation_query image=job.image config=algorithm.workstation_config %}">
+                                <a href="{% url 'workstations:workstation-session-redirect' slug=algorithm.workstation.slug %}?{% workstation_query image=result.job.image config=algorithm.workstation_config %}">
                                     <span class="badge badge-primary">
                                         <i class="fa fa-eye"></i> View Input
                                     </span>
                                 </a>
                             </li>
-                            {% for file in job.image.files.all %}
+                            {% for file in result.job.image.files.all %}
                                 <li>
                                     <a href="{{ file.file.url }}">
                                         <span class="badge badge-primary">
@@ -89,11 +87,11 @@
                     <td>
                         <a href="#jobInfoModal"
                            class="badge
-                            {% if job.status == job.FAILURE or job.status == job.CANCELLED %}
+                            {% if result.job.status == result.job.FAILURE or result.job.status == result.job.CANCELLED %}
                                 badge-danger
-                            {% elif job.status == job.RETRY %}
+                            {% elif result.job.status == result.job.RETRY %}
                                 badge-warning
-                            {% elif job.status == job.SUCCESS %}
+                            {% elif result.job.status == result.job.SUCCESS %}
                                 badge-success
                             {% else %}
                                 badge-info
@@ -101,10 +99,10 @@
                            data-toggle="modal"
                            data-target="#jobInfoModal"
                            data-title="Job Info"
-                           data-output="{% firstof job.output|user_error job.get_status_display %}"
-                           data-pk="{{ job.pk }}"
+                           data-output="{% firstof result.job.output|user_error result.job.get_status_display %}"
+                           data-pk="{{ result.job.pk }}"
                            title="Job Info">
-                            {{ job.get_status_display }}
+                            {{ result.job.get_status_display }}
                         </a>
                     </td>
                     <td>
@@ -113,14 +111,14 @@
                            data-toggle="modal"
                            data-target="#jobInfoModal"
                            data-title="Result Info"
-                           data-output="{% firstof job.result.output 'No output produced.' %}"
-                           data-pk="{{ job.result.pk }}"
+                           data-output="{% firstof result.output 'No output produced.' %}"
+                           data-pk="{{ result.pk }}"
                            title="Result Info">
                             <i class="fa fa-eye"></i> Result Info
                         </a>
                     </td>
                     <td>
-                        {% if job.result.public %}
+                        {% if result.public %}
                             <i class="fa fa-eye text-success"
                                title="Result is public"></i>
                         {% else %}
@@ -129,11 +127,11 @@
                         {% endif %}
                     </td>
                     <td>
-                        {% if job.result.images.all %}
+                        {% if result.images.all %}
                             <ul class="list-unstyled">
-                                {% for image in job.result.images.all %}
+                                {% for image in result.images.all %}
                                     <li>
-                                        <a href="{% url 'workstations:workstation-session-redirect' slug=job.algorithm_image.algorithm.workstation.slug %}?{% workstation_query image=job.image overlay=image config=algorithm.workstation_config %}">
+                                        <a href="{% url 'workstations:workstation-session-redirect' slug=algorithm.workstation.slug %}?{% workstation_query image=result.job.image overlay=image config=algorithm.workstation_config %}">
                                             <span class="badge badge-primary">
                                                 <i class="fa fa-eye"></i> View Input &amp; Output
                                             </span>
@@ -150,7 +148,7 @@
                                     {% endfor %}
                                 {% endfor %}
                             </ul>
-                        {% elif job.status == job.SUCCESS %}
+                        {% elif result.job.status == result.job.SUCCESS %}
                             <span class="badge badge-warning"
                                   title="No output images were found">
                                <i class="fa fa-eye-slash"></i>
@@ -158,21 +156,21 @@
                         {% endif %}
                     </td>
                     <td>
-                        {% if job.result.comment %}
+                        {% if result.comment %}
                             <a href="#jobInfoModal"
                                class="badge badge-primary"
                                data-toggle="modal"
                                data-target="#jobInfoModal"
                                data-title="Result Comment"
-                               data-output="{{ job.result.comment }}"
-                               data-pk="{{ job.result.pk }}"
+                               data-output="{{ result.comment }}"
+                               data-pk="{{ result.pk }}"
                                title="Result Comment">
                                 <i class="fa fa-file"></i>
                             </a>
                         {% endif %}
                         {# TODO: This should be change_result but is expensive to lookup here, do this when moving to results list #}
-                        {% if "change_algorithm" in algorithm_perms and job.result %}
-                            <a href="{% url 'algorithms:result-update' slug=job.algorithm_image.algorithm.slug pk=job.result.pk %}">
+                        {% if "change_algorithm" in algorithm_perms and result %}
+                            <a href="{% url 'algorithms:result-update' slug=algorithm.slug pk=result.pk %}">
                                 <span class="badge badge-primary" title="Edit result">
                                     <i class="fa fa-edit"></i>
                                 </span>

--- a/app/grandchallenge/algorithms/urls.py
+++ b/app/grandchallenge/algorithms/urls.py
@@ -8,12 +8,12 @@ from grandchallenge.algorithms.views import (
     AlgorithmImageCreate,
     AlgorithmImageDetail,
     AlgorithmImageUpdate,
-    AlgorithmJobsList,
     AlgorithmList,
     AlgorithmPermissionRequestCreate,
     AlgorithmPermissionRequestList,
     AlgorithmPermissionRequestUpdate,
     AlgorithmResultUpdate,
+    AlgorithmResultsList,
     AlgorithmUpdate,
     AlgorithmUserAutocomplete,
     EditorsUpdate,
@@ -58,7 +58,9 @@ urlpatterns = [
         name="execution-session-detail",
     ),
     path(
-        "<slug:slug>/results/", AlgorithmJobsList.as_view(), name="jobs-list"
+        "<slug:slug>/results/",
+        AlgorithmResultsList.as_view(),
+        name="results-list",
     ),
     path(
         "<slug:slug>/results/<uuid:pk>/update/",

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -343,7 +343,7 @@ class AlgorithmExecutionSessionDetail(
         return context
 
 
-class AlgorithmResultsList(LoginRequiredMixin, PermissionListMixin, ListView):
+class AlgorithmResultsList(PermissionListMixin, ListView):
     model = Result
     permission_required = (
         f"{Result._meta.app_label}.view_{Result._meta.model_name}"

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -374,9 +374,11 @@ class AlgorithmResultsList(PermissionListMixin, ListView):
 
     def get_queryset(self, *args, **kwargs):
         qs = super().get_queryset(*args, **kwargs)
-        return qs.filter(
-            job__algorithm_image__algorithm=self.algorithm
-        ).select_related("job")
+        return (
+            qs.filter(job__algorithm_image__algorithm=self.algorithm)
+            .prefetch_related("images__files", "job__image__files")
+            .select_related("job__creator__user_profile")
+        )
 
 
 class AlgorithmResultUpdate(

--- a/app/grandchallenge/evaluation/templates/evaluation/result_list.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/result_list.html
@@ -1,6 +1,6 @@
 {% extends "challenge.html" %}
 {% load evaluation_extras %}
-{% load user_profile_link from profiles %}
+{% load profiles %}
 {% load humanize %}
 {% load remove_whitespace %}
 

--- a/app/grandchallenge/evaluation/templatetags/evaluation_extras.py
+++ b/app/grandchallenge/evaluation/templatetags/evaluation_extras.py
@@ -20,7 +20,7 @@ def get_jsonpath(obj: dict, jsonpath):
     :return: The most relevant object in the dictionary
     """
     try:
-        keys = jsonpath.split(".")
+        keys = str(jsonpath).split(".")
         val = obj
 
         for key in keys:

--- a/app/tests/algorithms_tests/test_permissions.py
+++ b/app/tests/algorithms_tests/test_permissions.py
@@ -153,29 +153,29 @@ def test_algorithm_results_list_view(client):
     )
 
     # Create the results
-    _ = AlgorithmResultFactory(job=j1), AlgorithmResultFactory(job=j2)
+    r1, r2 = AlgorithmResultFactory(job=j1), AlgorithmResultFactory(job=j2)
 
-    all_jobs = {j1, j2}
+    all_results = {r1, r2}
 
     tests = (
-        (None, alg_set.alg1, 302, set()),
-        (None, alg_set.alg2, 302, set()),
+        (None, alg_set.alg1, 200, set()),
+        (None, alg_set.alg2, 200, set()),
         (alg_set.creator, alg_set.alg1, 200, set()),
         (alg_set.creator, alg_set.alg2, 200, set()),
-        (alg_set.editor1, alg_set.alg1, 200, {j1}),
+        (alg_set.editor1, alg_set.alg1, 200, {r1}),
         (alg_set.editor1, alg_set.alg2, 200, set()),
         (alg_set.user1, alg_set.alg1, 200, set()),
         (alg_set.user1, alg_set.alg2, 200, set()),
         (alg_set.editor2, alg_set.alg1, 200, set()),
-        (alg_set.editor2, alg_set.alg2, 200, {j2}),
+        (alg_set.editor2, alg_set.alg2, 200, {r2}),
         (alg_set.user2, alg_set.alg1, 200, set()),
         (alg_set.user2, alg_set.alg2, 200, set()),
         (alg_set.u, alg_set.alg1, 200, set()),
         (alg_set.u, alg_set.alg2, 200, set()),
-        (extra_user1, alg_set.alg1, 200, {j1}),
+        (extra_user1, alg_set.alg1, 200, {r1}),
         (extra_user1, alg_set.alg2, 200, set()),
         (extra_user2, alg_set.alg1, 200, set()),
-        (extra_user2, alg_set.alg2, 200, {j2}),
+        (extra_user2, alg_set.alg2, 200, {r2}),
     )
 
     for test in tests:
@@ -189,14 +189,15 @@ def test_algorithm_results_list_view(client):
 
         # Check that the results are filtered
         if response.status_code == 200:
-            expected_jobs = test[3]
-            excluded_jobs = all_jobs - expected_jobs
+            expected_results = test[3]
+            excluded_results = all_results - expected_results
             assert all(
-                str(j.pk) in response.rendered_content for j in expected_jobs
+                str(j.pk) in response.rendered_content
+                for j in expected_results
             )
             assert all(
                 str(j.pk) not in response.rendered_content
-                for j in excluded_jobs
+                for j in excluded_results
             )
 
 

--- a/app/tests/algorithms_tests/test_permissions.py
+++ b/app/tests/algorithms_tests/test_permissions.py
@@ -132,7 +132,7 @@ def test_algorithm_detail_view_permissions(client, view_name, index):
 
 
 @pytest.mark.django_db
-def test_algorithm_jobs_view(client):
+def test_algorithm_results_list_view(client):
     # This view is a bit special, all algorithm users should be able to
     # view it, but the results should be filtered
 
@@ -151,6 +151,9 @@ def test_algorithm_jobs_view(client):
             algorithm_image__algorithm=alg_set.alg2, creator=extra_user2
         ),
     )
+
+    # Create the results
+    _ = AlgorithmResultFactory(job=j1), AlgorithmResultFactory(job=j2)
 
     all_jobs = {j1, j2}
 
@@ -177,7 +180,7 @@ def test_algorithm_jobs_view(client):
 
     for test in tests:
         response = get_view_for_user(
-            viewname=f"algorithms:jobs-list",
+            viewname=f"algorithms:results-list",
             reverse_kwargs={"slug": test[1].slug},
             client=client,
             user=test[0],


### PR DESCRIPTION
This PR:

- Tidies up the algorithm results page
- Makes it visible to non-logged in users (but the results are still filtered)
- Fixes the pre-commit hook which is broken with the release of `virtualenv==20.0.6`
- Fixes the algorithm job cleanup

With this PR there is nowhere to see the failed jobs, I will add an upload list page tomorrow.