### PR TITLE
Adds a link to edit the observable notebook

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -636,6 +636,7 @@ REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer"],
     "DEFAULT_PAGINATION_CLASS": "grandchallenge.api.pagination.MaxLimit1000OffsetPagination",
     "PAGE_SIZE": 100,
+    "UNAUTHENTICATED_USER": "guardian.utils.get_anonymous_user",
 }
 
 SWAGGER_SETTINGS = {
@@ -646,7 +647,8 @@ SWAGGER_SETTINGS = {
 
 VALID_SUBDOMAIN_REGEX = r"[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?"
 CORS_ORIGIN_REGEX_WHITELIST = [
-    rf"^https:\/\/{VALID_SUBDOMAIN_REGEX}{re.escape(SESSION_COOKIE_DOMAIN)}$"
+    rf"^https:\/\/{VALID_SUBDOMAIN_REGEX}{re.escape(SESSION_COOKIE_DOMAIN)}$",
+    rf"^https:\/\/{VALID_SUBDOMAIN_REGEX}.static.observableusercontent.com$",
 ]
 CORS_ALLOW_HEADERS = [
     *default_headers,

--- a/app/grandchallenge/core/permissions/rest_framework.py
+++ b/app/grandchallenge/core/permissions/rest_framework.py
@@ -1,3 +1,4 @@
+from guardian.utils import get_anonymous_user
 from rest_framework.permissions import DjangoObjectPermissions
 
 
@@ -19,7 +20,11 @@ class DjangoObjectOnlyPermissions(DjangoObjectPermissions):
             return True
 
         if not request.user or (
-            not request.user.is_authenticated and self.authenticated_users_only
+            (
+                not request.user.is_authenticated
+                or request.user == get_anonymous_user()
+            )
+            and self.authenticated_users_only
         ):
             return False
 

--- a/app/grandchallenge/evaluation/static/js/evaluation/observable.js
+++ b/app/grandchallenge/evaluation/static/js/evaluation/observable.js
@@ -1,28 +1,37 @@
 import {Inspector, Runtime} from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
 
 if (window.self !== window.top) {
-    import(JSON.parse(document.getElementById("observableNotebook").textContent)).then(
+    const observableNotebookJS = JSON.parse(document.getElementById("observableNotebookJS").textContent);
+    const observableNotebookEdit = JSON.parse(document.getElementById("observableNotebookEdit").textContent);
+    const selectedCells = JSON.parse(document.getElementById("observableCells").textContent);
+    const evaluations = JSON.parse(document.getElementById("evaluations").textContent);
+
+    import(observableNotebookJS).then(
         module => {
-            const evaluations = JSON.parse(document.getElementById("evaluations").textContent)
-            const selectedCells = JSON.parse(document.getElementById("observableCells").textContent)
             const runtime = new Runtime()
             let main
 
             if (selectedCells.length === 1 && selectedCells.every((c) => c === "*")) {
-                const cell = document.querySelector("#observableCell")
-                cell.textContent = ""
+                const cell = document.querySelector("#observableCell");
+                cell.textContent = "";
                 main = runtime.module(module.default, Inspector.into(cell));
             } else {
                 main = runtime.module(module.default, (name) => {
-                    let selected = selectedCells.indexOf(name)
+                    let selected = selectedCells.indexOf(name);
                     if (selected > -1) {
-                        const id = selectedCells[selected].replace(/[\s*]/g, "")  // remove spaces and * from cell names
-                        return new Inspector(document.querySelector("#observableCell" + id))
+                        const id = selectedCells[selected].replace(/[\s*]/g, "");  // remove spaces and * from cell names
+                        return new Inspector(document.querySelector("#observableCell" + id));
                     }
                 });
             }
 
-            main.redefine("parse_results", evaluations)
+            main.redefine("parse_results", evaluations);
         }
     )
+
+    const observableEditLink = document.getElementById("observableEditLink");
+    if (observableEditLink !== undefined) {
+        let search = new URLSearchParams([["d", LZString.compressToEncodedURIComponent(JSON.stringify(evaluations.slice(0,2)))]]);
+        observableEditLink.href = `${observableNotebookEdit}?${search}`;
+    }
 }

--- a/app/grandchallenge/evaluation/static/js/evaluation/observable.js
+++ b/app/grandchallenge/evaluation/static/js/evaluation/observable.js
@@ -2,7 +2,6 @@ import {Inspector, Runtime} from "https://cdn.jsdelivr.net/npm/@observablehq/run
 
 if (window.self !== window.top) {
     const observableNotebookJS = JSON.parse(document.getElementById("observableNotebookJS").textContent);
-    const observableNotebookEdit = JSON.parse(document.getElementById("observableNotebookEdit").textContent);
     const selectedCells = JSON.parse(document.getElementById("observableCells").textContent);
     const evaluations = JSON.parse(document.getElementById("evaluations").textContent);
 
@@ -28,10 +27,4 @@ if (window.self !== window.top) {
             main.redefine("parse_results", evaluations);
         }
     )
-
-    const observableEditLink = document.getElementById("observableEditLink");
-    if (observableEditLink !== undefined) {
-        let search = new URLSearchParams(evaluations.map(e => ["pk", e.pk]));
-        observableEditLink.href = `${observableNotebookEdit}?${search}`;
-    }
 }

--- a/app/grandchallenge/evaluation/static/js/evaluation/observable.js
+++ b/app/grandchallenge/evaluation/static/js/evaluation/observable.js
@@ -31,7 +31,7 @@ if (window.self !== window.top) {
 
     const observableEditLink = document.getElementById("observableEditLink");
     if (observableEditLink !== undefined) {
-        let search = new URLSearchParams([["d", LZString.compressToEncodedURIComponent(JSON.stringify(evaluations.slice(0,2)))]]);
+        let search = new URLSearchParams(evaluations.map(e => ["pk", e.pk]));
         observableEditLink.href = `${observableNotebookEdit}?${search}`;
     }
 }

--- a/app/grandchallenge/evaluation/static/js/evaluation/observable.js
+++ b/app/grandchallenge/evaluation/static/js/evaluation/observable.js
@@ -24,7 +24,16 @@ if (window.self !== window.top) {
                 });
             }
 
-            main.redefine("parse_results", evaluations);
+            try {
+                main.redefine("parse_results", evaluations);
+            } catch (error) {
+                const alert = document.getElementById("observableAlert");
+                alert.textContent = "The variable 'parse_results' has not been defined in the provided notebook.";
+                alert.classList.remove("d-none");
+
+                const cells = document.getElementsByClassName("observableCell");
+                while (cells.length > 0) cells[0].remove();
+            }
         }
     )
 }

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -29,7 +29,7 @@
             <iframe id="observableNotebook"
                     class="border-0"
                     style="height: 75vh; min-width: 100%;"
