### PR TITLE
Use immutable signature for setting inputs

### DIFF
--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -139,7 +139,7 @@ def get_model_instance(*, pk, app_label, model_name):
 @shared_task
 def execute_job(
     *_, job_pk: uuid.UUID, job_app_label: str, job_model_name: str
-) -> dict:
+) -> None:
     Job = apps.get_model(  # noqa: N806
         app_label=job_app_label, model_name=job_model_name
     )
@@ -188,7 +188,6 @@ def execute_job(
         )
         job.create_result(result=result)
         job.update_status(status=job.SUCCESS, output=logs)
-        return result
 
 
 @shared_task

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -562,7 +562,8 @@ class Submission(UUIDModel):
                 (
                     group(*jobs)
                     | set_evaluation_inputs.signature(
-                        kwargs={"evaluation_pk": evaluation.pk}
+                        kwargs={"evaluation_pk": evaluation.pk},
+                        immutable=True,
                     )
                 ).apply_async()
 

--- a/app/grandchallenge/evaluation/tasks.py
+++ b/app/grandchallenge/evaluation/tasks.py
@@ -8,7 +8,7 @@ from grandchallenge.evaluation.utils import Metric, rank_results
 
 
 @shared_task
-def set_evaluation_inputs(*_, evaluation_pk):
+def set_evaluation_inputs(evaluation_pk):
     """
     Sets the inputs to the Evaluation for a algorithm submission.
 


### PR DESCRIPTION
This disables passing the results from the jobs to the aggregation. Before,
all json output was sent which caused the message passed to SQS to exceed
the size limit, resulting in workflow failure. The return values were
anyway ignored as these are always refreshed from the db.

Closes #1565