### PR TITLE
Initialise the internal protected storage only once

### DIFF
--- a/app/grandchallenge/core/storage.py
+++ b/app/grandchallenge/core/storage.py
@@ -116,6 +116,7 @@ class PublicS3Storage(S3Storage):
 
 private_s3_storage = PrivateS3Storage()
 protected_s3_storage = ProtectedS3Storage()
+internal_protected_s3_storage = ProtectedS3Storage(internal=True)
 public_s3_storage = PublicS3Storage()
 
 storages = [private_s3_storage, protected_s3_storage, public_s3_storage]

--- a/app/grandchallenge/serving/views.py
+++ b/app/grandchallenge/serving/views.py
@@ -8,7 +8,7 @@ from rest_framework.authentication import TokenAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 
 from grandchallenge.cases.models import Image
-from grandchallenge.core.storage import ProtectedS3Storage
+from grandchallenge.core.storage import internal_protected_s3_storage
 from grandchallenge.evaluation.models import Submission
 from grandchallenge.serving.permissions import (
     user_can_download_image,
@@ -20,17 +20,15 @@ from grandchallenge.serving.tasks import create_download
 def protected_storage_redirect(*, name):
     # Get the storage with the internal redirect and auth. This will prepend
     # settings.PROTECTED_S3_STORAGE_KWARGS['endpoint_url'] to the url
-    storage = ProtectedS3Storage(internal=True)
-
-    if not storage.exists(name=name):
+    if not internal_protected_s3_storage.exists(name=name):
         raise Http404("File not found.")
 
     if settings.PROTECTED_S3_STORAGE_USE_CLOUDFRONT:
         response = HttpResponseRedirect(
-            storage.cloudfront_signed_url(name=name)
+            internal_protected_s3_storage.cloudfront_signed_url(name=name)
         )
     else:
-        url = storage.url(name=name)
+        url = internal_protected_s3_storage.url(name=name)
         response = HttpResponseRedirect(url)
 
     return response


### PR DESCRIPTION
Initialising the internal protected storage is quite slow, so move this out of the view.

Sentry APM was showing that this could take up to 250ms, this is a speculative fix for that issue.