### PR TITLE
Workstation region assignments

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -706,7 +706,7 @@ WORKSTATION_INTERNAL_NETWORK = strtobool(
 )
 # Which regions are available for workstations to run in
 WORKSTATIONS_ACTIVE_REGIONS = os.environ.get(
-    "WORKSTATIONS_ACTIVE_REGIONS", "eu-central-1,ap-northeast-1"
+    "WORKSTATIONS_ACTIVE_REGIONS", "eu-central-1"
 ).split(",")
 WORKSTATIONS_RENDERING_SUBDOMAINS = {
     # Possible AWS regions

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -706,7 +706,7 @@ WORKSTATION_INTERNAL_NETWORK = strtobool(
 )
 # Which regions are available for workstations to run in
 WORKSTATIONS_ACTIVE_REGIONS = os.environ.get(
-    "WORKSTATIONS_ACTIVE_REGIONS", "eu-nl-1"
+    "WORKSTATIONS_ACTIVE_REGIONS", "eu-central-1,ap-northeast-1"
 ).split(",")
 WORKSTATIONS_RENDERING_SUBDOMAINS = {
     # Possible AWS regions

--- a/app/grandchallenge/algorithms/templates/algorithms/result_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/result_list.html
@@ -85,7 +85,7 @@
                         <ul class="list-unstyled">
                             {% if result.job.image %}
                                 <li>
-                                    <a href="{% url 'workstations:workstation-session-redirect' slug=algorithm.workstation.slug %}?{% workstation_query algorithm_result=result config=algorithm.workstation_config %}">
+                                    <a href="{% url 'workstations:workstation-session-create' slug=algorithm.workstation.slug %}?{% workstation_query algorithm_result=result config=algorithm.workstation_config %}">
                                         <span class="badge badge-primary"
                                               title="View algorithm result">
                                             <i class="fa fa-eye"></i> View Result

--- a/app/grandchallenge/archives/templates/archives/archive_cases_list.html
+++ b/app/grandchallenge/archives/templates/archives/archive_cases_list.html
@@ -55,7 +55,7 @@
                     </td>
                     <td>{{ object.origin.creator|user_profile_link }}</td>
                     <td>
-                        <a href="{% url 'workstations:workstation-session-redirect' slug=archive.workstation.slug %}?{% workstation_query image=object config=archive.workstation_config %}">
+                        <a href="{% url 'workstations:workstation-session-create' slug=archive.workstation.slug %}?{% workstation_query image=object config=archive.workstation_config %}">
                             <span class="badge badge-primary">
                                 <i class="fa fa-eye"></i> View Case
                             </span>

--- a/app/grandchallenge/cases/templates/cases/rawimageuploadsession_detail.html
+++ b/app/grandchallenge/cases/templates/cases/rawimageuploadsession_detail.html
@@ -83,7 +83,7 @@
                             </ul>
                         </td>
                         <td>
-                            <a href="{% url 'workstations:default-session-redirect' %}?{% workstation_query image=image %}">
+                            <a href="{% url 'workstations:default-session-create' %}?{% workstation_query image=image %}">
                                 <span class="badge badge-primary">
                                     <i class="fa fa-eye"></i> View Image
                                 </span>

--- a/app/grandchallenge/datasets/templates/datasets/annotationset_detail.html
+++ b/app/grandchallenge/datasets/templates/datasets/annotationset_detail.html
@@ -69,10 +69,10 @@
             {% for match in object.matched_images %}
                 <tr>
                     <td>{{ match.key }}</td>
-                    <td><a href="{% url 'workstations:default-session-redirect' %}?{% workstation_query image=match.base overlay=match.annotation %}"
+                    <td><a href="{% url 'workstations:default-session-create' %}?{% workstation_query image=match.base overlay=match.annotation %}"
                            title="View Image and Annotation">{{ match.base }}</a>
                     </td>
-                    <td><a href="{% url 'workstations:default-session-redirect' %}?{% workstation_query image=match.base overlay=match.annotation %}"
+                    <td><a href="{% url 'workstations:default-session-create' %}?{% workstation_query image=match.base overlay=match.annotation %}"
                            title="View Image and Annotation">{{ match.annotation }}</a>
                     </td>
                 </tr>
@@ -152,7 +152,7 @@
             {% for match in object.matched_labels %}
                 <tr>
                     <td>{{ match.key }}</td>
-                    <td><a href="{% url 'workstations:default-session-redirect' %}?{% workstation_query image=match.base %}"
+                    <td><a href="{% url 'workstations:default-session-create' %}?{% workstation_query image=match.base %}"
                            title="View Image">{{ match.base }}</a>
                     </td>
                     <td><{{ match.label }}</td>

--- a/app/grandchallenge/datasets/templates/datasets/imageset_detail.html
+++ b/app/grandchallenge/datasets/templates/datasets/imageset_detail.html
@@ -67,7 +67,7 @@
             {% for im in object.images_with_keys %}
                 <tr>
                     <td>{{ im.key }}</td>
-                    <td><a href="{% url 'workstations:default-session-redirect' %}?{% workstation_query image=im.image %}"
+                    <td><a href="{% url 'workstations:default-session-create' %}?{% workstation_query image=im.image %}"
                            title="View Image">{{ im.image }}</a></td>
                 </tr>
             {% endfor %}

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -153,7 +153,7 @@
             {% if user_is_reader and object.is_valid %}
                 <p>
                     <a class="btn btn-primary"
-                       href="{% url 'workstations:workstation-session-redirect' slug=object.workstation.slug %}?{% workstation_query reader_study=object %}">
+                       href="{% url 'workstations:workstation-session-create' slug=object.workstation.slug %}?{% workstation_query reader_study=object %}">
                         <i class="fas fa-eye"></i> Launch this Reader Study
                     </a>
                 </p>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_statistics.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_statistics.html
@@ -42,7 +42,7 @@
                             <td data-order="{{ ground_truth }}">{{ ground_truth }}</td>
                         {% endfor %}
                         <td data-order="{{ entry.images__name }}">
-                            <a href="{% url 'workstations:workstation-session-redirect' slug=object.workstation.slug %}?{% workstation_query image=entry.images__pk config=object.workstation_config %}">
+                            <a href="{% url 'workstations:workstation-session-create' slug=object.workstation.slug %}?{% workstation_query image=entry.images__pk config=object.workstation_config %}">
                                 <span class="badge badge-primary">
                                     <i class="fa fa-eye"></i>
                                 </span>

--- a/app/grandchallenge/workstations/forms.py
+++ b/app/grandchallenge/workstations/forms.py
@@ -67,6 +67,11 @@ class SessionForm(ModelForm):
         ],
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.attrs.update({"class": "d-none"})
+
     class Meta:
         model = Session
         fields = ("region",)

--- a/app/grandchallenge/workstations/forms.py
+++ b/app/grandchallenge/workstations/forms.py
@@ -15,7 +15,11 @@ from guardian.utils import get_anonymous_user
 from grandchallenge.core.forms import SaveFormInitMixin
 from grandchallenge.core.validators import ExtensionValidator
 from grandchallenge.jqfileupload.widgets import uploader
-from grandchallenge.workstations.models import Workstation, WorkstationImage
+from grandchallenge.workstations.models import (
+    Session,
+    Workstation,
+    WorkstationImage,
+)
 
 
 class WorkstationForm(SaveFormInitMixin, ModelForm):
@@ -51,6 +55,21 @@ class WorkstationImageForm(ModelForm):
             "websocket_port",
             "chunked_upload",
         )