-                    sandbox="allow-scripts"
+                    sandbox="allow-scripts allow-popups"
                     src="{% url 'evaluation:observable-detail' challenge_short_name=challenge.short_name slug=object.submission.phase.slug kind='detail' %}?pk={{ object.pk }}">
             </iframe>
         {% else %}

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
@@ -116,7 +116,7 @@
                         <iframe id="observableNotebook"
                                 class="border-0"
                                 style="height: 75vh; min-width: 100%;"
-                                sandbox="allow-scripts">
+                                sandbox="allow-scripts allow-popups">
                         </iframe>
                     </div>
                 </div>

--- a/app/grandchallenge/evaluation/templates/evaluation/observable_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/observable_detail.html
@@ -36,9 +36,5 @@
     {{ observable_notebook_js|json_script:"observableNotebookJS" }}
     {{ observable_notebook_edit|json_script:"observableNotebookEdit" }}
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.4.4/lz-string.min.js"
-            integrity="sha512-qoCTmFwBtCPvFhA+WAqatSOrghwpDhFHxwAGh+cppWonXbHA09nG1z5zi4/NGnp8dUhXiVrzA6EnKgJA+fyrpw=="
-            crossorigin="anonymous"></script>
-
     <script type="module" src="{% static 'js/evaluation/observable.js' %}"></script>
 {% endblock %}

