### PR TITLE
Fix CSV export of annotations

### DIFF
--- a/app/grandchallenge/core/renderers.py
+++ b/app/grandchallenge/core/renderers.py
@@ -1,3 +1,5 @@
+import json
+
 from rest_framework_csv.renderers import CSVRenderer
 
 
@@ -9,3 +11,19 @@ class PaginatedCSVRenderer(CSVRenderer):
             data = data[self.results_field]
 
         return super().render(data, *args, **kwargs)
+
+    def flatten_data(self, data):
+        """
+        Create a dictionary that is 1 level deep, with nested values serialized
+        as json. This means that the header rows are now consistent.
+        """
+        for row in data:
+            flat_row = {k: self._flatten_value(v) for k, v in row.items()}
+            yield flat_row
+
+    @staticmethod
+    def _flatten_value(value):
+        if isinstance(value, (dict, list)):
+            return json.dumps(value)
+        else:
+            return value


### PR DESCRIPTION
This PR flattens any nested structures to strings via JSON serialization, loads in excel out of the box. This has the nice property that the number of columns is now constant.

![image](https://user-images.githubusercontent.com/12661555/108522986-b413f100-72cd-11eb-8960-5c3e0f290821.png)

Closes #1726 