### PR TITLE
Use csv files for leaderboard export

### DIFF
--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
@@ -57,7 +57,7 @@
         {% for offset in offsets %}
             <p>
                 <a class="btn btn-primary"
-                   href="{% url 'api:evaluation-list' %}?format=json&submission__phase={{ phase.pk }}&offset={{ offset }}&limit={{ limit }}"
+                   href="{% url 'api:evaluation-list' %}?format=csv&submission__phase={{ phase.pk }}&offset={{ offset }}&limit={{ limit }}"
                    download="{{ phase.challenge.short_name }}_{{ phase.slug }}_evaluations_{{ offset|add:1 }}_{{ offset|add:limit }}_{{ now }}">
                     <i class="fas fa-file-csv"></i> Evaluations ({{ offset|add:1 }} to {{ offset|add:limit }})
                 </a>

--- a/app/grandchallenge/evaluation/views/api.py
+++ b/app/grandchallenge/evaluation/views/api.py
@@ -1,6 +1,8 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.permissions import DjangoObjectPermissions
+from rest_framework.settings import api_settings
 from rest_framework.viewsets import ReadOnlyModelViewSet
+from rest_framework_csv.renderers import PaginatedCSVRenderer
 from rest_framework_guardian.filters import ObjectPermissionsFilter
 
 from grandchallenge.evaluation.models import (
@@ -39,3 +41,7 @@ class EvaluationViewSet(ReadOnlyModelViewSet):
     filterset_fields = [
         "submission__phase",
     ]
+    renderer_classes = (
+        *api_settings.DEFAULT_RENDERER_CLASSES,
+        PaginatedCSVRenderer,
+    )


### PR DESCRIPTION
JSON is still available via the API by CSV is probably preferred by challenge admins.