### PR TITLE
Add cases nav item back to reader study page

### DIFF
--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -44,6 +44,11 @@
                 ><i class="fas fa-question fa-fw"></i>&nbsp;Requests&nbsp;<span
                         class="badge badge-pill badge-secondary align-middle">{{ pending_permission_requests }}</span>
                 </a>
+                <a class="nav-link" id="v-pills-cases-tab" data-toggle="pill"
+                   href="#v-pills-cases" role="tab" aria-controls="v-pills-cases"
+                   aria-selected="false"><i class="fas fa-image fa-fw"></i>&nbsp;Cases&nbsp;<span
+                        class="badge badge-pill badge-secondary align-middle">{{ object.images.all.count }}</span>
+                </a>
                 <a class="nav-link" id="v-pills-questions-tab" data-toggle="pill"
                    href="#v-pills-questions" role="tab"
                    aria-controls="v-pills-questions"


### PR DESCRIPTION
The menu item was accidentally removed in https://github.com/comic/grand-challenge.org/pull/1703/files