--- a/app/grandchallenge/evaluation/templates/evaluation/observable_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/observable_detail.html
@@ -1,7 +1,4 @@
 {% extends "base.html" %}
-{% load url %}
-{% load profiles %}
-{% load evaluation_extras %}
 {% load static %}
 
 {% block breadcrumbs %}
@@ -18,6 +15,17 @@
             </div>
         </div>
     {% endfor %}
+
+    {% if "change_challenge" in challenge_perms %}
+        <p>
+            <a id="observableEditLink"
+               class="btn btn-primary"
+               title="Edit notebook in observable"
+               target="_blank">
+                <i class="fa fa-edit"></i>
+            </a>
+        </p>
+    {% endif %}
 {% endblock %}
 
 {% block script %}
@@ -25,7 +33,12 @@
 
     {{ evaluations|json_script:"evaluations" }}
     {{ observable_cells|json_script:"observableCells" }}
-    {{ observable_notebook|json_script:"observableNotebook" }}
+    {{ observable_notebook_js|json_script:"observableNotebookJS" }}
+    {{ observable_notebook_edit|json_script:"observableNotebookEdit" }}
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.4.4/lz-string.min.js"
+            integrity="sha512-qoCTmFwBtCPvFhA+WAqatSOrghwpDhFHxwAGh+cppWonXbHA09nG1z5zi4/NGnp8dUhXiVrzA6EnKgJA+fyrpw=="
+            crossorigin="anonymous"></script>
 
     <script type="module" src="{% static 'js/evaluation/observable.js' %}"></script>
 {% endblock %}

--- a/app/grandchallenge/evaluation/templates/evaluation/observable_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/observable_detail.html
@@ -21,7 +21,8 @@
             <a id="observableEditLink"
                class="btn btn-primary"
                title="Edit notebook in observable"
-               target="_blank">
+               target="_blank"
+               href="{{ observable_notebook_edit }}">
                 <i class="fa fa-edit"></i>
             </a>
         </p>
@@ -34,7 +35,6 @@
     {{ evaluations|json_script:"evaluations" }}
     {{ observable_cells|json_script:"observableCells" }}
     {{ observable_notebook_js|json_script:"observableNotebookJS" }}
-    {{ observable_notebook_edit|json_script:"observableNotebookEdit" }}
 
     <script type="module" src="{% static 'js/evaluation/observable.js' %}"></script>
 {% endblock %}

--- a/app/grandchallenge/evaluation/templates/evaluation/observable_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/observable_detail.html
@@ -8,8 +8,10 @@
 {% endblock %}
 
 {% block body %}
+    <div id="observableAlert" class="alert alert-danger d-none" role="alert"></div>
+
     {% for cell in observable_cells %}
