### PR TITLE
Fixes for lesion migration command

### DIFF
--- a/app/grandchallenge/retina_core/management/commands/migratelesionnames.py
+++ b/app/grandchallenge/retina_core/management/commands/migratelesionnames.py
@@ -21,6 +21,10 @@ def migrate_annotations(annotations):  # noqa: C901
     oct_no_match = []
     no_match = []
 
+    old_to_boolean_lesion_map_lower = map(
+        lambda s: s.lower(), old_to_boolean_lesion_map
+    )
+
     paginator = Paginator(annotations, 100)
 
     print(f"Found {paginator.count} annotations")
@@ -38,7 +42,7 @@ def migrate_annotations(annotations):  # noqa: C901
             ):
                 modality = "oct"
 
-            if annotation.name in old_to_boolean_lesion_map:
+            if annotation.name.lower() in old_to_boolean_lesion_map_lower:
                 if modality == "oct":
                     boolean_oct_no_match.append(annotation.id)
                     continue
@@ -55,7 +59,9 @@ def migrate_annotations(annotations):  # noqa: C901
                 continue
 
             for lesions in old_to_new_lesion_map:
-                if annotation.name in lesions[0]:
+                if annotation.name.lower() in map(
+                    lambda s: s.lower(), lesions[0]
+                ):
                     new_name = (
                         lesions[1] if modality == "enface" else lesions[2]
                     )

--- a/app/grandchallenge/retina_core/management/commands/migratelesionnames.py
+++ b/app/grandchallenge/retina_core/management/commands/migratelesionnames.py
@@ -480,21 +480,16 @@ old_to_new_lesion_map = [
         "enface::rf_present::Macular (pseudo) hole",
         "oct::macular::Lamellar hole",
     ),
