### PR TITLE
Implement draggable question for reordering

### DIFF
--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1091,15 +1091,11 @@ class Question(UUIDModel):
     class Meta:
         ordering = ("order", "created")
 
-    @property
-    def answer_type_display(self):
-        return self.get_answer_type_display()
-
     def __str__(self):
         return (
             f"{self.question_text} "
             "("
-            f"{self.answer_type_display}, "
+            f"{self.get_answer_type_display()}, "
             f"{self.get_image_port_display() + ' port,' if self.image_port else ''}"
             f"{'' if self.required else 'not'} required, "
             f"order {self.order}"
@@ -1111,7 +1107,7 @@ class Question(UUIDModel):
         """Values that are included in this ``Question``'s csv export."""
         return [
             self.question_text,
-            self.answer_type_display,
+            self.get_answer_type_display(),
             self.required,
             f"{self.get_image_port_display() + ' port,' if self.image_port else ''}",
         ]

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1091,11 +1091,15 @@ class Question(UUIDModel):
     class Meta:
         ordering = ("order", "created")
 
+    @property
+    def answer_type_display(self):
+        return self.get_answer_type_display()
+
     def __str__(self):
         return (
             f"{self.question_text} "
             "("
-            f"{self.get_answer_type_display()}, "
+            f"{self.answer_type_display}, "
             f"{self.get_image_port_display() + ' port,' if self.image_port else ''}"
             f"{'' if self.required else 'not'} required, "
             f"order {self.order}"
@@ -1107,7 +1111,7 @@ class Question(UUIDModel):
         """Values that are included in this ``Question``'s csv export."""
         return [
             self.question_text,
-            self.get_answer_type_display(),
+            self.answer_type_display,
             self.required,
             f"{self.get_image_port_display() + ' port,' if self.image_port else ''}",
         ]

--- a/app/grandchallenge/reader_studies/serializers.py
+++ b/app/grandchallenge/reader_studies/serializers.py
@@ -47,6 +47,7 @@ class QuestionSerializer(HyperlinkedModelSerializer):
             "reader_study",
             "required",
             "options",
+            "order",
         )
         swagger_schema_fields = swagger_schema_fields_for_charfield(
             answer_type=model._meta.get_field("answer_type"),

--- a/app/grandchallenge/reader_studies/static/reader_studies/css/sortablelist.css
+++ b/app/grandchallenge/reader_studies/static/reader_studies/css/sortablelist.css
@@ -1,0 +1,3 @@
+.sortablejs-draggable {
+    background-color: red;
+}

--- a/app/grandchallenge/reader_studies/templates/reader_studies/inline_question_editor_form.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/inline_question_editor_form.html
@@ -1,0 +1,17 @@
+<div class="w-100 d-flex justify-content-between">
+    {{ question }}
+    {{ question.keys }}
+
+    <div>
+        <i class="fa fa-grip-vertical grip-handle" style="cursor: grab; color: gray;"></i>
+        {{ question.question_text }}
+    </div>
+    <div>
+        {{ question.answer_type_display }}
+    </div>
+
+    <a class="btn btn-primary btn-sm"
+       href="% url 'reader-studies:question-update' slug=object.slug pk=question.pk %">
+        <i class="fa fa-edit"></i>
+    </a>
+</div>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -295,11 +295,20 @@
                  aria-labelledby="v-pills-questions-tab">
                 <h2>Questions</h2>
 
-                <ul class="list-group list-group-flush">
+                <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
+
+                <ul class="list-group list-group-flush" id="full-questions-list">
                     {% for question in object.questions.all %}
-                        <li class="list-group-item">
+                        <li class="list-group-item" gc-update-link="{% url 'api:reader-studies-question-detail' pk=question.pk %}">
                             <div class="w-100 d-flex justify-content-between">
-                                <div>{{ question }}</div>
+                                <div>
+                                    <i class="fa fa-grip-vertical grip-handle" style="cursor: grab; color: gray;"></i>
+                                    {{ question.question_text }}
+                                </div>
+                                <div>
+                                    {{ question.answer_type_display }}
+                                </div>
+
                                 <a class="btn btn-primary btn-sm"
                                    href="{% url 'reader-studies:question-update' slug=object.slug pk=question.pk %}">
                                     <i class="fa fa-edit"></i>
@@ -308,6 +317,36 @@
                         </li>
                     {% endfor %}
                 </ul>
+                <script>
+                    (function () {
+                        const el = document.getElementById("full-questions-list");
+
+                        function processUpdate() {
+                            let i = 1;
+                            for (const c of el.children) {
+                                const url = c.attributes.getNamedItem("gc-update-link").value;
+                                jQuery.ajax({
+                                    url: url,
+                                    method: 'PATCH',
+                                    data: {order: i}
+                                }).fail(() => {
+                                    console.log("FAILED");
+                                }).done(() => {
+                                    console.log("success");
+                                });
+                                i += 1;
+                            }
+                        }
+
+                        const sortable = new Sortable(
+                            el,
+                            {
+                                handle: ".grip-handle",
+                                onUpdate: processUpdate,
+                            }
+                        );
+                    })();
+                </script>
 
                 <p class="mt-3">
                     <a class="btn btn-primary"

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -295,7 +295,12 @@
                  aria-labelledby="v-pills-questions-tab">
                 <h2>Questions</h2>
 
-                <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
+                <p>------------</p>
+
+                {{ questions_list_form.management_form }}
+                {{ questions_list_form.as_ul }}
+
+                <p>------------</p>
 
                 <ul class="list-group list-group-flush" id="full-questions-list">
                     {% for question in object.questions.all %}
@@ -317,7 +322,23 @@
                         </li>
                     {% endfor %}
                 </ul>
+
+                <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
                 <script>
+                    (function() {
+                        var sortables = document.getElementsByClassName("sortablejs-sortable");
+
+                        for (const sortable of sortables) {
+                            new Sortable(
+                                sortable,
+                                {
+                                    handle: ".grip-handle",
+                                    //onUpdate: processUpdate,
+                                }
+                            );
+                        }
+                    })();
+
                     (function () {
                         const el = document.getElementById("full-questions-list");
 
@@ -562,6 +583,8 @@
 
 {% block script %}
     {{ block.super }}
+    {{ questions_list_form.media }}
+
     <script>
         window.drf = {
             csrfHeaderName: "{{ csrf_header_name|default:'X-CSRFToken' }}",

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -896,7 +896,7 @@ class ReaderStudyViewSet(ExportCSVMixin, ReadOnlyModelViewSet):
         )
 
 
-class QuestionViewSet(ReadOnlyModelViewSet):
+class QuestionViewSet(ModelViewSet):
     serializer_class = QuestionSerializer
     queryset = Question.objects.all().select_related("reader_study")
     permission_classes = [DjangoObjectPermissions]

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -17,6 +17,11 @@ from django.core.exceptions import (
 )
 from django.core.paginator import Paginator
 from django.db import transaction
+from django.forms import (
+    formset_factory,
+    modelform_factory,
+    modelformset_factory,
+)
 from django.forms.utils import ErrorList
 from django.http import (
     Http404,
@@ -72,6 +77,7 @@ from grandchallenge.reader_studies.forms import (
     ReaderStudyPermissionRequestUpdateForm,
     ReaderStudyUpdateForm,
     ReadersForm,
+    QuestionEditForm, SortableJSListForm,
 )
 from grandchallenge.reader_studies.models import (
     Answer,
@@ -215,6 +221,16 @@ class ReaderStudyDetail(
         editor_remove_form.fields["action"].initial = EditorsForm.REMOVE
         answers_remove_form = AnswersRemoveForm()
 
+        questions_list = modelformset_factory(
+            Question,
+            form=QuestionEditForm,
+            formset=SortableJSListForm,
+            fields=("question_text", "answer_type"),
+            can_order=True,
+            can_delete=False,
+            extra=0,
+        )
+
         context.update(
             {
                 "user_score": self.object.score_for_user(self.request.user),
@@ -223,6 +239,7 @@ class ReaderStudyDetail(
                 "editor_remove_form": editor_remove_form,
                 "reader_remove_form": reader_remove_form,
                 "answers_remove_form": answers_remove_form,
+                "questions_list_form": questions_list,
                 "user_is_reader": self.object.is_reader(
                     user=self.request.user
                 ),


### PR DESCRIPTION
- Add [SortableJS](https://github.com/SortableJS/Sortable) to easily implement draggable list items. Development seems pretty active - better than "dragula", for example.
- Messily adapted the REST-API to allow patching of the order-field
- Rewriting the order of each question to force absolute ordering

I am pretty sure this is not well implemented, but maybe a nice feature! I thought: "let's try something that might be useful for grand-challenge, just to get up to speed with that project again..."

![out](https://user-images.githubusercontent.com/11632379/94282720-72666080-ff50-11ea-9385-531ad5dc3eac.gif)