-        <div id="observableCell{{ cell|cut:" "|cut:"*" }}" class="text-center my-1">
+        <div id="observableCell{{ cell|cut:" "|cut:"*" }}" class="text-center my-1 observableCell">
             <div class="text-secondary spinner-border" role="status">
                 <span class="sr-only">Loading Results...</span>
             </div>

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -588,7 +588,7 @@ class ObservableDetail(LeaderboardDetail):
         context.update(
             {
                 "observable_notebook_js": f"{js_url}.js?v=3",
-                "observable_notebook_edit": edit_url,
+                "observable_notebook_edit": f"{edit_url}?{self.request.GET.urlencode()}",
                 "observable_cells": cells,
                 "evaluations": evaluations,
             }

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -574,14 +574,22 @@ class ObservableDetail(LeaderboardDetail):
         else:
             raise Http404()
 
-        url = url.replace(
-            "//observablehq.com/embed/", "//api.observablehq.com/"
+        parsed_url = urlparse(url)
+        cells = parse_qs(parsed_url.query)["cell"]
+        url = f"{urljoin(url, parsed_url.path)}"
+
+        js_url = url.replace(
+            "https://observablehq.com/embed/", "https://api.observablehq.com/"
+        )
+        edit_url = url.replace(
+            "https://observablehq.com/embed/", "https://observablehq.com/"
         )
 
         context.update(
             {
-                "observable_notebook": f"{urljoin(url, urlparse(url).path)}.js?v=3",
-                "observable_cells": parse_qs(urlparse(url).query)["cell"],
+                "observable_notebook_js": f"{js_url}.js?v=3",
+                "observable_notebook_edit": edit_url,
+                "observable_cells": cells,
                 "evaluations": evaluations,
             }
         )

--- a/app/tests/algorithms_tests/test_permissions.py
+++ b/app/tests/algorithms_tests/test_permissions.py
@@ -338,7 +338,7 @@ def test_api_algorithm_list_permissions(client):
     alg_set = TwoAlgorithms()
 
     tests = (
-        (None, 401, []),
+        (None, 200, []),
         (alg_set.creator, 200, []),
         (alg_set.editor1, 200, [alg_set.alg1.pk]),
         (alg_set.user1, 200, [alg_set.alg1.pk]),
@@ -356,14 +356,10 @@ def test_api_algorithm_list_permissions(client):
         )
         assert response.status_code == test[1]
 
-        if test[1] != 401:
-            # We provided auth details and get a response
-            assert response.json()["count"] == len(test[2])
+        assert response.json()["count"] == len(test[2])
 
-            pks = [obj["pk"] for obj in response.json()["results"]]
-
-            for pk in test[2]:
-                assert str(pk) in pks
+        pks = {obj["pk"] for obj in response.json()["results"]}
+        assert {str(pk) for pk in test[2]} == pks
 
 
 @pytest.mark.django_db
@@ -374,7 +370,7 @@ def test_api_algorithm_image_list_permissions(client):
     alg2_image_pk = AlgorithmImageFactory(algorithm=alg_set.alg2).pk
 
     tests = (
-        (None, 401, []),
+        (None, 200, []),
         (alg_set.creator, 200, []),
         (alg_set.editor1, 200, [alg1_image_pk]),
         (alg_set.user1, 200, []),
@@ -392,14 +388,10 @@ def test_api_algorithm_image_list_permissions(client):
         )
         assert response.status_code == test[1]
 
-        if test[1] != 401:
-            # We provided auth details and get a response
-            assert response.json()["count"] == len(test[2])
+        assert response.json()["count"] == len(test[2])
 
-            pks = [obj["pk"] for obj in response.json()["results"]]
-
-            for pk in test[2]:
-                assert str(pk) in pks
+        pks = {obj["pk"] for obj in response.json()["results"]}
+        assert {str(pk) for pk in test[2]} == pks
 
 
 @pytest.mark.django_db
@@ -416,7 +408,7 @@ def test_api_job_list_permissions(client):
     )
 
     tests = (
-        (None, 401, []),
+        (None, 200, []),
         (alg_set.creator, 200, []),
         (alg_set.editor1, 200, [alg1_job]),
         (alg_set.user1, 200, []),
@@ -436,26 +428,24 @@ def test_api_job_list_permissions(client):
         )
         assert response.status_code == test[1]
 
-        if test[1] != 401:
-            # We provided auth details and get a response
-            assert response.json()["count"] == len(test[2])
+        assert response.json()["count"] == len(test[2])
 
-            job_pks = {obj["pk"] for obj in response.json()["results"]}
-            assert job_pks == {str(j.pk) for j in test[2]}
+        job_pks = {obj["pk"] for obj in response.json()["results"]}
+        assert job_pks == {str(j.pk) for j in test[2]}
 
-            # Ensure that the images are downloadable
-            response = get_view_for_user(
-                viewname="api:image-list",
-                client=client,
-                user=test[0],
-                content_type="application/json",
-            )
-            assert response.status_code == 200
+        # Ensure that the images are downloadable
+        response = get_view_for_user(
+            viewname="api:image-list",
+            client=client,
+            user=test[0],
+            content_type="application/json",
+        )
+        assert response.status_code == 200
 
-            image_pks = {obj["pk"] for obj in response.json()["results"]}
-            assert image_pks == {
-                str(i.image.pk) for j in test[2] for i in j.inputs.all()
-            }
+        image_pks = {obj["pk"] for obj in response.json()["results"]}
+        assert image_pks == {
+            str(i.image.pk) for j in test[2] for i in j.inputs.all()
+        }
 
 
 @pytest.mark.django_db

--- a/app/tests/algorithms_tests/test_signals.py
+++ b/app/tests/algorithms_tests/test_signals.py
@@ -48,7 +48,7 @@ def test_user_can_download_images(client, reverse):
         alg1_job.outputs.remove(iv3, iv4)
 
     tests = (
-        (None, 401, []),
+        (None, 200, []),
         (alg_set.creator, 200, []),
         (
             alg_set.editor1,
@@ -84,14 +84,10 @@ def test_user_can_download_images(client, reverse):
         )
         assert response.status_code == test[1]
 
-        if test[1] != 401:
-            # We provided auth details and get a response
-            assert response.json()["count"] == len(test[2])
+        assert response.json()["count"] == len(test[2])
 
-            pks = [obj["pk"] for obj in response.json()["results"]]
-
-            for pk in test[2]:
-                assert str(pk) in pks
+        pks = {obj["pk"] for obj in response.json()["results"]}
+        assert {str(pk) for pk in test[2]} == pks
 
     # Test clearing
     if reverse:
@@ -148,7 +144,7 @@ def test_user_can_download_input_images(client, reverse):
         alg1_job.inputs.remove(iv3, iv4)
 
     tests = (
-        (None, 401, []),
+        (None, 200, []),
         (alg_set.creator, 200, []),
         (
             alg_set.editor1,
@@ -172,14 +168,10 @@ def test_user_can_download_input_images(client, reverse):
         )
         assert response.status_code == test[1]
 
-        if test[1] != 401:
-            # We provided auth details and get a response
-            assert response.json()["count"] == len(test[2])
+        assert response.json()["count"] == len(test[2])
 
-            pks = [obj["pk"] for obj in response.json()["results"]]
-
-            for pk in test[2]:
-                assert str(pk) in pks
+        pks = {obj["pk"] for obj in response.json()["results"]}
+        assert {str(pk) for pk in test[2]} == pks
 
     # Test clearing
     if reverse:

--- a/app/tests/archives_tests/test_signals.py
+++ b/app/tests/archives_tests/test_signals.py
@@ -33,7 +33,7 @@ def test_user_can_download_images(client, reverse):  # noqa: C901
         arch_set.arch1.images.remove(im3, im4)
 
     tests = (
-        (None, 401, set()),
+        (None, 200, set()),
         (arch_set.editor1, 200, {im1.pk, im2.pk}),
         (arch_set.uploader1, 200, {im1.pk, im2.pk}),
         (arch_set.user1, 200, {im1.pk, im2.pk}),
@@ -52,14 +52,13 @@ def test_user_can_download_images(client, reverse):  # noqa: C901
         )
         assert response.status_code == test[1]
 
-        if test[1] != 401:
-            pks = [obj["pk"] for obj in response.json()["results"]]
+        pks = [obj["pk"] for obj in response.json()["results"]]
 
-            for pk in test[2]:
-                assert str(pk) in pks
+        for pk in test[2]:
+            assert str(pk) in pks
 
-            for pk in images - test[2]:
-                assert str(pk) not in pks
+        for pk in images - test[2]:
+            assert str(pk) not in pks
 
     # Test clearing
     if reverse:

--- a/app/tests/profiles_tests/test_views.py
+++ b/app/tests/profiles_tests/test_views.py
@@ -1,6 +1,5 @@
 import pytest
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from guardian.shortcuts import assign_perm
 from rest_framework import status
 from rest_framework.test import force_authenticate
@@ -148,17 +147,16 @@ class TestProfileViewSets:
             (None, False, 0),
             ({}, False, 0),
             ({"is_staff": True}, False, 0),
-            ({"is_superuser": True}, False, 3),
+            ({"is_superuser": True}, False, 5),
             (None, True, 0),
             ({}, True, 1),
             ({"is_staff": True}, True, 1),
-            ({"is_superuser": True}, True, 3),
+            ({"is_superuser": True}, True, 5),
         ),
     )
     def test_profiles_list_permissions(
         self, rf, user_kwargs, permission, expected_count
     ):
-        get_user_model().objects.all().delete()
         user = None
         if user_kwargs is not None:
             user = UserFactory(**user_kwargs)

--- a/app/tests/reader_studies_tests/test_permissions.py
+++ b/app/tests/reader_studies_tests/test_permissions.py
@@ -278,7 +278,7 @@ def test_api_rs_question_list_permissions(client):
     )
 
     tests = (
-        (None, 401, []),
+        (None, 200, []),
         (rs_set.creator, 200, []),
         (rs_set.editor1, 200, [q1.pk]),
         (rs_set.reader1, 200, [q1.pk]),
@@ -296,14 +296,10 @@ def test_api_rs_question_list_permissions(client):
         )
         assert response.status_code == test[1]
 
