### PR TITLE
Fix downloading of image files in development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       "
     restart: always
 
-  minio-protected:
+  minio-protected.localhost:
     # This is for protected data, should only be exposed via an internal link
     # in nginx
     image: minio/minio
@@ -77,7 +77,7 @@ services:
       <<: &protected_storage_credentials
         PROTECTED_S3_STORAGE_ACCESS_KEY: minioprotected
         PROTECTED_S3_STORAGE_SECRET_KEY: minioprotected12345
-        PROTECTED_S3_STORAGE_ENDPOINT_URL: http://minio-protected:9081
+        PROTECTED_S3_STORAGE_ENDPOINT_URL: http://minio-protected.localhost:9081
       PUBLIC_S3_STORAGE_ACCESS_KEY: miniopublic
       PUBLIC_S3_STORAGE_SECRET_KEY: miniopublic12345
       PYTHONDONTWRITEBYTECODE: 1
@@ -96,7 +96,7 @@ services:
         condition: service_healthy
       minio-private:
         condition: service_started
-      minio-protected:
+      minio-protected.localhost:
         condition: service_started
       minio-public:
         condition: service_started

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -27,16 +27,7 @@ For the same reason, we currently recommend running PyCharm from wsl rather than
     $ git clone https://github.com/comic/grand-challenge.org
     $ cd grand-challenge.org
 
-3. Add the following to your hosts file (``/etc/hosts`` on Linux, ``C:\Windows\System32\drivers\etc\hosts`` on Windows):
-
-.. code-block:: console
-
-    127.0.0.1 gc.localhost
-    127.0.0.1 demo.gc.localhost
-    127.0.0.1 minio-public
-    127.0.0.1 minio-protected
-
-4. You can then start the development site by invoking
+3. You can then start the development site by invoking
 
 .. code-block:: console
 


### PR DESCRIPTION
This PR allows developers to download image files from minio-protected.localhost,
which Firefox allows mixed HTTP and HTTPS traffic from. Also removes setting
the hosts in the developers host file as the urls now work natively with
Firefox 84 and Edge (not tested in Chrome but I believe this is ok).