### PR TITLE
Enhance websocket proxy capture

### DIFF
--- a/dockerfiles/http/nginx.conf.template
+++ b/dockerfiles/http/nginx.conf.template
@@ -161,7 +161,7 @@ http {
       return 200 '443$ref';
     }
 
-    location ~ ^/workstation-proxy/([^/]*)/mlab4d4c4142/(.*)$ {
+    location ~ ^/workstation-proxy/([^/]*)/(.*)mlab4d4c4142/(.*)$ {
       # MeVisLab uses a magic string to determine if this should
       # be routed to the websocket handler, this is handled here
 
@@ -169,7 +169,7 @@ http {
 
       proxy_buffering off;
       proxy_set_header Host $1;
-      proxy_pass http://workstations_websocket/mlab4d4c4142/$2;
+      proxy_pass http://workstations_websocket/mlab4d4c4142/$3;
 
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Current situation: Cirrus workstation does not use MWT options 'webSocketBasePath'. Instead it makes a call to /Settings/webSocketPort, which not only returns the port 443 but also the path needed for GC to correctly proxy the ws request.
SATORI on the other hand uses 'webSocketBasePath' and sets it to the path of window.location. This leads to a URI that includes the workstation initial path. But the nginx location to match 'mlab4d4c4142' URI does not match then.
Solution: cirrus also makes use of 'webSocketBasePath' and the nginx location adds a regex capture to strip everything between the workstation hostname and mlab4d4c4142.

This PR implements the later