+
+
+class SessionForm(ModelForm):
+    region = ChoiceField(
+        required=True,
+        choices=[
+            c
+            for c in Session.Region.choices
+            if c[0] in settings.WORKSTATIONS_ACTIVE_REGIONS
+        ],
+    )
+
+    class Meta:
+        model = Session
+        fields = ("region",)
 
 
 class UserGroupForm(SaveFormInitMixin, Form):

--- a/app/grandchallenge/workstations/models.py
+++ b/app/grandchallenge/workstations/models.py
@@ -505,6 +505,10 @@ class Session(UUIDModel):
         """Save the session instance, starting or stopping the service if needed."""
         created = self._state.adding
 
+        if created and not self.region:
+            # Launch in the first active region if no preference set
+            self.region = settings.WORKSTATIONS_ACTIVE_REGIONS[0]
+
         super().save(*args, **kwargs)
 
         if created:

--- a/app/grandchallenge/workstations/static/workstations/js/session-region.js
+++ b/app/grandchallenge/workstations/static/workstations/js/session-region.js
@@ -1,7 +1,14 @@
+function setModalLoadingMessage(msg) {
+    document.getElementById("sessionStateMsg").innerHTML = msg;
+}
+
 $(document).ready(function () {
+    const session_modal = $("#sessionModal");
+
+    session_modal.modal({show: true});
+
     const ping_endpoint = JSON.parse(document.getElementById("ping-endpoint-data").textContent);
     const region_selection = document.getElementById("id_region");
-
     const urls = [...region_selection.options].map(function (o) {
         return `https://${o.value}.${ping_endpoint}`
     });
@@ -14,24 +21,26 @@ $(document).ready(function () {
                         return response.ok ? response : Promise.reject(response)
                     }
                 )
+                .catch(
+                    // Nothing resolved
+                    error => console.log(error)
+                )
         )
     )
         .then(
             response => {
-                let regexp = /^https:\/\/([\w-]+).*/;
-                let m = response.url.match(regexp);
+                if (response !== undefined) {
+                    // If we have a match, find out what server this is for
+                    let regexp = /^https:\/\/([\w-]+).*/;
+                    let m = response.url.match(regexp);
 
-                if (m !== undefined) {
-                    region_selection.value = m[1];
-
-                    console.log(`Selected ${m[1]}`);
-
-                    // region_selection.form.submit();
+                    if (m !== undefined) {
+                        region_selection.value = m[1];
+                    }
                 }
+
+                setModalLoadingMessage(`Connecting to ${region_selection.value}...`);
+                region_selection.form.submit();
             }
         )
-        .catch(
-            // Nothing resolved
-            error => console.log(error)
-        );
 })

