### PR TITLE
Show help text on reader study detail page

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -476,7 +476,7 @@ BLEACH_ALLOWED_TAGS = [
 ]
 BLEACH_ALLOWED_ATTRIBUTES = {
     "*": ["class", "data-toggle", "id", "style", "role"],
-    "a": ["href", "title"],
+    "a": ["href", "title", "target", "rel"],
     "abbr": ["title"],
     "acronym": ["title"],
     "img": ["height", "src", "width"],
@@ -499,6 +499,7 @@ MARKDOWNX_MARKDOWN_EXTENSIONS = [
 MARKDOWNX_MARKDOWNIFY_FUNCTION = (
     "grandchallenge.core.templatetags.bleach.md2html"
 )
+MARKDOWNX_MARKDOWN_EXTENSION_CONFIGS = {}
 MARKDOWNX_IMAGE_MAX_SIZE = {"size": (2000, 0), "quality": 90}
 
 AUTH_PASSWORD_VALIDATORS = [

--- a/app/grandchallenge/core/templatetags/bleach.py
+++ b/app/grandchallenge/core/templatetags/bleach.py
@@ -4,7 +4,9 @@ import bleach
 from django import template
 from django.conf import settings
 from django.utils.safestring import mark_safe
-from markdownx.utils import markdownify
+from markdown import markdown as render_markdown
+
+from grandchallenge.core.utils.markdown import LinkBlankTargetExtension
 
 register = template.Library()
 
@@ -25,6 +27,18 @@ def clean(html: str):
 
 
 @register.filter
-def md2html(markdown: Union[str, None]):
+def md2html(markdown: Union[str, None], link_blank_target=False):
     """Convert markdown to clean html"""
-    return clean(markdownify(markdown or ""))
+
+    extensions = settings.MARKDOWNX_MARKDOWN_EXTENSIONS
+
+    if link_blank_target:
+        extensions.append(LinkBlankTargetExtension())
+
+    html = render_markdown(
+        text=markdown or "",
+        extensions=extensions,
+        extension_configs=settings.MARKDOWNX_MARKDOWN_EXTENSION_CONFIGS,
+    )
+
+    return clean(html)

--- a/app/grandchallenge/core/utils/markdown.py
+++ b/app/grandchallenge/core/utils/markdown.py
@@ -22,3 +22,19 @@ class BS4Treeprocessor(Treeprocessor):
 
             elif el.tag == "thead":
                 el.set("class", "thead-light")
+
+
+class LinkBlankTargetExtension(Extension):
+    def extendMarkdown(self, md):  # noqa: N802
+        md.registerExtension(self)
+        md.treeprocessors.register(
+            LinkBlankTargetTreeprocessor(md), "link_blank_target_extension", 0
+        )
+
+
+class LinkBlankTargetTreeprocessor(Treeprocessor):
+    def run(self, root):
+        for el in root.iter():
+            if el.tag == "a":
+                el.set("target", "_blank")
+                el.set("rel", "noopener")

--- a/app/grandchallenge/reader_studies/forms.py
+++ b/app/grandchallenge/reader_studies/forms.py
@@ -45,9 +45,9 @@ from grandchallenge.reader_studies.models import (
 )
 
 READER_STUDY_HELP_TEXTS = {
-    "title": "The title of this reader study",
-    "logo": "The logo for this reader study",
-    "description": "Describe what this reader study is for",
+    "title": "The title of this reader study.",
+    "logo": "The logo for this reader study.",
+    "description": "Describe what this reader study is for.",
     "workstation": (
         "Which workstation should be used for this reader study? "
         "Note that in order to add a workstation you must be a member "
@@ -57,7 +57,7 @@ READER_STUDY_HELP_TEXTS = {
     ),
     "help_text_markdown": (
         "Extra information that will be presented to the reader in the help "
-        "text modal"
+        "text modal and on the reader study detail page."
     ),
 }
 
@@ -79,6 +79,9 @@ class ReaderStudyCreateForm(
             "allow_case_navigation",
         )
         help_texts = READER_STUDY_HELP_TEXTS
+        widgets = {
+            "description": TextInput,
+        }
 
     def clean(self):
         super().clean()
@@ -113,6 +116,7 @@ class ReaderStudyUpdateForm(ReaderStudyCreateForm, ModelForm):
             "hanging_list": JSONEditorWidget(schema=HANGING_LIST_SCHEMA),
             "case_text": JSONEditorWidget(schema=CASE_TEXT_SCHEMA),
             "help_text_markdown": MarkdownEditorWidget,
+            "description": TextInput,
         }
         help_texts = {
             **READER_STUDY_HELP_TEXTS,

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -359,7 +359,7 @@ class ReaderStudy(UUIDModel, TitleSlugDescriptionModel):
     @property
     def help_text(self):
         """The cleaned help text from the markdown sources"""
-        return md2html(self.help_text_markdown)
+        return md2html(self.help_text_markdown, link_blank_target=True)
 
     @property
     def cleaned_case_text(self):

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -4,6 +4,7 @@
 {% load profiles %}
 {% load workstations %}
 {% load guardian_tags %}
+{% load bleach %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
@@ -127,7 +128,7 @@
 
             <h2>{{ object.title }}</h2>
 
-            <p>{{ object.description }}</p>
+            {{ object.help_text_markdown|md2html }}
 
             {% if user_score.score__sum is not None and progress.hangings == 100.0 %}
                 <div class="alert alert-info" role="alert">


### PR DESCRIPTION
Help text links open in new tab in CIRRUS

Note: Here I could not use the `MARKDOWNX_MARKDOWN_EXTENSION_CONFIGS` as it only works with a dotted path importer. Looping over the element tree twice is inefficient but will need to be solved some other time.

Closes #1286
Closes #1285