### PR TITLE
Separate out the docker base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,6 @@ jobs:
           echo ::set-env name=GIT_COMMIT_ID::$(git describe --always --dirty)
           echo ::set-env name=GIT_BRANCH_NAME::$(echo ${{ github.ref }} | cut -d/ -f3- | sed "s/[^[:alnum:]]//g")
           echo ::set-env name=DOCKER_GID::$(getent group docker | cut -d: -f3)
-      - name: 'Build the base container (TODO: remove!)'
-        run: make build_web_base
       - name: Build the containers
         run: |
           make -j2 build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
           echo ::set-env name=GIT_COMMIT_ID::$(git describe --always --dirty)
           echo ::set-env name=GIT_BRANCH_NAME::$(echo ${{ github.ref }} | cut -d/ -f3- | sed "s/[^[:alnum:]]//g")
           echo ::set-env name=DOCKER_GID::$(getent group docker | cut -d: -f3)
+      - name: 'Build the base container (TODO: remove!)'
+        run: make build_web_base
       - name: Build the containers
         run: |
           make -j2 build

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,16 @@ POETRY_HASH = $(shell shasum -a 512 poetry.lock | cut -c 1-8)
 
 build_web:
 	@docker pull grandchallenge/web-base:$(PYTHON_VERSION)-$(GDCM_VERSION_TAG)-$(POETRY_HASH) || { \
-  		docker build \
-        --build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
-        --build-arg GDCM_VERSION_TAG=$(GDCM_VERSION_TAG) \
-        -t grandchallenge/web-base:$(PYTHON_VERSION)-$(GDCM_VERSION_TAG)-$(POETRY_HASH) \
-        -f dockerfiles/web-base/Dockerfile \
-        .; \
-  	}
+		docker build \
+			--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
+			--build-arg GDCM_VERSION_TAG=$(GDCM_VERSION_TAG) \
+			-t grandchallenge/web-base:$(PYTHON_VERSION)-$(GDCM_VERSION_TAG)-$(POETRY_HASH) \
+			-f dockerfiles/web-base/Dockerfile \
+			.; \
+	}
 	docker build \
 		--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
-        --build-arg GDCM_VERSION_TAG=$(GDCM_VERSION_TAG) \
+		--build-arg GDCM_VERSION_TAG=$(GDCM_VERSION_TAG) \
 		--build-arg COMMIT_ID=$(GIT_COMMIT_ID) \
 		--build-arg POETRY_HASH=$(POETRY_HASH) \
 		--target test \
@@ -25,7 +25,7 @@ build_web:
 		.
 	docker build \
 		--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
-        --build-arg GDCM_VERSION_TAG=$(GDCM_VERSION_TAG) \
+		--build-arg GDCM_VERSION_TAG=$(GDCM_VERSION_TAG) \
 		--build-arg COMMIT_ID=$(GIT_COMMIT_ID) \
 		--build-arg POETRY_HASH=$(POETRY_HASH) \
 		--target dist \

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build_http:
 build: build_web build_http
 
 push_web_base:
-	docker push grandchallenge/web-base:py$(PYTHON_VERSION)-gdcm$(GDCM_VERSION_TAG)-$(POETRY_HASH)
+	docker push grandchallenge/web-base:$(PYTHON_VERSION)-$(GDCM_VERSION_TAG)-$(POETRY_HASH)
 
 push_web:
 	docker push grandchallenge/web:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,20 @@
 USER_ID = $(shell id -u)
 export DOCKER_BUILDKIT = 1
+PYTHON_VERSION = 3.8
+GDCM_VERSION_TAG = 3.0.6
+
+build_web_base:
+	docker build \
+        --build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
+        --build-arg GDCM_VERSION_TAG=$(GDCM_VERSION_TAG) \
+        -t grandchallenge/web-base:py$(PYTHON_VERSION)-gdcm$(GDCM_VERSION_TAG) \
+        -f dockerfiles/web-base/Dockerfile \
+        .
 
 build_web:
 	docker build \
+		--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
+        --build-arg GDCM_VERSION_TAG=$(GDCM_VERSION_TAG) \
 		--build-arg COMMIT_ID=$(GIT_COMMIT_ID) \
 		--target test \
 		-t grandchallenge/web-test:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME) \
@@ -10,6 +22,8 @@ build_web:
 		-f dockerfiles/web/Dockerfile \
 		.
 	docker build \
