### PR TITLE
Disable changing the page length

### DIFF
--- a/app/grandchallenge/algorithms/templates/algorithms/job_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_list.html
@@ -81,7 +81,8 @@
         $(document).ready(function () {
             $('.table').DataTable({
                 order: [[0, "desc"]],
-                pageLength: 50,
+                lengthChange: false,
+                pageLength: 100,
                 serverSide: true,
                 ajax: {
                     url: "",

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
@@ -64,8 +64,8 @@
                     set up.
                 {% endcomment %}
                 order: [[0, "asc"]],
-                lengthMenu: [[10, 25, 50, -1], [10, 25, 50, "All"]],
-                pageLength: 50,
+                lengthChange: false,
+                pageLength: 100,
                 serverSide: true,
                 ajax: {
                     url: "",


### PR DESCRIPTION
We now show 100 results by default as this will render fast enough, but disable
showing all results as this takes too long to render. The search and sorting tools
are enabled to help with finding results.

Closes #1506