### PR TITLE
Adds CloudFront signed URLs for protected storage

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -141,6 +141,7 @@ PRIVATE_S3_STORAGE_KWARGS = {
     "file_overwrite": False,
     "default_acl": "private",
 }
+
 PROTECTED_S3_STORAGE_KWARGS = {
     "access_key": os.environ.get("PROTECTED_S3_STORAGE_ACCESS_KEY", ""),
     "secret_key": os.environ.get("PROTECTED_S3_STORAGE_SECRET_KEY", ""),
@@ -160,6 +161,13 @@ PROTECTED_S3_STORAGE_KWARGS = {
     "file_overwrite": False,
     "default_acl": "private",
 }
+PROTECTED_S3_STORAGE_USE_CLOUDFRONT = strtobool(
+    os.environ.get("PROTECTED_S3_STORAGE_USE_CLOUDFRONT", "False")
+)
+PROTECTED_S3_STORAGE_CLOUDFRONT_DOMAIN = os.environ.get(
+    "PROTECTED_S3_STORAGE_CLOUDFRONT_DOMAIN_NAME", ""
+)
+
 PUBLIC_S3_STORAGE_KWARGS = {
     "access_key": os.environ.get("PUBLIC_S3_STORAGE_ACCESS_KEY", ""),
     "secret_key": os.environ.get("PUBLIC_S3_STORAGE_SECRET_KEY", ""),
@@ -171,6 +179,14 @@ PUBLIC_S3_STORAGE_KWARGS = {
     "querystring_auth": False,
     "default_acl": "public-read",
 }
+
+# Key pair used for signing CloudFront URLS, only used if
+# PROTECTED_S3_STORAGE_USE_CLOUDFRONT is True
+CLOUDFRONT_KEY_PAIR_ID = os.environ.get("CLOUDFRONT_KEY_PAIR_ID", "")
+CLOUDFRONT_PRIVATE_KEY_PATH = os.environ.get("CLOUDFRONT_PRIVATE_KEY_PATH", "")
+CLOUDFRONT_URL_EXPIRY_SECONDS = int(
+    os.environ.get("CLOUDFRONT_URL_EXPIRY_SECONDS", "300")  # 5 mins
+)
 
 ##############################################################################
 #

--- a/app/grandchallenge/core/storage.py
+++ b/app/grandchallenge/core/storage.py
@@ -48,6 +48,13 @@ class PrivateS3Storage(S3Storage):
             *args, config=settings.PRIVATE_S3_STORAGE_KWARGS, **kwargs
         )
 
+    def url(self, *args, **kwargs):
+        """
+        Urls for private storage should never be used, as S3Storage will
+        generate a signed URL which will allow users to download the file.
+        """
+        raise NotImplementedError
+
 
 @deconstructible
 class ProtectedS3Storage(S3Storage):

--- a/app/grandchallenge/serving/views.py
+++ b/app/grandchallenge/serving/views.py
@@ -2,6 +2,7 @@ import posixpath
 import re
 
 from django.conf import settings
+from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.utils._os import safe_join
 from rest_framework.authentication import TokenAuthentication
@@ -52,7 +53,7 @@ def serve_images(request, *, pk, path, pa="", pb=""):
     try:
         image = Image.objects.get(pk=pk)
     except Image.DoesNotExist:
-        raise Http404("File not found.")
+        raise Http404("Image not found.")
 
     try:
         user, _ = TokenAuthentication().authenticate(request)
@@ -64,16 +65,16 @@ def serve_images(request, *, pk, path, pa="", pb=""):
             name=name, internal="internal" in request.GET
         )
 
-    raise Http404("File not found.")
+    raise PermissionDenied
 
 
 def serve_submissions(request, *, submission_pk, **_):
     try:
         submission = Submission.objects.get(pk=submission_pk)
     except Submission.DoesNotExist:
-        raise Http404("File not found.")
+        raise Http404("Submission not found.")
 
     if user_can_download_submission(user=request.user, submission=submission):
         return protected_storage_redirect(name=submission.file.name)
 
-    raise Http404("File not found.")
+    raise PermissionDenied

--- a/app/tests/core_tests/test_storage.py
+++ b/app/tests/core_tests/test_storage.py
@@ -114,3 +114,10 @@ def test_cloudfront_urls(settings, tmpdir):
     )
 
     assert signed_url == expected_url
+
+
+def test_private_storage_url_generation_fails():
+    storage = grandchallenge.core.storage.PrivateS3Storage()
+
+    with pytest.raises(NotImplementedError):
+        storage.url(name="test.jpg")

--- a/app/tests/evaluation_tests/test_tasks.py
+++ b/app/tests/evaluation_tests/test_tasks.py
@@ -29,8 +29,8 @@ def test_submission_evaluation(
     )
 
     # We should not be able to download methods