--- a/app/grandchallenge/workstations/static/workstations/js/session-region.js
+++ b/app/grandchallenge/workstations/static/workstations/js/session-region.js
@@ -1,0 +1,37 @@
+$(document).ready(function () {
+    const ping_endpoint = JSON.parse(document.getElementById("ping-endpoint-data").textContent);
+    const region_selection = document.getElementById("id_region");
+
+    const urls = [...region_selection.options].map(function (o) {
+        return `https://${o.value}.${ping_endpoint}`
+    });
+
+    Promise.race(
+        urls.map(
+            u => fetch(u)
+                .then(
+                    response => {
+                        return response.ok ? response : Promise.reject(response)
+                    }
+                )
+        )
+    )
+        .then(
+            response => {
+                let regexp = /^https:\/\/([\w-]+).*/;
+                let m = response.url.match(regexp);
+
+                if (m !== undefined) {
+                    region_selection.value = m[1];
+
+                    console.log(`Selected ${m[1]}`);
+
+                    // region_selection.form.submit();
+                }
+            }
+        )
+        .catch(
+            // Nothing resolved
+            error => console.log(error)
+        );
+})

--- a/app/grandchallenge/workstations/templates/workstations/session_form.html
+++ b/app/grandchallenge/workstations/templates/workstations/session_form.html
@@ -15,11 +15,17 @@
                 href="{{ object.get_absolute_url }}">{{ object }}</a>
         </li>
         <li class="breadcrumb-item active"
