### PR TITLE
Add pre-commit linting of template files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,7 @@ repos:
           - pep8-naming
           - flake8-docstrings
           - mccabe
+  - repo: https://github.com/thibaudcolas/curlylint
+    rev: "6a111be"
+    hooks:
+      - id: curlylint

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_execution_session_create.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_execution_session_create.html
@@ -16,7 +16,7 @@
         </li>
         <li class="breadcrumb-item"><a
                 href="{{ algorithm.get_absolute_url }}">{{ algorithm.title }}
-        </a>
+        </a></li>
         <li class="breadcrumb-item active"
             aria-current="page">Create Experiment
         </li>

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_execution_session_create.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_execution_session_create.html
@@ -36,19 +36,19 @@
                 It will not cost an algorithm user any credits to try this algorithm.
             {% else %}
                 It will require an algorithm user {{ algorithm.credits_per_job }} credits per image to try
-            this algorithm.
-            {%  endif %}
+                this algorithm.
+            {% endif %}
             You can change the amount of credits that it will cost to try this algorithm by changing the Job credits in
             <a href="{% url 'algorithms:update' slug=algorithm.slug %}"> Settings</a>
             (a user receives a 1000 credits a month).
             A job credit of zero means users can try this algorithm an unlimited number of times.
-            </p>
+        </p>
         {% crispy form %}
     {% else %}
         {% if remaining_jobs <= 0 %}
             <p>
-            You have run out of credits to try this algorithm. You can try again on {{ next_job_at }}.
-            You can request more credits by sending an e-mail to
+                You have run out of credits to try this algorithm. You can try again on {{ next_job_at }}.
+                You can request more credits by sending an e-mail to
                 <a href="{{ 'mailto:support@grand-challenge.org'|random_encode }}" class="text-radboud">
                     support@grand-challenge.org</a>.
             </p>
@@ -56,22 +56,23 @@
             <p>Select the images that you would like to run the algorithm on.</p>
             {% if algorithm.credits_per_job != 0 %}
                 <p>
-                    Trying this algorithm requires {{ algorithm.credits_per_job }} credit{{ algorithm.credits_per_job|pluralize }}
+                    Trying this algorithm requires {{ algorithm.credits_per_job }}
+                    credit{{ algorithm.credits_per_job|pluralize }}
                     per image. You have {{ user_credits }} credit{{ user_credits|pluralize }} left for this month,
                     allowing you to upload {{ remaining_jobs }} image{{ remaining_jobs|pluralize }}.
                 </p>
-            {%  endif %}
+            {% endif %}
             {% crispy form %}
-        {%  endif %}
-    <p>
-        By running this algorithm you agree to the
-        <a href="{% url 'policies:detail' slug='terms-of-service' %}"> General
-            Terms of Service</a>{% if algorithm.additional_terms_markdown %},
-        as well as this algorithm's specific Terms of Service:
+        {% endif %}
+        <p>
+            By running this algorithm you agree to the
+            <a href="{% url 'policies:detail' slug='terms-of-service' %}"> General
+                Terms of Service</a>{% if algorithm.additional_terms_markdown %},
+            as well as this algorithm's specific Terms of Service:
         {% else %}.
         {% endif %}
+        </p>
     {% endif %}
-    </p>
 
     {{ algorithm.additional_terms_markdown|md2html }}
 

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithmimage_form.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithmimage_form.html
@@ -12,7 +12,7 @@
         </li>
         <li class="breadcrumb-item"><a
                 href="{{ algorithm.get_absolute_url }}">{{ algorithm.title }}
-        </a>
+        </a></li>
         <li class="breadcrumb-item active"
             aria-current="page">Create image
         </li>

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithmpermissionrequest_form.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithmpermissionrequest_form.html
@@ -11,7 +11,7 @@
         </li>
         <li class="breadcrumb-item"><a
                 href="{{ algorithm.get_absolute_url }}">{{ algorithm.title }}
