### PR TITLE
Added link to stats page to footer

### DIFF
--- a/app/grandchallenge/core/templates/grandchallenge/partials/footer.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/footer.html
@@ -20,6 +20,10 @@
                             </a>
                         </li>
                     {% endfor %}
+                   <a class="text-muted"
+                           href="{% url 'statistics:detail' %}">
+                            Stats
+                   </a>
                 </ul>
             </div>
             <div class="col-sm-6 col-md-3 p-3">

--- a/app/grandchallenge/core/templates/grandchallenge/partials/footer.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/footer.html
@@ -20,10 +20,12 @@
                             </a>
                         </li>
                     {% endfor %}
-                   <a class="text-muted"
+                   <li class="my-1">
+                       <a class="text-muted"
                            href="{% url 'statistics:detail' %}">
-                            Stats
-                   </a>
+                            Statistics
+                        </a>
+                   </li>
                 </ul>
             </div>
             <div class="col-sm-6 col-md-3 p-3">


### PR DESCRIPTION
The statistics page can now be accessed through a link in the footer, in the About section. 

Closes #1741 