### PR TITLE
Adds a Job Detail Page

### DIFF
--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -439,15 +439,6 @@ class Job(UUIDModel, ComponentJob):
     def executor_cls(self):
         return AlgorithmExecutor
 
-    @property
-    def duration(self):
-        try:
-            duration = self.completed_at - self.started_at
-        except TypeError:
-            duration = None
-
-        return duration
-
     def create_result(self, *, result: dict):
         interface = ComponentInterface.objects.get(slug="results-json-file")
 

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -439,6 +439,15 @@ class Job(UUIDModel, ComponentJob):
     def executor_cls(self):
         return AlgorithmExecutor
 
+    @property
+    def duration(self):
+        try:
+            duration = self.completed_at - self.started_at
+        except TypeError:
+            duration = None
+
+        return duration
+
     def create_result(self, *, result: dict):
         interface = ComponentInterface.objects.get(slug="results-json-file")
 
@@ -476,8 +485,11 @@ class Job(UUIDModel, ComponentJob):
 
     def get_absolute_url(self):
         return reverse(
-            "algorithms:jobs-list",
-            kwargs={"slug": self.algorithm_image.algorithm.slug},
+            "algorithms:job-detail",
+            kwargs={
+                "slug": self.algorithm_image.algorithm.slug,
+                "pk": self.pk,
+            },
         )
 
     @property

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.utils._os import safe_join
+from django.utils.functional import cached_property
 from django_extensions.db.models import TitleSlugDescriptionModel
 from guardian.shortcuts import assign_perm, get_objects_for_group, remove_perm
 from jinja2 import sandbox
@@ -452,7 +453,7 @@ class Job(UUIDModel, ComponentJob):
             )
             self.outputs.add(output_civ)
 
