### PR TITLE
Allow adding users to job with change_job permission

### DIFF
--- a/app/grandchallenge/algorithms/forms.py
+++ b/app/grandchallenge/algorithms/forms.py
@@ -123,13 +123,11 @@ class UserGroupForm(SaveFormInitMixin, Form):
             raise ValidationError("You cannot add this user!")
         return user
 
-    def add_or_remove_user(self, *, algorithm):
+    def add_or_remove_user(self, *, obj):
         if self.cleaned_data["action"] == self.ADD:
-            getattr(algorithm, f"add_{self.role}")(self.cleaned_data["user"])
+            getattr(obj, f"add_{self.role}")(self.cleaned_data["user"])
         elif self.cleaned_data["action"] == self.REMOVE:
-            getattr(algorithm, f"remove_{self.role}")(
-                self.cleaned_data["user"]
-            )
+            getattr(obj, f"remove_{self.role}")(self.cleaned_data["user"])
 
 
 class EditorsForm(UserGroupForm):
@@ -139,14 +137,14 @@ class EditorsForm(UserGroupForm):
 class UsersForm(UserGroupForm):
     role = "user"
 
-    def add_or_remove_user(self, *, algorithm):
-        super().add_or_remove_user(algorithm=algorithm)
+    def add_or_remove_user(self, *, obj):
+        super().add_or_remove_user(obj=obj)
 
         user = self.cleaned_data["user"]
 
         try:
             permission_request = AlgorithmPermissionRequest.objects.get(
-                user=user, algorithm=algorithm
+                user=user, algorithm=obj
             )
         except ObjectDoesNotExist:
             return
@@ -157,6 +155,10 @@ class UsersForm(UserGroupForm):
             permission_request.status = AlgorithmPermissionRequest.ACCEPTED
 
         permission_request.save()
+
+
+class ViewersForm(UserGroupForm):
+    role = "viewer"
 
 
 class JobForm(SaveFormInitMixin, ModelForm):

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -416,6 +416,9 @@ class Job(UUIDModel, ComponentJob):
     class Meta:
         ordering = ("created",)
 
+    def __str__(self):
+        return f"Job {self.pk}"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._public_orig = self.public
@@ -472,7 +475,10 @@ class Job(UUIDModel, ComponentJob):
         return md2html(template_output)
 
     def get_absolute_url(self):
-        return reverse("algorithms:jobs-detail", kwargs={"pk": self.pk})
+        return reverse(
+            "algorithms:jobs-list",
+            kwargs={"slug": self.algorithm_image.algorithm.slug},
+        )
 
     @property
     def api_url(self):
@@ -522,6 +528,12 @@ class Job(UUIDModel, ComponentJob):
             self.viewer_groups.add(g)
         else:
             self.viewer_groups.remove(g)
+
+    def add_viewer(self, user):
+        return user.groups.add(self.viewers)
+
+    def remove_viewer(self, user):
+        return user.groups.remove(self.viewers)
 
 
 @receiver(post_delete, sender=Job)

--- a/app/grandchallenge/algorithms/templates/algorithms/data_tables/job_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/data_tables/job_list.html
@@ -5,6 +5,7 @@
 {% load pathlib %}
 {% load humanize %}
 {% load evaluation_extras %}
+{% load remove_whitespace %}
 
 {{ job.created|naturaltime }}
 <split/>
@@ -48,8 +49,14 @@
     <i class="fa fa-eye text-success"
        title="Job and images are public"></i>
 {% else %}