-    response = client.get(method.image.url)
-    assert response.status_code == 404
+    with pytest.raises(NotImplementedError):
+        _ = method.image.url
 
     num_containers_before = len(dockerclient.containers.list())
     num_volumes_before = len(dockerclient.volumes.list())

--- a/app/tests/serving_tests/test_views.py
+++ b/app/tests/serving_tests/test_views.py
@@ -1,5 +1,6 @@
+from textwrap import dedent
+
 import pytest
-from django.conf import settings
 from guardian.shortcuts import assign_perm
 
 from grandchallenge.datasets.models import AnnotationSet, ImageSet
@@ -38,21 +39,21 @@ def test_imageset_annotationset_download(
         #   annotation response - testing gt,
         #   user
         # )
-        (404, 404, None),
-        (404, 404, UserFactory()),
-        (404, 404, UserFactory(is_staff=True)),
-        (404, 404, two_challenge_sets.challenge_set_1.non_participant),
-        (200, 404, two_challenge_sets.challenge_set_1.participant),
-        (200, 404, two_challenge_sets.challenge_set_1.participant1),
+        (403, 403, None),
+        (403, 403, UserFactory()),
+        (403, 403, UserFactory(is_staff=True)),
+        (403, 403, two_challenge_sets.challenge_set_1.non_participant),
+        (200, 403, two_challenge_sets.challenge_set_1.participant),
+        (200, 403, two_challenge_sets.challenge_set_1.participant1),
         (200, 200, two_challenge_sets.challenge_set_1.creator),
         (200, 200, two_challenge_sets.challenge_set_1.admin),
-        (404, 404, two_challenge_sets.challenge_set_2.non_participant),
-        (404, 404, two_challenge_sets.challenge_set_2.participant),
-        (404, 404, two_challenge_sets.challenge_set_2.participant1),
-        (404, 404, two_challenge_sets.challenge_set_2.creator),
-        (404, 404, two_challenge_sets.challenge_set_2.admin),
+        (403, 403, two_challenge_sets.challenge_set_2.non_participant),
+        (403, 403, two_challenge_sets.challenge_set_2.participant),
+        (403, 403, two_challenge_sets.challenge_set_2.participant1),
+        (403, 403, two_challenge_sets.challenge_set_2.creator),
+        (403, 403, two_challenge_sets.challenge_set_2.admin),
         (200, 200, two_challenge_sets.admin12),
-        (200, 404, two_challenge_sets.participant12),
+        (200, 403, two_challenge_sets.participant12),
         (200, 200, two_challenge_sets.admin1participant2),
     ]
 
@@ -77,7 +78,35 @@ def test_imageset_annotationset_download(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("internal", (True, False))
-def test_image_response(client, internal):
+@pytest.mark.parametrize("cloudfront", (True, False))
+def test_image_response(client, internal, settings, cloudfront, tmpdir):
+    pem = tmpdir.join("cf.pem")
+    pem.write(
+        dedent(
+            """
+            -----BEGIN RSA PRIVATE KEY-----
+            MIICXQIBAAKBgQDA7ki9gI/lRygIoOjV1yymgx6FYFlzJ+z1ATMaLo57nL57AavW
+            hb68HYY8EA0GJU9xQdMVaHBogF3eiCWYXSUZCWM/+M5+ZcdQraRRScucmn6g4EvY
+            2K4W2pxbqH8vmUikPxir41EeBPLjMOzKvbzzQy9e/zzIQVREKSp/7y1mywIDAQAB
+            AoGABc7mp7XYHynuPZxChjWNJZIq+A73gm0ASDv6At7F8Vi9r0xUlQe/v0AQS3yc
+            N8QlyR4XMbzMLYk3yjxFDXo4ZKQtOGzLGteCU2srANiLv26/imXA8FVidZftTAtL
+            viWQZBVPTeYIA69ATUYPEq0a5u5wjGyUOij9OWyuy01mbPkCQQDluYoNpPOekQ0Z
+            WrPgJ5rxc8f6zG37ZVoDBiexqtVShIF5W3xYuWhW5kYb0hliYfkq15cS7t9m95h3
+            1QJf/xI/AkEA1v9l/WN1a1N3rOK4VGoCokx7kR2SyTMSbZgF9IWJNOugR/WZw7HT
+            njipO3c9dy1Ms9pUKwUF46d7049ck8HwdQJARgrSKuLWXMyBH+/l1Dx/I4tXuAJI
+            rlPyo+VmiOc7b5NzHptkSHEPfR9s1OK0VqjknclqCJ3Ig86OMEtEFBzjZQJBAKYz
+            470hcPkaGk7tKYAgP48FvxRsnzeooptURW5E+M+PQ2W9iDPPOX9739+Xi02hGEWF
+            B0IGbQoTRFdE4VVcPK0CQQCeS84lODlC0Y2BZv2JxW3Osv/WkUQ4dslfAQl1T303
+            7uwwr7XTroMv8dIFQIPreoPhRKmd/SbJzbiKfS/4QDhU
+            -----END RSA PRIVATE KEY-----
+            """
+        )
+    )
+
+    settings.CLOUDFRONT_PRIVATE_KEY_PATH = pem.strpath
+    settings.CLOUDFRONT_KEY_PAIR_ID = "PK123456789754"
+    settings.PROTECTED_S3_STORAGE_USE_CLOUDFRONT = cloudfront
+
     image_file = ImageFileFactory()
     user = UserFactory()
 
@@ -91,7 +120,7 @@ def test_image_response(client, internal):
     )
 
     # Forbidden view