-    @property
+    @cached_property
     def rendered_result_text(self):
         try:
             result_dict = get(

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
@@ -152,7 +152,7 @@
                     see all of the results:
                 </p>
 
-                <ul class="list-group list-group-flush mb-2">
+                <ul class="list-group list-group-flush mb-3">
                     {% for user in object.editors_group.user_set.all %}
                         <li class="list-group-item">
                             <div class="d-flex justify-content-between align-items-center">
@@ -203,7 +203,7 @@
                 <h2>Users</h2>
                 <p>The following users are able to use this algorithm:</p>
 
-                <ul class="list-group list-group-flush mb-2">
+                <ul class="list-group list-group-flush mb-3">
                     {% for user in object.users_group.user_set.all %}
                         <li class="list-group-item">
                             <div class="d-flex justify-content-between align-items-center">

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
@@ -67,7 +67,7 @@
             {% endif %}
 
             <a class="nav-link"
-               href="{% url 'algorithms:jobs-list' slug=object.slug %}">
+               href="{% url 'algorithms:job-list' slug=object.slug %}">
                 <i class="fas fa-file-export fa-fw"></i>&nbsp;Results
             </a>
 

--- a/app/grandchallenge/algorithms/templates/algorithms/data_tables/job_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/data_tables/job_list.html
@@ -6,6 +6,13 @@
 {% load humanize %}
 {% load remove_whitespace %}
 
+<a class="badge badge-primary"
+   href="{% url 'algorithms:job-detail' slug=algorithm.slug pk=job.pk %}"
+   title="View result details">
+    <i class="fa fa-info-circle"></i>
+</a>
+<split/>
+
 {{ job.created|naturaltime }}
 <split/>
 
@@ -44,92 +51,33 @@
     {% endfor %}
     ({{ job.get_status_display }}{% if job.status == job.SUCCESS and job.stderr %}, with Warnings{% endif %})
 </a>
-{{ job.rendered_result_text|json_script:job.pk }}
+{% if job.rendered_result_text %}
+    {{ job.rendered_result_text|json_script:job.pk }}
+{% endif %}
+<split/>
+
+{{ job.comment }}
 <split/>
 
 {% if job.public %}
     <i class="fa fa-eye text-success"
-       title="Job and images are public"></i>
+       title="Result and images are public"></i>
 {% else %}
     {% if job.viewers.user_set.all|length > 1 %}
         {# TODO: Hack, we need to exclude the creator rather than checking the length is > 1 #}
         <i class="fa fa-eye text-warning"
-           title="Job and images are visible by {{ job.viewers.user_set.all|oxford_comma }}"></i>
+           title="Result and images are visible by {{ job.viewers.user_set.all|oxford_comma }}"></i>
     {% else %}
         <i class="fa fa-eye-slash text-danger"
-           title="Job and images are private"></i>
+           title="Result and images are private"></i>
     {% endif %}
 {% endif %}
 <split/>
 
 {% if job.status == job.SUCCESS %}
-    <ul class="list-unstyled">
-        <li>
-            <a class="badge badge-primary"
-               title="View algorithm result"
-               href="{% url 'workstations:workstation-session-create' slug=algorithm.workstation.slug %}?{% workstation_query algorithm_job=job config=algorithm.workstation_config %}">
-                <i class="fa fa-eye"></i> View Result
-            </a>
-        </li>
-        {% for output in job.outputs.all %}
-            {% for file in output.image.files.all %}
-                <li>
-                    <a class="badge badge-primary"
-                       title="Download Output {{ forloop.parentloop.counter }} ({{ file.image.name }})"
-                       href="{{ file.file.url }}">
-                        <i class="fa fa-download"></i> Output {{ forloop.parentloop.counter }} ({{ file.file|suffix }})
-                    </a>
-                </li>
-            {% endfor %}
-        {% empty %}
-            <li>
-            <span class="badge badge-warning"
-                  title="No output images were found">
-                <i class="fa fa-eye-slash"></i>
-            </span>
-            </li>
-        {% endfor %}
-        {% for input in job.inputs.all %}
-            {% for file in input.image.files.all %}
-                <li>
-                    <a class="badge badge-primary"
-                       title="Download Input {{ input.image.name|stem }} ({{ file.file|suffix }})"
-                       href="{{ file.file.url }}">
-                        <i class="fa fa-download"></i> Input ({{ file.file|suffix }})
-                    </a>
-                </li>
-            {% endfor %}
-        {% endfor %}
-    </ul>
-{% endif %}
-<split/>
-
-<a class="badge badge-primary"
-   href="{% url 'algorithms:job-detail' slug=algorithm.slug pk=job.pk %}"
-   title="View job">
-    <i class="fa fa-info-circle"></i>
-</a>
-{% if job.comment %}
-    <a href="#commentInfoModal"
-       class="badge badge-primary"
-       data-toggle="modal"
-       data-target="#commentInfoModal"
-       data-title="Result Comment"
-       data-comment="{{ job.comment }}"
-       data-pk="{{ job.pk }}"
-       title="Result Comment">
-        <i class="fa fa-file"></i>
-    </a>
-{% endif %}
-{% if change_job %}
     <a class="badge badge-primary"
-       href="{% url 'algorithms:job-update' slug=algorithm.slug pk=job.pk %}"
-       title="Edit job">
-        <i class="fa fa-edit"></i>
-    </a>
-    <a class="badge badge-primary"
-       href="{% url 'algorithms:job-viewers-update' slug=algorithm.slug pk=job.pk %}"
-       title="Share this job with another user">
-        <i class="fa fa-user-plus"></i>
+       title="View algorithm result"
+       href="{% url 'workstations:workstation-session-create' slug=algorithm.workstation.slug %}?{% workstation_query algorithm_job=job config=algorithm.workstation_config %}">
+        <i class="fa fa-eye"></i> Open Result in Viewer
     </a>
 {% endif %}

--- a/app/grandchallenge/algorithms/templates/algorithms/data_tables/job_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/data_tables/job_list.html
@@ -19,7 +19,11 @@
 {% elif job.status == job.RETRY %}
     badge-warning
 {% elif job.status == job.SUCCESS %}
-    badge-success
+    {% if job.stderr %}
+        badge-warning
+    {% else %}
+        badge-success
+    {% endif %}
 {% else %}
     badge-info
 {% endif %}"
@@ -38,7 +42,7 @@
     {% for input in job.inputs.all %}
         {{ input.image.name }}
     {% endfor %}
-    ({{ job.get_status_display }})
+    ({{ job.get_status_display }}{% if job.status == job.SUCCESS and job.stderr %}, with Warnings{% endif %})
 </a>
 {{ job.rendered_result_text|json_script:job.pk }}
 <split/>

--- a/app/grandchallenge/algorithms/templates/algorithms/data_tables/job_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/data_tables/job_list.html
@@ -8,8 +8,10 @@
 
 {{ job.created|naturaltime }}
 <split/>
+
 {{ job.creator|user_profile_link }}
 <split/>
+
 <a href="#resultInfoModal"
    class="badge
 {% if job.status == job.FAILURE or job.status == object.CANCELLED %}
@@ -38,10 +40,9 @@
     {% endfor %}
     ({{ job.get_status_display }})
 </a>
-{% if job.rendered_result_text %}
-    {{ job.rendered_result_text|json_script:job.pk }}
-{% endif %}
+{{ job.rendered_result_text|json_script:job.pk }}
 <split/>
+
 {% if job.public %}
     <i class="fa fa-eye text-success"
        title="Job and images are public"></i>
@@ -56,24 +57,23 @@
     {% endif %}
 {% endif %}
 <split/>
+
 {% if job.status == job.SUCCESS %}
     <ul class="list-unstyled">
         <li>
-            <a href="{% url 'workstations:workstation-session-create' slug=algorithm.workstation.slug %}?{% workstation_query algorithm_job=job config=algorithm.workstation_config %}">
-            <span class="badge badge-primary"
-                  title="View algorithm result">
+            <a class="badge badge-primary"
+               title="View algorithm result"
+               href="{% url 'workstations:workstation-session-create' slug=algorithm.workstation.slug %}?{% workstation_query algorithm_job=job config=algorithm.workstation_config %}">
                 <i class="fa fa-eye"></i> View Result
-            </span>
             </a>
         </li>
         {% for output in job.outputs.all %}
             {% for file in output.image.files.all %}
                 <li>
-                    <a href="{{ file.file.url }}">
-                    <span class="badge badge-primary"
-                          title="Download Output {{ forloop.parentloop.counter }} ({{ file.image.name }})">
+                    <a class="badge badge-primary"
+                       title="Download Output {{ forloop.parentloop.counter }} ({{ file.image.name }})"
+                       href="{{ file.file.url }}">
                         <i class="fa fa-download"></i> Output {{ forloop.parentloop.counter }} ({{ file.file|suffix }})
-                    </span>
                     </a>
                 </li>
             {% endfor %}
@@ -88,11 +88,10 @@
         {% for input in job.inputs.all %}
             {% for file in input.image.files.all %}
                 <li>
-                    <a href="{{ file.file.url }}">
-                    <span class="badge badge-primary"
-                          title="Download Input {{ input.image.name|stem }} ({{ file.file|suffix }})">
+                    <a class="badge badge-primary"
+                       title="Download Input {{ input.image.name|stem }} ({{ file.file|suffix }})"
+                       href="{{ file.file.url }}">
                         <i class="fa fa-download"></i> Input ({{ file.file|suffix }})
-                    </span>
                     </a>
                 </li>
             {% endfor %}
@@ -100,6 +99,12 @@
     </ul>
 {% endif %}
 <split/>
+
+<a class="badge badge-primary"
+   href="{% url 'algorithms:job-detail' slug=algorithm.slug pk=job.pk %}"
+   title="View job">
+    <i class="fa fa-info-circle"></i>
+</a>
 {% if job.comment %}
     <a href="#commentInfoModal"
        class="badge badge-primary"

--- a/app/grandchallenge/algorithms/templates/algorithms/executionsession_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/executionsession_detail.html
@@ -58,7 +58,7 @@
                     <div class="text-center p-3 statusSymbol">
                     </div>
                     <p class="card-text">
-                        <a href="{% url 'algorithms:jobs-list' slug=algorithm.slug %}"
+                        <a href="{% url 'algorithms:job-list' slug=algorithm.slug %}"
                            class="stretched-link statusMessage"></a>
                     </p>
                 </div>

--- a/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
@@ -138,9 +138,10 @@
                             {% for file in input.image.files.all %}
                                 <li>
                                     <a class="badge badge-primary"
-                                       title="Download Input {{ input.image.name|stem }} ({{ file.file|suffix }})"
                                        href="{{ file.file.url }}">
-                                        <i class="fa fa-download"></i> Input ({{ file.file|suffix }})
+                                        <i class="fa fa-download"></i>
+                                        Input {{ forloop.parentloop.counter }} {{ input.image.name|stem }}
+                                        ({{ file.file|suffix }})
                                     </a>
                                 </li>
                             {% endfor %}
@@ -156,9 +157,9 @@
                                 {% for file in output.image.files.all %}
                                     <li>
                                         <a class="badge badge-primary"
-                                           title="Download Output {{ forloop.parentloop.counter }} ({{ file.image.name }})"
                                            href="{{ file.file.url }}">
-                                            <i class="fa fa-download"></i> Output {{ forloop.parentloop.counter }}
+                                            <i class="fa fa-download"></i>
+                                            Output {{ forloop.parentloop.counter }} {{ file.image.name|stem }}
                                             ({{ file.file|suffix }})
                                         </a>
                                     </li>
@@ -185,10 +186,55 @@
             <div class="tab-pane fade" id="v-pills-viewers" role="tabpanel"
                  aria-labelledby="v-pills-viewers-tab">
                 <h2>Viewers</h2>
+
+                <p>
+                    Members of the {{ object.viewer_groups.all|oxford_comma }} groups are able to view this result.
+                </p>
+
+                {% if object.viewers in object.viewer_groups.all %}
+
+                    <p>
+                        The following users are members of this results viewers group:
+                    </p>
+
+                    <ul class="list-group list-group-flush mb-3">
+                        {% for user in object.viewers.user_set.all %}
+                            <li class="list-group-item">
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <div>{{ user|user_profile_link }}</div>
+                                    <div>
+                                        {% if user != request.user %}
+                                            <form action="{% url 'algorithms:job-viewers-update' slug=object.algorithm_image.algorithm.slug pk=object.pk %}"
+                                                  method="POST">
+                                                {% for field in viewers_form %}
+                                                    {% csrf_token %}
+                                                    {% if field.name == "user" %}
+                                                        <input type="hidden" name="user" value="{{ user.id }}"/>
+                                                    {% else %}
+                                                        {{ field }}
+                                                    {% endif %}
+                                                {% endfor %}
+                                                <button type="submit" class="btn btn-danger">Revoke access</button>
+                                            </form>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            </li>
+                        {% empty %}
+                            <li class="list-group-item">There are no users in this results viewers group.</li>
+                        {% endfor %}
+                    </ul>
+
+                    <a class="btn btn-primary"
+                       href="{% url 'algorithms:job-viewers-update' slug=object.algorithm_image.algorithm.slug pk=object.pk %}">
+                        <i class="fa fa-user-plus"></i> Add users
+                    </a>
+
+                {% endif %}
             </div>
         {% endif %}
 
-        {% if "change_job" in job_perms %}
+        {% if "change_algorithm" in algorithm_perms %}
             <div class="tab-pane fade" id="v-pills-logs" role="tabpanel"
                  aria-labelledby="v-pills-logs-tab">
                 <h2>Logs</h2>

--- a/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load guardian_tags %}
 {% load naturaldelta %}
 {% load remove_whitespace %}
 {% load profiles %}
@@ -25,9 +24,6 @@
 {% endblock %}
 
 {% block sidebar %}
-    {% get_obj_perms request.user for object as "job_perms" %}
-    {% get_obj_perms request.user for object.algorithm_image.algorithm as "algorithm_perms" %}
-
     <div class="col-12 col-md-4 col-lg-3 mb-3">
         <div class="nav nav-pills flex-column" id="v-pills-tab" role="tablist"
              aria-orientation="vertical">
@@ -55,9 +51,6 @@
 {% endblock %}
 
 {% block content %}
-    {% get_obj_perms request.user for object as "job_perms" %}
-    {% get_obj_perms request.user for object.algorithm_image.algorithm as "algorithm_perms" %}
-
     <div class="tab-content" id="v-pills-tabContent">
         <div class="tab-pane fade show active" id="v-pills-info" role="tabpanel"
              aria-labelledby="v-pills-info-tab">

--- a/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
@@ -1,0 +1,198 @@
+{% extends "base.html" %}
+{% load guardian_tags %}
+{% load naturaldelta %}
+{% load remove_whitespace %}
+{% load profiles %}
+{% load pathlib %}
+{% load workstations %}
+
+{% block title %}
+    Algorithm Result - {{ block.super }}
+{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a
+                href="{% url 'algorithms:list' %}">Algorithms</a>
+        </li>
+        <li class="breadcrumb-item"><a
+                href="{{ object.algorithm_image.algorithm.get_absolute_url }}">{{ object.algorithm_image.algorithm.title }}
+        </a>
+        <li class="breadcrumb-item"><a
+                href="{% url 'algorithms:job-list' slug=object.algorithm_image.algorithm.slug %}">Results</a>
+        <li class="breadcrumb-item active" aria-current="page">{{ object.pk }}</li>
+    </ol>
+{% endblock %}
+
+{% block sidebar %}
+    {% get_obj_perms request.user for object as "job_perms" %}
+    {% get_obj_perms request.user for object.algorithm_image.algorithm as "algorithm_perms" %}
+
+    <div class="col-12 col-md-4 col-lg-3 mb-3">
+        <div class="nav nav-pills flex-column" id="v-pills-tab" role="tablist"
+             aria-orientation="vertical">
+            <a class="nav-link active" id="v-pills-info-tab" data-toggle="pill"
+               href="#v-pills-info" role="tab" aria-controls="v-pills-info"
+               aria-selected="true"><i
+                    class="fas fa-info fa-fw"></i>&nbsp;Information
+            </a>
+
+            {% if "change_job" in job_perms %}
+                <a class="nav-link" id="v-pills-viewers-tab" data-toggle="pill"
+                   href="#v-pills-viewers" role="tab" aria-controls="v-pulls-viewers"
+                   aria-selected="false"><i class="fas fa-users fa-fw"></i>&nbsp;Viewers
+                </a>
+            {% endif %}
+
+            {% if "change_algorithm" in algorithm_perms %}
+                <a class="nav-link" id="v-pills-logs-tab" data-toggle="pill"
+                   href="#v-pills-logs" role="tab" aria-controls="v-pills-logs"
+                   aria-selected="false"><i class="fas fa-terminal fa-fw"></i>&nbsp;Logs
+                </a>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}
+
+{% block content %}
+    {% get_obj_perms request.user for object as "job_perms" %}
+    {% get_obj_perms request.user for object.algorithm_image.algorithm as "algorithm_perms" %}
+
+    <div class="tab-content" id="v-pills-tabContent">
+        <div class="tab-pane fade show active" id="v-pills-info" role="tabpanel"
+             aria-labelledby="v-pills-info-tab">
+            <h2>Algorithm Result</h2>
+
+            {{ object.rendered_result_text }}
+
+            {% if object.status == object.SUCCESS %}
+                <a class="btn btn-primary mb-3"
+                   href="{% url 'workstations:workstation-session-create' slug=object.algorithm_image.algorithm.workstation.slug %}?{% workstation_query algorithm_job=object config=object.algorithm_image.algorithm.workstation_config %}">
+                    <i class="fa fa-eye"></i> Open Result in Viewer
+                </a>
+            {% endif %}
+
+            <dl class="row">
+                <dt class="col-sm-3">Result ID</dt>
+                <dd class="col-sm-9">{{ object.pk }}</dd>
+
+                <dt class="col-sm-3">Algorithm</dt>
+                <dd class="col-sm-9"><a
+                        href="{{ object.algorithm_image.algorithm.get_absolute_url }}">{{ object.algorithm_image.algorithm }}</a>
+                </dd>
+
+                <dt class="col-sm-3">Algorithm Version</dt>
+                <dd class="col-sm-9">{{ object.algorithm_image.pk }}</dd>
+
+                <dt class="col-sm-3">Creator</dt>
+                <dd class="col-sm-9">{{ object.creator|user_profile_link }}</dd>
+
+                <dt class="col-sm-3">Created</dt>
+                <dd class="col-sm-9">{{ object.created }}</dd>
+
+                <dt class="col-sm-3">Status</dt>
+                <dd class="col-sm-9">
+                    <span class="badge
+                        {% if job.status == job.FAILURE or job.status == object.CANCELLED %}
+                            badge-danger
+                        {% elif job.status == job.RETRY %}
+                            badge-warning
+                        {% elif job.status == job.SUCCESS %}
+                            badge-success
+                        {% else %}
+                            badge-info
+                        {% endif %}">
+                        {{ object.get_status_display }}
+                    </span>
+                </dd>
+
+                {% if object.duration %}
+                    <dt class="col-sm-3">Duration</dt>
+                    <dd class="col-sm-9">{{ object.duration|naturaldelta }}</dd>
+                {% endif %}
+
+                {% if object.comment %}
+                    <dt class="col-sm-3">Comment</dt>
+                    <dd class="col-sm-9">{{ object.comment }}</dd>
+                {% endif %}
+
+                <dt class="col-sm-3">Visibility</dt>
+                <dd class="col-sm-9">
+                    {% if object.public %}
+                        <i class="fa fa-eye text-success"></i> Result and images are public
+                    {% else %}
+                        {% if object.viewers.user_set.all|length > 1 %}
+                            {# TODO: Hack, we need to exclude the creator rather than checking the length is > 1 #}
+                            <i class="fa fa-eye text-warning"></i>
+                            Result and images are visible by {{ object.viewers.user_set.all|oxford_comma }}
+                        {% else %}
+                            <i class="fa fa-eye-slash text-danger"></i> Result and images are private
+                        {% endif %}
+                    {% endif %}
+                </dd>
+
+                <dt class="col-sm-3">Inputs</dt>
+                <dd class="col-sm-9">
+                    <ul class="list-unstyled mb-0">
+                        {% for input in object.inputs.all %}
+                            {% for file in input.image.files.all %}
+                                <li>
+                                    <a class="badge badge-primary"
+                                       title="Download Input {{ input.image.name|stem }} ({{ file.file|suffix }})"
+                                       href="{{ file.file.url }}">
+                                        <i class="fa fa-download"></i> Input ({{ file.file|suffix }})
+                                    </a>
+                                </li>
+                            {% endfor %}
+                        {% endfor %}
+                    </ul>
+                </dd>
+
+                {% if object.status == object.SUCCESS %}
+                    <dt class="col-sm-3">Outputs</dt>
+                    <dd class="col-sm-9">
+                        <ul class="list-unstyled mb-0">
+                            {% for output in object.outputs.all %}
+                                {% for file in output.image.files.all %}
+                                    <li>
+                                        <a class="badge badge-primary"
+                                           title="Download Output {{ forloop.parentloop.counter }} ({{ file.image.name }})"
+                                           href="{{ file.file.url }}">
+                                            <i class="fa fa-download"></i> Output {{ forloop.parentloop.counter }}
+                                            ({{ file.file|suffix }})
+                                        </a>
+                                    </li>
+                                {% endfor %}
+                            {% empty %}
+                                <li>
+                                    <i class="fa fa-eye-slash text-warning"></i> No output images were found
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </dd>
+                {% endif %}
+            </dl>
+
+            {% if "change_job" in job_perms %}
+                <a class="btn btn-primary"
+                   href="{% url 'algorithms:job-update' slug=object.algorithm_image.algorithm.slug pk=object.pk %}">
+                    <i class="fa fa-edit"></i> Edit this Result
+                </a>
+            {% endif %}
+        </div>
+
+        {% if "change_job" in job_perms %}
+            <div class="tab-pane fade" id="v-pills-viewers" role="tabpanel"
+                 aria-labelledby="v-pills-viewers-tab">
+                <h2>Viewers</h2>
+            </div>
+        {% endif %}
+
+        {% if "change_job" in job_perms %}
+            <div class="tab-pane fade" id="v-pills-logs" role="tabpanel"
+                 aria-labelledby="v-pills-logs-tab">
+                <h2>Logs</h2>
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
@@ -93,18 +93,28 @@
                 <dt class="col-sm-3">Status</dt>
                 <dd class="col-sm-9">
                     <span class="badge
-                        {% if job.status == job.FAILURE or job.status == object.CANCELLED %}
+                        {% if object.status == object.FAILURE or object.status == object.CANCELLED %}
                             badge-danger
-                        {% elif job.status == job.RETRY %}
+                        {% elif object.status == object.RETRY %}
                             badge-warning
-                        {% elif job.status == job.SUCCESS %}
-                            badge-success
+                        {% elif object.status == object.SUCCESS %}
+                            {% if object.stderr %}
+                                badge-warning
+                            {% else %}
+                                badge-success
+                            {% endif %}
                         {% else %}
                             badge-info
                         {% endif %}">
-                        {{ object.get_status_display }}
+                        {{ object.get_status_display }}{% if object.status == object.SUCCESS and object.stderr %}, with
+                            Warnings{% endif %}
                     </span>
                 </dd>
+
+                {% if object.error_message %}
+                    <dt class="col-sm-3">Error Message</dt>
+                    <dd class="col-sm-9">{{ object.error_message }}</dd>
+                {% endif %}
 
                 {% if object.duration %}
                     <dt class="col-sm-3">Duration</dt>
@@ -238,6 +248,17 @@
             <div class="tab-pane fade" id="v-pills-logs" role="tabpanel"
                  aria-labelledby="v-pills-logs-tab">
                 <h2>Logs</h2>
+
+                <h3>Stdout</h3>
+                {# @formatter:off #}
+                <pre class="console">{% if object.stdout %}{{ object.stdout }}{% else %}No logs found on stdout{% endif %}</pre>
+                {# @formatter:on #}
+
+                <h3>Stderr</h3>
+                {# @formatter:off #}
+                <pre class="console">{% if object.stderr %}{{ object.stderr }}{% else %}No logs found on stderr{% endif %}</pre>
+                {# @formatter:on #}
+
             </div>
         {% endif %}
     </div>

--- a/app/grandchallenge/algorithms/templates/algorithms/job_form.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_form.html
@@ -15,8 +15,8 @@
                 href="{{ object.algorithm_image.algorithm.get_absolute_url }}">{{ object.algorithm_image.algorithm.title }}
         </a>
         <li class="breadcrumb-item"><a
-                href="{% url 'algorithms:jobs-list' slug=object.algorithm_image.algorithm.slug %}">Results</a>
-        <li class="breadcrumb-item"><a href="">{{ object.pk }}</a></li>
+                href="{% url 'algorithms:job-list' slug=object.algorithm_image.algorithm.slug %}">Results</a>
+        <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{{ object.pk }}</a></li>
         <li class="breadcrumb-item active"
             aria-current="page">Update
         </li>

--- a/app/grandchallenge/algorithms/templates/algorithms/job_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_list.html
@@ -75,26 +75,11 @@
                 </div>
                 <div class="modal-body">
                     <p class="modal-job-output"></p>
-                    <p id="footerText" class="small text-muted"></p>
                 </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="modal fade" id="commentInfoModal" tabindex="-1" role="dialog"
-         aria-labelledby="commentInfoModalTitle" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title"></h5>
-                    <button type="button" class="close" data-dismiss="modal"
-                            aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <div class="modal-body">
-                    <p class="modal-job-comment"></p>
-                    <p id="footerText" class="small text-muted"></p>
+                <div class="modal-footer">
+                    <a class="btn btn-primary" id="resultDetailLink" href="">
+                        <i class="fa fa-info-circle"></i> View Result Details
+                    </a>
                 </div>
             </div>
         </div>
@@ -124,24 +109,13 @@
             let button = $(event.relatedTarget);
             let modal = $(this);
             const json_element = document.getElementById(button.data('pk'));
-            if (json_element){
+            if (json_element) {
                 modal.find('.modal-job-output').html(JSON.parse(json_element.textContent));
-            }else {
+            } else {
                 modal.find('.modal-job-output').text(button.data('output'));
             }
             modal.find('.modal-title').text(button.data('title'));
-            modal.find('#footerText').text("ID: " + button.data('pk'));
+            modal.find('#resultDetailLink').attr("href", `${button.data("pk")}/`);
         })
     </script>
-
-    <script type="text/javascript">
-        $('#commentInfoModal').on('show.bs.modal', function (event) {
-            let button = $(event.relatedTarget);
-            let modal = $(this);
-            modal.find('.modal-title').text(button.data('title'));
-            modal.find('.modal-job-comment').text(button.data('comment'));
-            modal.find('#footerText').text("ID: " + button.data('pk'));
-        })
-    </script>
-
 {% endblock %}

--- a/app/grandchallenge/algorithms/urls.py
+++ b/app/grandchallenge/algorithms/urls.py
@@ -8,8 +8,6 @@ from grandchallenge.algorithms.views import (
     AlgorithmImageCreate,
     AlgorithmImageDetail,
     AlgorithmImageUpdate,
-    AlgorithmJobUpdate,
-    AlgorithmJobsList,
     AlgorithmList,
     AlgorithmPermissionRequestCreate,
     AlgorithmPermissionRequestList,
@@ -17,7 +15,10 @@ from grandchallenge.algorithms.views import (
     AlgorithmUpdate,
     AlgorithmUserAutocomplete,
     EditorsUpdate,
+    JobDetail,
+    JobUpdate,
     JobViewersUpdate,
+    JobsList,
     UsersUpdate,
 )
 
@@ -58,10 +59,11 @@ urlpatterns = [
         AlgorithmExecutionSessionDetail.as_view(),
         name="execution-session-detail",
     ),
-    path("<slug>/jobs/", AlgorithmJobsList.as_view(), name="jobs-list"),
+    path("<slug>/jobs/", JobsList.as_view(), name="job-list"),
+    path("<slug>/jobs/<uuid:pk>/", JobDetail.as_view(), name="job-detail",),
     path(
         "<slug>/jobs/<uuid:pk>/update/",
-        AlgorithmJobUpdate.as_view(),
+        JobUpdate.as_view(),
         name="job-update",
     ),
     path(

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -423,7 +423,7 @@ class AlgorithmExecutionSessionDetail(
         return context
 
 
-class AlgorithmJobsList(PermissionListMixin, PaginatedTableListView):
+class JobsList(PermissionListMixin, PaginatedTableListView):
     model = Job
     permission_required = f"{Job._meta.app_label}.view_{Job._meta.model_name}"
     row_template = "algorithms/data_tables/job_list.html"
@@ -483,21 +483,17 @@ class AlgorithmJobsList(PermissionListMixin, PaginatedTableListView):
         return context
 
 
-class AlgorithmJobUpdate(
-    LoginRequiredMixin, ObjectPermissionRequiredMixin, UpdateView
-):
+class JobDetail(DetailView):
+    model = Job
+
+
+class JobUpdate(LoginRequiredMixin, ObjectPermissionRequiredMixin, UpdateView):
     model = Job
     form_class = JobForm
     permission_required = (
         f"{Job._meta.app_label}.change_{Job._meta.model_name}"
     )
     raise_exception = True
-
-    def get_success_url(self):
-        return reverse(
-            "algorithms:jobs-list",
-            kwargs={"slug": self.object.algorithm_image.algorithm.slug},
-        )
 
 
 class AlgorithmViewSet(ReadOnlyModelViewSet):

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -484,7 +484,9 @@ class JobsList(PermissionListMixin, PaginatedTableListView):
         return context
 
 
-class JobDetail(DetailView):
+class JobDetail(ObjectPermissionRequiredMixin, DetailView):
+    permission_required = f"{Job._meta.app_label}.view_{Job._meta.model_name}"
+    raise_exception = True
     queryset = (
         Job.objects.with_duration()
         .prefetch_related(

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -484,7 +484,16 @@ class JobsList(PermissionListMixin, PaginatedTableListView):
 
 
 class JobDetail(DetailView):
-    model = Job
+    queryset = Job.objects.with_duration()
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        viewers_form = ViewersForm()
+        viewers_form.fields["action"].initial = ViewersForm.REMOVE
+        context.update({"viewers_form": viewers_form})
+
+        return context
 
 
 class JobUpdate(LoginRequiredMixin, ObjectPermissionRequiredMixin, UpdateView):

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -26,7 +26,6 @@ from django.views.generic import (
     UpdateView,
 )
 from django_filters.rest_framework import DjangoFilterBackend
-from guardian.core import ObjectPermissionChecker
 from guardian.mixins import (
     LoginRequiredMixin,
     PermissionListMixin,
@@ -435,26 +434,21 @@ class JobsList(PermissionListMixin, PaginatedTableListView):
         "comment",
     ]
     columns = [
+        Column(title="Details", sort_field="created"),
         Column(title="Created", sort_field="created"),
         Column(title="Creator", sort_field="creator__username"),
         Column(title="Result", sort_field="inputs__image__name"),
+        Column(title="Comment", sort_field="comment"),
         Column(title="Visibility", sort_field="public"),
-        Column(title="Output", sort_field="inputs__image__files__file"),
-        Column(title="Settings", sort_field="comment"),
+        Column(title="Viewer", sort_field="inputs__image__files__file"),
     ]
     order_by = "created"
 
-    def get_row_context(self, job, *args, checker, **kwargs):
+    def get_row_context(self, job, *args, **kwargs):
         return {
             "job": job,
             "algorithm": self.algorithm,
-            "change_job": checker.has_perm("change_job", job),
         }
-
-    def get_data(self, jobs, *args, **kwargs):
-        checker = ObjectPermissionChecker(self.request.user)
-        checker.prefetch_perms(jobs.object_list)
-        return [self.render_row_data(job, checker=checker) for job in jobs]
 
     @cached_property
     def algorithm(self):

--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -100,3 +100,8 @@ dl.inline dt:after {
 .select2-container input:placeholder-shown {
   width: 100% !important;
 }
+
+.console {
+    background-color: var(--gray-dark);
+    color: var(--light);
+}

--- a/app/grandchallenge/profiles/templatetags/profiles.py
+++ b/app/grandchallenge/profiles/templatetags/profiles.py
@@ -46,7 +46,7 @@ def user_profile_link(user: Union[AbstractUser, None]) -> str:
         mugshot = mark_safe('<i class="fas fa-user fa-lg"></i>')
 
     return format_html(
-        '<a href="{0}">{1}</a>&nbsp;<a href="{0}">{2}</a>&nbsp;{3}',
+        '<a class="text-nowrap" href="{0}">{1}</a>&nbsp;<a href="{0}">{2}</a>&nbsp;{3}',
         profile_url,
         mugshot,
         username,

--- a/app/tests/algorithms_tests/test_models.py
+++ b/app/tests/algorithms_tests/test_models.py
@@ -98,12 +98,15 @@ def test_outputs_are_set():
 
     assert job.rendered_result_text == ""
     job.create_result(result={"foo": 13.37})
+    del job.rendered_result_text
     assert job.rendered_result_text == "<p>foo score: 13.37</p>"
 
     job.algorithm_image.algorithm.result_template = "{% for key, value in dict.metrics.items() -%}{{ key }}  {{ value }}{% endfor %}"
+    del job.rendered_result_text
     assert job.rendered_result_text == "Jinja template is invalid"
 
     job.algorithm_image.algorithm.result_template = "{{ str.__add__('test')}}"
+    del job.rendered_result_text
     assert job.rendered_result_text == "Jinja template is invalid"
 
 

--- a/app/tests/algorithms_tests/test_permissions.py
+++ b/app/tests/algorithms_tests/test_permissions.py
@@ -181,7 +181,7 @@ def test_algorithm_jobs_list_view(client):
 
     for test in tests:
         response = get_view_for_user(
-            viewname="algorithms:jobs-list",
+            viewname="algorithms:job-list",
             reverse_kwargs={"slug": test[1].slug},
             client=client,
             user=test[0],

--- a/app/tests/algorithms_tests/test_views.py
+++ b/app/tests/algorithms_tests/test_views.py
@@ -352,7 +352,7 @@ def test_algorithm_jobs_list_view(client):
         job.save()
 
     response = get_view_for_user(
-        viewname="algorithms:jobs-list",
+        viewname="algorithms:job-list",
         reverse_kwargs={"slug": slugify(alg.slug)},
         client=client,
         user=editor,
@@ -363,7 +363,7 @@ def test_algorithm_jobs_list_view(client):
     assert response.status_code == 200
 
     response = get_view_for_user(
-        viewname="algorithms:jobs-list",
+        viewname="algorithms:job-list",
         reverse_kwargs={"slug": slugify(alg.slug)},
         client=client,
         user=editor,
@@ -378,7 +378,7 @@ def test_algorithm_jobs_list_view(client):
     assert len(resp["data"]) == 10
 
     response = get_view_for_user(
-        viewname="algorithms:jobs-list",
+        viewname="algorithms:job-list",
         reverse_kwargs={"slug": slugify(alg.slug)},
         client=client,
         user=editor,
@@ -393,7 +393,7 @@ def test_algorithm_jobs_list_view(client):
     assert len(resp["data"]) == 50
 
     response = get_view_for_user(
-        viewname="algorithms:jobs-list",
+        viewname="algorithms:job-list",
         reverse_kwargs={"slug": slugify(alg.slug)},
         client=client,
         user=editor,
@@ -410,7 +410,7 @@ def test_algorithm_jobs_list_view(client):
     resp_new["data"] == resp["data"][::-1]
 
     response = get_view_for_user(
-        viewname="algorithms:jobs-list",
+        viewname="algorithms:job-list",
         reverse_kwargs={"slug": slugify(alg.slug)},
         client=client,
         user=editor,


### PR DESCRIPTION
This PR adds a job detail page, which allows the job editor to manage the users group, and the algorithm editors to see the logs. As this is a new page, I have removed some of the clutter from the job list view, such as downloading images and editing the job. Job editors are able to remove users from the viewers group as long as they are not the request user. If the job is successful but there is output on stderr the job badge will have a warning.

Demo: https://youtu.be/v7rP35j2xks

Closes #1599 