### PR TITLE
Mailchimp subscribe

### DIFF
--- a/app/grandchallenge/products/templates/products/base.html
+++ b/app/grandchallenge/products/templates/products/base.html
@@ -64,18 +64,18 @@
         <div class="container py-5 px-4">
             <div class="row">
                 <div class="col-md-3">
-                    <img src="{% static 'products/images/banner2.png' %}" alt="Logo" style="width:100%">
-                </div>
-
-                <div class="col-md-6 px-4">
                     <div class="h4">About</div>
                     <div>
-                        This is an initiative of the <a href="http://diagnijmegen.nl/" title="DIAG" target="_blank"
+                        AI for Radiology is a non-commercial initiative of the <a href="http://diagnijmegen.nl/" title="DIAG" target="_blank"
                                                         class="text-radboud">Diagnostic Image Analysis Group</a>,
                         part of the Department of Radiology and Nuclear Medicine at the <a
                             href="https://www.radboudumc.nl/en/" title="Radboudumc" target="_blank"
-                            class="text-radboud">Radboud university medical center</a>, Nijmegen, the Netherlands.
+                            class="text-radboud">Radboud university medical center</a>.
                     </div>
+                </div>
+
+                <div class="col-md-6 px-4">
+                    {% include "products/partials/subscribe.html" %}
                 </div>
 
                 <div class="col-md-3 px-4">

--- a/app/grandchallenge/products/templates/products/partials/subscribe.html
+++ b/app/grandchallenge/products/templates/products/partials/subscribe.html
@@ -21,7 +21,7 @@
                 <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_61c3909f930db10295f1abf6b_19bc800e8e" tabindex="-1" value=""></div>
                 <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="btn btn-dark btn-square"></div>
             </div>
-            <p class="legal small mt-1"> By subscribing you agree to receive emails from <a href="https://www.aiforradiology.com/about">AI for Radiology</a> with news related to commercial developments in the field of AI and radiology. A confirmation will be sent to your email address. You can unsubscribe at any time using the link in the footer of each email. Your email address will not be shared with third parties other than our email provider. </p>
+            <p class="legal small mt-1"> By subscribing you agree to receive emails from <a class= "text-radboud" href="https://www.aiforradiology.com/about">AI for Radiology</a> with news related to commercial developments in the field of AI and radiology. A confirmation will be sent to your email address. You can unsubscribe at any time using the link in the footer of each email. Your email address will not be shared with third parties other than our email provider. </p>
 
         </div>
     </form>

--- a/app/grandchallenge/products/templates/products/partials/subscribe.html
+++ b/app/grandchallenge/products/templates/products/partials/subscribe.html
@@ -1,10 +1,4 @@
 <!-- Begin Mailchimp Signup Form -->
-<!-- <link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
-<style type="text/css">
-	#mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
-	/* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
-	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
-</style> -->
 <div id="mc_embed_signup">
     <form action="https://meetup.us7.list-manage.com/subscribe/post?u=61c3909f930db10295f1abf6b&amp;id=19bc800e8e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
         <div id="mc_embed_signup_scroll">

--- a/app/grandchallenge/products/templates/products/partials/subscribe.html
+++ b/app/grandchallenge/products/templates/products/partials/subscribe.html
@@ -1,0 +1,31 @@
+<!-- Begin Mailchimp Signup Form -->
+<!-- <link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
+<style type="text/css">
+	#mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
+	/* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
+	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+</style> -->
+<div id="mc_embed_signup">
+    <form action="https://meetup.us7.list-manage.com/subscribe/post?u=61c3909f930db10295f1abf6b&amp;id=19bc800e8e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+        <div id="mc_embed_signup_scroll">
+            <h4>Newsletter</h4>
+            <p>Subscribe to our monthly newsletter to stay tuned on the commercial developments of AI in Radiology.</p>
+            <div class="d-flex">
+                <input type="email" value="" name="EMAIL" class="form-control email mr-1" id="mce-EMAIL" placeholder="email address" required>
+                            
+                <div id="mce-responses" class="clear">
+                    <div class="response" id="mce-error-response" style="display:none"></div>
+                    <div class="response" id="mce-success-response" style="display:none"></div>
+                </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+
+                <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_61c3909f930db10295f1abf6b_19bc800e8e" tabindex="-1" value=""></div>
+                <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="btn btn-dark btn-square"></div>
+            </div>
+            <p class="legal small mt-1"> By subscribing you agree to receive emails from <a href="https://www.aiforradiology.com/about">AI for Radiology</a> with news related to commercial developments in the field of AI and radiology. A confirmation will be sent to your email address. You can unsubscribe at any time using the link in the footer of each email. Your email address will not be shared with third parties other than our email provider. </p>
+
+        </div>
+    </form>
+</div>
+<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='ADDRESS';ftypes[3]='address';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='BIRTHDAY';ftypes[5]='birthday';fnames[6]='MMERGE6';ftypes[6]='text';fnames[7]='MMERGE7';ftypes[7]='text';fnames[8]='MMERGE8';ftypes[8]='text';fnames[9]='MMERGE9';ftypes[9]='text';fnames[10]='MMERGE10';ftypes[10]='text';fnames[11]='MMERGE11';ftypes[11]='text';fnames[12]='MMERGE12';ftypes[12]='text';fnames[13]='MMERGE13';ftypes[13]='text';fnames[14]='MMERGE14';ftypes[14]='text';fnames[15]='MMERGE15';ftypes[15]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+<!--End mc_embed_signup-->
+

--- a/app/grandchallenge/products/templates/products/product_list.html
+++ b/app/grandchallenge/products/templates/products/product_list.html
@@ -4,8 +4,33 @@
     AI for radiology
 {% endblock %}
 
+
 {% block content %}
+<script>
+  $(window).on('load',function(){
+  if (!sessionStorage.getItem('shown-modal')){
+    $('#myModal').modal('show');
+    sessionStorage.setItem('shown-modal', 'true');
+  }
+});
+  
+</script>
+
   <div class="d-flex justify-content-between align-items-center">
+    
+    <div class="modal fade" id="myModal">
+      <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+            <div class="modal-content">
+                <div class="modal-body">
+                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">×</span>
+                  </button>
+                  {% include "products/partials/subscribe.html" %}
+                </div>
+            </div>
+      </div>
+    </div>
+
     <h1>Products</h1>
   </div>
     <p> Find the artificial intelligence based software for radiology that you are looking for. <br>


### PR DESCRIPTION
I have added a mailchimp subscribe option in the footer and a popup that opens once each browser session. Mailchimp has an integration for popups that uses cookies to track whether users have seen the popup somewhere in the year before to not overload people with it. However this requires the whole circus around cookie approval (which mailchimp doesn't handle for you). We don't have anything like that yet in grand-challenge right? For now (wanting to have it live before ECR next week) I fixed it in this manner. For the long term arranging the cookie thing might be better though..?