+		--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
+        --build-arg GDCM_VERSION_TAG=$(GDCM_VERSION_TAG) \
 		--build-arg COMMIT_ID=$(GIT_COMMIT_ID) \
 		--target dist \
 		-t grandchallenge/web:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME) \
@@ -24,6 +38,9 @@ build_http:
 		dockerfiles/http
 
 build: build_web build_http
+
+push_web_base:
+	docker push grandchallenge/web-base:py$(PYTHON_VERSION)-gdcm$(GDCM_VERSION_TAG)
 
 push_web:
 	docker push grandchallenge/web:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,13 @@ USER_ID = $(shell id -u)
 export DOCKER_BUILDKIT = 1
 PYTHON_VERSION = 3.8
 GDCM_VERSION_TAG = 3.0.6
+POETRY_HASH = $(shell shasum -a 512 poetry.lock | cut -c 1-8)
 
 build_web_base:
 	docker build \
         --build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
         --build-arg GDCM_VERSION_TAG=$(GDCM_VERSION_TAG) \
-        -t grandchallenge/web-base:py$(PYTHON_VERSION)-gdcm$(GDCM_VERSION_TAG) \
+        -t grandchallenge/web-base:py$(PYTHON_VERSION)-gdcm$(GDCM_VERSION_TAG)-$(POETRY_HASH) \
         -f dockerfiles/web-base/Dockerfile \
         .
 
@@ -16,8 +17,9 @@ build_web:
 		--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
         --build-arg GDCM_VERSION_TAG=$(GDCM_VERSION_TAG) \
 		--build-arg COMMIT_ID=$(GIT_COMMIT_ID) \
+		--build-arg POETRY_HASH=$(POETRY_HASH) \
 		--target test \
-		-t grandchallenge/web-test:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME) \
+		-t grandchallenge/web-test:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH) \
 		-t grandchallenge/web-test:latest \
 		-f dockerfiles/web/Dockerfile \
 		.
@@ -25,29 +27,30 @@ build_web:
 		--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
         --build-arg GDCM_VERSION_TAG=$(GDCM_VERSION_TAG) \
 		--build-arg COMMIT_ID=$(GIT_COMMIT_ID) \
+		--build-arg POETRY_HASH=$(POETRY_HASH) \
 		--target dist \
-		-t grandchallenge/web:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME) \
+		-t grandchallenge/web:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH) \
 		-t grandchallenge/web:latest \
 		-f dockerfiles/web/Dockerfile \
 		.
 
 build_http:
 	docker build \
-		-t grandchallenge/http:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME) \
+		-t grandchallenge/http:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH) \
 		-t grandchallenge/http:latest \
 		dockerfiles/http
 
 build: build_web build_http
 
 push_web_base:
-	docker push grandchallenge/web-base:py$(PYTHON_VERSION)-gdcm$(GDCM_VERSION_TAG)
+	docker push grandchallenge/web-base:py$(PYTHON_VERSION)-gdcm$(GDCM_VERSION_TAG)-$(POETRY_HASH)
 
 push_web:
-	docker push grandchallenge/web:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)
+	docker push grandchallenge/web:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)
 	docker push grandchallenge/web:latest
 
 push_http:
-	docker push grandchallenge/http:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)
+	docker push grandchallenge/http:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)
 	docker push grandchallenge/http:latest
 
 push: push_web push_http

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,15 @@ PYTHON_VERSION = 3.8
 GDCM_VERSION_TAG = 3.0.6
 POETRY_HASH = $(shell shasum -a 512 poetry.lock | cut -c 1-8)
 
-build_web_base:
-	docker build \
+build_web:
+	@docker pull grandchallenge/web-base:$(PYTHON_VERSION)-$(GDCM_VERSION_TAG)-$(POETRY_HASH) || { \
+  		docker build \
         --build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
         --build-arg GDCM_VERSION_TAG=$(GDCM_VERSION_TAG) \
-        -t grandchallenge/web-base:py$(PYTHON_VERSION)-gdcm$(GDCM_VERSION_TAG)-$(POETRY_HASH) \
+        -t grandchallenge/web-base:$(PYTHON_VERSION)-$(GDCM_VERSION_TAG)-$(POETRY_HASH) \
         -f dockerfiles/web-base/Dockerfile \
-        .
-
-build_web:
+        .; \
+  	}
 	docker build \
 		--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
         --build-arg GDCM_VERSION_TAG=$(GDCM_VERSION_TAG) \