-            aria-current="page">Create Session</li>
+            aria-current="page">Create Session
+        </li>
     </ol>
 {% endblock %}
 
 {% block content %}
     <h2>Create Session</h2>
+
+    {% if unsupported_browser_message %}
+        <div class="alert alert-danger">{{ unsupported_browser_message }}</div>
+    {% endif %}
+
     {% crispy form %}
 {% endblock %}

--- a/app/grandchallenge/workstations/templates/workstations/session_form.html
+++ b/app/grandchallenge/workstations/templates/workstations/session_form.html
@@ -9,10 +9,10 @@
         <li class="breadcrumb-item"><a href="{% url 'workstations:list' %}">Workstations</a>
         </li>
         <li class="breadcrumb-item"><a
-                href="{{ object.workstation_image.workstation.get_absolute_url }}">{{ object.workstation_image.workstation.title }}</a>
+                href="{{ object.workstation.get_absolute_url }}">{{ object.workstation.title }}</a>
         </li>
         <li class="breadcrumb-item"><a
-                href="{{ object.workstation_image.get_absolute_url }}">{{ object.workstation_image }}</a>
+                href="{{ object.get_absolute_url }}">{{ object }}</a>
         </li>
         <li class="breadcrumb-item active"
             aria-current="page">Create Session</li>

--- a/app/grandchallenge/workstations/templates/workstations/session_form.html
+++ b/app/grandchallenge/workstations/templates/workstations/session_form.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags %}
+{% load static %}
 
 {% block title %}Create Session - {{ block.super }}{% endblock %}
 
@@ -28,4 +29,15 @@
     {% endif %}
 
     {% crispy form %}
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+
+    {{ ping_endpoint|json_script:"ping-endpoint-data" }}
+
+    <script src="{% static 'workstations/js/session-region.js' %}"
+            type="text/javascript">
+    </script>
+
 {% endblock %}

--- a/app/grandchallenge/workstations/templates/workstations/session_form.html
+++ b/app/grandchallenge/workstations/templates/workstations/session_form.html
@@ -29,6 +29,25 @@
     {% endif %}
 
     {% crispy form %}
+
+    <div class="modal fade" id="sessionModal" tabindex="-1"
+         data-keyboard="false" data-backdrop="static" role="dialog"
+         aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content" id="sessionState">
+                <div class="modal-body" id="sessionStateBody">
+                    <div class="d-flex align-items-center">
+                        <span class="spinner-border"
+                              role="status"
+                              aria-hidden="true"></span>
+                        <b class="ml-3" id="sessionStateMsg">
+                            Determining best available server...
+                        </b>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}
 
 {% block script %}

--- a/app/grandchallenge/workstations/templates/workstations/workstation_detail.html
+++ b/app/grandchallenge/workstations/templates/workstations/workstation_detail.html
@@ -162,14 +162,9 @@
 
         <h3>Sessions</h3>
 
-        <form method="post"
-              action="{% url 'workstations:session-create' slug=object.slug %}">
-            {% csrf_token %}
-            <button type="submit"
-                    class="btn btn-primary">
-                <i class="fas fa-flask"></i> Start a new session
-            </button>
-        </form>
+        <a class="btn btn-primary" href="{% url 'workstations:workstation-session-create' slug=object.slug %}">
+            <i class="fas fa-flask"></i> Start a new session
+        </a>
 
     {% endif %}
 {% endblock %}

