### PR TITLE
Moves verification domain out of title

### DIFF
--- a/app/grandchallenge/groups/views.py
+++ b/app/grandchallenge/groups/views.py
@@ -99,8 +99,8 @@ class UserAutocomplete(
             return format_html(
                 '<img src="{}" width ="20" height ="20" style="vertical-align:top"> '
                 "&nbsp; <b>{}</b> &nbsp; {} &nbsp;"
-                '<i class="fas fa-user-check text-success" '
-                'title="Verified email address at {}">',
+                '<i class="fas fa-user-check text-success">'
+                '&nbsp;Verified email address at {}',
                 result.user_profile.get_mugshot_url(),
                 result.get_username(),
                 result.get_full_name().title(),

--- a/app/grandchallenge/groups/views.py
+++ b/app/grandchallenge/groups/views.py
@@ -100,7 +100,7 @@ class UserAutocomplete(
                 '<img src="{}" width ="20" height ="20" style="vertical-align:top"> '
                 "&nbsp; <b>{}</b> &nbsp; {} &nbsp;"
                 '<i class="fas fa-user-check text-success">'
-                '&nbsp;Verified email address at {}',
+                "&nbsp;Verified email address at {}",
                 result.user_profile.get_mugshot_url(),
                 result.get_username(),
                 result.get_full_name().title(),


### PR DESCRIPTION
Small change - when adding users to groups I think that it's important people see which domain the user has verified with, so this saves users having to hover over the icon.