@@ -53,7 +53,7 @@ push_http:
 	docker push grandchallenge/http:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)
 	docker push grandchallenge/http:latest
 
-push: push_web push_http
+push: push_web_base push_web push_http
 
 migrations:
 	docker-compose run -u $(USER_ID) --rm web python manage.py makemigrations

--- a/dockerfiles/http/Dockerfile
+++ b/dockerfiles/http/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get install -y \
     gettext
 
-RUN useradd -u 2001 cwww
+RUN useradd cwww
 
 COPY dhparams.pem /etc/ssl/private/dhparams.pem
 COPY mime.types /etc/nginx/mime.types

--- a/dockerfiles/web-base/Dockerfile
+++ b/dockerfiles/web-base/Dockerfile
@@ -1,0 +1,72 @@
+###################
+#  Base Container #
+###################
+ARG PYTHON_VERSION
+
+FROM python:${PYTHON_VERSION}
+
+ARG GDCM_VERSION_TAG
+
+# Build and install gdcm and install system dependencies
+RUN apt-get update \
+    && apt-get install -y \
+        cmake \
+        swig \
+        python-openssl \
+        libpng-dev \
+        libjpeg-dev \
+        libjpeg62-turbo-dev \
+        libfreetype6-dev \
+        libxft-dev \
+        libffi-dev \
+        wget \
+        gettext \
+        libopenslide-dev \
+        libvips-dev \
+    && mkdir -p /opt/gdcm/build \
+    && cd /opt/gdcm \
+    && git clone --branch v${GDCM_VERSION_TAG} --depth 1 git://git.code.sf.net/p/gdcm/gdcm \
+    && cd /opt/gdcm/build \
+    && cmake \
+        -DCMAKE_SKIP_RPATH:BOOL=YES \
+        -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+        -DGDCM_BUILD_SHARED_LIBS:BOOL=ON \
+        -DGDCM_DOCUMENTATION:BOOL=OFF \
+        -DGDCM_BUILD_DOCBOOK_MANPAGES:BOOL=OFF \
+        -DGDCM_BUILD_TESTING:BOOL=OFF \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DGDCM_WRAP_PYTHON:BOOL=ON \
+        -DGDCM_INSTALL_PYTHONMODULE_DIR=$(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())") \
+        -DGDCM_USE_VTK:BOOL=OFF \
+        -DGDCM_USE_JPEGLS:BOOL=ON \
+        -DGDCM_USE_PVRG:BOOL=ON \
+        -DGDCM_USE_SYSTEM_EXPAT:BOOL=ON \
+        -DGDCM_USE_SYSTEM_ZLIB:BOOL=ON \
+        -DGDCM_USE_SYSTEM_UUID:BOOL=ON \
+        -DGDCM_USE_SYSTEM_OPENJPEG:BOOL=ON \
+        -DGDCM_USE_SYSTEM_OPENSSL:BOOL=ON \
+        -DCMAKE_C_FLAGS=-fPIC \
+        -DCMAKE_CXX_FLAGS=-fPIC \
+        /opt/gdcm/gdcm \
+    && make -j $(nproc) \
+    && make install \
+    && ldconfig \
+    && rm -r /opt/gdcm \
+    && apt-get purge -y swig cmake
+
+ENV PYTHONUNBUFFERED 1
+
+RUN mkdir -p /opt/poetry /app /static /opt/static \
+    && python -m pip install -U "pip!=20.0" setuptools==45 \
+    && python -m pip install -U poetry \
+    && groupadd -r django && useradd -m -r -g django django \
+    && chown django:django /opt/poetry /app /static /opt/static
+
+# Install base python packages
+COPY poetry.toml /opt/poetry
+COPY pyproject.toml /opt/poetry
+COPY poetry.lock /opt/poetry
+
+WORKDIR /opt/poetry
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-dev --no-root

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -1,71 +1,11 @@
 ###################
 #  Base Container #
 ###################
-FROM python:3.8 as base
 