--- a/app/grandchallenge/workstations/urls.py
+++ b/app/grandchallenge/workstations/urls.py
@@ -2,7 +2,6 @@ from django.urls import path
 
 from grandchallenge.workstations.views import (
     SessionCreate,
-    SessionRedirectView,
     WorkstationCreate,
     WorkstationDetail,
     WorkstationEditorsUpdate,
@@ -25,18 +24,21 @@ urlpatterns = [
         name="users-autocomplete",
     ),
     path("create/", WorkstationCreate.as_view(), name="create"),
+    # TODO - add region
     path(
-        "load/", SessionRedirectView.as_view(), name="default-session-redirect"
+        "sessions/create/",
+        SessionCreate.as_view(),
+        name="default-session-create",
     ),
     path(
-        "<slug>/load/",
-        SessionRedirectView.as_view(),
-        name="workstation-session-redirect",
+        "<slug>/sessions/create/",
+        SessionCreate.as_view(),
+        name="workstation-session-create",
     ),
     path(
-        "<slug>/images/<uuid:pk>/load/",
-        SessionRedirectView.as_view(),
-        name="workstation-image-session-redirect",
+        "<slug>/<uuid:pk>/sessions/create/",
+        SessionCreate.as_view(),
+        name="workstation-image-session-create",
     ),
     path(
         "<slug>/editors/update/",
@@ -64,10 +66,5 @@ urlpatterns = [
         "<slug>/images/<uuid:pk>/update/",
         WorkstationImageUpdate.as_view(),
         name="image-update",
-    ),
-    path(
-        "<slug>/sessions/create/",
-        SessionCreate.as_view(),
-        name="session-create",
     ),
 ]

--- a/app/grandchallenge/workstations/utils.py
+++ b/app/grandchallenge/workstations/utils.py
@@ -1,5 +1,3 @@
-from random import choice
-
 from django.conf import settings
 from django.http import Http404
 from django.shortcuts import get_object_or_404
@@ -12,7 +10,7 @@ from grandchallenge.workstations.models import (
 
 
 def get_or_create_active_session(
-    *, user, workstation_image: WorkstationImage
+    *, user, workstation_image: WorkstationImage, region: str,
 ) -> Session:
     """
     Queries the database to see if there is an active session for this user and
@@ -35,19 +33,15 @@ def get_or_create_active_session(
             creator=user,
             status__in=[Session.QUEUED, Session.STARTED, Session.RUNNING],
             workstation_image=workstation_image,
+            region=region,
         )
         .order_by("-created")
         .first()
     )
 
     if session is None:
-        # Start a session in one of the available regions. In the future,
-        # rather than doing a random choice here we could look at the
-        # region with the least connections, or the region closest to the user.
         session = Session.objects.create(
-            creator=user,
-            workstation_image=workstation_image,
-            region=choice(settings.WORKSTATIONS_ACTIVE_REGIONS),
+            creator=user, workstation_image=workstation_image, region=region,
         )
 
     return session

--- a/app/grandchallenge/workstations/views.py
+++ b/app/grandchallenge/workstations/views.py
@@ -38,6 +38,7 @@ from grandchallenge.core.permissions.rest_framework import (
 )
 from grandchallenge.workstations.forms import (
     EditorsForm,
+    SessionForm,
     UsersForm,
     WorkstationForm,
     WorkstationImageForm,
@@ -257,7 +258,7 @@ class SessionCreate(
     LoginRequiredMixin, ObjectPermissionRequiredMixin, CreateView
 ):
     model = Session
-    fields = []
+    form_class = SessionForm
     permission_required = (
         f"{Workstation._meta.app_label}.view_{Workstation._meta.model_name}"
     )
@@ -277,7 +278,9 @@ class SessionCreate(
 
     def form_valid(self, form):
         session = get_or_create_active_session(
-            user=self.request.user, workstation_image=self.workstation_image
+            user=self.request.user,
+            workstation_image=self.workstation_image,
+            region=form.cleaned_data["region"],
         )
 
         url = session.get_absolute_url()

--- a/app/grandchallenge/workstations/views.py
+++ b/app/grandchallenge/workstations/views.py
@@ -317,7 +317,12 @@ class SessionCreate(
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data()
-        context.update({"object": self.workstation_image})
+        context.update(
+            {
+                "object": self.workstation_image,
+                "ping_endpoint": f"{self.request.site.domain.lower()}/ping",
+            }
+        )
         return context
 
     def form_valid(self, form):

--- a/app/tests/workstations_tests/test_permissions.py
+++ b/app/tests/workstations_tests/test_permissions.py
@@ -97,7 +97,11 @@ def test_workstation_editor_permissions(
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "viewname",
-    ["workstations:detail", "workstations:session-create", "session-detail"],
+    [
+        "workstations:detail",
+        "workstations:workstation-session-create",
+        "session-detail",
+    ],
 )
 def test_workstation_user_permissions(client, two_workstation_sets, viewname):
     tests = (
@@ -109,6 +113,9 @@ def test_workstation_user_permissions(client, two_workstation_sets, viewname):
         (UserFactory(is_staff=True), 403),
         (None, 302),
     )
+
+    two_workstation_sets.ws1.image.ready = True
+    two_workstation_sets.ws1.image.save()
 
     kwargs = {"slug": two_workstation_sets.ws1.workstation.slug}
 
@@ -134,9 +141,9 @@ def test_workstation_user_permissions(client, two_workstation_sets, viewname):
 @pytest.mark.parametrize(
     "viewname",
     [
-        "workstations:default-session-redirect",
-        "workstations:workstation-session-redirect",
-        "workstations:workstation-image-session-redirect",
+        "workstations:default-session-create",
+        "workstations:workstation-session-create",
+        "workstations:workstation-image-session-create",
     ],
 )
 def test_workstation_redirect_permissions(
@@ -163,12 +170,12 @@ def test_workstation_redirect_permissions(
     kwargs = {}
 
     if viewname in [
-        "workstations:workstation-session-redirect",
-        "workstations:workstation-image-session-redirect",
+        "workstations:workstation-session-create",
+        "workstations:workstation-image-session-create",
     ]:
         kwargs.update({"slug": two_workstation_sets.ws1.workstation.slug})
 
-    if viewname == "workstations:workstation-image-session-redirect":
+    if viewname == "workstations:workstation-image-session-create":
         kwargs.update({"pk": two_workstation_sets.ws1.image.pk})
 
     for test in tests:
@@ -177,6 +184,7 @@ def test_workstation_redirect_permissions(
             client=client,
             user=test[0],
             reverse_kwargs=kwargs,
+            method=client.post,
         )
         assert response.status_code == test[1]
 

--- a/app/tests/workstations_tests/test_permissions.py
+++ b/app/tests/workstations_tests/test_permissions.py
@@ -185,6 +185,7 @@ def test_workstation_redirect_permissions(
             user=test[0],
             reverse_kwargs=kwargs,
             method=client.post,
+            data={"region": "eu-central-1"},
         )
         assert response.status_code == test[1]
 

--- a/app/tests/workstations_tests/test_utils.py
+++ b/app/tests/workstations_tests/test_utils.py
@@ -21,19 +21,25 @@ def test_get_or_create_active_session():
 
     assert Session.objects.all().count() == 0
 
-    s = get_or_create_active_session(user=user, workstation_image=wsi)
+    s = get_or_create_active_session(
+        user=user, workstation_image=wsi, region="eu-central-1"
+    )
 
     assert s.workstation_image == wsi
     assert s.creator == user
     assert Session.objects.all().count() == 1
 
     # Same workstation image and user
-    s_1 = get_or_create_active_session(user=user, workstation_image=wsi)
+    s_1 = get_or_create_active_session(
+        user=user, workstation_image=wsi, region="eu-central-1"
+    )
     assert s == s_1
 
     # Different workstation image, same user
     wsi_1 = WorkstationImageFactory()
-    s_2 = get_or_create_active_session(user=user, workstation_image=wsi_1)
+    s_2 = get_or_create_active_session(
+        user=user, workstation_image=wsi_1, region="eu-central-1"
+    )
 
     assert s_2.workstation_image == wsi_1
     assert s_2.creator == user
@@ -42,7 +48,9 @@ def test_get_or_create_active_session():
 
     # Same workstation image, different user
     user_1 = UserFactory()
-    s_3 = get_or_create_active_session(user=user_1, workstation_image=wsi)
+    s_3 = get_or_create_active_session(
+        user=user_1, workstation_image=wsi, region="eu-central-1"
+    )
     assert s_3.workstation_image == wsi
     assert s_3.creator == user_1
     assert Session.objects.all().count() == 3
@@ -51,7 +59,9 @@ def test_get_or_create_active_session():
     s.status = s.STOPPED
     s.save()
 
-    s_4 = get_or_create_active_session(user=user, workstation_image=wsi)
+    s_4 = get_or_create_active_session(
+        user=user, workstation_image=wsi, region="eu-central-1"
+    )
     assert s_4.workstation_image == wsi
     assert s_4.creator == user
     assert Session.objects.all().count() == 4

--- a/app/tests/workstations_tests/test_views.py
+++ b/app/tests/workstations_tests/test_views.py
@@ -239,7 +239,7 @@ def test_session_create(client):
     response = get_view_for_user(
         client=client,
         method=client.post,
-        viewname="workstations:session-create",
+        viewname="workstations:workstation-session-create",
         reverse_kwargs={"slug": ws.slug},
         user=user,
     )
@@ -266,7 +266,8 @@ def test_session_redirect(client):
 
     response = get_view_for_user(
         client=client,
-        viewname="workstations:default-session-redirect",
+        method=client.post,
+        viewname="workstations:default-session-create",
         user=user,
     )
 

--- a/app/tests/workstations_tests/test_views.py
+++ b/app/tests/workstations_tests/test_views.py
@@ -242,6 +242,7 @@ def test_session_create(client):
         viewname="workstations:workstation-session-create",
         reverse_kwargs={"slug": ws.slug},
         user=user,
+        data={"region": "eu-central-1"},
     )
 
     assert response.status_code == 302
@@ -269,6 +270,7 @@ def test_session_redirect(client):
         method=client.post,
         viewname="workstations:default-session-create",
         user=user,
+        data={"region": "eu-central-1"},
     )
 
     assert response.status_code == 302

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,7 +195,7 @@ services:
       <<: *protected_storage_credentials
       PYTHONDONTWRITEBYTECODE: 1
     restart: always
-    command: "celery -A config worker -l info -Q evaluation,images,workstations-eu-nl-1 -c 1"
+    command: "celery -A config worker -l info -Q evaluation,images,workstations-eu-central-1 -c 1"
     scale: 1
     hostname: "celery-worker-evaluation"
     depends_on:

--- a/dockerfiles/http/nginx.conf.template
+++ b/dockerfiles/http/nginx.conf.template
@@ -141,6 +141,17 @@ http {
       return 301 $scheme://${SERVER_NAME}/challenges/;
     }
 
+    location =/ping {
+      # Used for determining if a workstation rendering region is active
+
+      add_header 'Access-Control-Allow-Origin' 'https://${SERVER_NAME}';
+
+      expires -1;
+
+      add_header Content-Type text/plain;
+      return 200 'healthy';
+    }
+
     location =/Settings/webSocketPort {
       # MeVisLab will query this endpoint to find out how to connect to the
       # websocket. It assumes that each worker gets its own host, which is


### PR DESCRIPTION
This PR:

- Removes the workstation session redirect view, instead uses the create view which is doing a get or create for a running session for that user in the requested region
- Adds region assignment to the create view
- Adds a ping endpoint with CORS for the main domain to nginx
- Automatically determine the region

This PR does not let you override the region, but on failure will launch in the default region. Overrides can follow later if needed (I will use a vpn for now).

Fixes #888 
Closes #1382 