-        </a>
+        </a></li>
         <li class="breadcrumb-item active"
             aria-current="page">
             {% if "change_algorithm" in algorithm_perms %}

--- a/app/grandchallenge/algorithms/templates/algorithms/executionsession_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/executionsession_detail.html
@@ -12,7 +12,7 @@
         </li>
         <li class="breadcrumb-item"><a
                 href="{{ algorithm.get_absolute_url }}">{{ algorithm.title }}
-        </a>
+        </a></li>
         <li class="breadcrumb-item active"
             aria-current="page">Experiment {{ object.pk }}
         </li>

--- a/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
@@ -16,9 +16,9 @@
         </li>
         <li class="breadcrumb-item"><a
                 href="{{ object.algorithm_image.algorithm.get_absolute_url }}">{{ object.algorithm_image.algorithm.title }}
-        </a>
+        </a></li>
         <li class="breadcrumb-item"><a
-                href="{% url 'algorithms:job-list' slug=object.algorithm_image.algorithm.slug %}">Results</a>
+                href="{% url 'algorithms:job-list' slug=object.algorithm_image.algorithm.slug %}">Results</a></li>
         <li class="breadcrumb-item active" aria-current="page">{{ object.pk }}</li>
     </ol>
 {% endblock %}

--- a/app/grandchallenge/algorithms/templates/algorithms/job_form.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_form.html
@@ -13,9 +13,9 @@
         </li>
         <li class="breadcrumb-item"><a
                 href="{{ object.algorithm_image.algorithm.get_absolute_url }}">{{ object.algorithm_image.algorithm.title }}
-        </a>
+        </a></li>
         <li class="breadcrumb-item"><a
-                href="{% url 'algorithms:job-list' slug=object.algorithm_image.algorithm.slug %}">Results</a>
+            href="{% url 'algorithms:job-list' slug=object.algorithm_image.algorithm.slug %}">Results</a></li>
         <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{{ object.pk }}</a></li>
         <li class="breadcrumb-item active"
             aria-current="page">Update

--- a/app/grandchallenge/algorithms/templates/algorithms/job_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_list.html
@@ -9,7 +9,7 @@
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'algorithms:list' %}">Algorithms</a></li>
-        <li class="breadcrumb-item"><a href="{{ algorithm.get_absolute_url }}">{{ algorithm.title }}</a>
+        <li class="breadcrumb-item"><a href="{{ algorithm.get_absolute_url }}">{{ algorithm.title }}</a></li>
         <li class="breadcrumb-item active" aria-current="page">Results</li>
     </ol>
 {% endblock %}

--- a/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
@@ -11,13 +11,13 @@
    title="View result details">
     <i class="fa fa-info-circle"></i>
 </a>
-<split/>
+<split></split>
 
 {{ object.created|naturaltime }}
-<split/>
+<split></split>
 
 {{ object.creator|user_profile_link }}
-<split/>
+<split></split>
 
 <a href="#resultInfoModal"
    class="badge
@@ -54,10 +54,10 @@
 {% if object.rendered_result_text %}
     {{ object.rendered_result_text|json_script:object.pk }}
 {% endif %}
-<split/>
+<split></split>
 
 {{ object.comment }}
-<split/>
+<split></split>
 
 {% if object.public %}
     <i class="fa fa-eye text-success"
@@ -72,7 +72,7 @@
            title="Result and images are private"></i>
     {% endif %}
 {% endif %}
-<split/>
+<split></split>
 
 {% if object.status == object.SUCCESS %}
     <a class="badge badge-primary"

--- a/app/grandchallenge/algorithms/templates/algorithms/user_groups_form.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/user_groups_form.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'algorithms:list' %}">Algorithms</a></li>
-        <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{% firstof object.title object %}</a>
+        <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{% firstof object.title object %}</a></li>
         <li class="breadcrumb-item active" aria-current="page">Add user</li>
     </ol>
 {% endblock %}