-# Build and install gdcm and install system dependencies
-RUN apt-get update \
-    && apt-get install -y \
-        cmake \
-        swig \
-        python-openssl \
-        libpng-dev \
-        libjpeg-dev \
-        libjpeg62-turbo-dev \
-        libfreetype6-dev \
-        libxft-dev \
-        libffi-dev \
-        wget \
-        gettext \
-        libopenslide-dev \
-        libvips-dev \
-    && mkdir -p /opt/gdcm/build \
-    && cd /opt/gdcm \
-    && git clone --branch v3.0.6 --depth 1 git://git.code.sf.net/p/gdcm/gdcm \
-    && cd /opt/gdcm/build \
-    && cmake \
-        -DCMAKE_SKIP_RPATH:BOOL=YES \
-        -DCMAKE_INSTALL_PREFIX:PATH=/usr \
-        -DGDCM_BUILD_SHARED_LIBS:BOOL=ON \
-        -DGDCM_DOCUMENTATION:BOOL=OFF \
-        -DGDCM_BUILD_DOCBOOK_MANPAGES:BOOL=OFF \
-        -DGDCM_BUILD_TESTING:BOOL=OFF \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DGDCM_WRAP_PYTHON:BOOL=ON \
-        -DGDCM_INSTALL_PYTHONMODULE_DIR=$(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())") \
-        -DGDCM_USE_VTK:BOOL=OFF \
-        -DGDCM_USE_JPEGLS:BOOL=ON \
-        -DGDCM_USE_PVRG:BOOL=ON \
-        -DGDCM_USE_SYSTEM_EXPAT:BOOL=ON \
-        -DGDCM_USE_SYSTEM_ZLIB:BOOL=ON \
-        -DGDCM_USE_SYSTEM_UUID:BOOL=ON \
-        -DGDCM_USE_SYSTEM_OPENJPEG:BOOL=ON \
-        -DGDCM_USE_SYSTEM_OPENSSL:BOOL=ON \
-        -DCMAKE_C_FLAGS=-fPIC \
-        -DCMAKE_CXX_FLAGS=-fPIC \
-        /opt/gdcm/gdcm \
-    && make -j $(nproc) \
-    && make install \
-    && ldconfig \
-    && rm -r /opt/gdcm \
-    && apt-get purge -y swig cmake
+ARG PYTHON_VERSION
+ARG GDCM_VERSION_TAG
 
-ENV PYTHONUNBUFFERED 1
-
-RUN mkdir -p /opt/poetry /app /static /opt/static
-RUN python -m pip install -U "pip!=20.0" setuptools==45
-RUN python -m pip install -U poetry
-
-RUN groupadd -g 2001 -r django && useradd -m -u 2001 -r -g django django
-RUN chown django:django /opt/poetry /app /static /opt/static
-
-# Install base python packages
-WORKDIR /opt/poetry
-COPY poetry.toml /opt/poetry
-COPY pyproject.toml /opt/poetry
-COPY poetry.lock /opt/poetry
-RUN poetry config virtualenvs.create false \
-    && poetry install --no-dev --no-root
+FROM grandchallenge/web-base:py${PYTHON_VERSION}-gdcm${GDCM_VERSION_TAG} as base
 
 ###################
 #  Webpack        #

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -6,7 +6,7 @@ ARG PYTHON_VERSION
 ARG GDCM_VERSION_TAG
 ARG POETRY_HASH
 
-FROM grandchallenge/web-base:py${PYTHON_VERSION}-gdcm${GDCM_VERSION_TAG}-${POETRY_HASH} as base
+FROM grandchallenge/web-base:${PYTHON_VERSION}-${GDCM_VERSION_TAG}-${POETRY_HASH} as base
 
 ###################
 #  Webpack        #

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -4,8 +4,9 @@
 
 ARG PYTHON_VERSION
 ARG GDCM_VERSION_TAG
+ARG POETRY_HASH
 
-FROM grandchallenge/web-base:py${PYTHON_VERSION}-gdcm${GDCM_VERSION_TAG} as base
+FROM grandchallenge/web-base:py${PYTHON_VERSION}-gdcm${GDCM_VERSION_TAG}-${POETRY_HASH} as base
 
 ###################
 #  Webpack        #


### PR DESCRIPTION
This PR separates out the docker base image into a separate `web-base` image that is tagged by the python, gdcm, and hash of the poetry lock file. In the Makefile:

- `build_web` checks if the correct `web-base` image can be pulled from docker hub, if not, builds it
- On master, the `web-base` container will be pushed as before
- If we want a new version of the base containers, the poetry lock file, python version, or gdcm version needs to be updated. 

Once this is on master builds that use the same poetry lock file, python version and gdcm version should be ~8 minutes faster, give or take the time to pull the image.

Next steps: hashing the files and installing the test libraries takes a while, so we could think about unifying the containers.