### PR TITLE
Disable sorting on leaderboard extra fields

### DIFF
--- a/app/grandchallenge/evaluation/static/js/evaluation/leaderboard.js
+++ b/app/grandchallenge/evaluation/static/js/evaluation/leaderboard.js
@@ -35,6 +35,7 @@ $(document).ready(function () {
             {
                 targets: 'toggleable',
                 visible: false,
+                orderable: false,
             }
         ],
         ordering: true,


### PR DESCRIPTION
Sorting on extra fields does not work right now as otherwise, we would need to make a custom lookup for the extra field in the DB, opening up a SQL injection vulnerability, so disable this for now until we have a better solution.