-    <i class="fa fa-eye-slash text-danger"
-       title="Job and images are private"></i>
+    {% if job.viewers.user_set.all|length > 1 %}
+        {# TODO: Hack, we need to exclude the creator rather than checking the length is > 1 #}
+        <i class="fa fa-eye text-warning"
+           title="Job and images are visible by {{ job.viewers.user_set.all|oxford_comma }}"></i>
+    {% else %}
+        <i class="fa fa-eye-slash text-danger"
+           title="Job and images are private"></i>
+    {% endif %}
 {% endif %}
 <split/>
 {% if job.status == job.SUCCESS %}
@@ -109,9 +116,14 @@
     </a>
 {% endif %}
 {% if change_job %}
-    <a href="{% url 'algorithms:job-update' slug=algorithm.slug pk=job.pk %}">
-        <span class="badge badge-primary" title="Edit job">
-            <i class="fa fa-edit"></i>
-        </span>
+    <a class="badge badge-primary"
+       href="{% url 'algorithms:job-update' slug=algorithm.slug pk=job.pk %}"
+       title="Edit job">
+        <i class="fa fa-edit"></i>
+    </a>
+    <a class="badge badge-primary"
+       href="{% url 'algorithms:job-viewers-update' slug=algorithm.slug pk=job.pk %}"
+       title="Share this job with another user">
+        <i class="fa fa-user-plus"></i>
     </a>
 {% endif %}

--- a/app/grandchallenge/algorithms/templates/algorithms/user_groups_form.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/user_groups_form.html
@@ -7,7 +7,7 @@
         <li class="breadcrumb-item"><a href="{% url 'algorithms:list' %}">Algorithms</a>
         </li>
         <li class="breadcrumb-item"><a
-                href="{{ object.get_absolute_url }}">{{ object.title }}
+                href="{{ object.get_absolute_url }}">{% firstof object.title object %}
         </a>
         <li class="breadcrumb-item active"
             aria-current="page">Add user

--- a/app/grandchallenge/algorithms/urls.py
+++ b/app/grandchallenge/algorithms/urls.py
@@ -17,6 +17,7 @@ from grandchallenge.algorithms.views import (
     AlgorithmUpdate,
     AlgorithmUserAutocomplete,
     EditorsUpdate,
+    JobViewersUpdate,
     UsersUpdate,
 )
 
@@ -62,6 +63,11 @@ urlpatterns = [
         "<slug>/jobs/<uuid:pk>/update/",
         AlgorithmJobUpdate.as_view(),
         name="job-update",
+    ),
+    path(
+        "<slug>/jobs/<uuid:pk>/viewers/update/",
+        JobViewersUpdate.as_view(),
+        name="job-viewers-update",
     ),
     path(
         "<slug>/editors/update/",

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -44,6 +44,7 @@ from grandchallenge.algorithms.forms import (
     EditorsForm,
     JobForm,
     UsersForm,
+    ViewersForm,
 )
 from grandchallenge.algorithms.models import (
     Algorithm,
@@ -218,38 +219,53 @@ class AlgorithmUserAutocomplete(
         return qs
 
 
-class AlgorithmUserGroupUpdateMixin(
+class UserGroupUpdateMixin(
     LoginRequiredMixin,
     ObjectPermissionRequiredMixin,
     SuccessMessageMixin,
     FormView,
 ):
-    template_name = "algorithms/algorithm_user_groups_form.html"
-    permission_required = (
-        f"{Algorithm._meta.app_label}.change_{Algorithm._meta.model_name}"
-    )
+    template_name = "algorithms/user_groups_form.html"
     raise_exception = True
 
     def get_permission_object(self):
-        return self.algorithm
+        return self.obj
 
     @property
-    def algorithm(self):
-        return get_object_or_404(Algorithm, slug=self.kwargs["slug"])
+    def obj(self):
+        raise NotImplementedError
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update(
-            {"object": self.algorithm, "role": self.get_form().role}
-        )
+        context.update({"object": self.obj, "role": self.get_form().role})
         return context
 
     def get_success_url(self):
-        return self.algorithm.get_absolute_url()
+        return self.obj.get_absolute_url()
 
     def form_valid(self, form):
-        form.add_or_remove_user(algorithm=self.algorithm)
+        form.add_or_remove_user(obj=self.obj)
         return super().form_valid(form)
+
+
+class AlgorithmUserGroupUpdateMixin(UserGroupUpdateMixin):
+    permission_required = (
+        f"{Algorithm._meta.app_label}.change_{Algorithm._meta.model_name}"
+    )
+
+    @property
+    def obj(self):
+        return get_object_or_404(Algorithm, slug=self.kwargs["slug"])
+
+
+class JobUserGroupUpdateMixin(UserGroupUpdateMixin):
+    permission_required = (
+        f"{Job._meta.app_label}.change_{Job._meta.model_name}"
+    )
+
+    @property
+    def obj(self):
+        return get_object_or_404(Job, pk=self.kwargs["pk"])
 
 
 class EditorsUpdate(AlgorithmUserGroupUpdateMixin):
@@ -260,6 +276,20 @@ class EditorsUpdate(AlgorithmUserGroupUpdateMixin):
 class UsersUpdate(AlgorithmUserGroupUpdateMixin):
     form_class = UsersForm
     success_message = "Users successfully updated"
+
+
+class JobViewersUpdate(JobUserGroupUpdateMixin):
+    form_class = ViewersForm
+
+    def get_success_message(self, cleaned_data):
+        return format_html(
+            (
+                "Viewers for {} successfully updated. <br>"
+                "They will be able to see the job by visiting {}"
+            ),
+            self.obj,
+            self.obj.get_absolute_url(),
+        )
 
 
 class AlgorithmImageCreate(
@@ -409,7 +439,7 @@ class AlgorithmJobsList(PermissionListMixin, PaginatedTableListView):
         Column(title="Result", sort_field="inputs__image__name"),
         Column(title="Visibility", sort_field="public"),
         Column(title="Output", sort_field="inputs__image__files__file"),
-        Column(title="Edit", sort_field="comment"),
+        Column(title="Settings", sort_field="comment"),
     ]
     order_by = "created"
 
@@ -437,6 +467,7 @@ class AlgorithmJobsList(PermissionListMixin, PaginatedTableListView):
                 "outputs__image__files",
                 "outputs__interface",
                 "inputs__image__files",
+                "viewers__user_set",
             )
             .select_related(
                 "creator__user_profile",

--- a/app/grandchallenge/core/templatetags/remove_whitespace.py
+++ b/app/grandchallenge/core/templatetags/remove_whitespace.py
@@ -12,6 +12,8 @@ def remove_whitespace(value):
 
 @register.filter
 def oxford_comma(items):
+    items = [str(item) for item in items]
+
     if len(items) > 2:
         return ", and ".join([", ".join(items[:-1]), items[-1]])
     elif len(items) == 2:


### PR DESCRIPTION
This PR allows people with permissions to change the job (currently algorithm editors) to add other users to the jobs viewers group so that they can view this job. The public eye is set to a warning if the job is shared with more than 1 person. If you hover over the eye you can see which users have access to view this job.

The users who have view permissions will have to manually navigate to the jobs list page, as they might not have permission to view or execute the algorithm. The link for this is displayed in the success message.

Demo: https://youtu.be/J1C45nTF0uc

Closes #1053