### PR TITLE
Give challenge admins permissions to view algorithm evaluations

### DIFF
--- a/app/tests/evaluation_tests/test_permissions.py
+++ b/app/tests/evaluation_tests/test_permissions.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+from guardian.shortcuts import get_groups_with_perms, get_users_with_perms
+
+from grandchallenge.evaluation.models import AlgorithmEvaluation
+from tests.evaluation_tests.factories import AlgorithmEvaluationFactory
+
+
+class TestAlgorithmEvaluationPermissions(TestCase):
+    def test_algorithm_evaluation_permissions(self):
+        """
+        Only the challenge admins should be able to view algorithm evaluations
+        The submission creator, algorithm groups and participants should not
+        have view permissions
+        """
+        ae: AlgorithmEvaluation = AlgorithmEvaluationFactory()
+
+        assert get_groups_with_perms(ae, attach_perms=True) == {
+            ae.submission.phase.challenge.admins_group: [
+                "view_algorithmevaluation"
+            ]
+        }
+        assert get_users_with_perms(ae, with_group_users=False).count() == 0


### PR DESCRIPTION
This allows challenge admins to view the outputs to the algorithm evaluations. It does
not allow them to run the algorithm on new data, even with legacy submission as they
do not have permission to use the algorithm. This does not leak the test set to the
participant or algorithm creators as only the challenge admins can view this info.

Closes #1473