### PR TITLE
Adds image-level endpoints

### DIFF
--- a/app/grandchallenge/api/urls.py
+++ b/app/grandchallenge/api/urls.py
@@ -22,7 +22,10 @@ from grandchallenge.reader_studies.views import (
     QuestionViewSet,
     ReaderStudyViewSet,
 )
-from grandchallenge.retina_api.views import LandmarkAnnotationSetViewSet
+from grandchallenge.retina_api.views import (
+    ImageLevelAnnotationsForImageViewSet,
+    LandmarkAnnotationSetViewSet,
+)
 from grandchallenge.subdomains.utils import reverse_lazy
 from grandchallenge.workstation_configs.views import WorkstationConfigViewSet
 from grandchallenge.workstations.views import SessionViewSet
@@ -74,6 +77,11 @@ router.register(
     LandmarkAnnotationSetViewSet,
     basename="landmark-annotation",
 )
+router.register(
+    r"retina/image-level-annotation-for-image",
+    ImageLevelAnnotationsForImageViewSet,
+    basename="image-level-annotation-for-image",
+)
 
 # Workstations
 router.register(
@@ -82,7 +90,6 @@ router.register(
     basename="workstations-config",
 )
 router.register(r"workstations/sessions", SessionViewSet)
-
 
 schema_view = get_schema_view(
     openapi.Info(

--- a/app/grandchallenge/api/urls.py
+++ b/app/grandchallenge/api/urls.py
@@ -25,6 +25,10 @@ from grandchallenge.reader_studies.views import (
 from grandchallenge.retina_api.views import (
     ImageLevelAnnotationsForImageViewSet,
     LandmarkAnnotationSetViewSet,
+    PathologyAnnotationViewSet,
+    QualityAnnotationViewSet,
+    RetinaPathologyAnnotationViewSet,
+    TextAnnotationViewSet,
 )
 from grandchallenge.subdomains.utils import reverse_lazy
 from grandchallenge.workstation_configs.views import WorkstationConfigViewSet
@@ -81,6 +85,26 @@ router.register(
     r"retina/image-level-annotation-for-image",
     ImageLevelAnnotationsForImageViewSet,
     basename="image-level-annotation-for-image",
+)
+router.register(
+    r"retina/quality-annotation",
+    QualityAnnotationViewSet,
+    basename="quality-annotation",
+)
+router.register(
+    r"retina/pathology-annotation",
+    PathologyAnnotationViewSet,
+    basename="pathology-annotation",
+)
+router.register(
+    r"retina/retina-pathology-annotation",
+    RetinaPathologyAnnotationViewSet,
+    basename="retina-pathology-annotation",
+)
+router.register(
+    r"retina/text-annotation",
+    TextAnnotationViewSet,
+    basename="text-annotation",
 )
 
 # Workstations

--- a/app/grandchallenge/api/urls.py
+++ b/app/grandchallenge/api/urls.py
@@ -79,32 +79,32 @@ router.register(r"reader-studies", ReaderStudyViewSet, basename="reader-study")
 router.register(
     r"retina/landmark-annotation",
     LandmarkAnnotationSetViewSet,
-    basename="landmark-annotation",
+    basename="retina-landmark-annotation",
 )
 router.register(
     r"retina/image-level-annotation-for-image",
     ImageLevelAnnotationsForImageViewSet,
-    basename="image-level-annotation-for-image",
+    basename="retina-image-level-annotation-for-image",
 )
 router.register(
     r"retina/quality-annotation",
     QualityAnnotationViewSet,
-    basename="quality-annotation",
+    basename="retina-quality-annotation",
 )
 router.register(
     r"retina/pathology-annotation",
     PathologyAnnotationViewSet,
-    basename="pathology-annotation",
+    basename="retina-pathology-annotation",
 )
 router.register(
     r"retina/retina-pathology-annotation",
     RetinaPathologyAnnotationViewSet,
-    basename="retina-pathology-annotation",
+    basename="retina-retina-pathology-annotation",
 )
 router.register(
     r"retina/text-annotation",
     TextAnnotationViewSet,
-    basename="text-annotation",
+    basename="retina-text-annotation",
 )
 
 # Workstations

--- a/app/grandchallenge/retina_api/serializers.py
+++ b/app/grandchallenge/retina_api/serializers.py
@@ -86,3 +86,18 @@ class TreeImageSerializer(TreeObjectSerializer):
     modality = ImagingModalitySerializer()
     study = TreeStudySerializer(required=False)
     archive_set = TreeArchiveSerializer(many=True)
+
+
+class ImageLevelAnnotationsForImageSerializer(serializers.BaseSerializer):
+    quality = serializers.UUIDField(allow_null=True)
+    pathology = serializers.UUIDField(allow_null=True)
+    retina_pathology = serializers.UUIDField(allow_null=True)
+    text = serializers.UUIDField(allow_null=True)
+
+    def to_representation(self, instance):
+        return {
+            "quality": instance.get("quality"),
+            "pathology": instance.get("pathology"),
+            "retina_pathology": instance.get("retina_pathology"),
+            "text": instance.get("text"),
+        }

--- a/app/grandchallenge/retina_api/views.py
+++ b/app/grandchallenge/retina_api/views.py
@@ -929,3 +929,39 @@ class ImageLevelAnnotationsForImageViewSet(
             except (IndexError, AttributeError):
                 data[key] = None
         return data
+
+
+class QualityAnnotationViewSet(viewsets.ModelViewSet):
+    permission_classes = (RetinaAPIPermission,)
+    authentication_classes = (authentication.TokenAuthentication,)
+    serializer_class = ImageQualityAnnotationSerializer
+    filter_backends = (filters.ObjectPermissionsFilter, RetinaAnnotationFilter)
+    pagination_class = None
+    queryset = ImageQualityAnnotation.objects.all()
+
+
+class PathologyAnnotationViewSet(viewsets.ModelViewSet):
+    permission_classes = (RetinaAPIPermission,)
+    authentication_classes = (authentication.TokenAuthentication,)
+    serializer_class = ImagePathologyAnnotationSerializer
+    filter_backends = (filters.ObjectPermissionsFilter, RetinaAnnotationFilter)
+    pagination_class = None
+    queryset = ImagePathologyAnnotation.objects.all()
+
+
+class RetinaPathologyAnnotationViewSet(viewsets.ModelViewSet):
+    permission_classes = (RetinaAPIPermission,)
+    authentication_classes = (authentication.TokenAuthentication,)
+    serializer_class = RetinaImagePathologyAnnotationSerializer
+    filter_backends = (filters.ObjectPermissionsFilter, RetinaAnnotationFilter)
+    pagination_class = None
+    queryset = RetinaImagePathologyAnnotation.objects.all()
+
+
+class TextAnnotationViewSet(viewsets.ModelViewSet):
+    permission_classes = (RetinaAPIPermission,)
+    authentication_classes = (authentication.TokenAuthentication,)
+    serializer_class = ImageTextAnnotationSerializer
+    filter_backends = (filters.ObjectPermissionsFilter, RetinaAnnotationFilter)
+    pagination_class = None
+    queryset = ImageTextAnnotation.objects.all()

--- a/app/grandchallenge/retina_api/views.py
+++ b/app/grandchallenge/retina_api/views.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.csrf import ensure_csrf_cookie
-from rest_framework import authentication, status, viewsets
+from rest_framework import authentication, mixins, status, viewsets
 from rest_framework.exceptions import NotFound
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.response import Response
@@ -61,6 +61,7 @@ from grandchallenge.retina_api.models import ArchiveDataModel
 from grandchallenge.retina_api.renderers import Base64Renderer
 from grandchallenge.retina_api.serializers import (
     BytesImageSerializer,
+    ImageLevelAnnotationsForImageSerializer,
     TreeImageSerializer,
     TreeObjectSerializer,
 )
@@ -898,3 +899,33 @@ class LandmarkAnnotationSetViewSet(viewsets.ModelViewSet):
             )
 
         return queryset
+
+
+class ImageLevelAnnotationsForImageViewSet(
+    mixins.RetrieveModelMixin, viewsets.GenericViewSet
+):
+    permission_classes = (RetinaAPIPermission,)
+    authentication_classes = (authentication.TokenAuthentication,)
+    serializer_class = ImageLevelAnnotationsForImageSerializer
+    filter_backends = (filters.ObjectPermissionsFilter,)
+
+    def get_object(self):
+        keys_to_models_map = {
+            "quality": ImageQualityAnnotation,
+            "pathology": ImagePathologyAnnotation,
+            "retina_pathology": RetinaImagePathologyAnnotation,
+            "text": ImageTextAnnotation,
+        }
+        image_id = self.kwargs.get("pk")
+        if image_id is None:
+            raise NotFound()
+        data = {}
+        for key, model in keys_to_models_map.items():
+            objects = model.objects.filter(
+                image__id=image_id, grader=self.request.user
+            )
+            try:
+                data[key] = objects[0].id
+            except (IndexError, AttributeError):
+                data[key] = None
+        return data

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -17,10 +17,14 @@ from tests.annotations_tests.factories import (
     BooleanClassificationAnnotationFactory,
     CoordinateListAnnotationFactory,
     ETDRSGridAnnotationFactory,
+    ImagePathologyAnnotationFactory,
+    ImageQualityAnnotationFactory,
+    ImageTextAnnotationFactory,
     IntegerClassificationAnnotationFactory,
     LandmarkAnnotationSetFactory,
     MeasurementAnnotationFactory,
     PolygonAnnotationSetFactory,
+    RetinaImagePathologyAnnotationFactory,
     SingleLandmarkAnnotationFactory,
     SinglePolygonAnnotationFactory,
 )
@@ -669,3 +673,20 @@ def reader_study_with_gt():
             ans.images.add(im)
 
     return rs
+
+
+@pytest.fixture
+def image_with_image_level_annotations():
+    grader = UserFactory()
+    add_to_graders_group([grader])
+    image = ImageFactory()
+    factory_kwargs = {"image": image, "grader": grader}
+    annotations = {
+        "quality": ImageQualityAnnotationFactory(**factory_kwargs),
+        "pathology": ImagePathologyAnnotationFactory(**factory_kwargs),
+        "retina_pathology": RetinaImagePathologyAnnotationFactory(
+            **factory_kwargs
+        ),
+        "text": ImageTextAnnotationFactory(**factory_kwargs),
+    }
+    return image, grader, annotations

--- a/app/tests/retina_api_tests/test_viewsets.py
+++ b/app/tests/retina_api_tests/test_viewsets.py
@@ -1355,28 +1355,28 @@ class TestETDRSAnnotationViewSet:
             QualityAnnotationViewSet,
             ImageQualityAnnotationFactory,
             ImageQualityAnnotationSerializer,
-            "quality-annotation",
+            "retina-quality-annotation",
             False,
         ),
         (
             PathologyAnnotationViewSet,
             ImagePathologyAnnotationFactory,
             ImagePathologyAnnotationSerializer,
-            "pathology-annotation",
+            "retina-pathology-annotation",
             False,
         ),
         (
             RetinaPathologyAnnotationViewSet,
             RetinaImagePathologyAnnotationFactory,
             RetinaImagePathologyAnnotationSerializer,
-            "retina-pathology-annotation",
+            "retina-retina-pathology-annotation",
             False,
         ),
         (
             TextAnnotationViewSet,
             ImageTextAnnotationFactory,
             ImageTextAnnotationSerializer,
-            "text-annotation",
+            "retina-text-annotation",
             False,
         ),
     ),
@@ -1675,7 +1675,7 @@ class TestAnnotationViewSets:
             LandmarkAnnotationSetViewSet,
             LandmarkAnnotationSetFactory,
             LandmarkAnnotationSetSerializer,
-            "landmark-annotation",
+            "retina-landmark-annotation",
         ),
     ),
 )
