### PR TITLE
Adds guardian permissions to all evaluation models

### DIFF
--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -23,6 +23,7 @@ from grandchallenge.challenges.emails import (
     send_external_challenge_created_email,
 )
 from grandchallenge.core.storage import public_s3_storage
+from grandchallenge.evaluation.tasks import assign_evaluation_permissions
 from grandchallenge.pages.models import Page
 from grandchallenge.subdomains.utils import reverse
 
@@ -475,6 +476,11 @@ class Challenge(ChallengeBase):
                 pass
 
             send_challenge_created_email(self)
+
+        # Changing the hidden state requires updating all evaluation permissions
+        assign_evaluation_permissions.apply_async(
+            kwargs={"challenge_pk": self.pk}
+        )
 
     def create_default_pages(self):
         Page.objects.create(

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -446,6 +446,10 @@ class Challenge(ChallengeBase):
         editable=False, blank=True, null=True
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._hidden_orig = self.hidden
+
     def save(self, *args, **kwargs):
         adding = self._state.adding
 
@@ -477,10 +481,10 @@ class Challenge(ChallengeBase):
 
             send_challenge_created_email(self)
 
-        # Changing the hidden state requires updating all evaluation permissions
-        assign_evaluation_permissions.apply_async(
-            kwargs={"challenge_pk": self.pk}
-        )
+        if self.hidden != self._hidden_orig:
+            assign_evaluation_permissions.apply_async(
+                kwargs={"challenge_pk": self.pk}
+            )
 
     def create_default_pages(self):
         Page.objects.create(

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -451,9 +451,6 @@ class Challenge(ChallengeBase):
         super().save(*args, **kwargs)
 
         if adding:
-            # Create the evaluation config
-            self.phase_set.create(challenge=self)
-
             # Create the groups only on first save
             admins_group = Group.objects.create(name=self.admin_group_name())
             participants_group = Group.objects.create(
@@ -462,6 +459,9 @@ class Challenge(ChallengeBase):
             self.admins_group = admins_group
             self.participants_group = participants_group
             self.save()
+
+            # Create the evaluation config
+            self.phase_set.create(challenge=self)
 
             self.create_default_pages()
 

--- a/app/grandchallenge/core/management/commands/migrate_evaluation_permissions.py
+++ b/app/grandchallenge/core/management/commands/migrate_evaluation_permissions.py
@@ -1,0 +1,33 @@
+from django.core.management import BaseCommand
+from django.core.paginator import Paginator
+
+from grandchallenge.evaluation.models import (
+    AlgorithmEvaluation,
+    Evaluation,
+    Method,
+    Phase,
+    Submission,
+)
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        for model in [
+            Phase,
+            Method,
+            Submission,
+            AlgorithmEvaluation,
+            Evaluation,
+        ]:
+            objs = model.objects.all().order_by("created")
+            paginator = Paginator(objs, 100)
+
+            print(f"Found {paginator.count} {model}")
+
+            for idx in paginator.page_range:
+                print(f"Page {idx} of {paginator.num_pages}")
+
+                page = paginator.page(idx)
+
+                for o in page.object_list:
+                    o.assign_permissions()

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -732,6 +732,7 @@ class Evaluation(UUIDModel, ComponentJob):
 
     def assign_permissions(self):
         admins_group = self.submission.phase.challenge.admins_group
+
         assign_perm("view_evaluation", admins_group, self)
         assign_perm("change_evaluation", admins_group, self)
 

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -373,6 +373,7 @@ class Phase(UUIDModel):
 
         if adding:
             self.set_default_interfaces()
+            self.assign_permissions()
 
         calculate_ranks.apply_async(kwargs={"phase_pk": self.pk})
 
@@ -383,6 +384,10 @@ class Phase(UUIDModel):
         self.outputs.set(
             [ComponentInterface.objects.get(slug="metrics-json-file")]
         )
+
+    def assign_permissions(self):
+        assign_perm("view_phase", self.challenge.admins_group, self)
+        assign_perm("change_phase", self.challenge.admins_group, self)
 
     def get_absolute_url(self):
         return reverse(
@@ -587,9 +592,9 @@ class AlgorithmEvaluation(ComponentJob):
         super().save(*args, **kwargs)
 
         if adding:
-            self.update_permissions()
+            self.assign_permissions()
 
-    def update_permissions(self):
+    def assign_permissions(self):
         assign_perm(
             "view_algorithmevaluation",
             self.submission.phase.challenge.admins_group,

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -736,14 +736,25 @@ class Evaluation(UUIDModel, ComponentJob):
         assign_perm("view_evaluation", admins_group, self)
         assign_perm("change_evaluation", admins_group, self)
 
-        g_reg_anon = Group.objects.get(
-            name=settings.REGISTERED_AND_ANON_USERS_GROUP_NAME
-        )
+        if self.submission.phase.challenge.hidden:
+            viewer_group = self.submission.phase.challenge.participants_group
+            non_viewer_group = Group.objects.get(
+                name=settings.REGISTERED_AND_ANON_USERS_GROUP_NAME
+            )
+        else:
+            viewer_group = Group.objects.get(
+                name=settings.REGISTERED_AND_ANON_USERS_GROUP_NAME
+            )
+            non_viewer_group = (
+                self.submission.phase.challenge.participants_group
+            )
 
         if self.published:
-            assign_perm("view_evaluation", g_reg_anon, self)
+            assign_perm("view_evaluation", viewer_group, self)
+            remove_perm("view_evaluation", non_viewer_group, self)
         else:
-            remove_perm("view_evaluation", g_reg_anon, self)
+            remove_perm("view_evaluation", viewer_group, self)
+            remove_perm("view_evaluation", non_viewer_group, self)
 
     @property
     def container(self):

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -412,6 +412,18 @@ class Method(UUIDModel, ComponentImage):
 
     phase = models.ForeignKey(Phase, on_delete=models.CASCADE, null=True)
 
+    def save(self, *args, **kwargs):
+        adding = self._state.adding
+
+        super().save(*args, **kwargs)
+
+        if adding:
+            self.assign_permissions()
+
+    def assign_permissions(self):
+        assign_perm("view_method", self.phase.challenge.admins_group, self)
+        assign_perm("change_method", self.phase.challenge.admins_group, self)
+
     def get_absolute_url(self):
         return reverse(
             "evaluation:method-detail",

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -508,6 +508,11 @@ class Submission(UUIDModel):
 
         if adding:
             self.create_evaluation()
+            self.assign_permissions()
+
+    def assign_permissions(self):
+        assign_perm("view_submission", self.phase.challenge.admins_group, self)
+        assign_perm("view_submission", self.creator, self)
 
     def create_evaluation(self):
         method = self.latest_ready_method

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -750,10 +750,10 @@ class Evaluation(UUIDModel, ComponentJob):
 
         if self.published:
             assign_perm("view_evaluation", viewer_group, self)
-            remove_perm("view_evaluation", non_viewer_group, self)
         else:
             remove_perm("view_evaluation", viewer_group, self)
-            remove_perm("view_evaluation", non_viewer_group, self)
+
+        remove_perm("view_evaluation", non_viewer_group, self)
 
     @property
     def container(self):

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -423,7 +423,6 @@ class Method(UUIDModel, ComponentImage):
 
     def assign_permissions(self):
         assign_perm("view_method", self.phase.challenge.admins_group, self)
-        assign_perm("change_method", self.phase.challenge.admins_group, self)
 
     def get_absolute_url(self):
         return reverse(

--- a/app/grandchallenge/evaluation/tasks.py
+++ b/app/grandchallenge/evaluation/tasks.py
@@ -4,10 +4,6 @@ from statistics import mean, median
 from celery import shared_task
 from django.apps import apps
 
-from grandchallenge.components.models import (
-    ComponentInterface,
-    ComponentInterfaceValue,
-)
 from grandchallenge.evaluation.utils import Metric, rank_results
 
 
@@ -47,6 +43,10 @@ def set_evaluation_inputs(*_, evaluation_pk):
     else:
         from grandchallenge.evaluation.serializers import (
             AlgorithmEvaluationSerializer,
+        )
+        from grandchallenge.components.models import (
+            ComponentInterface,
+            ComponentInterfaceValue,
         )
 
         serializer = AlgorithmEvaluationSerializer(
@@ -194,3 +194,15 @@ def _update_evaluations(*, evaluations, final_positions):
     Evaluation.objects.bulk_update(
         evaluations, ["rank", "rank_score", "rank_per_metric"]
     )
+
+
+@shared_task
+def assign_evaluation_permissions(*, challenge_pk: uuid.UUID):
+    Evaluation = apps.get_model(  # noqa: N806
+        app_label="evaluation", model_name="Evaluation"
+    )
+
+    for e in Evaluation.objects.filter(
+        submission__phase__challenge__id=challenge_pk
+    ):
+        e.assign_permissions()

--- a/app/tests/evaluation_tests/test_permissions.py
+++ b/app/tests/evaluation_tests/test_permissions.py
@@ -1,9 +1,10 @@
 from django.test import TestCase
 from guardian.shortcuts import get_groups_with_perms, get_users_with_perms
 
-from grandchallenge.evaluation.models import AlgorithmEvaluation, Phase
+from grandchallenge.evaluation.models import AlgorithmEvaluation, Method, Phase
 from tests.evaluation_tests.factories import (
     AlgorithmEvaluationFactory,
+    MethodFactory,
     PhaseFactory,
 )
 
@@ -17,6 +18,17 @@ class TestPhasePermissions(TestCase):
             p.challenge.admins_group: ["change_phase", "view_phase"]
         }
         assert get_users_with_perms(p, with_group_users=False).count() == 0
+
+
+class TestMethodPermissions(TestCase):
+    def test_method_permissions(self):
+        """Only challenge admins should be able to view and change methods."""
+        m: Method = MethodFactory()
+
+        assert get_groups_with_perms(m, attach_perms=True) == {
+            m.phase.challenge.admins_group: ["change_method", "view_method"]
+        }
+        assert get_users_with_perms(m, with_group_users=False).count() == 0
 
 
 class TestAlgorithmEvaluationPermissions(TestCase):

--- a/app/tests/evaluation_tests/test_permissions.py
+++ b/app/tests/evaluation_tests/test_permissions.py
@@ -47,7 +47,7 @@ class TestMethodPermissions(TestCase):
         m: Method = MethodFactory()
 
         assert get_groups_with_set_perms(m) == {
-            m.phase.challenge.admins_group: {"change_method", "view_method"}
+            m.phase.challenge.admins_group: {"view_method"}
         }
         assert get_users_with_perms(m, with_group_users=False).count() == 0
 

--- a/app/tests/evaluation_tests/test_permissions.py
+++ b/app/tests/evaluation_tests/test_permissions.py
@@ -1,8 +1,22 @@
 from django.test import TestCase
 from guardian.shortcuts import get_groups_with_perms, get_users_with_perms
 
-from grandchallenge.evaluation.models import AlgorithmEvaluation
-from tests.evaluation_tests.factories import AlgorithmEvaluationFactory
+from grandchallenge.evaluation.models import AlgorithmEvaluation, Phase
+from tests.evaluation_tests.factories import (
+    AlgorithmEvaluationFactory,
+    PhaseFactory,
+)
+
+
+class TestPhasePermissions(TestCase):
+    def test_phase_permissions(self):
+        """Only challenge admins should be able to view and change phases."""
+        p: Phase = PhaseFactory()
+
+        assert get_groups_with_perms(p, attach_perms=True) == {
+            p.challenge.admins_group: ["change_phase", "view_phase"]
+        }
+        assert get_users_with_perms(p, with_group_users=False).count() == 0
 
 
 class TestAlgorithmEvaluationPermissions(TestCase):

--- a/app/tests/evaluation_tests/test_permissions.py
+++ b/app/tests/evaluation_tests/test_permissions.py
@@ -1,11 +1,17 @@
 from django.test import TestCase
 from guardian.shortcuts import get_groups_with_perms, get_users_with_perms
 
-from grandchallenge.evaluation.models import AlgorithmEvaluation, Method, Phase
+from grandchallenge.evaluation.models import (
+    AlgorithmEvaluation,
+    Method,
+    Phase,
+    Submission,
+)
 from tests.evaluation_tests.factories import (
     AlgorithmEvaluationFactory,
     MethodFactory,
     PhaseFactory,
+    SubmissionFactory,
 )
 
 
@@ -29,6 +35,22 @@ class TestMethodPermissions(TestCase):
             m.phase.challenge.admins_group: ["change_method", "view_method"]
         }
         assert get_users_with_perms(m, with_group_users=False).count() == 0
+
+
+class TestSubmissionPermissions(TestCase):
+    def test_submission_permissions(self):
+        """
+        Challenge admins and submission creators should be able to view
+        submissions
+        """
+        s: Submission = SubmissionFactory()
+
+        assert get_groups_with_perms(s, attach_perms=True) == {
+            s.phase.challenge.admins_group: ["view_submission"]
+        }
+        assert get_users_with_perms(
+            s, attach_perms=True, with_group_users=False
+        ) == {s.creator: ["view_submission"]}
 
 
 class TestAlgorithmEvaluationPermissions(TestCase):

--- a/app/tests/evaluation_tests/test_permissions.py
+++ b/app/tests/evaluation_tests/test_permissions.py
@@ -90,8 +90,10 @@ class TestEvaluationPermissions:
     @pytest.mark.parametrize("hidden_challenge", [True, False])
     def test_published_evaluation_permissions(self, hidden_challenge):
         """
-        Challenge admins can change and view published evaluations,
-        and anyone can view published evaluations.
+        Challenge admins can change and view published evaluations.
+
+        If the challenge is hidden, only the participants can view published
+        evaluations, otherwise anyone can view published evaluations.
         """
         e: Evaluation = EvaluationFactory(
             submission__phase__auto_publish_new_results=True,
@@ -170,6 +172,7 @@ class TestEvaluationPermissions:
         }
 
     def test_hiding_challenge_updates_perms(self, settings):
+        """If a challenge is hidden then the viewer group should be updated"""
         e: Evaluation = EvaluationFactory(
             submission__phase__auto_publish_new_results=True,
             submission__phase__challenge__hidden=False,
@@ -204,6 +207,7 @@ class TestEvaluationPermissions:
         }
 
     def test_unhiding_challenge_updates_perms(self, settings):
+        """If a challenge is unhidden then the viewer group should be updated"""
         e: Evaluation = EvaluationFactory(
             submission__phase__auto_publish_new_results=True,
             submission__phase__challenge__hidden=True,

--- a/app/tests/evaluation_tests/test_permissions.py
+++ b/app/tests/evaluation_tests/test_permissions.py
@@ -43,7 +43,7 @@ class TestPhasePermissions(TestCase):
 
 class TestMethodPermissions(TestCase):
     def test_method_permissions(self):
-        """Only challenge admins should be able to view and change methods."""
+        """Only challenge admins should be able to view methods."""
         m: Method = MethodFactory()
 
         assert get_groups_with_set_perms(m) == {


### PR DESCRIPTION
This PR updates the evaluations app to set guardian permissions. For each model:

- The challenge admins group can view all `Phase`s, `Method`s, `Submission`s, `AlgorithmEvaluation`s and `Evaluation`s for their challenge
- The challenge admins group can change all `Phase`s and `Evaluation`s for their challenge
- The submission creator can view their `Submission`s
- If an `Evaluation` is published, and the `Challenge` is hidden, then only the challenge participants group can view it
- If an `Evaluation` is published, and the `Challenge` is not hidden, then anyone can view it

The permissions will need to be added to the existing objects before the views can be updated to use these.

#682