### PR TITLE
Prevent upload retries for empty files

### DIFF
--- a/app/grandchallenge/jqfileupload/static/jqfileupload/js/upload_widget.js
+++ b/app/grandchallenge/jqfileupload/static/jqfileupload/js/upload_widget.js
@@ -162,8 +162,8 @@
 
         upload_element.on('fileuploadfail', function (e, data) {
             var file = data.files[0];
-            // This is a failed chunk and gets handled seprately.
-            if (file.size > data.maxChunkSize) {
+            // This is an empty file or a failed chunk and gets handled seprately.
+            if (file.size <= 0 || file.size > data.maxChunkSize) {
                 return
             }
             if (!is_multiupload) {


### PR DESCRIPTION
When uploading an empty file, drf raises a validation error `The submitted file is empty.` and returns a status code 400. This would trigger jqfileupload to retry the upload numerous times. This PR adds a check for empty files in the retry handling.