### PR TITLE
Cache the test container image, separate docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,6 @@ jobs:
       - name: Build the containers
         run: |
           make -j2 build
-      - name: Build the docs
-        run: |
-          make docs
       - name: Run the django tests
         run: |
           docker pull crccheck/hello-world
@@ -66,6 +63,23 @@ jobs:
         env:
           DOCKER_USER: grandchallenge
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+  docs:
+    needs: [precommit]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set the environment
+        run: |
+          echo ::set-env name=GIT_COMMIT_ID::$(git describe --always --dirty)
+          echo ::set-env name=GIT_BRANCH_NAME::$(echo ${{ github.ref }} | cut -d/ -f3- | sed "s/[^[:alnum:]]//g")
+          echo ::set-env name=DOCKER_GID::$(getent group docker | cut -d: -f3)
+      - name: Build the containers
+        run: |
+          make -j2 build
+      - name: Build the docs
+        run: |
+          make docs
       - name: Deploy the documentation on master
         if: github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           echo ::set-env name=DOCKER_GID::$(getent group docker | cut -d: -f3)
       - name: Build the containers
         run: |
-          make -j2 build
+          make build
       - name: Run the django tests
         run: |
           docker pull crccheck/hello-world
@@ -76,7 +76,7 @@ jobs:
           echo ::set-env name=DOCKER_GID::$(getent group docker | cut -d: -f3)
       - name: Build the containers
         run: |
-          make -j2 build
+          make build
       - name: Build the docs
         run: |
           make docs

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,17 @@ build_web:
 		docker build \
 			--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
 			--build-arg GDCM_VERSION_TAG=$(GDCM_VERSION_TAG) \
+			--target base \
 			-t grandchallenge/web-base:$(PYTHON_VERSION)-$(GDCM_VERSION_TAG)-$(POETRY_HASH) \
+			-f dockerfiles/web-base/Dockerfile \
+			.; \
+	}
+	@docker pull grandchallenge/web-test-base:$(PYTHON_VERSION)-$(GDCM_VERSION_TAG)-$(POETRY_HASH) || { \
+		docker build \
+			--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
+			--build-arg GDCM_VERSION_TAG=$(GDCM_VERSION_TAG) \
+			--target test-base \
+			-t grandchallenge/web-test-base:$(PYTHON_VERSION)-$(GDCM_VERSION_TAG)-$(POETRY_HASH) \
 			-f dockerfiles/web-base/Dockerfile \
 			.; \
 	}
@@ -45,6 +55,9 @@ build: build_web build_http
 push_web_base:
 	docker push grandchallenge/web-base:$(PYTHON_VERSION)-$(GDCM_VERSION_TAG)-$(POETRY_HASH)
 
+push_web_test_base:
+	docker push grandchallenge/web-test-base:$(PYTHON_VERSION)-$(GDCM_VERSION_TAG)-$(POETRY_HASH)
+
 push_web:
 	docker push grandchallenge/web:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)
 	docker push grandchallenge/web:latest
@@ -53,7 +66,7 @@ push_http:
 	docker push grandchallenge/http:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)
 	docker push grandchallenge/http:latest
 
-push: push_web_base push_web push_http
+push: push_web_base push_web_test_base push_web push_http
 
 migrations:
 	docker-compose run -u $(USER_ID) --rm web python manage.py makemigrations

--- a/app/tests/settings.py
+++ b/app/tests/settings.py
@@ -12,6 +12,7 @@ from config.settings import *  # noqa: F401, F403, E402
 ALLOWED_HOSTS = [".testserver"]
 
 WHITENOISE_AUTOREFRESH = True
+STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
 
 PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 

--- a/dockerfiles/web-base/Dockerfile
+++ b/dockerfiles/web-base/Dockerfile
@@ -3,7 +3,7 @@
 ###################
 ARG PYTHON_VERSION
 
-FROM python:${PYTHON_VERSION}
+FROM python:${PYTHON_VERSION} as base
 
 ARG GDCM_VERSION_TAG
 
@@ -70,3 +70,12 @@ COPY poetry.lock /opt/poetry
 WORKDIR /opt/poetry
 RUN poetry config virtualenvs.create false \
     && poetry install --no-dev --no-root
+
+##################
+# TEST CONTAINER #
+##################
+FROM base as test-base
+
+# Add java and graphviz for plantuml documentation
+RUN apt-get update && apt-get install -y default-jre graphviz
+RUN poetry install --no-root

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -34,7 +34,6 @@ USER django:django
 WORKDIR /app
 COPY --chown=django:django ./app/ /app/
 COPY --from=npm --chown=django:django /src/dist/ /opt/static/vendor/
-RUN python manage.py collectstatic --noinput
 
 ##################
 # Dist Container #

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -1,16 +1,11 @@
-###################
-#  Base Container #
-###################
-
+# Build args used in FROM
 ARG PYTHON_VERSION
 ARG GDCM_VERSION_TAG
 ARG POETRY_HASH
 
-FROM grandchallenge/web-base:${PYTHON_VERSION}-${GDCM_VERSION_TAG}-${POETRY_HASH} as base
-
-###################
-#  Webpack        #
-###################
+#############
+# Vendor JS #
+#############
 FROM node:11-alpine as npm
 RUN mkdir /src
 COPY package.json /src/
@@ -19,14 +14,10 @@ WORKDIR /src
 
 RUN npm install && npm run build
 
-###################
-#  Test Container #
-###################
-FROM base as test
-
-# Add java and graphviz for plantuml documentation
-RUN apt-get update && apt-get install -y default-jre graphviz
-RUN poetry install --no-root
+##################
+# Test Container #
+##################
+FROM grandchallenge/web-test-base:${PYTHON_VERSION}-${GDCM_VERSION_TAG}-${POETRY_HASH} as test
 
 COPY --chown=django:django setup.cfg /home/django
 
@@ -38,7 +29,7 @@ COPY --from=npm --chown=django:django /src/dist/ /opt/static/vendor/
 ##################
 # Dist Container #
 ##################
-FROM base as dist
+FROM grandchallenge/web-base:${PYTHON_VERSION}-${GDCM_VERSION_TAG}-${POETRY_HASH} as dist
 
 USER django:django
 WORKDIR /app


### PR DESCRIPTION
This PR adds caching of the test image, separates the docs build and uses simple staticfile serving in tests, taking another 200s off each build.

Closes #1436 as we're getting in to the territory of diminishing returns.