### PR TITLE
Replace deprecated tostring with tobytes

### DIFF
--- a/app/grandchallenge/cases/image_builders/dicom.py
+++ b/app/grandchallenge/cases/image_builders/dicom.py
@@ -313,7 +313,7 @@ def _create_itk_from_dcm(
     # anymore. Then create a SimpleITK image from it.
     with tempfile.NamedTemporaryFile() as temp:
         temp.seek(0)
-        temp.write(dcm_array.tostring())
+        temp.write(dcm_array.tobytes())
         temp.flush()
         temp.seek(0)
 

--- a/app/pytest.ini
+++ b/app/pytest.ini
@@ -12,5 +12,6 @@ filterwarnings =
     ignore::PendingDeprecationWarning:crispy_forms
     ignore::PendingDeprecationWarning:django_extensions
     ignore::PendingDeprecationWarning:storages
+    ignore::DeprecationWarning:SimpleITK
     # https://github.com/comic/grand-challenge.org/issues/1110
     ignore::DeprecationWarning:itypes


### PR DESCRIPTION
Fixes the 10 warnings in the CI tests.