-        if test[1] != 401:
-            # We provided auth details and get a response
-            assert response.json()["count"] == len(test[2])
+        assert response.json()["count"] == len(test[2])
 
-            pks = [obj["pk"] for obj in response.json()["results"]]
-
-            for pk in test[2]:
-                assert str(pk) in pks
+        pks = {obj["pk"] for obj in response.json()["results"]}
+        assert {str(pk) for pk in test[2]} == pks
 
 
 @pytest.mark.django_db
@@ -313,7 +309,7 @@ def test_api_rs_question_detail_permissions(client):
     q1 = QuestionFactory(reader_study=rs_set.rs1)
 
     tests = (
-        (None, 401),
+        (None, 404),
         (rs_set.creator, 404),
         (rs_set.editor1, 200),
         (rs_set.reader1, 200),

--- a/app/tests/reader_studies_tests/test_signals.py
+++ b/app/tests/reader_studies_tests/test_signals.py
@@ -37,7 +37,7 @@ def test_reader_can_download_images(client, reverse):
         rs_set.rs1.images.remove(im3, im4)
 
     tests = (
-        (None, 401, []),
+        (None, 200, []),
         (rs_set.creator, 200, []),
         (rs_set.editor1, 200, []),
         (rs_set.reader1, 200, [im1.pk, im2.pk]),
@@ -55,14 +55,10 @@ def test_reader_can_download_images(client, reverse):
         )
         assert response.status_code == test[1]
 
-        if test[1] != 401:
-            # We provided auth details and get a response
-            assert response.json()["count"] == len(test[2])
+        assert response.json()["count"] == len(test[2])
 
-            pks = [obj["pk"] for obj in response.json()["results"]]
-
-            for pk in test[2]:
-                assert str(pk) in pks
+        pks = {obj["pk"] for obj in response.json()["results"]}
+        assert {str(pk) for pk in test[2]} == pks
 
     # Test clearing
     if reverse:


### PR DESCRIPTION
This PR:

- Adds a link for challenge admins to edit the notebook on observablehq.com with the data pre-provisioned
- Allows access from `*.static.observableusercontent.com` to CORS
- Allows popups from the iframe in order to edit the notebook in a new tab