### PR TITLE
Clean code of reader-study detail and readers progress pages

### DIFF
--- a/app/grandchallenge/reader_studies/templates/reader_studies/readers_progress.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readers_progress.html
@@ -144,30 +144,13 @@
                 user = button.data("user");
             });
             $('#proceed').on('click', () => {
-                if (user) {
-                    $.post({
-                        url: "{% url 'reader-studies:answers-remove' slug=object.slug %}",
-                        data: {user: user, csrfmiddlewaretoken: window.drf.csrfToken},
-                        success: () => {
-                            window.location.replace(window.location.href);
-                        }
-                    })
-                } else {
-                    $.ajax({
-                        type: 'PATCH',
-                        url: "{% url 'api:reader-study-generate-hanging-list' pk=object.pk %}",
-                        data: {},
-                        contentType: 'application/json',
-                        complete: (response) => {
-                            $('#page').prepend(
-                                '<div class="alert alert-success" role="alert">' +
-                                `${response.responseJSON.status}` +
-                                '</div>'
-                            );
-                            window.location.replace(window.location.href);
-                        }
-                    })
-                }
+                $.post({
+                    url: "{% url 'reader-studies:answers-remove' slug=object.slug %}",
+                    data: {user: user, csrfmiddlewaretoken: window.drf.csrfToken},
+                    success: () => {
+                        window.location.replace(window.location.href);
+                    }
+                })
             });
         });
     </script>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -441,28 +441,31 @@
             csrfToken: "{% if request %}{{ csrf_token }}{% endif %}"
         };
 