-    # ===================================================
-    (("myopia_present::Retinoschisis",), "", ""),  # ?
-    (
-        ("oda_present::Vertical cup to disc ratio (CDR)",),
-        "enface::_present",
-        "oct::optic_disc::",
-    ),  # remove?
+    (("myopia_present::Retinoschisis",), "", ""),
+    (("oda_present::Vertical cup to disc ratio (CDR)",), "", "",),
     (
         (
             "dr_present::retinal neovascularization",
             "vascular changes::neo vascularization",
         ),
-        "enface::rf_present::",
-        "oct::",
-    ),  # in db so needed...
+        "",
+        "",
+    ),
 ]
 
 old_to_boolean_lesion_map = [

--- a/app/grandchallenge/retina_core/management/commands/migratelesionnames.py
+++ b/app/grandchallenge/retina_core/management/commands/migratelesionnames.py
@@ -43,14 +43,12 @@ def migrate_annotations(annotations):  # noqa: C901
                     boolean_oct_no_match.append(annotation.id)
                     continue
                 new_name = f"retina::enface::{annotation.name.split('::')[-1]}"
-                BooleanClassificationAnnotation.object.create(
-                    {
-                        "grader": annotation.grader,
-                        "created": annotation.created,
-                        "image": annotation.image,
-                        "name": new_name,
-                        "value": True,
-                    }
+                BooleanClassificationAnnotation.objects.create(
+                    grader=annotation.grader,
+                    created=annotation.created,
+                    image=annotation.image,
+                    name=new_name,
+                    value=True,
                 )
                 annotation.delete()
                 translated += 1

--- a/app/grandchallenge/retina_core/management/commands/migratelesionnames.py
+++ b/app/grandchallenge/retina_core/management/commands/migratelesionnames.py
@@ -21,10 +21,6 @@ def migrate_annotations(annotations):  # noqa: C901
     oct_no_match = []
     no_match = []
 
-    old_to_boolean_lesion_map_lower = map(
-        lambda s: s.lower(), old_to_boolean_lesion_map
-    )
-
     paginator = Paginator(annotations, 100)
 
     print(f"Found {paginator.count} annotations")
@@ -42,7 +38,7 @@ def migrate_annotations(annotations):  # noqa: C901
             ):
                 modality = "oct"
 
-            if annotation.name.lower() in old_to_boolean_lesion_map_lower:
+            if annotation.name.lower() in old_to_boolean_lesion_map:
                 if modality == "oct":
                     boolean_oct_no_match.append(annotation.id)
                     continue
@@ -497,9 +493,9 @@ old_to_new_lesion_map = [
 ]
 
 old_to_boolean_lesion_map = [
-    "other_present::Vascular::Branch retinal artery occlusion",
-    "other_present::Vascular::Branch retinal vein occlusion",
-    "other_present::Vascular::Central retinal artery occlusion",
-    "other_present::Vascular::Central retinal vein occlusion",
-    "other_present::Vitreous::Asteroid hyalosis/synch scintillans",
+    "other_present::vascular::branch retinal artery occlusion",
+    "other_present::vascular::branch retinal vein occlusion",
+    "other_present::vascular::central retinal artery occlusion",
+    "other_present::vascular::central retinal vein occlusion",
+    "other_present::vitreous::asteroid hyalosis/synch scintillans",
 ]

--- a/app/tests/retina_core_tests/test_commands.py
+++ b/app/tests/retina_core_tests/test_commands.py
@@ -129,6 +129,9 @@ class TestMigratelesionnamesCommand:
         PolygonAnnotationSetFactory(
             name="retina::enface::rf_present::Hard drusen"
         )
+        PolygonAnnotationSetFactory(
+            name="other_present::Vascular::Branch retinal artery occlusion",
+        )
         annotation_oct_no_match_boolean = PolygonAnnotationSetFactory(
             name="other_present::Vascular::Branch retinal artery occlusion",
             image=image,
@@ -142,8 +145,10 @@ class TestMigratelesionnamesCommand:
         )
         annotation_no_match = PolygonAnnotationSetFactory(name="No match")
 
+        assert BooleanClassificationAnnotation.objects.count() == 0
         result = migrate_annotations(PolygonAnnotationSet.objects.all())
-        assert result["translated"] == 2
+        assert result["translated"] == 3
+        assert BooleanClassificationAnnotation.objects.count() == 1
         assert result["already_translated"] == 2
         assert result["boolean_oct_no_match"] == [
             annotation_oct_no_match_boolean.id

--- a/app/tests/retina_core_tests/test_commands.py
+++ b/app/tests/retina_core_tests/test_commands.py
@@ -96,6 +96,24 @@ class TestMigratelesionnamesCommand:
         annotation_oct.refresh_from_db()
         assert annotation_oct.name == "retina::oct::macular::Drusen"
 
+    def test_testmigratelesionnames_correctly_migrated_case_insensitive(self):
+        image = ImageFactory(modality=ImagingModalityFactory(modality="OCT"))
+        annotation_oct = PolygonAnnotationSetFactory(
+            name="amd_present::DrUsEn AnD DrUsEn lIkE sTruCtUrEs::HARD dRuSeN",
+            image=image,
+        )
+        annotation_enface = PolygonAnnotationSetFactory(
+            name="DrUsEn AnD DrUsEn lIkE sTruCtUrEs::HARD dRuSeN"
+        )
+        result = migrate_annotations(PolygonAnnotationSet.objects.all())
+        assert result["translated"] == 2
+        annotation_enface.refresh_from_db()
+        assert (
+            annotation_enface.name == "retina::enface::rf_present::Hard drusen"
+        )
+        annotation_oct.refresh_from_db()
+        assert annotation_oct.name == "retina::oct::macular::Drusen"
+
     def test_testmigratelesionnames_combined(self):
         image = ImageFactory(modality=ImagingModalityFactory(modality="OCT"))
         annotation_oct = PolygonAnnotationSetFactory(


### PR DESCRIPTION
I noticed a few mistakes in my implementation for the lesion migration command:
- Conversion to BooleanClassificationAnnotation was implemented incorrectly and test was missing
- Lesion name lookup in old-to-new mapping was case sensitive
- 2 unmatched lesion names would have converted to `"retina::enface::"` instead of `""` which would not have added them as unmatched lesions in the results.

This PR fixes the issues and adds tests for them.