### PR TITLE
Expose minio to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     environment:
       MINIO_ACCESS_KEY: minioprivate
       MINIO_SECRET_KEY: minioprivate12345
-    expose:
-      - 9000
     entrypoint: "/bin/sh"
     command: >-
       -c "
@@ -50,13 +48,13 @@ services:
     environment:
       MINIO_ACCESS_KEY: minioprotected
       MINIO_SECRET_KEY: minioprotected12345
-    expose:
-      - 9000
+    ports:
+      - "9001:9001"
     entrypoint: "/bin/sh"
     command: >-
       -c "
       mkdir -p /data/grand-challenge-protected/
-      && minio --compat server /data
+      && minio --compat server --address :9001 /data
       "
     restart: always
 
@@ -87,7 +85,7 @@ services:
       <<: &protected_storage_credentials
         PROTECTED_S3_STORAGE_ACCESS_KEY: minioprotected
         PROTECTED_S3_STORAGE_SECRET_KEY: minioprotected12345
-        PROTECTED_S3_STORAGE_ENDPOINT_URL: http://minio-protected:9000
+        PROTECTED_S3_STORAGE_ENDPOINT_URL: http://minio-protected:9001
       PUBLIC_S3_STORAGE_ACCESS_KEY: miniopublic
       PUBLIC_S3_STORAGE_SECRET_KEY: miniopublic12345
       PYTHONDONTWRITEBYTECODE: 1

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -23,6 +23,12 @@ Installation
     $ git clone https://github.com/comic/grand-challenge.org
     $ cd grand-challenge.org
 
+3. Add the following to your ``/etc/hosts`` file:
+
+.. code-block:: console
+
+    127.0.0.1 minio-protected
+
 3. You can then start the site by invoking
 
 .. code-block:: console
@@ -54,9 +60,11 @@ Running Grand-Challenge within a Windows environment requires additional steps b
 
     # Using Docker for Windows:
     127.0.0.1 gc.localhost
+    127.0.0.1 minio-protected
 
     # Using Docker Toolbox:
     192.168.99.100 gc.localhost
+    192.168.99.100 minio-protected
 
 
 4. Share the drive where this repository is located with Docker


### PR DESCRIPTION
Note: this also updates the documentation. In order to access the protected objects both windows and linux users will need to add minio-protected to their hosts file.

Fixes #1381