--- a/app/grandchallenge/archives/templates/archives/archive_cases_row.html
+++ b/app/grandchallenge/archives/templates/archives/archive_cases_row.html
@@ -4,20 +4,20 @@
 {% load pathlib %}
 
 {{ object.name }}
-<split/>
+<split></split>
 
 {{ object.created|naturaltime }}
-<split/>
+<split></split>
 
 {{ object.origin.creator|user_profile_link }}
-<split/>
+<split></split>
 
 <a href="{% url 'workstations:workstation-session-create' slug=archive.workstation.slug %}?{% workstation_query image=object config=archive.workstation_config %}">
     <span class="badge badge-primary">
         <i class="fa fa-eye"></i> View Case
     </span>
 </a>
-<split/>
+<split></split>
 
 <ul class="list-unstyled mb-0">
     {% for civ in object.componentinterfacevalue_set.all %}
@@ -31,7 +31,7 @@
         {% endfor %}
     {% endfor %}
 </ul>
-<split/>
+<split></split>
 
 <ul class="list-unstyled mb-0">
     {% for file in object.files.all %}
@@ -44,4 +44,4 @@
         </li>
     {% endfor %}
 </ul>
-<split/>
+<split></split>

--- a/app/grandchallenge/archives/templates/archives/archive_upload_session_create.html
+++ b/app/grandchallenge/archives/templates/archives/archive_upload_session_create.html
@@ -14,7 +14,7 @@
         </li>
         <li class="breadcrumb-item"><a
                 href="{{ archive.get_absolute_url }}">{{ archive.title }}
-        </a>
+        </a></li>
         <li class="breadcrumb-item active"
             aria-current="page">Add Cases
         </li>

--- a/app/grandchallenge/archives/templates/archives/archivepermissionrequest_form.html
+++ b/app/grandchallenge/archives/templates/archives/archivepermissionrequest_form.html
@@ -11,7 +11,7 @@
         </li>
         <li class="breadcrumb-item"><a
                 href="{{ archive.get_absolute_url }}">{{ archive.title }}
-        </a>
+        </a></li>
         <li class="breadcrumb-item active"
             aria-current="page">
             {% if "change_archive" in archive_perms %}

--- a/app/grandchallenge/cases/templates/cases/rawimageuploadsession_row.html
+++ b/app/grandchallenge/cases/templates/cases/rawimageuploadsession_row.html
@@ -1,10 +1,10 @@
 {% load humanize %}
 
 <a href="{{ object.get_absolute_url }}">{{ object.pk }}</a>
-<split/>
+<split></split>
 
 {{ object.created|naturaltime }}
-<split/>
+<split></split>
 
 <span class="badge
     {% if object.status == object.FAILURE or object.status == object.CANCELLED %}
@@ -18,4 +18,4 @@
     {% endif %}">
         {{ object.get_status_display }}
 </span>
-<split/>
+<split></split>

--- a/app/grandchallenge/challenges/templates/challenges/challenge_users_row.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_users_row.html
@@ -8,18 +8,18 @@
     <i class="fa fa-eye-slash text-danger"
        title="Challenge not listed on the all challenges page"></i>
 {% endif %}
-<split/>
+<split></split>
 
 {{ object.created }}
-<split/>
+<split></split>
 
 {% for user in object.get_admins %}
     {{ user|user_profile_link }}<br/>
 {% endfor %}
-<split/>
+<split></split>
 
 {{ object.description }}
-<split/>
+<split></split>
 
 {% if object.use_evaluation %}
     <i class="fas fa-check text-success"
@@ -28,4 +28,4 @@
     <i class="fas fa-times text-danger"
        title="Challenge is not using automated evaluation"></i>
 {% endif %}
-<split/>
+<split></split>

--- a/app/grandchallenge/datatables/views.py
+++ b/app/grandchallenge/datatables/views.py
@@ -27,7 +27,7 @@ class PaginatedTableListView(ListView):
     def render_row(self, *, object_, page_context):
         return render_to_string(
             self.row_template, context={**page_context, "object": object_},
-        ).split("<split/>")
+        ).split("<split></split>")
 
     def render_rows(self, *, object_list):
         page_context = self.get_context_data(object_list=object_list)

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_row.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_row.html
@@ -12,14 +12,14 @@
                title="Select for comparison"
                value="{{ object.pk }}">
     </div>
