### PR TITLE
Reduce load-time of the reader-study detail page

### DIFF
--- a/app/grandchallenge/groups/templates/groups/partials/user_list.html
+++ b/app/grandchallenge/groups/templates/groups/partials/user_list.html
@@ -26,6 +26,6 @@
             </div>
         </li>
     {% empty %}
-        <li class="list-group-item">No users found.</li>
+        <li class="list-group-item">No {{ role_name | default:"users" }} found.</li>
     {% endfor %}
 </ul>

--- a/app/grandchallenge/groups/templates/groups/partials/user_list.html
+++ b/app/grandchallenge/groups/templates/groups/partials/user_list.html
@@ -26,6 +26,6 @@
             </div>
         </li>
     {% empty %}
-        <li class="list-group-item">No {{ role_name | default:"users" }} found.</li>
+        <li class="list-group-item">No {{ role_name|default:"users" }} found.</li>
     {% endfor %}
 </ul>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readers_list.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readers_list.html
@@ -1,0 +1,192 @@
+{% extends "base.html" %}
+{% load static %}
+{% load url %}
+{% load profiles %}
+{% load humanize %}
+
+{% block title %}
+    Readers - {{ block.super }}
+{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a
+                href="{% url 'reader-studies:list' %}">Reader Studies</a>
+        </li>
+
+        <li class="breadcrumb-item"><a
+                href="{{ reader_study.get_absolute_url }}">{{ reader_study.title }}</a></li>
+        <li class="breadcrumb-item active"
+            aria-current="page">Readers
+        </li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <h2>Readers for {{ reader_study.title }}</h2>
+
+     {# TODO: Use the common user group management templates #}
+
+     <p class="mt-3">
+        <a class="btn btn-primary"
+           href="{% url 'reader-studies:readers-update' slug=object.slug %}">
+            <i class="fas fa-plus"></i> Add Readers
+        </a>
+    </p>
+    <ul class="list-group list-group-flush">
+    {% for reader in readers %}
+        <li class="list-group-item">
+            <div class="row">
+                <div class="col-3 mb-1">
+                    <div class="h-100 d-flex justify-content-start align-items-center">
+                        {{ reader.obj|user_profile_link }}
+                    </div>
+                </div>
+                <div class="col-5 mb-1">
+                    <div class="h-100 d-flex align-items-center">
+                        <div class="flex-fill progress h-100">
+                            <div class="progress-bar" role="progressbar"
+                                 style="width: {{ reader.progress.questions }}%"
+                                 aria-valuenow="{{ reader.progress.questions }}"
+                                 aria-valuemin="0" aria-valuemax="100">
+                            </div>
+                        </div>
+                        <div>
+                            &nbsp;Progress: {{ reader.progress.questions|floatformat }}%
+                        </div>
+                    </div>
+                </div>
+                <div class="col-4 mb-1">
+                    <div class="d-flex justify-content-end align-items-center">
+                        <form
+                                action="{% url 'reader-studies:readers-update' slug=object.slug %}"
+                                method="POST">
+                            {% csrf_token %}
+                            {% for field in reader_remove_form %}
+                                {% if field.name == "user" %}
+                                    <input
+                                            type="hidden"
+                                            name="user"
+                                            value="{{ reader.obj.id }}"/>
+                                {% else %}
+                                    {{ field }}
+                                {% endif %}
+                            {% endfor %}
+                            <button type="submit"
+                                    class="btn btn-danger mr-1">
+                                <small>Remove Reader</small>
+                            </button>
+                        </form>
+                        <!-- Answer removal is handled by Modal, see below -->
+                        <button type="button"
+                                class="btn btn-danger"
+                                data-toggle="modal"
+                                data-target="#warningModal"
+                                data-title="Remove answers"
+                                data-warning="This will remove all answers for user '{{ reader.obj }}'. This action cannot be undone."
+                                data-user="{{ reader.obj.id }}"
+                                data-action="Remove Answers">
+                            <small>Remove Answers</small>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </li>
+    {% empty %}
+        <li class="list-group-item">
+            There are no readers for this reader study.
+        </li>
+    {% endfor %}
+    </ul>
+
+    {% if num_readers > 5 %}
+        <p class="mt-3">
+                <a class="btn btn-primary"
+                   href="{% url 'reader-studies:readers-update' slug=object.slug %}">
+                    <i class="fas fa-plus"></i> Add Readers
+                </a>
+        </p>
+    {% endif %}
+
+    <!-- Modal -->
+    <div class="modal fade" id="warningModal" tabindex="-1" role="dialog"
+         aria-labelledby="warningModalLabel" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="warningModalLabel"></h5>
+                    <button type="button" class="close" data-dismiss="modal"
+                            aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p class="warning-text"></p>
+
+                    <p><b>Are you sure that you want to continue?</b></p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary"
+                            data-dismiss="modal">Cancel
+                    </button>
+                    <button type="button" class="btn btn-danger"
+                            id="proceed">
+                        <i class="fa fa-trash"></i> <span class="modal-action"></span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    <script>
+        window.drf = {
+            csrfHeaderName: "{{ csrf_header_name|default:'X-CSRFToken' }}",
+            csrfToken: "{% if request %}{{ csrf_token }}{% endif %}"
+        };
+
+        let user;
+
+        $(document).ready(() => {
+
+            $('#warningModal').on('show.bs.modal', function (event) {
+                const button = $(event.relatedTarget);
+                const modal = $(this);
+                modal.find(".warning-text").text(button.data("warning"));
+                modal.find(".modal-action").text(button.data("action"));
+                $("#warningModalLabel").text(button.data("title"));
+                user = button.data("user");
+            });
+            $('#proceed').on('click', () => {
+                if (user) {
+                    $.post({
+                        url: "{% url 'reader-studies:answers-remove' slug=object.slug %}",
+                        data: {user: user, csrfmiddlewaretoken: window.drf.csrfToken},
+                        success: () => {
+                            window.location.replace(window.location.href);
+                        }
+                    })
+                } else {
+                    $.ajax({
+                        type: 'PATCH',
+                        url: "{% url 'api:reader-study-generate-hanging-list' pk=object.pk %}",
+                        data: {},
+                        contentType: 'application/json',
+                        complete: (response) => {
+                            $('#page').prepend(
+                                '<div class="alert alert-success" role="alert">' +
+                                `${response.responseJSON.status}` +
+                                '</div>'
+                            );
+                            window.location.replace(window.location.href);
+                        }
+                    })
+                }
+            });
+        });
+    </script>
+    <script src="{% static "rest_framework/js/csrf.js" %}"></script>
+{% endblock %}

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readers_progress.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readers_progress.html
@@ -17,22 +17,14 @@
         <li class="breadcrumb-item"><a
                 href="{{ reader_study.get_absolute_url }}">{{ reader_study.title }}</a></li>
         <li class="breadcrumb-item active"
-            aria-current="page">Readers
+            aria-current="page">Readers Progress
         </li>
     </ol>
 {% endblock %}
 
 {% block content %}
-    <h2>Readers for {{ reader_study.title }}</h2>
+    <h2>Readers progress for {{ reader_study.title }}</h2>
 
-     {# TODO: Use the common user group management templates #}
-
-     <p class="mt-3">
-        <a class="btn btn-primary"
-           href="{% url 'reader-studies:readers-update' slug=object.slug %}">
-            <i class="fas fa-plus"></i> Add Readers
-        </a>
-    </p>
     <ul class="list-group list-group-flush">
     {% for reader in readers %}
         <li class="list-group-item">
@@ -98,15 +90,6 @@
         </li>
     {% endfor %}
     </ul>
-
-    {% if num_readers > 5 %}
-        <p class="mt-3">
-                <a class="btn btn-primary"
-                   href="{% url 'reader-studies:readers-update' slug=object.slug %}">
-                    <i class="fas fa-plus"></i> Add Readers
-                </a>
-        </p>
-    {% endif %}
 
     <!-- Modal -->
     <div class="modal fade" id="warningModal" tabindex="-1" role="dialog"

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -30,20 +30,19 @@
                    href="#v-pills-editors" role="tab" aria-controls="v-pills-editors"
                    aria-selected="false"><i class="fas fa-user fa-fw"></i>&nbsp;Editors
                 </a>
-                <a class="nav-link" id="v-pills-readers-tab"
-                   href="{% url 'reader-studies:readers-list' slug=object.slug %}"
-                ><i class="fas fa-users fa-fw"></i> Readers <span
+                 <a class="nav-link" id="v-pills-readers-tab" data-toggle="pill"
+                   href="#v-pills-readers" role="tab" aria-controls="v-pills-readers"
+                   aria-selected="false"><i class="fas fa-users fa-fw"></i> Readers &nbsp;<span
                         class="badge badge-pill badge-secondary align-middle">{{ num_readers }}</span>
+                </a>
+                <a class="nav-link" id="v-pills-readers-tab"
+                   href="{% url 'reader-studies:readers-progress' slug=object.slug %}"
+                ><i class="fas fa-tasks fa-fw"></i> Readers Progress
                 </a>
                 <a class="nav-link"
                    href="{% url 'reader-studies:permission-request-list' slug=object.slug %}"
                 ><i class="fas fa-question fa-fw"></i>&nbsp;Requests&nbsp;<span
                         class="badge badge-pill badge-secondary align-middle">{{ pending_permission_requests }}</span>
-                </a>
-                <a class="nav-link" id="v-pills-cases-tab" data-toggle="pill"
-                   href="#v-pills-cases" role="tab" aria-controls="v-pills-cases"
-                   aria-selected="false"><i class="fas fa-image fa-fw"></i>&nbsp;Cases&nbsp;<span
-                        class="badge badge-pill badge-secondary align-middle">{{ object.images.all.count }}</span>
                 </a>
                 <a class="nav-link" id="v-pills-questions-tab" data-toggle="pill"
                    href="#v-pills-questions" role="tab"
@@ -215,8 +214,8 @@
 
                 <h2>Editors</h2>
 
-                {% url 'reader-studies:editors-update' slug=object.slug as edit_url %}
-                {% include "groups/partials/user_list.html" with edit_url=edit_url form=editor_remove_form users=object.editors_group.user_set.all %}
+                {% url 'reader-studies:editors-update' slug=object.slug as editor_update_url %}
+                {% include "groups/partials/user_list.html" with edit_url=editor_update_url form=editor_remove_form users=object.editors_group.user_set.all %}
 
                 <p class="mt-3">
                     <a class="btn btn-primary"
@@ -277,6 +276,31 @@
                         <i class="fas fa-plus"></i> Add a Question
                     </a>
                 </p>
+            </div>
+
+            <div class="tab-pane fade"
+                 id="v-pills-readers"
+                 role="tabpanel"
+                 aria-labelledby="v-pills-readers-tab">
+
+                <h2> Readers </h2>
+                  {% if num_readers > 10 %}
+                    <p class="mt-3">
+                            <a class="btn btn-primary"
+                               href="{% url 'reader-studies:readers-update' slug=object.slug %}">
+                                <i class="fas fa-plus"></i> Add Readers
+                            </a>
+                    </p>
+                  {% endif %}
+                {% url 'reader-studies:readers-update' slug=object.slug as readers_update_url %}
+                {% include "groups/partials/user_list.html" with role_name="readers" edit_url=readers_update_url form=editor_remove_form users=object.readers_group.user_set.all %}
+                  <p class="mt-3">
+                        <a class="btn btn-primary"
+                           href="{% url 'reader-studies:readers-update' slug=object.slug %}">
+                            <i class="fas fa-plus"></i> Add Readers
+                        </a>
+                  </p>
+
             </div>
 
             <div class="tab-pane fade"

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -30,9 +30,10 @@
                    href="#v-pills-editors" role="tab" aria-controls="v-pills-editors"
                    aria-selected="false"><i class="fas fa-user fa-fw"></i>&nbsp;Editors
                 </a>
-                <a class="nav-link" id="v-pills-readers-tab" data-toggle="pill"
-                   href="#v-pills-readers" role="tab" aria-controls="v-pills-readers"
-                   aria-selected="false"><i class="fas fa-users fa-fw"></i>&nbsp;Readers
+                <a class="nav-link" id="v-pills-readers-tab"
+                   href="{% url 'reader-studies:readers-list' slug=object.slug %}"
+                ><i class="fas fa-users fa-fw"></i> Readers <span
+                        class="badge badge-pill badge-secondary align-middle">{{ num_readers }}</span>
                 </a>
                 <a class="nav-link"
                    href="{% url 'reader-studies:permission-request-list' slug=object.slug %}"
@@ -274,88 +275,6 @@
                     <a class="btn btn-primary"
                        href="{% url 'reader-studies:add-question' slug=object.slug %}">
                         <i class="fas fa-plus"></i> Add a Question
-                    </a>
-                </p>
-            </div>
-
-            <div class="tab-pane fade"
-                 id="v-pills-readers"
-                 role="tabpanel"
-                 aria-labelledby="v-pills-readers-tab">
-
-                <h2>Readers</h2>
-
-                {# TODO: Use the common user group management templates, decouple the progress view #}
-
-                <ul class="list-group list-group-flush">
-                    {% for reader in readers %}
-                        <li class="list-group-item">
-                            <div class="row">
-                                <div class="col-3 mb-1">
-                                    <div class="h-100 d-flex justify-content-start align-items-center">
-                                        {{ reader.obj|user_profile_link }}
-                                    </div>
-                                </div>
-                                <div class="col-5 mb-1">
-                                    <div class="h-100 d-flex align-items-center">
-                                        <div class="flex-fill progress h-100">
-                                            <div class="progress-bar" role="progressbar"
-                                                 style="width: {{ reader.progress.questions }}%"
-                                                 aria-valuenow="{{ reader.progress.questions }}"
-                                                 aria-valuemin="0" aria-valuemax="100">
-                                            </div>
-                                        </div>
-                                        <div>
-                                            &nbsp;Progress: {{ reader.progress.questions|floatformat }}%
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-4 mb-1">
-                                    <div class="d-flex justify-content-end align-items-center">
-                                        <form
-                                                action="{% url 'reader-studies:readers-update' slug=object.slug %}"
-                                                method="POST">
-                                            {% csrf_token %}
-                                            {% for field in reader_remove_form %}
-                                                {% if field.name == "user" %}
-                                                    <input
-                                                            type="hidden"
-                                                            name="user"
-                                                            value="{{ reader.obj.id }}"/>
-                                                {% else %}
-                                                    {{ field }}
-                                                {% endif %}
-                                            {% endfor %}
-                                            <button type="submit"
-                                                    class="btn btn-danger mr-1">
-                                                <small>Remove reader</small>
-                                            </button>
-                                        </form>
-                                        <button type="button"
-                                                class="btn btn-danger"
-                                                data-toggle="modal"
-                                                data-target="#warningModal"
-                                                data-title="Remove answers"
-                                                data-warning="This will remove all answers for user '{{ reader.obj }}'. This action cannot be undone."
-                                                data-user="{{ reader.obj.id }}"
-                                                data-action="Remove answers">
-                                            <small>Remove Answers</small>
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
-                        </li>
-                    {% empty %}
-                        <li class="list-group-item">
-                            There are no readers for this reader study.
-                        </li>
-                    {% endfor %}
-                </ul>
-
-                <p class="mt-3">
-                    <a class="btn btn-primary"
-                       href="{% url 'reader-studies:readers-update' slug=object.slug %}">
-                        <i class="fas fa-plus"></i> Add Readers
                     </a>
                 </p>
             </div>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -292,8 +292,10 @@
                             </a>
                     </p>
                   {% endif %}
+
                 {% url 'reader-studies:readers-update' slug=object.slug as readers_update_url %}
-                {% include "groups/partials/user_list.html" with role_name="readers" edit_url=readers_update_url form=editor_remove_form users=object.readers_group.user_set.all %}
+                {% include "groups/partials/user_list.html" with role_name="readers" edit_url=readers_update_url form=editor_remove_form users=readers %}
+
                   <p class="mt-3">
                         <a class="btn btn-primary"
                            href="{% url 'reader-studies:readers-update' slug=object.slug %}">

--- a/app/grandchallenge/reader_studies/urls.py
+++ b/app/grandchallenge/reader_studies/urls.py
@@ -20,6 +20,7 @@ from grandchallenge.reader_studies.views import (
     ReaderStudyPermissionRequestUpdate,
     ReaderStudyStatistics,
     ReaderStudyUpdate,
+    ReadersList,
     ReadersUpdate,
 )
 
@@ -83,6 +84,7 @@ urlpatterns = [
         ReadersUpdate.as_view(),
         name="readers-update",
     ),
+    path("<slug>/readers", ReadersList.as_view(), name="readers-list",),
     path(
         "<slug>/permission-requests/",
         ReaderStudyPermissionRequestList.as_view(),

--- a/app/grandchallenge/reader_studies/urls.py
+++ b/app/grandchallenge/reader_studies/urls.py
@@ -20,7 +20,7 @@ from grandchallenge.reader_studies.views import (
     ReaderStudyPermissionRequestUpdate,
     ReaderStudyStatistics,
     ReaderStudyUpdate,
-    ReadersList,
+    ReadersProgress,
     ReadersUpdate,
 )
 
@@ -84,7 +84,11 @@ urlpatterns = [
         ReadersUpdate.as_view(),
         name="readers-update",
     ),
-    path("<slug>/readers", ReadersList.as_view(), name="readers-list",),
+    path(
+        "<slug>/readers/progress",
+        ReadersProgress.as_view(),
+        name="readers-progress",
+    ),
     path(
         "<slug>/permission-requests/",
         ReaderStudyPermissionRequestList.as_view(),

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -186,6 +186,8 @@ class ReaderStudyDetail(ObjectPermissionRequiredMixin, DetailView):
         object_perms = get_perms(self.request.user, self.object)
 
         if f"change_{ReaderStudy._meta.model_name}" in object_perms:
+            reader_remove_form = ReadersForm()
+            reader_remove_form.fields["action"].initial = ReadersForm.REMOVE
 
             editor_remove_form = EditorsForm()
             editor_remove_form.fields["action"].initial = EditorsForm.REMOVE
@@ -198,6 +200,7 @@ class ReaderStudyDetail(ObjectPermissionRequiredMixin, DetailView):
             context.update(
                 {
                     "num_readers": self.object.readers_group.user_set.count(),
+                    "reader_remove_form": reader_remove_form,
                     "editor_remove_form": editor_remove_form,
                     "example_ground_truth": self.object.get_example_ground_truth_csv_text(
                         limit=2
@@ -618,11 +621,11 @@ class ReadersUpdate(ReaderStudyUserGroupUpdateMixin):
     success_message = "Readers successfully updated"
 
 
-class ReadersList(
+class ReadersProgress(
     LoginRequiredMixin, ObjectPermissionRequiredMixin, DetailView
 ):
     model = ReaderStudy
-    template_name = "reader_studies/readers_list.html"
+    template_name = "reader_studies/readers_progress.html"
     permission_required = (
         f"{ReaderStudy._meta.app_label}.change_{ReaderStudy._meta.model_name}"
     )

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -186,21 +186,9 @@ class ReaderStudyDetail(ObjectPermissionRequiredMixin, DetailView):
         object_perms = get_perms(self.request.user, self.object)
 
         if f"change_{ReaderStudy._meta.model_name}" in object_perms:
-            readers = [
-                {
-                    "obj": reader,
-                    "progress": self.object.get_progress_for_user(reader),
-                }
-                for reader in self.object.readers_group.user_set.all()
-            ]
-
-            reader_remove_form = ReadersForm()
-            reader_remove_form.fields["action"].initial = ReadersForm.REMOVE
 
             editor_remove_form = EditorsForm()
             editor_remove_form.fields["action"].initial = EditorsForm.REMOVE
-
-            answers_remove_form = AnswersRemoveForm()
 
             pending_permission_requests = ReaderStudyPermissionRequest.objects.filter(
                 reader_study=context["object"],
@@ -209,10 +197,8 @@ class ReaderStudyDetail(ObjectPermissionRequiredMixin, DetailView):
 
             context.update(
                 {
-                    "readers": readers,
+                    "num_readers": self.object.readers_group.user_set.count(),
                     "editor_remove_form": editor_remove_form,
-                    "reader_remove_form": reader_remove_form,
-                    "answers_remove_form": answers_remove_form,
                     "example_ground_truth": self.object.get_example_ground_truth_csv_text(
                         limit=2
                     ),
@@ -630,6 +616,42 @@ class EditorsUpdate(ReaderStudyUserGroupUpdateMixin):
 class ReadersUpdate(ReaderStudyUserGroupUpdateMixin):
     form_class = ReadersForm
     success_message = "Readers successfully updated"
+
+
+class ReadersList(
+    LoginRequiredMixin, ObjectPermissionRequiredMixin, DetailView
+):
+    model = ReaderStudy
+    template_name = "reader_studies/readers_list.html"
+    permission_required = (
+        f"{ReaderStudy._meta.app_label}.change_{ReaderStudy._meta.model_name}"
+    )
+    raise_exception = True
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        reader_remove_form = ReadersForm()
+        reader_remove_form.fields["action"].initial = ReadersForm.REMOVE
+
+        readers = [
+            {
+                "obj": reader,
+                "progress": self.object.get_progress_for_user(reader),
+            }
+            for reader in self.object.readers_group.user_set.all()
+        ]
+
+        context.update(
+            {
+                "reader_study": self.object,
+                "readers": readers,
+                "reader_remove_form": reader_remove_form,
+                "num_readers": self.object.readers_group.user_set.count(),
+            }
+        )
+
+        return context
 
 
 class AnswersRemove(

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -197,8 +197,16 @@ class ReaderStudyDetail(ObjectPermissionRequiredMixin, DetailView):
                 status=ReaderStudyPermissionRequest.PENDING,
             ).count()
 
+            readers = (
+                self.object.readers_group.user_set.select_related(
+                    "user_profile", "verification"
+                )
+                .order_by("username")
+                .all()
+            )
             context.update(
                 {
+                    "readers": readers,
                     "num_readers": self.object.readers_group.user_set.count(),
                     "reader_remove_form": reader_remove_form,
                     "editor_remove_form": editor_remove_form,
@@ -642,7 +650,11 @@ class ReadersProgress(
                 "obj": reader,
                 "progress": self.object.get_progress_for_user(reader),
             }
-            for reader in self.object.readers_group.user_set.all()
+            for reader in self.object.readers_group.user_set.select_related(
+                "user_profile", "verification"
+            )
+            .order_by("username")
+            .all()
         ]
 
         context.update(

--- a/app/tests/reader_studies_tests/test_permissions.py
+++ b/app/tests/reader_studies_tests/test_permissions.py
@@ -124,6 +124,7 @@ def test_rs_detail_view_permissions(client):
         "add-question",
         "editors-update",
         "readers-update",
+        "readers-list",
     ],
 )
 def test_rs_edit_view_permissions(client, view_name):

--- a/app/tests/reader_studies_tests/test_permissions.py
+++ b/app/tests/reader_studies_tests/test_permissions.py
@@ -124,7 +124,7 @@ def test_rs_detail_view_permissions(client):
         "add-question",
         "editors-update",
         "readers-update",
-        "readers-list",
+        "readers-progress",
     ],
 )
 def test_rs_edit_view_permissions(client, view_name):


### PR DESCRIPTION
# Closes #1158 
* decoupling the readers progress from the reader-study detail page (for editors)
* split reader list+progress into 
  * reader list (in page)
  * reader progress (separate page)

# Misc.:
* Uses user group management templates
* Readers now have a badge that shows the number of readers

# Performance
The current load time for the editor page for 110 readers is *12.7s*. 
The new load time is *2.6s* for the reader-study page (for editors) and *6.3s* for the reader progress overview page.

The reader progress overview page is not yet as optimized as I'd like but I am calling it "good enough" .

## Current

https://user-images.githubusercontent.com/7871310/106597360-98cb8680-6556-11eb-8a18-e929a777b2c9.mp4


## This PR


https://user-images.githubusercontent.com/7871310/106597374-9ec16780-6556-11eb-828a-b224ced6639a.mp4

