### PR TITLE
Set RetinaIkmagePathologyAnnotations for new lesion names with command

### DIFF
--- a/app/grandchallenge/annotations/admin.py
+++ b/app/grandchallenge/annotations/admin.py
@@ -32,7 +32,7 @@ class PolygonAnnotationSetAdmin(admin.ModelAdmin):
         "image__name",
         "id",
     )
-    list_filter = ("created", "name", "grader__username")
+    list_filter = ("created", "name")
     inlines = [SinglePolygonAnnotationInline]
     readonly_fields = ("grader", "image", "created")
 

--- a/app/grandchallenge/retina_core/management/commands/setretinapathologies.py
+++ b/app/grandchallenge/retina_core/management/commands/setretinapathologies.py
@@ -40,7 +40,7 @@ def set_retina_pathologies(annotations):
 
         for annotation in page.object_list:
             name_parts = annotation.name.split("::")
-            if name_parts[0] != "retina":
+            if len(name_parts) < 3 or name_parts[0] != "retina":
                 old_annotation += 1
                 continue
 

--- a/app/grandchallenge/retina_core/management/commands/setretinapathologies.py
+++ b/app/grandchallenge/retina_core/management/commands/setretinapathologies.py
@@ -1,0 +1,83 @@
+from django.core.management.base import BaseCommand
+from django.core.paginator import Paginator
+
+from grandchallenge.annotations.models import (
+    PolygonAnnotationSet,
+    RetinaImagePathologyAnnotation,
+)
+
+
+def array_to_string(a):
+    if len(a) == 0:
+        return "[]"
+    return '[\n\t"' + '",\n\t"'.join(map(lambda v: str(v), a)) + '"\n]'
+
+
+pathology_options = [
+    "rf_present",
+    "oda_present",
+    "myopia_present",
+    "other_present",
+    "amd_present",
+    "dr_present",
+    "cysts_present",
+]
+
+
+def set_retina_pathologies(annotations):
+    pathology_set = 0
+    old_annotation = 0
+    non_matching_pathology = []
+
+    paginator = Paginator(annotations, 100)
+
+    print(f"Found {paginator.count} annotations")
+
+    for idx in paginator.page_range:
+        print(f"Page {idx} of {paginator.num_pages}")
+
+        page = paginator.page(idx)
+
+        for annotation in page.object_list:
+            name_parts = annotation.name.split("::")
+            if name_parts[0] != "retina":
+                old_annotation += 1
+                continue
+
+            if name_parts[2] not in pathology_options:
+                non_matching_pathology.append(
+                    {"id": annotation.id, "name": annotation.name}
+                )
+                continue
+
+            pathology_annotation = RetinaImagePathologyAnnotation.objects.get_or_create(
+                grader=annotation.grader,
+                image=annotation.image,
+                defaults={v: False for v in pathology_options},
+            )
+
+            pathology_annotation[name_parts[2]] = True
+            pathology_annotation.save()
+            pathology_set += 1
+
+    return {
+        "pathology_set": pathology_set,
+        "old_annotation": old_annotation,
+        "non_matching_pathology": non_matching_pathology,
+    }
+
+
+class Command(BaseCommand):
+    help = "Sets RetinaImagePathologyAnnotation according to new lesion names"
+
+    def handle(self, *args, **options):
+        annotations = PolygonAnnotationSet.objects.all().order_by("created")
+        result = set_retina_pathologies(annotations)
+        print(
+            f"Done! {result['pathology_set']} retina pathologies of {len(annotations)} polygon annotations set, {result['old_annotation']} old annotations (non translatable), {len(result['non_matching_pathology'])} non matching pathologies."
+        )
+
+        print(
+            "non_matching_pathology = "
+            + array_to_string(result["non_matching_pathology"])
+        )

--- a/app/grandchallenge/retina_core/management/commands/setretinapathologies.py
+++ b/app/grandchallenge/retina_core/management/commands/setretinapathologies.py
@@ -50,13 +50,16 @@ def set_retina_pathologies(annotations):
                 )
                 continue
 
-            pathology_annotation = RetinaImagePathologyAnnotation.objects.get_or_create(
+            (
+                pathology_annotation,
+                _,
+            ) = RetinaImagePathologyAnnotation.objects.get_or_create(
                 grader=annotation.grader,
                 image=annotation.image,
                 defaults={v: False for v in pathology_options},
             )
 
-            pathology_annotation[name_parts[2]] = True
+            setattr(pathology_annotation, name_parts[2], True)
             pathology_annotation.save()
             pathology_set += 1
 


### PR DESCRIPTION
Adds a command that sets the `RetinaImagePathologyAnnotation` for each migrated/translated annotation. In other words, it sets `rf_present` to `True` for each annotation that has a name like `retina::[enface|oct]::rf_present::[lesion name]`.

Also removes grader from the list_filter in `PolygonAnnotationSetAdmin` because this unfortunately shows every existing user in the filter sidebar instead of only the users that are related to an existing PolygonAnnotationSet.

Related issue #1327 