-    <split/>
+    <split></split>
 {% endif %}
 
 {{ object.rank|ordinal }}
 {% if object.submission.phase.evaluation_detail_observable_url %}
     <input type="hidden" class="browseEvaluationPK" value="{{ object.pk }}">
 {% endif %}
-<split/>
+<split></split>
 
 {{ object.submission.creator|user_profile_link }}
 {% if object.submission.phase.challenge.use_teams %}
@@ -29,16 +29,16 @@
         {% endif %}
     {% endwith %}
 {% endif %}
-<split/>
+<split></split>
 
 {{ object.submission.created|date:"j N Y" }}
-<split/>
+<split></split>
 
 {% if object.submission.phase.scoring_method_choice != object.submission.phase.ABSOLUTE %}
     <a href="{{ object.get_absolute_url }}">
         <b>{{ object.rank_score|floatformat }}</b>
     </a>
-    <split/>
+    <split></split>
 {% endif %}
 
 {% with object.metrics.0|get_jsonpath:object.submission.phase.score_jsonpath as metric %}
@@ -60,7 +60,7 @@
         {% if object.submission.phase.scoring_method_choice == object.submission.phase.ABSOLUTE %}
             </b>{% endif %}
     </a>
-    <split/>
+    <split></split>
 {% endwith %}
 
 {% for col in object.submission.phase.extra_results_columns %}
@@ -79,13 +79,13 @@
                 {% endif %}
             {% endfilter %}
         </a>
-        <split/>
+        <split></split>
     {% endwith %}
 {% endfor %}
 
 {% if object.submission.phase.display_submission_comments %}
     {{ object.submission.comment }}
-    <split/>
+    <split></split>
 {% endif %}
 
 {% if object.submission.phase.show_publication_url %}
@@ -94,7 +94,7 @@
             <i class="fa fa-file"></i>
         </a>
     {% endif %}
-    <split/>
+    <split></split>
 {% endif %}
 
 {% if object.submission.phase.show_supplementary_file_link %}
@@ -103,6 +103,6 @@
             <i class="fa fa-file"></i>
         </a>
     {% endif %}
-    <split/>
+    <split></split>
 {% endif %}
 

--- a/app/grandchallenge/organizations/templates/organizations/user_groups_form.html
+++ b/app/grandchallenge/organizations/templates/organizations/user_groups_form.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'organizations:list' %}">Organizations</a></li>
-        <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{% firstof object.title object %}</a>
+        <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{% firstof object.title object %}</a></li>
         <li class="breadcrumb-item active" aria-current="page">Add user</li>
     </ol>
 {% endblock %}

--- a/app/grandchallenge/products/templates/products/about.html
+++ b/app/grandchallenge/products/templates/products/about.html
@@ -62,6 +62,7 @@
           </thead>
           <tr>
             <td class="text-muted">Focused on Radiology or Nuclear Medicine</td>
+          </tr>
           <tr>
             <td class="text-muted">Contains machine learning components</td>
           </tr>

--- a/app/grandchallenge/products/templates/products/contact.html
+++ b/app/grandchallenge/products/templates/products/contact.html
@@ -14,7 +14,7 @@
   <div>
       <h1>Contact us</h1>
       <p>Contact us if you have questions, ideas, would like to update information, or if you believe your product is missing from this overview. <br>
-        Please send an e-mail to:
+          Please send an e-mail to:</p>
       <div class='text-black pb-5'>
         Kicky van Leeuwen <br>
         <a href="{{ 'mailto:kicky.vanleeuwen@radboudumc.nl'|random_encode }}" class="text-radboud">kicky.vanleeuwen@radboudumc.nl</a>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_images_row.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_images_row.html
