### PR TITLE
Add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,6 +11,7 @@
 
 # Owners of specific Django applications
 /app/grandchallenge/algorithms/       @miriam-groeneveld
+/app/grandchallenge/api/              @HarmvZ
 /app/grandchallenge/challenges/       @jmsmkn
 /app/grandchallenge/components/       @miriam-groeneveld
 /app/grandchallenge/evaluation/       @jmsmkn

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,22 @@
+# The default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @jmsmkn will be requested for review when someone 
+# opens a pull request.
+*       @jmsmkn
+
+# When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+*.js    @HarmvZ
+
+# Owners of specific Django applications
+/app/grandchallenge/algorithms/       @miriam-groeneveld
+/app/grandchallenge/challenges/       @jmsmkn
+/app/grandchallenge/components/       @miriam-groeneveld
+/app/grandchallenge/evaluation/       @jmsmkn
+/app/grandchallenge/reader_studies/   @MikeOverkamp-diag
+/app/grandchallenge/retina_api/       @HarmvZ
+/app/grandchallenge/retina_core/      @HarmvZ
+/app/grandchallenge/retina_importers/ @HarmvZ
+/app/grandchallenge/products/         @MikeOverkamp-diag
+/app/grandchallenge/workstations/     @jmsmkn


### PR DESCRIPTION
This PR adds a CODEOWNERS file for automatically routing review requests, I've assigned the most important apps to specific people, do you agree with these? Are there others you would like to be the owner for?