### PR TITLE
Adds admin pages for evaluations

### DIFF
--- a/app/grandchallenge/evaluation/admin.py
+++ b/app/grandchallenge/evaluation/admin.py
@@ -1,0 +1,86 @@
+from django.contrib import admin
+
+from grandchallenge.evaluation.models import (
+    Config,
+    Job,
+    Method,
+    Result,
+    Submission,
+)
+
+
+class ConfigAdmin(admin.ModelAdmin):
+    ordering = ("challenge",)
+    list_display = ("pk", "challenge", "modified")
+    search_fields = ("pk",)
+
+
+class MethodAdmin(admin.ModelAdmin):
+    ordering = ("created",)
+    list_display = ("pk", "created", "challenge", "ready", "status")
+    list_filter = ("challenge__short_name",)
+    search_fields = ("pk",)
+    readonly_fields = ("creator", "challenge")
+
+
+class SubmissionAdmin(admin.ModelAdmin):
+    ordering = ("created",)
+    list_display = ("pk", "created", "challenge", "creator")
+    list_filter = ("challenge__short_name",)
+    search_fields = (
+        "pk",
+        "creator__username",
+    )
+    readonly_fields = (
+        "creator",
+        "challenge",
+        "file",
+    )
+
+
+class ResultAdmin(admin.ModelAdmin):
+    ordering = ("created",)
+    list_display = (
+        "pk",
+        "created",
+        "challenge",
+        "creator",
+        "published",
+        "rank",
+    )
+    list_select_related = (
+        "job__submission__challenge",
+        "job__submission__creator",
+    )
+    list_filter = (
+        "job__submission__challenge__short_name",
+        "published",
+    )
+    search_fields = (
+        "pk",
+        "job__pk",
+        "job__submission__challenge__short_name",
+        "job__submission__creator__username",
+    )
+    readonly_fields = ("job",)
+
+
+class JobAdmin(admin.ModelAdmin):
+    ordering = ("created",)
+    list_display = ("pk", "created", "challenge", "creator", "status")
+    list_filter = ("submission__challenge__short_name", "status")
+    list_select_related = ("submission__challenge", "submission__creator")
+    search_fields = (
+        "pk",
+        "submission__pk",
+        "submission__challenge__short_name",
+        "submission__creator__username",
+    )
+    readonly_fields = ("status", "submission", "method")
+
+
+admin.site.register(Config, ConfigAdmin)
+admin.site.register(Method, MethodAdmin)
+admin.site.register(Submission, SubmissionAdmin)
+admin.site.register(Result, ResultAdmin)
+admin.site.register(Job, JobAdmin)

--- a/app/grandchallenge/evaluation/emails.py
+++ b/app/grandchallenge/evaluation/emails.py
@@ -11,25 +11,25 @@ def send_failed_job_email(job):
     message = (
         f"Dear {{}},\n\n"
         f"Unfortunately the evaluation for the submission to "
-        f"{job.submission.challenge.short_name} failed with an error. "
+        f"{job.challenge.short_name} failed with an error. "
         f"The error message is:\n\n"
         f"{user_error(job.output)}\n\n"
         f"You may wish to try and correct this, or contact the challenge "
         f"organizers. The following information may help them:\n"
-        f"User: {job.submission.creator.username}\n"
+        f"User: {job.creator.username}\n"
         f"Job ID: {job.pk}\n"
         f"Submission ID: {job.submission.pk}\n\n"
         f"Regards,\n"
         f"{site.name}\n\n"
         f"This is an automated service email from {site.domain}."
     )
-    recipients = list(job.submission.challenge.get_admins())
-    recipients.append(job.submission.creator)
+    recipients = list(job.challenge.get_admins())
+    recipients.append(job.creator)
     for recipient in recipients:
         send_mail(
             subject=(
                 f"[{site.domain.lower()}] "
-                f"[{job.submission.challenge.short_name.lower()}] "
+                f"[{job.challenge.short_name.lower()}] "
                 f"Evaluation Failed"
             ),
             message=message.format(recipient.username),
@@ -40,7 +40,7 @@ def send_failed_job_email(job):
 
 def send_new_result_email(result):
     site = Site.objects.get_current()
-    challenge = result.job.submission.challenge
+    challenge = result.challenge
 
     recipients = list(challenge.get_admins())
     message = (

--- a/app/grandchallenge/evaluation/signals.py
+++ b/app/grandchallenge/evaluation/signals.py
@@ -52,13 +52,7 @@ def create_evaluation_job(
 @disable_for_loaddata
 def recalculate_ranks(instance: Union[Result, Config] = None, *_, **__):
     """Recalculates the ranking on a new result"""
-    try:
-        challenge_pk = instance.challenge.pk
-    except AttributeError:
-        # For a Result
-        challenge_pk = instance.job.submission.challenge.pk
-
-    calculate_ranks.apply_async(kwargs={"challenge_pk": challenge_pk})
+    calculate_ranks.apply_async(kwargs={"challenge_pk": instance.challenge.pk})
 
 
 @receiver(post_save, sender=Result)

--- a/app/grandchallenge/evaluation/templates/evaluation/job_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/job_detail.html
@@ -18,7 +18,7 @@
     </div>
 
     <p><b>Challenge:</b> <a
-            href="{{ object.submission.challenge.get_absolute_url }}">{{ object.submission.challenge.short_name }}</a>
+            href="{{ object.challenge.get_absolute_url }}">{{ object.challenge.short_name }}</a>
     </p>
     <p><b>Submission:</b> <a
             href="{{ object.submission.get_absolute_url }}">{{ object.submission.pk }}</a>

--- a/app/grandchallenge/evaluation/templates/evaluation/result_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/result_detail.html
@@ -17,8 +17,8 @@
         </dd>
 
         <dt>Challenge</dt>
-        <dd><a href="{{ object.job.submission.challenge.get_absolute_url }}">
-            {{ object.job.submission.challenge.short_name }}</a></dd>
+        <dd><a href="{{ object.challenge.get_absolute_url }}">
+            {{ object.challenge.short_name }}</a></dd>
 
         <dt>Submission created</dt>
         <dd>{{ object.job.submission.created }}</dd>

--- a/app/grandchallenge/evaluation/templatetags/evaluation_extras.py
+++ b/app/grandchallenge/evaluation/templatetags/evaluation_extras.py
@@ -81,8 +81,7 @@ def json_dumps(obj: dict):
 def get_team_html(obj):
     try:
         team = Team.objects.get(
-            challenge=obj.job.submission.challenge,
-            teammember__user=obj.job.submission.creator,
+            challenge=obj.challenge, teammember__user=obj.creator,
         )
         return format_html(
             '<a href="{}">{}</a>', team.get_absolute_url(), team.name

--- a/app/grandchallenge/statistics/templates/statistics/statistics_detail.html
+++ b/app/grandchallenge/statistics/templates/statistics/statistics_detail.html
@@ -89,7 +89,7 @@
 
         <dt>Latest public result</dt>
         <dd><a href="{{ latest_result.get_absolute_url }}">Result
-            for {{ latest_result.job.submission.challenge }},
+            for {{ latest_result.challenge }},
             created {{ latest_result.created|naturaltime }},
             {{ latest_result.rank|ordinal }} position on leaderboard.</a></dd>
 


### PR DESCRIPTION
This PR adds admin pages for the existing evaluation models, which should make site administration much easier. This was skipped when adding this app initially due to the mis-use of the django admin for challenge admins.