@@ -4,20 +4,20 @@
 {% load pathlib %}
 
 {{ object.name }}
-<split/>
+<split></split>
 
 {{ object.created|naturaltime }}
-<split/>
+<split></split>
 
 {{ object.origin.creator|user_profile_link }}
-<split/>
+<split></split>
 
 <a href="{% url 'workstations:workstation-session-create' slug=reader_study.workstation.slug %}?{% workstation_query image=object config=reader_study.workstation_config %}">
     <span class="badge badge-primary">
         <i class="fa fa-eye"></i> View Case
     </span>
 </a>
-<split/>
+<split></split>
 
 <ul class="list-unstyled mb-0">
     {% for file in object.files.all %}
@@ -30,7 +30,7 @@
         </li>
     {% endfor %}
 </ul>
-<split/>
+<split></split>
 
 <button class="btn btn-danger btn-sm" onclick="removeImage('{{ object.id }}')">Remove</button>
-<split/>
+<split></split>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudypermissionrequest_form.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudypermissionrequest_form.html
@@ -11,7 +11,7 @@
         </li>
         <li class="breadcrumb-item"><a
                 href="{{ reader_study.get_absolute_url }}">{{ reader_study.title }}
-        </a>
+        </a></li>
         <li class="breadcrumb-item active"
             aria-current="page">
             {% if "change_readerstudy" in reader_study_perms %}

--- a/poetry.lock
+++ b/poetry.lock
@@ -315,24 +315,6 @@ ssh = ["bcrypt (>=3.1.5)"]
 test = ["pytest (>=3.6.0,<3.9.0 || >3.9.0,<3.9.1 || >3.9.1,<3.9.2 || >3.9.2)", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,<3.79.2 || >3.79.2)"]
 
 [[package]]
-category = "dev"
-description = "{{ 🎀}} Experimental HTML templates linting for Jinja, Nunjucks, Django templates, Twig, Liquid"
-name = "curlylint"
-optional = false
-python-versions = ">=3.6"
-version = "0.12.0"
-
-[package.dependencies]
-attrs = ">=17.2.0"
-click = ">=6.5"
-parsy = "1.1.0"
-pathspec = ">=0.6,<1"
-toml = ">=0.9.4"
-
-[package.extras]
-dev = ["black (19.10b0)", "flake8 (3.7.8)", "mypy (0.770)", "pytest (6.0.0rc1)", "coverage (5.1)"]
-
-[[package]]
 category = "main"
 description = "XML bomb protection for Python stdlib modules"
 name = "defusedxml"
@@ -1144,22 +1126,6 @@ pytz = ">=2017.2"
 
 [package.extras]
 test = ["pytest (>=4.0.2)", "pytest-xdist", "hypothesis (>=3.58)"]
-
-[[package]]
-category = "dev"
-description = "easy-to-use parser combinators, for parsing in pure Python"
-name = "parsy"
-optional = false
-python-versions = "*"
-version = "1.1.0"
-
-[[package]]
-category = "dev"
-description = "Utility library for gitignore style pattern matching of file paths."
-name = "pathspec"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.8.1"
 
 [[package]]
 category = "main"
@@ -2069,7 +2035,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.2.0"
 
 [metadata]
-content-hash = "5bbe67de67e7e31d0e240523059035ef9621f59dc44a4b9bd722c311e2f9fbc8"
+content-hash = "524fb0ebda64b8849068bc38df274d440bd401c5c66577b5b23078861ebc1536"
 lock-version = "1.0"
 python-versions = "^3.8"
 
