### PR TITLE
Add remove button for questions in reader studies

### DIFF
--- a/app/grandchallenge/reader_studies/templates/reader_studies/question_confirm_delete.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/question_confirm_delete.html
@@ -1,28 +1,18 @@
 {% extends "base.html" %}
 
 {% block content %}
-
-    {% if not object.is_fully_editable %}
-        <h2 class="text-danger">Not possible to delete this question</h2>
+    <h2>Confirm Deletion</h2>
+    <form action="" method="post">
         {% csrf_token %}
-        <p>The question "{{ object }}" already has answers associated to it. <br>You first need to delete all answers for this question before you can delete it. <br></p>
+        <p>Are you sure that you want to delete the question "{{ object }}"? <br>
+            <b class="text-danger">WARNING:
+                You are not able to undo this action. Once the question is deleted
+                it is deleted forever.</b></p>
         <a href="{% url 'reader-studies:detail' slug=object.reader_study.slug %}"
            type="button"
            class="btn btn-secondary">Cancel</a>
-    {% else %}
-        <h2>Confirm Deletion</h2>
-        <form action="" method="post">
-            {% csrf_token %}
-            <p>Are you sure that you want to delete the question "{{ object }}"? <br>
-                <b class="text-danger">WARNING:
-                    You are not able to undo this action. Once the question is deleted
-                    it is deleted forever.</b></p>
-            <a href="{% url 'reader-studies:detail' slug=object.reader_study.slug %}"
-               type="button"
-               class="btn btn-secondary">Cancel</a>
-            <input type="submit"
-                   value="I understand, delete the question '{{ object }}'"
-                   class="btn btn-danger"/>
-        </form>
-    {% endif %}
+        <input type="submit"
+               value="I understand, delete the question '{{ object }}'"
+               class="btn btn-danger"/>
+    </form>
 {% endblock %}

--- a/app/grandchallenge/reader_studies/templates/reader_studies/question_confirm_delete.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/question_confirm_delete.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+    {% if not object.is_fully_editable %}
+        <h2 class="text-danger">Not possible to delete this question</h2>
+        {% csrf_token %}
+        <p>The question "{{ object }}" already has answers associated to it. <br>You first need to delete all answers for this question before you can delete it. <br></p>
+        <a href="{% url 'reader-studies:detail' slug=object.reader_study.slug %}"
+           type="button"
+           class="btn btn-secondary">Cancel</a>
+    {% else %}
+        <h2>Confirm Deletion</h2>
+        <form action="" method="post">
+            {% csrf_token %}
+            <p>Are you sure that you want to delete the question "{{ object }}"? <br>
+                <b class="text-danger">WARNING:
+                    You are not able to undo this action. Once the question is deleted
+                    it is deleted forever.</b></p>
+            <a href="{% url 'reader-studies:detail' slug=object.reader_study.slug %}"
+               type="button"
+               class="btn btn-secondary">Cancel</a>
+            <input type="submit"
+                   value="I understand, delete the question '{{ object }}'"
+                   class="btn btn-danger"/>
+        </form>
+    {% endif %}
+{% endblock %}

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -264,12 +264,20 @@
                 <ul class="list-group list-group-flush">
                     {% for question in object.questions.all %}
                         <li class="list-group-item">
-                            <div class="w-100 d-flex justify-content-between">
-                                <div>{{ question }}</div>
-                                <a class="btn btn-primary btn-sm"
-                                   href="{% url 'reader-studies:question-update' slug=object.slug pk=question.pk %}">
-                                    <i class="fa fa-edit"></i>
-                                </a>
+                            <div class="row">
+                                <div class="col justify-content-start">
+                                    <div>{{ question }}</div>
+                                </div>
+                                <div class="col-md-auto justify-content-end">
+                                    <a class="btn btn-primary btn-sm"
+                                       href="{% url 'reader-studies:question-update' slug=object.slug pk=question.pk %}">
+                                        <i class="fa fa-edit"></i>
+                                    </a>
+                                    <a class="btn btn-danger btn-sm"
+                                       href="{% url 'reader-studies:question-delete' slug=object.slug pk=question.pk %}">
+                                        <i class="fa fa-trash-alt"></i>
+                                    </a>
+                                </div>
                             </div>
                         </li>
                     {% endfor %}

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -273,10 +273,16 @@
                                        href="{% url 'reader-studies:question-update' slug=object.slug pk=question.pk %}">
                                         <i class="fa fa-edit"></i>
                                     </a>