@@ -1978,7 +1978,7 @@ class TestLandmarkAnnotationSetViewSetForImage:
 
         user = get_user_from_user_type(user_type, **kwargs)
 
-        url = reverse(f"api:landmark-annotation-list") + querystring
+        url = reverse(f"api:retina-landmark-annotation-list") + querystring
 
         request = rf.get(url)
 
@@ -2075,7 +2075,7 @@ class TestImageLevelAnnotationsForImageViewSet:
         user = get_user_from_user_type(user_type, grader=grader)
 
         url = reverse(
-            "api:image-level-annotation-for-image-detail", kwargs=kwargs
+            "api:retina-image-level-annotation-for-image-detail", kwargs=kwargs
         )
 
         request = rf.get(url)

--- a/app/tests/viewset_helpers.py
+++ b/app/tests/viewset_helpers.py
@@ -250,6 +250,9 @@ def view_test(
     check_response_status_code=True,
     with_user=True,
 ):
+    if not with_user and user_type == "retina_grader_non_allowed":
+        user_type = "normal_user"
+
     user = get_user_from_user_type(user_type, grader=grader)
 
     url, kwargs = get_viewset_url_kwargs(


### PR DESCRIPTION
- Adds a new url, serializer and viewset that returns ids of most recent image-level annotations for a specific image and user
- Adds new viewsets for image-level annotations and adds these to the core API router
- Adds tests for new endpoints

Closes #1203 