### PR TITLE
Use a SpooledTemporaryFile for putting files to the containers

### DIFF
--- a/app/grandchallenge/components/backends/docker.py
+++ b/app/grandchallenge/components/backends/docker.py
@@ -20,7 +20,7 @@ from docker.tls import TLSConfig
 from docker.types import LogConfig
 from requests import HTTPError
 
-MAX_SPOOL_SIZE = 1024 * 1024 * 1024  # 1g
+MAX_SPOOL_SIZE = 1_000_000_000  # 1GB
 
 
 class ComponentException(Exception):


### PR DESCRIPTION
On June 30th we added resource limits to the evaluation worker of 4GB per evaluation. Unfortunately, when copying large submission files to the docker volume this limit was exceeded, resulting in worker loss. Use a Spooled temporary file with a limit of 1GB to allow large file puts.

Related issue: https://sentry.io/organizations/grand-challenge/issues/1512758619/?project=303639&query=is%3Aunresolved

This could also be the cause of the forever queued jobs.