-                                    <a class="btn btn-danger btn-sm"
-                                       href="{% url 'reader-studies:question-delete' slug=object.slug pk=question.pk %}">
-                                        <i class="fa fa-trash-alt"></i>
-                                    </a>
+                                    {% if question.is_fully_editable %}
+                                        <a class="btn btn-danger btn-sm"
+                                           href="{% url 'reader-studies:question-delete' slug=object.slug pk=question.pk %}">
+                                            <i class="fa fa-trash-alt"></i>
+                                        </a>
+                                    {% else %}
+                                         <button type="button" class="btn btn-danger btn-sm" title="This question cannot be deleted. It already has answers associated with it." disabled>
+                                            <i class="fa fa-trash-alt"></i>
+                                        </button>
+                                    {% endif %}
                                 </div>
                             </div>
                         </li>

--- a/app/grandchallenge/reader_studies/urls.py
+++ b/app/grandchallenge/reader_studies/urls.py
@@ -6,6 +6,7 @@ from grandchallenge.reader_studies.views import (
     AddQuestionToReaderStudy,
     AnswersRemove,
     EditorsUpdate,
+    QuestionDelete,
     QuestionUpdate,
     ReaderStudyCopy,
     ReaderStudyCreate,
@@ -73,6 +74,11 @@ urlpatterns = [
         "<slug>/questions/<pk>/update/",
         QuestionUpdate.as_view(),
         name="question-update",
+    ),
+    path(
+        "<slug>/questions/<pk>/delete/",
+        QuestionDelete.as_view(),
+        name="question-delete",
     ),
     path(
         "<slug>/editors/update/",

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -14,6 +14,7 @@ from django.forms.utils import ErrorList
 from django.http import (
     Http404,
     HttpResponse,
+    HttpResponseForbidden,
     HttpResponseRedirect,
     JsonResponse,
 )
@@ -976,5 +977,10 @@ class QuestionDelete(
         )
 
     def delete(self, request, *args, **kwargs):
-        messages.success(self.request, self.success_message)
-        return super().delete(request, *args, **kwargs)
+        question = self.get_object()
+        if question.is_fully_editable:
+            messages.success(self.request, self.success_message)
+            return super().delete(request, *args, **kwargs)
+        return HttpResponseForbidden(
+            reason="This question already has answers associated with it"
+        )

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -949,3 +949,32 @@ class AnswerViewSet(ModelViewSet):
 
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
+
+
+class QuestionDelete(
+    LoginRequiredMixin, ObjectPermissionRequiredMixin, DeleteView
+):
+    model = Question
+
+    permission_required = (
+        f"{ReaderStudy._meta.app_label}.change_{ReaderStudy._meta.model_name}"
+    )
+    raise_exception = True
+
+    success_message = "Question was successfully deleted"
+
+    def get_permission_object(self):
+        return self.reader_study
+
+    @property
+    def reader_study(self):
+        return get_object_or_404(ReaderStudy, slug=self.kwargs["slug"])
+
+    def get_success_url(self):
+        return reverse(
+            "reader-studies:detail", kwargs={"slug": self.kwargs["slug"]}
+        )
+
+    def delete(self, request, *args, **kwargs):
+        messages.success(self.request, self.success_message)
+        return super().delete(request, *args, **kwargs)

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -128,3 +128,92 @@ def test_answer_remove(client):
     assert Answer.objects.count() == 1
     assert Answer.objects.filter(creator=r1).count() == 0
     assert Answer.objects.filter(creator=r2).count() == 1
+
+
+@pytest.mark.django_db
+def test_question_delete(client):
+    rs = ReaderStudyFactory()
+    r1, editor = UserFactory(), UserFactory()
+    rs.add_reader(r1)
+    rs.add_editor(editor)
+    q = QuestionFactory(
+        reader_study=rs,
+        question_text="q1",
+        answer_type=Question.ANSWER_TYPE_BOOL,
+    )
+    assert Question.objects.count() == 1
+
+    response = get_view_for_user(
+        viewname="reader-studies:question-delete",
+        client=client,
+        method=client.post,
+        reverse_kwargs={"slug": rs.slug, "pk": q.pk},
+        follow=True,
+        user=r1,
+    )
+
+    assert response.status_code == 403
+
+    response = get_view_for_user(
+        viewname="reader-studies:question-delete",
+        client=client,
+        method=client.post,
+        reverse_kwargs={"slug": rs.slug, "pk": q.pk},
+        user=editor,
+    )
+
+    assert response.status_code == 302
+    assert Question.objects.count() == 0
+    assert str(rs) in response.url
+
+
+@pytest.mark.django_db
+def test_question_delete_disabled_for_questions_with_answers(client):
+    rs = ReaderStudyFactory()
+    r1, editor = UserFactory(), UserFactory()
+    rs.add_reader(r1)
+    rs.add_editor(editor)
+    q = QuestionFactory(
+        reader_study=rs,
+        question_text="q1",
+        answer_type=Question.ANSWER_TYPE_BOOL,
+    )
+    AnswerFactory(creator=r1, question=q, answer=True)
+
+    assert Answer.objects.count() == 1
+    assert Question.objects.count() == 1
+    assert not q.is_fully_editable
+
+    response = get_view_for_user(
+        viewname="reader-studies:question-delete",
+        client=client,
+        method=client.get,
+        reverse_kwargs={"slug": rs.slug, "pk": q.pk},
+        user=editor,
+    )
+
+    assert b"Not possible to delete this question" in response.content
+    assert Question.objects.count() == 1
+
+    # if answer is deleted, deletion of the question is possible again
+    get_view_for_user(
+        viewname="reader-studies:answers-remove",
+        client=client,
+        method=client.post,
+        reverse_kwargs={"slug": rs.slug},
+        data={"user": r1.id},
+        follow=True,
+        user=editor,
+    )
+
+    assert Answer.objects.count() == 0
+
+    response = get_view_for_user(
+        viewname="reader-studies:question-delete",
+        client=client,
+        method=client.get,
+        reverse_kwargs={"slug": rs.slug, "pk": q.pk},
+        user=editor,
+    )
+
+    assert b"Not possible to delete this question" not in response.content

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -187,12 +187,12 @@ def test_question_delete_disabled_for_questions_with_answers(client):
     response = get_view_for_user(
         viewname="reader-studies:question-delete",
         client=client,
-        method=client.get,
+        method=client.post,
         reverse_kwargs={"slug": rs.slug, "pk": q.pk},
         user=editor,
     )
 
-    assert b"Not possible to delete this question" in response.content
+    assert response.status_code == 403
     assert Question.objects.count() == 1
 
     # if answer is deleted, deletion of the question is possible again
@@ -211,9 +211,9 @@ def test_question_delete_disabled_for_questions_with_answers(client):
     response = get_view_for_user(
         viewname="reader-studies:question-delete",
         client=client,
-        method=client.get,
+        method=client.post,
         reverse_kwargs={"slug": rs.slug, "pk": q.pk},
         user=editor,
     )
-
-    assert b"Not possible to delete this question" not in response.content
+    assert response.status_code == 302
+    assert Question.objects.count() == 0


### PR DESCRIPTION
Editors of reader studies can now delete questions if the question has no answers associated to it yet. If a question has answers, deleting is not possible and editors first have to manually remove the answers.


https://user-images.githubusercontent.com/30069334/107365067-93cd8080-6adc-11eb-981f-83953f48f948.mp4


Closes #1544