### PR TITLE
Adds filtering back to the challenge list page

### DIFF
--- a/app/grandchallenge/challenges/filters.py
+++ b/app/grandchallenge/challenges/filters.py
@@ -21,7 +21,7 @@ from grandchallenge.challenges.models import (
 
 
 class ChallengeFilter(FilterSet):
-    search = CharFilter(method="search_filter", label="Search")
+    search = CharFilter(method="search_filter", label="Title or Description")
     modalities = ModelMultipleChoiceFilter(
         queryset=ImagingModality.objects.all(),
         widget=Select2MultipleWidget,

--- a/app/grandchallenge/challenges/filters.py
+++ b/app/grandchallenge/challenges/filters.py
@@ -2,18 +2,63 @@ from functools import reduce
 from operator import or_
 
 from django.db.models import Q
-from django_filters import CharFilter, FilterSet
+from django_filters import (
+    CharFilter,
+    FilterSet,
+    ModelMultipleChoiceFilter,
+)
+from django_select2.forms import Select2MultipleWidget
 
 from grandchallenge.challenges.forms import ChallengeFilterForm
-from grandchallenge.challenges.models import Challenge
+from grandchallenge.challenges.models import (
+    BodyRegion,
+    BodyStructure,
+    Challenge,
+    ChallengeSeries,
+    ImagingModality,
+    TaskType,
+)
 
 
 class ChallengeFilter(FilterSet):
-    search = CharFilter(method="search_filter", label="Search Challenges")
+    search = CharFilter(method="search_filter", label="Search")
+    modalities = ModelMultipleChoiceFilter(
+        queryset=ImagingModality.objects.all(),
+        widget=Select2MultipleWidget,
+        label="Modality",
+    )
+    task_types = ModelMultipleChoiceFilter(
+        queryset=TaskType.objects.all(),
+        widget=Select2MultipleWidget,
+        label="Task Type",
+    )
+    structures = ModelMultipleChoiceFilter(
+        queryset=BodyStructure.objects.all(),
+        widget=Select2MultipleWidget,
+        label="Anatomical Structure",
+    )
+    structures__region = ModelMultipleChoiceFilter(
+        queryset=BodyRegion.objects.all(),
+        widget=Select2MultipleWidget,
+        label="Anatomical Region",
+    )
+    series = ModelMultipleChoiceFilter(
+        queryset=ChallengeSeries.objects.all(),
+        widget=Select2MultipleWidget,
+        label="Challenge Series",
+    )
 
     class Meta:
         model = Challenge
-        fields = ("search",)
+        fields = (
+            "search",
+            "series",
+            "task_types",
+            "modalities",
+            "structures",
+            "structures__region",
+            "educational",
+        )
         form = ChallengeFilterForm
 
     def search_filter(self, queryset, name, value):

--- a/app/grandchallenge/challenges/filters.py
+++ b/app/grandchallenge/challenges/filters.py
@@ -1,0 +1,32 @@
+from functools import reduce
+from operator import or_
+
+from django.db.models import Q
+from django_filters import CharFilter, FilterSet
+
+from grandchallenge.challenges.forms import ChallengeFilterForm
+from grandchallenge.challenges.models import Challenge
+
+
+class ChallengeFilter(FilterSet):
+    search = CharFilter(method="search_filter", label="Search Challenges")
+
+    class Meta:
+        model = Challenge
+        fields = ("search",)
+        form = ChallengeFilterForm
+
+    def search_filter(self, queryset, name, value):
+        search_fields = [
+            "title",
+            "short_name",
+            "description",
+            "event_name",
+        ]
+        return queryset.filter(
+            reduce(
+                or_,
+                [Q(**{f"{f}__icontains": value}) for f in search_fields],
+                Q(),
+            )
+        )

--- a/app/grandchallenge/challenges/forms.py
+++ b/app/grandchallenge/challenges/forms.py
@@ -2,6 +2,7 @@ from crispy_forms.bootstrap import Tab, TabHolder
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import ButtonHolder, Layout, Submit
 from django import forms
+from django.forms import Form
 from django_select2.forms import Select2MultipleWidget
 from django_summernote.widgets import SummernoteInplaceWidget
 
@@ -131,3 +132,11 @@ class ExternalChallengeUpdateForm(forms.ModelForm):
             "series": Select2MultipleWidget,
             "publications": Select2MultipleWidget,
         }
+
+
+class ChallengeFilterForm(Form):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.form_method = "GET"
+        self.helper.layout.append(Submit("submit", "Search"))

--- a/app/grandchallenge/challenges/forms.py
+++ b/app/grandchallenge/challenges/forms.py
@@ -1,6 +1,6 @@
-from crispy_forms.bootstrap import FormActions, Tab, TabHolder
+from crispy_forms.bootstrap import Tab, TabHolder
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import ButtonHolder, Layout, Reset, Submit
+from crispy_forms.layout import ButtonHolder, Layout, Submit
 from django import forms
 from django.forms import Form
 from django_select2.forms import Select2MultipleWidget
@@ -139,13 +139,4 @@ class ChallengeFilterForm(Form):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper(self)
         self.helper.form_method = "GET"
-        self.helper.layout.append(
-            FormActions(
-                Submit("submit", "Filter Results"),
-                Reset(
-                    "cancel",
-                    "Clear Filters",
-                    onclick='window.location.href="./"',
-                ),
-            )
-        )
+        self.helper.layout.append(Submit("submit", "Apply Filters"))

--- a/app/grandchallenge/challenges/forms.py
+++ b/app/grandchallenge/challenges/forms.py
@@ -1,6 +1,6 @@
-from crispy_forms.bootstrap import Tab, TabHolder
+from crispy_forms.bootstrap import FormActions, Tab, TabHolder
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import ButtonHolder, Layout, Submit
+from crispy_forms.layout import ButtonHolder, Layout, Reset, Submit
 from django import forms
 from django.forms import Form
 from django_select2.forms import Select2MultipleWidget
@@ -139,4 +139,13 @@ class ChallengeFilterForm(Form):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper(self)
         self.helper.form_method = "GET"
-        self.helper.layout.append(Submit("submit", "Search"))
+        self.helper.layout.append(
+            FormActions(
+                Submit("submit", "Filter Results"),
+                Reset(
+                    "cancel",
+                    "Clear Filters",
+                    onclick='window.location.href="./"',
+                ),
+            )
+        )

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -1,7 +1,5 @@
 import datetime
 import logging
-import re
-from collections import namedtuple
 from itertools import chain, product
 
 from django.conf import settings
@@ -73,11 +71,6 @@ class TaskType(models.Model):
         return self.type
 
     @property
-    def filter_tag(self):
-        cls = re.sub(r"\W+", "", self.type)
-        return f"task-{cls}"
-
-    @property
     def badge(self):
         return format_html(
             (
@@ -99,11 +92,6 @@ class ImagingModality(models.Model):
 
     def __str__(self):
         return self.modality
-
-    @property
-    def filter_tag(self):
-        cls = re.sub(r"\W+", "", self.modality)
-        return f"modality-{cls}"
 
     @property
     def badge(self):
@@ -128,11 +116,6 @@ class BodyRegion(models.Model):
     def __str__(self):
         return self.region
 
-    @property
-    def filter_tag(self):
-        cls = re.sub(r"\W+", "", self.region)
-        return f"region-{cls}"
-
 
 class BodyStructure(models.Model):
     """Store the organ name and what region it belongs to."""
@@ -147,11 +130,6 @@ class BodyStructure(models.Model):
 
     def __str__(self):
         return f"{self.structure} ({self.region})"
-
-    @property
-    def filter_tag(self):
-        cls = re.sub(r"\W+", "", self.structure)
-        return f"structure-{cls}"
 
     @property
     def badge(self):
@@ -175,11 +153,6 @@ class ChallengeSeries(models.Model):
 
     def __str__(self):
         return f"{self.name}"
-
-    @property
-    def filter_tag(self):
-        cls = re.sub(r"\W+", "", self.name)
-        return f"series-{cls}"
 
     @property
     def badge(self):
@@ -328,12 +301,6 @@ class ChallengeBase(models.Model):
     def upcoming_workshop_date(self):
         if self.workshop_date and self.workshop_date > datetime.date.today():
             return self.workshop_date
-
-    @property
-    def host_filter(self):
-        host_filter = namedtuple("host_filter", ["host", "filter_tag"])
-        domain = self.registered_domain
-        return host_filter(domain, re.sub(r"\W+", "", domain))
 
     @property
     def registered_domain(self):

--- a/app/grandchallenge/challenges/templates/challenges/challenge_list.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_list.html
@@ -24,7 +24,26 @@
         </p>
     {% endif %}
 
-    {% crispy int_filter.form %}
+    <p>
+        <a class="btn btn-primary"
+           role="button"
+           data-toggle="collapse"
+           data-target="#filterForm"
+           aria-expanded="false"
+           aria-controls="filterForm">
+            <i class="fas fa-filter"></i>&nbsp;Filter Challenges
+        </a>
+        {% if filters_applied %}
+            <a class="btn btn-danger" href="?page={{ current_page }}">
+                <i class="fas fa-times"></i>&nbsp;Remove Filters
+            </a>
+        {% endif %}
+    </p>
+    <div class="collapse" id="filterForm">
+        <div class="card card-body mb-3">
+            {% crispy int_filter.form %}
+        </div>
+    </div>
 
     <p class="text-muted">
         {{ num_results }} challenge{{ num_results|pluralize }} found

--- a/app/grandchallenge/challenges/templates/challenges/challenge_list.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_list.html
@@ -3,6 +3,8 @@
 {% load url %}
 {% load humanize %}
 {% load meta_attr %}
+{% load crispy_forms_tags %}
+{% load update_search_params %}
 
 {% block title %}Challenges - {{ block.super }}{% endblock %}
 
@@ -22,25 +24,11 @@
         </p>
     {% endif %}
 
-    <div class="d-flex mb-3 justify-content-end">
-        <form action="" method="GET">
-            <div class="form-row justify-content-end">
-                <div class="col-auto">
-                    <input class="form-control" name="search" type="text" placeholder="Search..."
-                           value={{ current_search }}>
-                </div>
-                <div class="col-auto">
-                    <input type="submit" class="btn btn-primary" value="Search">
-                </div>
-            </div>
-        </form>
-    </div>
+    {% crispy int_filter.form %}
 
-    <div>
-        <p class="text-right text-muted">
-            {{ num_results }} challenge{{ num_results|pluralize }} found
-        </p>
-    </div>
+    <p class="text-muted">
+        {{ num_results }} challenge{{ num_results|pluralize }} found
+    </p>
 
     <div class='row equal-height mx-n2'>
         {% for challenge in page_obj %}
@@ -168,7 +156,7 @@
             </div>
         {% empty %}
             <div class="col px-2">
-                <p>No results for {{ current_search }}.</p>
+                <p>No challenges found.</p>
             </div>
         {% endfor %}
     </div>
@@ -176,14 +164,14 @@
     <div class="d-flex justify-content-end">
         <ul class="pagination">
             <li class="page-item {% if current_page == 1 %}disabled{% endif %}">
-                <a class="page-link" href="?page={{ current_page|add:'-1' }}&search={{ current_search }}">Previous</a>
+                <a class="page-link" href="?{% update_search_params page=previous_page %}">Previous</a>
             </li>
 
             <li class="page-item disabled"><span class="page-link">Page {{ current_page }} of {{ num_pages }}</span>
             </li>
 
             <li class="page-item {% if current_page == num_pages %}disabled{% endif %}">
-                <a class="page-link" href="?page={{ current_page|add:'1' }}&search={{ current_search }}">Next</a>
+                <a class="page-link" href="?{% update_search_params page=next_page %}">Next</a>
             </li>
         </ul>
     </div>

--- a/app/grandchallenge/challenges/templates/challenges/challenge_list.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_list.html
@@ -94,10 +94,6 @@
                             {% endif %}
                         </div>
 
-                        {% for filter_tag in challenge.filter_tags %}
-                            {{ filter_tag.badge }}
-                        {% endfor %}
-
                         {% if challenge.event_name %}
                             <a class="badge badge-info above-stretched-link"
                                href="{% firstof challenge.event_url challenge.get_absolute_url %}"

--- a/app/grandchallenge/challenges/views.py
+++ b/app/grandchallenge/challenges/views.py
@@ -1,6 +1,3 @@
-from functools import reduce
-from operator import or_
-
 from django.contrib import messages
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.paginator import EmptyPage, Paginator
@@ -14,18 +11,15 @@ from django.views.generic import (
     UpdateView,
 )
 
+from grandchallenge.challenges.filters import ChallengeFilter
 from grandchallenge.challenges.forms import (
     ChallengeCreateForm,
     ChallengeUpdateForm,
     ExternalChallengeUpdateForm,
 )
 from grandchallenge.challenges.models import (
-    BodyRegion,
     Challenge,
-    ChallengeSeries,
     ExternalChallenge,
-    ImagingModality,
-    TaskType,
 )
 from grandchallenge.core.permissions.mixins import (
     UserIsChallengeAdminMixin,
@@ -52,52 +46,25 @@ class ChallengeList(TemplateView):
     template_name = "challenges/challenge_list.html"
 
     @property
-    def _search_filter(self):
-        search_query = self._current_search
-
-        q = Q()
-
-        if search_query:
-            search_fields = [
-                "title",
-                "short_name",
-                "description",
-                "event_name",
-            ]
-            q = reduce(
-                or_,
-                [
-                    Q(**{f"{f}__icontains": search_query})
-                    for f in search_fields
-                ],
-                Q(),
-            )
-
-        return q
-
-    @property
     def _current_page(self):
         return int(self.request.GET.get("page", 1))
 
-    @property
-    def _current_search(self):
-        return self.request.GET.get("search", "")
-
     def _get_page(self):
-        int_paginator = Paginator(
+        self.int_filter = ChallengeFilter(
+            self.request.GET,
             Challenge.objects.filter(hidden=False)
-            .filter(self._search_filter)
             .prefetch_related("phase_set", "publications")
             .order_by("-created"),
-            self.paginate_by // 2,
         )
-        ext_paginator = Paginator(
+        self.ext_filter = ChallengeFilter(
+            self.request.GET,
             ExternalChallenge.objects.filter(hidden=False)
-            .filter(self._search_filter)
             .prefetch_related("publications")
             .order_by("-created"),
-            self.paginate_by // 2,
         )
+
+        int_paginator = Paginator(self.int_filter.qs, self.paginate_by // 2)
+        ext_paginator = Paginator(self.ext_filter.qs, self.paginate_by // 2)
 
         num_pages = max(int_paginator.num_pages, ext_paginator.num_pages)
         num_results = int_paginator.count + ext_paginator.count
@@ -117,26 +84,17 @@ class ChallengeList(TemplateView):
     def get_context_data(self, *, object_list=None, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        modalities = ImagingModality.objects.all()
-        task_types = TaskType.objects.all()
-        regions = BodyRegion.objects.all().prefetch_related(
-            "bodystructure_set"
-        )
-        challenge_series = ChallengeSeries.objects.all()
-
         page_obj, num_pages, num_results = self._get_page()
 
         context.update(
             {
-                "modalities": modalities,
-                "body_regions": regions,
-                "task_types": task_types,
-                "challenge_series": challenge_series,
+                "int_filter": self.int_filter,
                 "page_obj": page_obj,
                 "num_pages": num_pages,
                 "num_results": num_results,
                 "current_page": self._current_page,
-                "current_search": self._current_search,
+                "next_page": self._current_page + 1,
+                "previous_page": self._current_page - 1,
                 "jumbotron_title": "Challenges",
                 "jumbotron_description": format_html(
                     (

--- a/app/grandchallenge/challenges/views.py
+++ b/app/grandchallenge/challenges/views.py
@@ -49,6 +49,10 @@ class ChallengeList(TemplateView):
     def _current_page(self):
         return int(self.request.GET.get("page", 1))
 
+    @property
+    def _filters_applied(self):
+        return any(k for k in self.request.GET if k.lower() != "page")
+
     def _get_page(self):
         self.int_filter = ChallengeFilter(
             self.request.GET,
@@ -89,6 +93,7 @@ class ChallengeList(TemplateView):
         context.update(
             {
                 "int_filter": self.int_filter,
+                "filters_applied": self._filters_applied,
                 "page_obj": page_obj,
                 "num_pages": num_pages,
                 "num_results": num_results,

--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -93,3 +93,10 @@ dl.inline dt:after {
 .breadcrumb-item > a {
     color: var(--secondary);
 }
+
+/* Fix display of select2 dropdowns when used in collapsible bootstrap elements */
+.select2-container,
+.select2-container li:only-child,
+.select2-container input:placeholder-shown {
+  width: 100% !important;
+}

--- a/app/grandchallenge/core/templatetags/update_search_params.py
+++ b/app/grandchallenge/core/templatetags/update_search_params.py
@@ -1,0 +1,12 @@
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def update_search_params(context, **kwargs):
+    """Update the set parameters of the current request"""
+    params = context["request"].GET.copy()
+    for k, v in kwargs.items():
+        params[k] = v
+    return params.urlencode()


### PR DESCRIPTION
This uses django filters on the challenge list page. This is kindof a complex example as we have 2 querysets of different models with a common abstract base class, but I think that we should replace any other searching or filtering of `ListViews` with a `FilterSet` so that we can use it in DRF. Should only be a few loc for other views. An `update_search_params` tag is added so that filtering and pagination work well together. 

We used to also filter by Host and Year, but those are not easily accessible as they are calculated in python right now.

Demo: https://youtu.be/BZMLGCgq6v4

Closes #1591 