@@ -2281,10 +2247,6 @@ cryptography = [
     {file = "cryptography-3.1-cp38-cp38-win32.whl", hash = "sha256:fa7fbcc40e2210aca26c7ac8a39467eae444d90a2c346cbcffd9133a166bcc67"},
     {file = "cryptography-3.1-cp38-cp38-win_amd64.whl", hash = "sha256:548b0818e88792318dc137d8b1ec82a0ab0af96c7f0603a00bb94f896fbf5e10"},
     {file = "cryptography-3.1.tar.gz", hash = "sha256:26409a473cc6278e4c90f782cd5968ebad04d3911ed1c402fc86908c17633e08"},
-]
-curlylint = [
-    {file = "curlylint-0.12.0-py3-none-any.whl", hash = "sha256:b03a200914a4c315169993c205054b86a49c1934a7d30d2583755a5a0939fed4"},
-    {file = "curlylint-0.12.0.tar.gz", hash = "sha256:e1b09acb26f5d2a3a5f9ee81c541ad76f1311e174e4c08be8e4f7ebd62c20bc0"},
 ]
 defusedxml = [
     {file = "defusedxml-0.6.0-py2.py3-none-any.whl", hash = "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93"},
@@ -2686,14 +2648,6 @@ pandas = [
     {file = "pandas-1.1.2-cp38-cp38-win32.whl", hash = "sha256:0936991228241db937e87f82ec552a33888dd04a2e0d5a2fa3c689f92fab09e0"},
     {file = "pandas-1.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:026d764d0b86ee53183aa4c0b90774b6146123eeada4e24946d7d24290777be1"},
     {file = "pandas-1.1.2.tar.gz", hash = "sha256:b64ffd87a2cfd31b40acd4b92cb72ea9a52a48165aec4c140e78fd69c45d1444"},
-]
-parsy = [
-    {file = "parsy-1.1.0-py3-none-any.whl", hash = "sha256:25bd5cea2954950ebbfdf71f8bdaf7fd45a5df5325fd36a1064be2204d9d4c94"},
-    {file = "parsy-1.1.0.tar.gz", hash = "sha256:36173ba01a5372c7a1b32352cc73a279a49198f52252adf1c8c1ed41d1f94e8d"},
-]
-pathspec = [
-    {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
-    {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
 ]
 pillow = [
     {file = "Pillow-7.2.0-cp35-cp35m-macosx_10_10_intel.whl", hash = "sha256:1ca594126d3c4def54babee699c055a913efb01e106c309fa6b04405d474d5ae"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -315,6 +315,24 @@ ssh = ["bcrypt (>=3.1.5)"]
 test = ["pytest (>=3.6.0,<3.9.0 || >3.9.0,<3.9.1 || >3.9.1,<3.9.2 || >3.9.2)", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,<3.79.2 || >3.79.2)"]
 
 [[package]]
+category = "dev"
+description = "{{ 🎀}} Experimental HTML templates linting for Jinja, Nunjucks, Django templates, Twig, Liquid"
+name = "curlylint"
+optional = false
+python-versions = ">=3.6"
+version = "0.12.0"
+
+[package.dependencies]
+attrs = ">=17.2.0"
+click = ">=6.5"
+parsy = "1.1.0"
+pathspec = ">=0.6,<1"
+toml = ">=0.9.4"
+
+[package.extras]
+dev = ["black (19.10b0)", "flake8 (3.7.8)", "mypy (0.770)", "pytest (6.0.0rc1)", "coverage (5.1)"]
+
+[[package]]
 category = "main"
 description = "XML bomb protection for Python stdlib modules"
 name = "defusedxml"
@@ -1126,6 +1144,22 @@ pytz = ">=2017.2"
 
 [package.extras]
 test = ["pytest (>=4.0.2)", "pytest-xdist", "hypothesis (>=3.58)"]
+
+[[package]]
+category = "dev"
+description = "easy-to-use parser combinators, for parsing in pure Python"
+name = "parsy"
+optional = false
+python-versions = "*"
+version = "1.1.0"
+
+[[package]]
+category = "dev"
+description = "Utility library for gitignore style pattern matching of file paths."
+name = "pathspec"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.8.1"
 
 [[package]]
 category = "main"
@@ -2035,7 +2069,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.2.0"
 
 [metadata]
-content-hash = "524fb0ebda64b8849068bc38df274d440bd401c5c66577b5b23078861ebc1536"
+content-hash = "5bbe67de67e7e31d0e240523059035ef9621f59dc44a4b9bd722c311e2f9fbc8"
 lock-version = "1.0"
 python-versions = "^3.8"
 
@@ -2247,6 +2281,10 @@ cryptography = [
     {file = "cryptography-3.1-cp38-cp38-win32.whl", hash = "sha256:fa7fbcc40e2210aca26c7ac8a39467eae444d90a2c346cbcffd9133a166bcc67"},
     {file = "cryptography-3.1-cp38-cp38-win_amd64.whl", hash = "sha256:548b0818e88792318dc137d8b1ec82a0ab0af96c7f0603a00bb94f896fbf5e10"},
     {file = "cryptography-3.1.tar.gz", hash = "sha256:26409a473cc6278e4c90f782cd5968ebad04d3911ed1c402fc86908c17633e08"},
+]
+curlylint = [
+    {file = "curlylint-0.12.0-py3-none-any.whl", hash = "sha256:b03a200914a4c315169993c205054b86a49c1934a7d30d2583755a5a0939fed4"},
+    {file = "curlylint-0.12.0.tar.gz", hash = "sha256:e1b09acb26f5d2a3a5f9ee81c541ad76f1311e174e4c08be8e4f7ebd62c20bc0"},
 ]
 defusedxml = [
     {file = "defusedxml-0.6.0-py2.py3-none-any.whl", hash = "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93"},
@@ -2648,6 +2686,14 @@ pandas = [
     {file = "pandas-1.1.2-cp38-cp38-win32.whl", hash = "sha256:0936991228241db937e87f82ec552a33888dd04a2e0d5a2fa3c689f92fab09e0"},
     {file = "pandas-1.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:026d764d0b86ee53183aa4c0b90774b6146123eeada4e24946d7d24290777be1"},
     {file = "pandas-1.1.2.tar.gz", hash = "sha256:b64ffd87a2cfd31b40acd4b92cb72ea9a52a48165aec4c140e78fd69c45d1444"},
+]
+parsy = [
+    {file = "parsy-1.1.0-py3-none-any.whl", hash = "sha256:25bd5cea2954950ebbfdf71f8bdaf7fd45a5df5325fd36a1064be2204d9d4c94"},
+    {file = "parsy-1.1.0.tar.gz", hash = "sha256:36173ba01a5372c7a1b32352cc73a279a49198f52252adf1c8c1ed41d1f94e8d"},
+]
+pathspec = [
+    {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
+    {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
 ]
 pillow = [
     {file = "Pillow-7.2.0-cp35-cp35m-macosx_10_10_intel.whl", hash = "sha256:1ca594126d3c4def54babee699c055a913efb01e106c309fa6b04405d474d5ae"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,16 @@ build-backend = "poetry.masonry.api"
 line-length = 79
 target-version = ['py38']
 
+[tool.curlylint.rules]
+html_has_lang = 'en'
+django_forms_rendering = true
+image_alt = true
+# TODO: Enable this, would otherwise be a big change
+# indent = 4
+meta_viewport = true
+no_autofocus = true
+tabindex_no_positive = true
+
 [tool.poetry]
 name = "grand-challenge.org"
 version = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,4 +91,3 @@ werkzeug = {extras = ["watchdog"], version = "^1.0.1"}
 sphinx-rtd-theme = "*"
 sphinxcontrib-plantuml = "*"
 pytest-randomly = "*"
-curlylint = "^0.12.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,3 +91,4 @@ werkzeug = {extras = ["watchdog"], version = "^1.0.1"}
 sphinx-rtd-theme = "*"
 sphinxcontrib-plantuml = "*"
 pytest-randomly = "*"
+curlylint = "^0.12.0"


### PR DESCRIPTION
With many developers now working on the project I've noticed that the template files are starting to get some errors. This PR adds `curlylint` as a pre-commit hook, which doesn't fix template errors but at least highlights them. Also fixes a few missing closing tags, indentation fixes will follow probably in another PR.