### PR TITLE
Catch celery soft time limit for image imports

### DIFF
--- a/app/grandchallenge/cases/tasks.py
+++ b/app/grandchallenge/cases/tasks.py
@@ -317,7 +317,6 @@ def build_images(*, upload_session_pk):
             upload_session.error_message = "Time limit exceeded."
             upload_session.status = upload_session.FAILURE
             upload_session.save()
-            raise
         except Exception:
             upload_session.error_message = "An unknown error occurred"
             upload_session.status = upload_session.FAILURE

--- a/app/grandchallenge/cases/tasks.py
+++ b/app/grandchallenge/cases/tasks.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Callable, Dict, Iterable, List, Sequence, Set, Tuple
 
+from billiard.exceptions import SoftTimeLimitExceeded
 from celery import shared_task
 from django.conf import settings
 from django.contrib.auth.models import Group
@@ -312,6 +313,11 @@ def build_images(*, upload_session_pk):
             upload_session.status = upload_session.FAILURE
             upload_session.save()
             return
+        except SoftTimeLimitExceeded:
+            upload_session.error_message = "Time limit exceeded."
+            upload_session.status = upload_session.FAILURE
+            upload_session.save()
+            raise
         except Exception:
             upload_session.error_message = "An unknown error occurred"
             upload_session.status = upload_session.FAILURE


### PR DESCRIPTION
Image import jobs now get marked as failed when they exceed the celery soft time limit and are cleaned up before the hard time limit is reached. 

Closes #1695 