-        $('#warningModal').on('show.bs.modal', function (event) {
-            const button = $(event.relatedTarget);
-            const modal = $(this);
-            modal.find(".warning-text").text(button.data("warning"));
-            modal.find(".modal-action").text(button.data("action"));
-            $("#warningModalLabel").text(button.data("title"));
-        });
-        $('#proceed').on('click', () => {
-            $.ajax({
-                type: 'PATCH',
-                url: "{% url 'api:reader-study-generate-hanging-list' pk=object.pk %}",
-                data: {},
-                contentType: 'application/json',
-                complete: (response) => {
-                    $('#page').prepend(
-                        '<div class="alert alert-success" role="alert">' +
-                        `${response.responseJSON.status}` +
-                        '</div>'
-                    );
-                    window.location.replace(window.location.href);
-                }
-            })
+        $(document).ready(() => {
+
+            $('#warningModal').on('show.bs.modal', function (event) {
+                const button = $(event.relatedTarget);
+                const modal = $(this);
+                modal.find(".warning-text").text(button.data("warning"));
+                modal.find(".modal-action").text(button.data("action"));
+                $("#warningModalLabel").text(button.data("title"));
+            });
+            $('#proceed').on('click', () => {
+                $.ajax({
+                    type: 'PATCH',
+                    url: "{% url 'api:reader-study-generate-hanging-list' pk=object.pk %}",
+                    data: {},
+                    contentType: 'application/json',
+                    complete: (response) => {
+                        $('#page').prepend(
+                            '<div class="alert alert-success" role="alert">' +
+                            `${response.responseJSON.status}` +
+                            '</div>'
+                        );
+                        window.location.replace(window.location.href);
+                    }
+                })
+            });
         });
     </script>
     <script src="{% static "rest_framework/js/csrf.js" %}"></script>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -441,31 +441,28 @@
             csrfToken: "{% if request %}{{ csrf_token }}{% endif %}"
         };
 
-        $(document).ready(() => {
-
-            $('#warningModal').on('show.bs.modal', function (event) {
-                const button = $(event.relatedTarget);
-                const modal = $(this);
-                modal.find(".warning-text").text(button.data("warning"));
-                modal.find(".modal-action").text(button.data("action"));
-                $("#warningModalLabel").text(button.data("title"));
-            });
-            $('#proceed').on('click', () => {
-                $.ajax({
-                    type: 'PATCH',
-                    url: "{% url 'api:reader-study-generate-hanging-list' pk=object.pk %}",
-                    data: {},
-                    contentType: 'application/json',
-                    complete: (response) => {
-                        $('#page').prepend(
-                            '<div class="alert alert-success" role="alert">' +
-                            `${response.responseJSON.status}` +
-                            '</div>'
-                        );
-                        window.location.replace(window.location.href);
-                    }
-                })
-            });
+        $('#warningModal').on('show.bs.modal', function (event) {
+            const button = $(event.relatedTarget);
+            const modal = $(this);
+            modal.find(".warning-text").text(button.data("warning"));
+            modal.find(".modal-action").text(button.data("action"));
+            $("#warningModalLabel").text(button.data("title"));
+        });
+        $('#proceed').on('click', () => {
+            $.ajax({
+                type: 'PATCH',
+                url: "{% url 'api:reader-study-generate-hanging-list' pk=object.pk %}",
+                data: {},
+                contentType: 'application/json',
+                complete: (response) => {
+                    $('#page').prepend(
+                        '<div class="alert alert-success" role="alert">' +
+                        `${response.responseJSON.status}` +
+                        '</div>'
+                    );
+                    window.location.replace(window.location.href);
+                }
+            })
         });
     </script>
     <script src="{% static "rest_framework/js/csrf.js" %}"></script>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -454,30 +454,20 @@
                 user = button.data("user");
             });
             $('#proceed').on('click', () => {
-                if (user) {
-                    $.post({
-                        url: "{% url 'reader-studies:answers-remove' slug=object.slug %}",
-                        data: {user: user, csrfmiddlewaretoken: window.drf.csrfToken},
-                        success: () => {
-                            window.location.replace(window.location.href);
-                        }
-                    })
-                } else {
-                    $.ajax({
-                        type: 'PATCH',
-                        url: "{% url 'api:reader-study-generate-hanging-list' pk=object.pk %}",
-                        data: {},
-                        contentType: 'application/json',
-                        complete: (response) => {
-                            $('#page').prepend(
-                                '<div class="alert alert-success" role="alert">' +
-                                `${response.responseJSON.status}` +
-                                '</div>'
-                            );
-                            window.location.replace(window.location.href);
-                        }
-                    })
-                }
+                $.ajax({
+                    type: 'PATCH',
+                    url: "{% url 'api:reader-study-generate-hanging-list' pk=object.pk %}",
+                    data: {},
+                    contentType: 'application/json',
+                    complete: (response) => {
+                        $('#page').prepend(
+                            '<div class="alert alert-success" role="alert">' +
+                            `${response.responseJSON.status}` +
+                            '</div>'
+                        );
+                        window.location.replace(window.location.href);
+                    }
+                })
             });
         });
     </script>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -441,8 +441,6 @@
             csrfToken: "{% if request %}{{ csrf_token }}{% endif %}"
         };
 
-        let user;
-
         $(document).ready(() => {
 
             $('#warningModal').on('show.bs.modal', function (event) {
@@ -451,7 +449,6 @@
                 modal.find(".warning-text").text(button.data("warning"));
                 modal.find(".modal-action").text(button.data("action"));
                 $("#warningModalLabel").text(button.data("title"));
-                user = button.data("user");
             });
             $('#proceed').on('click', () => {
                 $.ajax({

--- a/app/grandchallenge/reader_studies/urls.py
+++ b/app/grandchallenge/reader_studies/urls.py
@@ -85,7 +85,7 @@ urlpatterns = [
         name="readers-update",
     ),
     path(
-        "<slug>/readers/progress",
+        "<slug>/readers/progress/",
         ReadersProgress.as_view(),
         name="readers-progress",
     ),


### PR DESCRIPTION
Removes dead JS and, in style, add a trailing `/` to a path route definition.  