-    assert response.status_code == 404
+    assert response.status_code == 403
     assert not response.has_header("x-accel-redirect")
 
     assign_perm("view_image", user, image_file.image)
@@ -100,29 +129,39 @@ def test_image_response(client, internal):
         url=image_file.file.url, client=client, user=user, data=data
     )
 
-    if internal:
+    if internal or cloudfront:
         assert response.status_code == 302
         assert not response.has_header("x-accel-redirect")
 
         redirect = response.url
-
-        assert redirect.startswith(
-            f"{settings.PROTECTED_S3_STORAGE_KWARGS['endpoint_url']}/"
-            f"{settings.PROTECTED_S3_STORAGE_KWARGS['bucket_name']}/"
-        )
     else:
         assert response.status_code == 200
         assert response.has_header("x-accel-redirect")
 
         redirect = response.get("x-accel-redirect")
 
+    if cloudfront:
         assert redirect.startswith(
-            f"/{settings.PROTECTED_S3_STORAGE_KWARGS['bucket_name']}/"
+            f"https://{settings.PROTECTED_S3_STORAGE_CLOUDFRONT_DOMAIN}/"
         )
 
-    assert "AWSAccessKeyId" in redirect
-    assert "Signature" in redirect
-    assert "Expires" in redirect
+        assert "AWSAccessKeyId" not in redirect
+        assert "Signature" in redirect
+        assert "Expires" in redirect
+    else:
+        if internal:
+            assert redirect.startswith(
+                f"{settings.PROTECTED_S3_STORAGE_KWARGS['endpoint_url']}/"
+                f"{settings.PROTECTED_S3_STORAGE_KWARGS['bucket_name']}/"
+            )
+        else:
+            assert redirect.startswith(
+                f"/{settings.PROTECTED_S3_STORAGE_KWARGS['bucket_name']}/"
+            )
+
+        assert "AWSAccessKeyId" in redirect
+        assert "Signature" in redirect
+        assert "Expires" in redirect
 
 
 @pytest.mark.django_db
@@ -138,19 +177,19 @@ def test_submission_download(client, two_challenge_sets):
         #   image response + annotation response not test ground truth,
         #   user
         # )
-        (404, None),
-        (404, two_challenge_sets.challenge_set_1.non_participant),
-        (404, two_challenge_sets.challenge_set_1.participant),
-        (404, two_challenge_sets.challenge_set_1.participant1),
+        (403, None),
+        (403, two_challenge_sets.challenge_set_1.non_participant),
+        (403, two_challenge_sets.challenge_set_1.participant),
+        (403, two_challenge_sets.challenge_set_1.participant1),
         (200, two_challenge_sets.challenge_set_1.creator),
         (200, two_challenge_sets.challenge_set_1.admin),
-        (404, two_challenge_sets.challenge_set_2.non_participant),
-        (404, two_challenge_sets.challenge_set_2.participant),
-        (404, two_challenge_sets.challenge_set_2.participant1),
-        (404, two_challenge_sets.challenge_set_2.creator),
-        (404, two_challenge_sets.challenge_set_2.admin),
+        (403, two_challenge_sets.challenge_set_2.non_participant),
+        (403, two_challenge_sets.challenge_set_2.participant),
+        (403, two_challenge_sets.challenge_set_2.participant1),
+        (403, two_challenge_sets.challenge_set_2.creator),
+        (403, two_challenge_sets.challenge_set_2.admin),
         (200, two_challenge_sets.admin12),
-        (404, two_challenge_sets.participant12),
+        (403, two_challenge_sets.participant12),
         (200, two_challenge_sets.admin1participant2),
     ]
 


### PR DESCRIPTION
Includes test modified from https://github.com/boto/boto/blob/master/tests/unit/cloudfront/test_signed_urls.py#L356 and based on example code from https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudfront.html#id57