### PR TITLE
Allow reader study answer removal

### DIFF
--- a/app/grandchallenge/reader_studies/forms.py
+++ b/app/grandchallenge/reader_studies/forms.py
@@ -39,6 +39,7 @@ from grandchallenge.core.forms import (
 from grandchallenge.core.layout import Formset
 from grandchallenge.core.widgets import JSONEditorWidget, MarkdownEditorWidget
 from grandchallenge.reader_studies.models import (
+    Answer,
     CASE_TEXT_SCHEMA,
     CategoricalOption,
     HANGING_LIST_SCHEMA,
@@ -346,6 +347,21 @@ class ReadersForm(UserGroupForm):
             permission_request.status = ReaderStudyPermissionRequest.ACCEPTED
 
         permission_request.save()
+
+
+class AnswersRemoveForm(Form):
+    user = ModelChoiceField(
+        queryset=get_user_model().objects.all().order_by("username"),
+        required=True,
+    )
+
+    def remove_answers(self, *, reader_study):
+        user = self.cleaned_data["user"]
+        Answer.objects.filter(
+            question__reader_study=reader_study,
+            creator=user,
+            is_ground_truth=False,
+        ).delete()
 
 
 class ReaderStudyPermissionRequestUpdateForm(PermissionRequestUpdateForm):

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -119,8 +119,12 @@
             <hr>
 
             You might be able to solve these issues by re-generating the hanging list:
-            <button type="button" class="btn btn-primary" data-toggle="modal"
-                    data-target="#hangingListModal">
+            <button type="button" class="btn btn-primary"
+                    data-toggle="modal"
+                    data-target="#warningModal"
+                    data-title="Generate hanging list"
+                    data-warning="The generated hanging list will overwrite any existig hanging list by setting 1 image per hanging protocol."
+                    data-action="Re-generate the hanging list">
                 <i class="fas fa-sync"></i> Re-generate the hanging list
             </button>
 
@@ -331,7 +335,7 @@
                                         {{ reader.obj|user_profile_link }}
                                     </div>
                                 </div>
-                                <div class="col-6 mb-1">
+                                <div class="col-5 mb-1">
                                     <div class="h-100 d-flex align-items-center">
                                         <div class="flex-fill progress h-100">
                                             <div class="progress-bar" role="progressbar"
@@ -345,7 +349,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="col-3 mb-1">
+                                <div class="col-4 mb-1">
                                     <div class="d-flex justify-content-end align-items-center">
                                         <form
                                                 action="{% url 'reader-studies:readers-update' slug=object.slug %}"
@@ -362,10 +366,20 @@
                                                 {% endif %}
                                             {% endfor %}
                                             <button type="submit"
-                                                    class="btn btn-danger">
-                                                Remove
+                                                    class="btn btn-danger mr-1">
+                                                <small>Remove reader</small>
                                             </button>
                                         </form>
+                                        <button type="button"
+                                                class="btn btn-danger"
+                                                data-toggle="modal"
+                                                data-target="#warningModal"
+                                                data-title="Remove answers"
+                                                data-warning="This will remove all answers for user '{{ reader.obj }}'. This action cannot be undone."
+                                                data-user="{{ reader.obj.id }}"
+                                                data-action="Remove answers">
+                                            <small>Remove Answers</small>
+                                        </button>
                                     </div>
                                 </div>
                             </div>
@@ -476,22 +490,19 @@
         {% endif %}
 
         <!-- Modal -->
-        <div class="modal fade" id="hangingListModal" tabindex="-1" role="dialog"
-             aria-labelledby="hangingListModalLabel" aria-hidden="true">
+        <div class="modal fade" id="warningModal" tabindex="-1" role="dialog"
+             aria-labelledby="warningModalLabel" aria-hidden="true">
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h5 class="modal-title" id="hangingListModalLabel">Generate
-                            hanging list</h5>
+                        <h5 class="modal-title" id="warningModalLabel"></h5>
                         <button type="button" class="close" data-dismiss="modal"
                                 aria-label="Close">
                             <span aria-hidden="true">&times;</span>
                         </button>
                     </div>
                     <div class="modal-body">
-                        <p>The generated hanging list will overwrite any existing
-                            hanging
-                            list by setting 1 image per hanging protocol.</p>
+                        <p class="warning-text"></p>
 
                         <p><b>Are you sure that you want to continue?</b></p>
                     </div>
@@ -500,8 +511,8 @@
                                 data-dismiss="modal">Cancel
                         </button>
                         <button type="button" class="btn btn-danger"
-                                id="generateHangingList">
-                            <i class="fa fa-trash"></i> Re-generate the hanging list
+                                id="proceed">
+                            <i class="fa fa-trash"></i> <span class="modal-action"></span>
                         </button>
                     </div>
                 </div>
@@ -520,22 +531,43 @@
             csrfToken: "{% if request %}{{ csrf_token }}{% endif %}"
         };
 
+        let user;
+
         $(document).ready(() => {
-            $('#generateHangingList').on('click', () => {
-                $.ajax({
-                    type: 'PATCH',
-                    url: "{% url 'api:reader-study-generate-hanging-list' pk=object.pk %}",
-                    data: {},
-                    contentType: 'application/json',
-                    complete: (response) => {
-                        $('#page').prepend(
-                            '<div class="alert alert-success" role="alert">' +
-                            `${response.responseJSON.status}` +
-                            '</div>'
-                        );
-                        window.location.replace(window.location.href);
-                    }
-                })
+
+            $('#warningModal').on('show.bs.modal', function (event) {
+                const button = $(event.relatedTarget);
+                const modal = $(this);
+                modal.find(".warning-text").text(button.data("warning"));
+                modal.find(".modal-action").text(button.data("action"));
+                $("#warningModalLabel").text(button.data("title"));
+                user = button.data("user");
+            });
+            $('#proceed').on('click', () => {
+                if (user) {
+                    $.post({
+                        url: "{% url 'reader-studies:answers-remove' slug=object.slug %}",
+                        data: {user: user, csrfmiddlewaretoken: window.drf.csrfToken},
+                        success: () => {
+                            window.location.replace(window.location.href);
+                        }
+                    })
+                } else {
+                    $.ajax({
+                        type: 'PATCH',
+                        url: "{% url 'api:reader-study-generate-hanging-list' pk=object.pk %}",
+                        data: {},
+                        contentType: 'application/json',
+                        complete: (response) => {
+                            $('#page').prepend(
+                                '<div class="alert alert-success" role="alert">' +
+                                `${response.responseJSON.status}` +
+                                '</div>'
+                            );
+                            window.location.replace(window.location.href);
+                        }
+                    })
+                }
             });
         });
     </script>

--- a/app/grandchallenge/reader_studies/urls.py
+++ b/app/grandchallenge/reader_studies/urls.py
@@ -4,6 +4,7 @@ from grandchallenge.reader_studies.views import (
     AddGroundTruthToReaderStudy,
     AddImagesToReaderStudy,
     AddQuestionToReaderStudy,
+    AnswersRemove,
     EditorsUpdate,
     QuestionUpdate,
     ReaderStudyCopy,
@@ -48,6 +49,11 @@ urlpatterns = [
         name="statistics",
     ),
     path("<slug>/copy/", ReaderStudyCopy.as_view(), name="copy",),
+    path(
+        "<slug>/remove-answers/",
+        AnswersRemove.as_view(),
+        name="answers-remove",
+    ),
     path(
         "<slug>/ground-truth/add/",
         AddGroundTruthToReaderStudy.as_view(),

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -5,6 +5,7 @@ import pytest
 from grandchallenge.reader_studies.models import Answer, Question
 from tests.factories import ImageFactory, UserFactory
 from tests.reader_studies_tests.factories import (
+    AnswerFactory,
     CategoricalOptionFactory,
     QuestionFactory,
     ReaderStudyFactory,
@@ -80,3 +81,50 @@ def test_example_ground_truth(client, tmpdir):
             assert Answer.objects.filter(
                 images=image, question=question, is_ground_truth=True
             ).exists()
+
+
+@pytest.mark.django_db
+def test_answer_remove(client):
+    rs = ReaderStudyFactory()
+    r1, r2, editor = UserFactory(), UserFactory(), UserFactory()
+    rs.add_reader(r1)
+    rs.add_reader(r2)
+    rs.add_editor(editor)
+    q = QuestionFactory(
+        reader_study=rs,
+        question_text="q1",
+        answer_type=Question.ANSWER_TYPE_BOOL,
+    )
+    im = ImageFactory()
+    a1 = AnswerFactory(creator=r1, question=q, answer=True)
+    a1.images.set([im])
+    a2 = AnswerFactory(creator=r2, question=q, answer=True)
+    a2.images.set([im])
+    assert Answer.objects.count() == 2
+
+    response = get_view_for_user(
+        viewname="reader-studies:answers-remove",
+        client=client,
+        method=client.post,
+        reverse_kwargs={"slug": rs.slug},
+        data={"user": r1.id},
+        follow=True,
+        user=r1,
+    )
+
+    assert response.status_code == 403
+
+    response = get_view_for_user(
+        viewname="reader-studies:answers-remove",
+        client=client,
+        method=client.post,
+        reverse_kwargs={"slug": rs.slug},
+        data={"user": r1.id},
+        follow=True,
+        user=editor,
+    )
+
+    assert response.status_code == 200
+    assert Answer.objects.count() == 1
+    assert Answer.objects.filter(creator=r1).count() == 0
+    assert Answer.objects.filter(creator=r2).count() == 1


### PR DESCRIPTION
Closes #1111 

I decided against giving editors the `delete_answer` permission for answers in their reader studies, because it would make the permission check on the view more complex and it would add an extra management command that would probably take a long time to run on the production db. 

We want to give all editors permission to remove answers for readers in their reader studies, so while it would semantically be more correct to actually check for the `delete_answer` permission, I think the benefits of simply checking the `change_readerstudy` permission outweigh the negatives of the option.