### PR TITLE
Adds pydantic to panimg

### DIFF
--- a/app/grandchallenge/cases/tasks.py
+++ b/app/grandchallenge/cases/tasks.py
@@ -341,7 +341,9 @@ def _handle_raw_image_files(tmp_dir, upload_session):
         for raw_image_file in session_files
     }
 
-    importer_result = import_images(files=input_files, origin=upload_session,)
+    importer_result = import_images(
+        input_directory=tmp_dir, origin=upload_session,
+    )
 
     _handle_raw_files(
         input_files=input_files,
@@ -363,7 +365,7 @@ class ImporterResult:
 
 def import_images(
     *,
-    files: Set[Path],
+    input_directory: Path,
     origin: Optional[RawImageUploadSession] = None,
     builders: Optional[Iterable[Callable]] = None,
 ) -> ImporterResult:
@@ -389,7 +391,7 @@ def import_images(
 
     with TemporaryDirectory() as output_directory:
         panimg_result = convert(
-            files=files,
+            input_directory=input_directory,
             output_directory=output_directory,
             builders=builders,
             created_image_prefix=created_image_prefix,
@@ -449,7 +451,7 @@ def _convert_panimg_to_django(
         ImageFile(
             image_id=f.image_id,
             image_type=f.image_type,
-            file=File(open(f.file, "rb"), f.filename),
+            file=File(open(f.file, "rb"), f.file.name),
         )
         for f in panimg_result.new_image_files
     }

--- a/app/grandchallenge/cases/tasks.py
+++ b/app/grandchallenge/cases/tasks.py
@@ -387,22 +387,24 @@ def import_images(
     """
     created_image_prefix = str(origin.pk)[:8] if origin is not None else ""
 
-    panimg_result = convert(
-        files=files,
-        builders=builders,
-        created_image_prefix=created_image_prefix,
-    )
+    with TemporaryDirectory() as output_directory:
+        panimg_result = convert(
+            files=files,
+            output_directory=output_directory,
+            builders=builders,
+            created_image_prefix=created_image_prefix,
+        )
 
-    _check_all_ids(panimg_result=panimg_result)
+        _check_all_ids(panimg_result=panimg_result)
 
-    django_result = _convert_panimg_to_django(panimg_result=panimg_result)
+        django_result = _convert_panimg_to_django(panimg_result=panimg_result)
 
-    _store_images(
-        origin=origin,
-        images=django_result.new_images,
-        image_files=django_result.new_image_files,
-        folders=django_result.new_folders,
-    )
+        _store_images(
+            origin=origin,
+            images=django_result.new_images,
+            image_files=django_result.new_image_files,
+            folders=django_result.new_folders,
+        )
 
     return ImporterResult(
         new_images=django_result.new_images,
@@ -447,7 +449,7 @@ def _convert_panimg_to_django(
         ImageFile(
             image_id=f.image_id,
             image_type=f.image_type,
-            file=File(f.file, f.filename),
+            file=File(open(f.file, "rb"), f.filename),
         )
         for f in panimg_result.new_image_files
     }

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -164,7 +164,6 @@ class ComponentInterface(models.Model):
             return
 
         with TemporaryDirectory() as tmpdir:
-            input_files = set()
             for file in output_files:
                 temp_file = Path(safe_join(tmpdir, file.relative_to(base_dir)))
                 temp_file.parent.mkdir(parents=True, exist_ok=True)
@@ -177,10 +176,8 @@ class ComponentInterface(models.Model):
                         buffer = infile.read(1024)
                         outfile.write(buffer)
 
-                input_files.add(temp_file)
-
             importer_result = import_images(
-                files=input_files,
+                input_directory=tmpdir,
                 builders=[image_builder_mhd, image_builder_tiff],
             )
 

--- a/app/panimg/image_builders/fallback.py
+++ b/app/panimg/image_builders/fallback.py
@@ -15,7 +15,9 @@ def format_error(message):
     return f"Fallback image builder: {message}"
 
 
-def image_builder_fallback(*, files: Set[Path], **_) -> ImageBuilderResult:
+def image_builder_fallback(
+    *, files: Set[Path], output_directory: Path, **_
+) -> ImageBuilderResult:
     """
     Constructs image objects by inspecting files in a directory.
 
@@ -50,7 +52,10 @@ def image_builder_fallback(*, files: Set[Path], **_) -> ImageBuilderResult:
             is_vector = img.mode != "L"
             img = SimpleITK.GetImageFromArray(img_array, isVector=is_vector)
             n_image, n_image_files = convert_itk_to_internal(
-                img, name=file.name, use_spacing=False
+                simple_itk_image=img,
+                name=file.name,
+                use_spacing=False,
+                output_directory=output_directory,
             )
             new_images.add(n_image)
             new_image_files |= set(n_image_files)

--- a/app/panimg/image_builders/metaio_mhd_mha.py
+++ b/app/panimg/image_builders/metaio_mhd_mha.py
@@ -19,7 +19,7 @@ from panimg.types import ImageBuilderResult
 
 
 def image_builder_mhd(  # noqa: C901
-    *, files: Set[Path], **_
+    *, files: Set[Path], output_directory: Path, **_
 ) -> ImageBuilderResult:
     """
     Constructs image objects by inspecting files in a directory.
@@ -60,7 +60,7 @@ def image_builder_mhd(  # noqa: C901
         return data_file == "LOCAL"
 
     def convert_itk_file(
-        headers: Mapping[str, Union[str, None]], filename: Path
+        *, filename: Path, output_dir: Path,
     ) -> Tuple[PanImg, Sequence[PanImgFile]]:
         try:
             simple_itk_image = load_sitk_image(filename.absolute())
@@ -68,7 +68,11 @@ def image_builder_mhd(  # noqa: C901
         except RuntimeError:
             raise ValueError("SimpleITK cannot open file")
 
-        return convert_itk_to_internal(simple_itk_image, name=filename.name)
+        return convert_itk_to_internal(
+            simple_itk_image=simple_itk_image,
+            name=filename.name,
+            output_directory=output_dir,
+        )
 
     def format_error(message):
         return f"Mhd image builder: {message}"
@@ -104,7 +108,9 @@ def image_builder_mhd(  # noqa: C901
                     )
                     continue
 
-            n_image, n_image_files = convert_itk_file(parsed_headers, file)
+            n_image, n_image_files = convert_itk_file(
+                filename=file, output_dir=output_directory
+            )
             new_images.add(n_image)
             new_image_files |= set(n_image_files)
 

--- a/app/panimg/image_builders/metaio_mhd_mha.py
+++ b/app/panimg/image_builders/metaio_mhd_mha.py
@@ -7,8 +7,6 @@ See: https://itk.org/Wiki/MetaIO/Documentation
 from pathlib import Path
 from typing import Mapping, Sequence, Set, Tuple, Union
 
-import SimpleITK
-
 from panimg.image_builders.metaio_utils import (
     load_sitk_image,
     parse_mh_header,
@@ -64,7 +62,6 @@ def image_builder_mhd(  # noqa: C901
     ) -> Tuple[PanImg, Sequence[PanImgFile]]:
         try:
             simple_itk_image = load_sitk_image(filename.absolute())
-            simple_itk_image: SimpleITK.Image
         except RuntimeError:
             raise ValueError("SimpleITK cannot open file")
 

--- a/app/panimg/image_builders/nifti.py
+++ b/app/panimg/image_builders/nifti.py
@@ -11,7 +11,9 @@ def format_error(message):
     return f"NifTI image builder: {message}"
 
 
-def image_builder_nifti(*, files: Set[Path], **_) -> ImageBuilderResult:
+def image_builder_nifti(
+    *, files: Set[Path], output_directory: Path, **_
+) -> ImageBuilderResult:
     """
     Constructs image objects from files in NifTI format (nii/nii.gz)
 
@@ -47,7 +49,9 @@ def image_builder_nifti(*, files: Set[Path], **_) -> ImageBuilderResult:
 
         try:
             n_image, n_image_files = convert_itk_to_internal(
-                img, name=file.name
+                simple_itk_image=img,
+                name=file.name,
+                output_directory=output_directory,
             )
             new_images.add(n_image)
             new_image_files |= set(n_image_files)

--- a/app/panimg/image_builders/tiff.py
+++ b/app/panimg/image_builders/tiff.py
@@ -197,16 +197,15 @@ def _create_image_file(
 
     output_file = output_directory / f"{image.pk}{path.suffix}"
 
-    # TODO (jmsmkn): Would be good to remove tiff moving, but shutil is fast
-    # DZI and their files are created in the correct place anyway
-    shutil.move(src=path, dst=output_file)
+    if path.suffix.lower() == ".dzi":
+        image_type = ImageType.DZI
+    else:
+        # TODO (jmsmkn): Create the tiff files in the correct location
+        shutil.copy(src=str(path.resolve()), dst=str(output_file.resolve()))
+        image_type = ImageType.TIFF
 
     return PanImgFile(
-        image_id=image.pk,
-        image_type=ImageType.DZI
-        if path.suffix.lower() == ".dzi"
-        else ImageType.TIFF,
-        file=output_file,
+        image_id=image.pk, image_type=image_type, file=output_file
     )
 
 

--- a/app/panimg/image_builders/utils.py
+++ b/app/panimg/image_builders/utils.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import AnyStr, Optional, Sequence, Tuple
 from uuid import uuid4
 
@@ -25,66 +24,59 @@ def convert_itk_to_internal(
     if color_space is None:
         raise ValueError("Unknown color space for MetaIO image.")
 
-    with TemporaryDirectory() as work_dir:
-        work_dir = Path(work_dir)
+    pk = uuid4()
+    if not name:
+        name = str(pk)
 
-        pk = uuid4()
-        if not name:
-            name = str(pk)
-        SimpleITK.WriteImage(
-            simple_itk_image,
-            str(work_dir / f"{pk}.{ITK_INTERNAL_FILE_FORMAT}"),
-            True,
+    work_dir = Path(output_directory) / str(pk)
+    work_dir.mkdir()
+
+    SimpleITK.WriteImage(
+        simple_itk_image,
+        str(work_dir / f"{pk}.{ITK_INTERNAL_FILE_FORMAT}"),
+        True,
+    )
+
+    if simple_itk_image.GetDimension() == 4:
+        timepoints = simple_itk_image.GetSize()[-1]
+    else:
+        timepoints = None
+    depth = simple_itk_image.GetDepth()
+
+    try:
+        window_center = float(simple_itk_image.GetMetaData("WindowCenter"))
+    except (RuntimeError, ValueError):
+        window_center = None
+    try:
+        window_width = float(simple_itk_image.GetMetaData("WindowWidth"))
+    except (RuntimeError, ValueError):
+        window_width = None
+
+    db_image = PanImg(
+        pk=pk,
+        name=name,
+        width=simple_itk_image.GetWidth(),
+        height=simple_itk_image.GetHeight(),
+        depth=depth if depth else None,
+        window_center=window_center,
+        window_width=window_width,
+        timepoints=timepoints,
+        resolution_levels=None,
+        color_space=color_space,
+        voxel_width_mm=simple_itk_image.GetSpacing()[0]
+        if use_spacing
+        else None,
+        voxel_height_mm=simple_itk_image.GetSpacing()[1]
+        if use_spacing
+        else None,
+        voxel_depth_mm=simple_itk_image.GetSpacing()[2] if depth else None,
+    )
+
+    db_image_files = []
+    for file in work_dir.iterdir():
+        db_image_file = PanImgFile(
+            image_id=db_image.pk, image_type=ImageType.MHD, file=file,
         )
-
-        if simple_itk_image.GetDimension() == 4:
-            timepoints = simple_itk_image.GetSize()[-1]
-        else:
-            timepoints = None
-        depth = simple_itk_image.GetDepth()
-
-        try:
-            window_center = float(simple_itk_image.GetMetaData("WindowCenter"))
-        except (RuntimeError, ValueError):
-            window_center = None
-        try:
-            window_width = float(simple_itk_image.GetMetaData("WindowWidth"))
-        except (RuntimeError, ValueError):
-            window_width = None
-
-        db_image = PanImg(
-            pk=pk,
-            name=name,
-            width=simple_itk_image.GetWidth(),
-            height=simple_itk_image.GetHeight(),
-            depth=depth if depth else None,
-            window_center=window_center,
-            window_width=window_width,
-            timepoints=timepoints,
-            resolution_levels=None,
-            color_space=color_space,
-            voxel_width_mm=simple_itk_image.GetSpacing()[0]
-            if use_spacing
-            else None,
-            voxel_height_mm=simple_itk_image.GetSpacing()[1]
-            if use_spacing
-            else None,
-            voxel_depth_mm=simple_itk_image.GetSpacing()[2] if depth else None,
-        )
-        db_image_files = []
-        for _file in work_dir.iterdir():
-            temp_file = NamedTemporaryFile(delete=False, dir=output_directory)
-            with open(str(_file), "rb") as open_file:
-                buffer = True
-                while buffer:
-                    buffer = open_file.read(1024)
-                    temp_file.write(buffer)
-            db_image_file = PanImgFile(
-                image_id=db_image.pk,
-                image_type=ImageType.MHD,
-                file=Path(temp_file.name),
-                filename=_file.name,
-            )
-            db_image_files.append(db_image_file)
+        db_image_files.append(db_image_file)
 
     return db_image, db_image_files

--- a/app/panimg/models.py
+++ b/app/panimg/models.py
@@ -47,4 +47,4 @@ class PanImgFile:
 @dataclass(frozen=True)
 class PanImgFolder:
     image_id: UUID
-    folder: str
+    folder: Path

--- a/app/panimg/models.py
+++ b/app/panimg/models.py
@@ -41,7 +41,6 @@ class PanImgFile:
     image_id: UUID
     image_type: ImageType
     file: Path
-    filename: str
 
 
 @dataclass(frozen=True)

--- a/app/panimg/models.py
+++ b/app/panimg/models.py
@@ -1,18 +1,19 @@
-from dataclasses import dataclass
 from enum import Enum
-from tempfile import TemporaryFile
+from pathlib import Path
 from typing import Optional
 from uuid import UUID
 
+from pydantic.dataclasses import dataclass
 
-class ColorSpace(Enum):
+
+class ColorSpace(str, Enum):
     GRAY = "GRAY"
     RGB = "RGB"
     RGBA = "RGBA"
     YCBCR = "YCBCR"
 
 
-class ImageType(Enum):
+class ImageType(str, Enum):
     MHD = "MHD"
     TIFF = "TIFF"
     DZI = "DZI"
@@ -39,7 +40,7 @@ class PanImg:
 class PanImgFile:
     image_id: UUID
     image_type: ImageType
-    file: TemporaryFile
+    file: Path
     filename: str
 
 

--- a/app/panimg/panimg.py
+++ b/app/panimg/panimg.py
@@ -1,14 +1,15 @@
 from collections import defaultdict
 from pathlib import Path
-from typing import Callable, Iterable, Optional, Set
+from typing import Callable, DefaultDict, Iterable, List, Optional, Set
 
 from panimg.image_builders import DEFAULT_IMAGE_BUILDERS
+from panimg.models import PanImg, PanImgFile, PanImgFolder
 from panimg.types import ImageBuilderResult, PanimgResult
 
 
 def convert(
     *,
-    files: Set[Path],
+    input_directory: Path,
     output_directory: Path,
     builders: Optional[Iterable[Callable]] = None,
     created_image_prefix: str = "",
@@ -20,6 +21,61 @@ def convert(
     file_errors = defaultdict(list)
 
     builders = builders if builders is not None else DEFAULT_IMAGE_BUILDERS
+
+    _convert_directory(
+        input_directory=input_directory,
+        output_directory=output_directory,
+        builders=builders,
+        consumed_files=consumed_files,
+        new_images=new_images,
+        new_image_files=new_image_files,
+        new_folders=new_folders,
+        file_errors=file_errors,
+        created_image_prefix=created_image_prefix,
+    )
+
+    return PanimgResult(
+        new_images=new_images,
+        new_image_files=new_image_files,
+        new_folders=new_folders,
+        consumed_files=consumed_files,
+        file_errors={**file_errors},
+    )
+
+
+def _convert_directory(
+    *,
+    input_directory: Path,
+    output_directory: Path,
+    builders: Iterable[Callable],
+    consumed_files: Set[Path],
+    new_images: Set[PanImg],
+    new_image_files: Set[PanImgFile],
+    new_folders: Set[PanImgFolder],
+    file_errors: DefaultDict[Path, List[str]],
+    created_image_prefix: str = "",
+):
+    input_directory = Path(input_directory).resolve()
+    output_directory = Path(output_directory).resolve()
+
+    output_directory.mkdir(exist_ok=True)
+
+    files = set()
+    for o in Path(input_directory).iterdir():
+        if o.is_dir():
+            _convert_directory(
+                input_directory=input_directory / o,
+                output_directory=output_directory / o,
+                builders=builders,
+                consumed_files=consumed_files,
+                new_images=new_images,
+                new_image_files=new_image_files,
+                new_folders=new_folders,
+                file_errors=file_errors,
+                created_image_prefix=created_image_prefix,
+            )
+        elif o.is_file():
+            files.add(o)
 
     for builder in builders:
         builder_result: ImageBuilderResult = builder(
@@ -35,11 +91,3 @@ def convert(
 
         for filepath, msg in builder_result.file_errors.items():
             file_errors[filepath].append(msg)
-
-    return PanimgResult(
-        new_images=new_images,
-        new_image_files=new_image_files,
-        new_folders=new_folders,
-        consumed_files=consumed_files,
-        file_errors={**file_errors},
-    )

--- a/app/panimg/panimg.py
+++ b/app/panimg/panimg.py
@@ -9,6 +9,7 @@ from panimg.types import ImageBuilderResult, PanimgResult
 def convert(
     *,
     files: Set[Path],
+    output_directory: Path,
     builders: Optional[Iterable[Callable]] = None,
     created_image_prefix: str = "",
 ) -> PanimgResult:
@@ -23,6 +24,7 @@ def convert(
     for builder in builders:
         builder_result: ImageBuilderResult = builder(
             files=files - consumed_files,
+            output_directory=output_directory,
             created_image_prefix=created_image_prefix,
         )
 

--- a/app/tests/cases_tests/test_dicom.py
+++ b/app/tests/cases_tests/test_dicom.py
@@ -79,7 +79,7 @@ def test_image_builder_dicom_4dct(tmpdir):
     assert image.shape == [19, 4, 2, 3]
     assert len(result.new_image_files) == 1
     mha_file_obj = [
-        x for x in result.new_image_files if x.filename.endswith("mha")
+        x for x in result.new_image_files if x.file.suffix == ".mha"
     ][0]
 
     headers = parse_mh_header(mha_file_obj.file)
@@ -131,7 +131,7 @@ def test_dicom_rescaling(folder, element_type, tmpdir):
 
     assert len(result.new_image_files) == 1
     mha_file_obj = [
-        x for x in result.new_image_files if x.filename.endswith("mha")
+        x for x in result.new_image_files if x.file.suffix == ".mha"
     ][0]
 
     headers = parse_mh_header(mha_file_obj.file)
@@ -148,7 +148,7 @@ def test_dicom_window_level(tmpdir):
 
     assert len(result.new_image_files) == 1
     mha_file_obj = [
-        x for x in result.new_image_files if x.filename.endswith("mha")
+        x for x in result.new_image_files if x.file.suffix == ".mha"
     ][0]
 
     headers = parse_mh_header(mha_file_obj.file)

--- a/app/tests/cases_tests/test_fallback.py
+++ b/app/tests/cases_tests/test_fallback.py
@@ -5,22 +5,22 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
-from grandchallenge.cases.models import Image
 from panimg.image_builders.fallback import (
     format_error,
     image_builder_fallback,
 )
+from panimg.models import ColorSpace
 from tests.cases_tests import RESOURCE_PATH
 
 
 @pytest.mark.parametrize(
     "src,colorspace",
     (
-        (RESOURCE_PATH / "test_grayscale.jpg", Image.COLOR_SPACE_GRAY),
-        (RESOURCE_PATH / "test_rgb.jpg", Image.COLOR_SPACE_RGB),
-        (RESOURCE_PATH / "test_grayscale.png", Image.COLOR_SPACE_GRAY),
-        (RESOURCE_PATH / "test_rgb.png", Image.COLOR_SPACE_RGB),
-        (RESOURCE_PATH / "test_rgba.png", Image.COLOR_SPACE_RGBA),
+        (RESOURCE_PATH / "test_grayscale.jpg", ColorSpace.GRAY),
+        (RESOURCE_PATH / "test_rgb.jpg", ColorSpace.RGB),
+        (RESOURCE_PATH / "test_grayscale.png", ColorSpace.GRAY),
+        (RESOURCE_PATH / "test_rgb.png", ColorSpace.RGB),
+        (RESOURCE_PATH / "test_rgba.png", ColorSpace.RGBA),
     ),
 )
 def test_image_builder_fallback(tmpdir, src, colorspace):

--- a/app/tests/cases_tests/test_fallback.py
+++ b/app/tests/cases_tests/test_fallback.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 
@@ -26,7 +27,8 @@ def test_image_builder_fallback(tmpdir, src, colorspace):
     dest = Path(tmpdir) / src.name
     shutil.copy(str(src), str(dest))
     files = {Path(d[0]).joinpath(f) for d in os.walk(tmpdir) for f in d[2]}
-    result = image_builder_fallback(files=files)
+    with TemporaryDirectory() as output:
+        result = image_builder_fallback(files=files, output_directory=output)
     assert result.consumed_files == {dest}
     assert len(result.new_images) == 1
     image = result.new_images.pop()
@@ -42,7 +44,9 @@ def test_image_builder_fallback_corrupt_file(tmpdir):
     shutil.copy(str(src), str(dest))
 
     files = {Path(d[0]).joinpath(f) for d in os.walk(tmpdir) for f in d[2]}
-    result = image_builder_fallback(files=files)
+    with TemporaryDirectory() as output:
+        result = image_builder_fallback(files=files, output_directory=output)
+
     assert result.file_errors == {
         dest: format_error("Not a valid image file"),
     }

--- a/app/tests/cases_tests/test_nifti.py
+++ b/app/tests/cases_tests/test_nifti.py
@@ -1,11 +1,12 @@
 import os
 import shutil
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 
-from grandchallenge.cases.models import Image
 from panimg.image_builders.nifti import image_builder_nifti
+from panimg.models import ColorSpace
 from tests.cases_tests import RESOURCE_PATH
 
 
@@ -20,12 +21,13 @@ def test_image_builder_nifti(tmpdir, src: Path):
     dest = Path(tmpdir) / src.name
     shutil.copy(src, dest)
     files = {Path(d[0]).joinpath(f) for d in os.walk(tmpdir) for f in d[2]}
-    result = image_builder_nifti(files=files)
+    with TemporaryDirectory() as output:
+        result = image_builder_nifti(files=files, output_directory=output)
     assert result.consumed_files == {dest}
     assert len(result.new_images) == 1
 
     image = result.new_images.pop()
-    assert image.color_space == Image.COLOR_SPACE_GRAY
+    assert image.color_space == ColorSpace.GRAY.value
     assert image.width == 10
     assert image.height == 11
     assert image.depth == 12
@@ -38,6 +40,7 @@ def test_image_builder_with_other_file_extension(tmpdir):
     dest = Path(tmpdir) / "image10x10x10.mha"
     shutil.copy(RESOURCE_PATH / dest.name, dest)
     files = {Path(d[0]).joinpath(f) for d in os.walk(tmpdir) for f in d[2]}
-    result = image_builder_nifti(files=files)
+    with TemporaryDirectory() as output:
+        result = image_builder_nifti(files=files, output_directory=output)
     assert result.consumed_files == set()
     assert len(result.new_images) == 0

--- a/app/tests/cases_tests/test_tiff.py
+++ b/app/tests/cases_tests/test_tiff.py
@@ -19,7 +19,6 @@ from panimg.image_builders.tiff import (
     _create_tiff_image_entry,
     _extract_tags,
     _get_color_space,
-    _load_and_create_dzi,
     _load_gc_files,
     _load_with_tiff,
     image_builder_tiff,
@@ -187,7 +186,7 @@ def test_load_with_open_slide(
     gc_file = GrandChallengeTiffFile(temp_file)
     try:
         gc_file = _load_with_tiff(gc_file=gc_file)
-        _load_and_create_dzi(
+        _create_dzi_images(
             gc_file=gc_file,
             output_directory=Path(tmpdir_factory.mktemp("output")),
         )

--- a/app/tests/cases_tests/test_utils.py
+++ b/app/tests/cases_tests/test_utils.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import SimpleITK
 import pytest
@@ -71,5 +72,8 @@ def test_convert_itk_to_internal(image: Path):
         assert internal_image.resolution_levels is None
 
     img_ref = load_sitk_image(image)
-    internal_image = convert_itk_to_internal(img_ref)
+    with TemporaryDirectory() as output:
+        internal_image = convert_itk_to_internal(
+            simple_itk_image=img_ref, output_directory=output
+        )
     assert_img_properties(img_ref, internal_image[0])

--- a/app/tests/cases_tests/test_utils.py
+++ b/app/tests/cases_tests/test_utils.py
@@ -5,9 +5,9 @@ import SimpleITK
 import pytest
 from pytest import approx
 
-from grandchallenge.cases.models import Image
 from panimg.image_builders.metaio_utils import load_sitk_image
 from panimg.image_builders.utils import convert_itk_to_internal
+from panimg.models import ColorSpace, PanImg
 from tests.cases_tests import RESOURCE_PATH
 
 
@@ -44,11 +44,11 @@ def assert_sitk_img_equivalence(
     ),
 )
 def test_convert_itk_to_internal(image: Path):
-    def assert_img_properties(img: SimpleITK.Image, internal_image: Image):
+    def assert_img_properties(img: SimpleITK.Image, internal_image: PanImg):
         color_space = {
-            1: Image.COLOR_SPACE_GRAY,
-            3: Image.COLOR_SPACE_RGB,
-            4: Image.COLOR_SPACE_RGBA,
+            1: ColorSpace.GRAY,
+            3: ColorSpace.RGB,
+            4: ColorSpace.RGBA,
         }
 
         assert internal_image.color_space == color_space.get(

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,107 +1,104 @@
 [[package]]
-category = "dev"
-description = "A configurable sidebar-enabled Sphinx theme"
 name = "alabaster"
+version = "0.7.12"
+description = "A configurable sidebar-enabled Sphinx theme"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.7.12"
 
 [[package]]
-category = "main"
-description = "Low-level AMQP client for Python (fork of amqplib)."
 name = "amqp"
+version = "2.6.1"
+description = "Low-level AMQP client for Python (fork of amqplib)."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.6.1"
 
 [package.dependencies]
 vine = ">=1.1.3,<5.0.0a1"
 
 [[package]]
-category = "dev"
-description = "apipkg: namespace control and lazy-import mechanism"
 name = "apipkg"
+version = "1.5"
+description = "apipkg: namespace control and lazy-import mechanism"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.5"
 
 [[package]]
-category = "main"
-description = "ASGI specs, helper code, and adapters"
 name = "asgiref"
+version = "3.3.1"
+description = "ASGI specs, helper code, and adapters"
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "3.3.1"
 
 [package.extras]
 tests = ["pytest", "pytest-asyncio"]
 
 [[package]]
-category = "dev"
-description = "Atomic file writes."
-marker = "sys_platform == \"win32\""
 name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.4.0"
 
 [[package]]
-category = "main"
-description = "Classes Without Boilerplate"
 name = "attrs"
+version = "20.3.0"
+description = "Classes Without Boilerplate"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.3.0"
 
 [package.extras]
-dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
 docs = ["furo", "sphinx", "zope.interface"]
-tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
-category = "dev"
-description = "Internationalization utilities"
 name = "babel"
+version = "2.9.0"
+description = "Internationalization utilities"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.9.0"
 
 [package.dependencies]
 pytz = ">=2015.7"
 
 [[package]]
-category = "main"
-description = "Screen-scraping library"
 name = "beautifulsoup4"
+version = "4.9.3"
+description = "Screen-scraping library"
+category = "main"
 optional = false
 python-versions = "*"
-version = "4.9.3"
 
 [package.dependencies]
-[package.dependencies.soupsieve]
-python = ">=3.0"
-version = ">1.2"
+soupsieve = {version = ">1.2", markers = "python_version >= \"3.0\""}
 
 [package.extras]
 html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
-category = "main"
-description = "Python multiprocessing fork with improvements and bugfixes"
 name = "billiard"
+version = "3.6.3.0"
+description = "Python multiprocessing fork with improvements and bugfixes"
+category = "main"
 optional = false
 python-versions = "*"
-version = "3.6.3.0"
 
 [[package]]
-category = "main"
-description = "An easy safelist-based HTML-sanitizing tool."
 name = "bleach"
+version = "3.3.0"
+description = "An easy safelist-based HTML-sanitizing tool."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "3.3.0"
 
 [package.dependencies]
 packaging = "*"
@@ -109,12 +106,12 @@ six = ">=1.9.0"
 webencodings = "*"
 
 [[package]]
-category = "main"
-description = "The AWS SDK for Python"
 name = "boto3"
+version = "1.17.9"
+description = "The AWS SDK for Python"
+category = "main"
 optional = false
 python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-version = "1.17.9"
 
 [package.dependencies]
 botocore = ">=1.20.9,<1.21.0"
@@ -122,12 +119,12 @@ jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
 [[package]]
-category = "main"
-description = "Low-level, data-driven core of boto 3."
 name = "botocore"
+version = "1.20.9"
+description = "Low-level, data-driven core of boto 3."
+category = "main"
 optional = false
 python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-version = "1.20.9"
 
 [package.dependencies]
 jmespath = ">=0.7.1,<1.0.0"
@@ -135,47 +132,38 @@ python-dateutil = ">=2.1,<3.0.0"
 urllib3 = ">=1.25.4,<1.27"
 
 [[package]]
-category = "main"
-description = "Python bindings for the Brotli compression library"
 name = "brotli"
+version = "1.0.9"
+description = "Python bindings for the Brotli compression library"
+category = "main"
 optional = false
 python-versions = "*"
-version = "1.0.9"
 
 [[package]]
-category = "main"
-description = "Distributed Task Queue."
 name = "celery"
+version = "4.4.7"
+description = "Distributed Task Queue."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "4.4.7"
 
 [package.dependencies]
 billiard = ">=3.6.3.0,<4.0"
+boto3 = {version = ">=1.9.125", optional = true, markers = "extra == \"sqs\""}
 kombu = ">=4.6.10,<4.7"
+pycurl = {version = "7.43.0.5", optional = true, markers = "extra == \"sqs\""}
 pytz = ">0.0-dev"
+redis = {version = ">=3.2.0", optional = true, markers = "extra == \"redis\""}
 vine = "1.3.0"
-
-[package.dependencies.boto3]
-optional = true
-version = ">=1.9.125"
-
-[package.dependencies.pycurl]
-optional = true
-version = "7.43.0.5"
-
-[package.dependencies.redis]
-optional = true
-version = ">=3.2.0"
 
 [package.extras]
 arangodb = ["pyArango (>=1.3.2)"]
 auth = ["cryptography"]
-azureblockblob = ["azure-storage (0.36.0)", "azure-common (1.1.5)", "azure-storage-common (1.1.0)"]
+azureblockblob = ["azure-storage (==0.36.0)", "azure-common (==1.1.5)", "azure-storage-common (==1.1.0)"]
 brotli = ["brotli (>=1.0.0)", "brotlipy (>=0.7.0)"]
 cassandra = ["cassandra-driver (<3.21.0)"]
 consul = ["python-consul"]
-cosmosdbsql = ["pydocumentdb (2.3.2)"]
+cosmosdbsql = ["pydocumentdb (==2.3.2)"]
 couchbase = ["couchbase-cffi (<3.0.0)", "couchbase (<3.0.0)"]
 couchdb = ["pycouchdb"]
 django = ["Django (>=1.11)"]
@@ -186,7 +174,7 @@ gevent = ["gevent"]
 librabbitmq = ["librabbitmq (>=1.5.0)"]
 lzma = ["backports.lzma"]
 memcache = ["pylibmc"]
-mongodb = ["pymongo (>=3.3.0)"]
+mongodb = ["pymongo[srv] (>=3.3.0)"]
 msgpack = ["msgpack"]
 pymemcache = ["python-memcached"]
 pyro = ["pyro4"]
@@ -196,123 +184,122 @@ s3 = ["boto3 (>=1.9.125)"]
 slmq = ["softlayer-messaging (>=1.0.3)"]
 solar = ["ephem"]
 sqlalchemy = ["sqlalchemy"]
-sqs = ["boto3 (>=1.9.125)", "pycurl (7.43.0.5)"]
+sqs = ["boto3 (>=1.9.125)", "pycurl (==7.43.0.5)"]
 tblib = ["tblib (>=1.3.0)", "tblib (>=1.5.0)"]
 yaml = ["PyYAML (>=3.10)"]
 zookeeper = ["kazoo (>=1.3.1)"]
 zstd = ["zstandard"]
 
 [[package]]
-category = "main"
-description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
+version = "2020.12.5"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
 optional = false
 python-versions = "*"
-version = "2020.12.5"
 
 [[package]]
-category = "main"
-description = "Foreign Function Interface for Python calling C code."
 name = "cffi"
+version = "1.14.5"
+description = "Foreign Function Interface for Python calling C code."
+category = "main"
 optional = false
 python-versions = "*"
-version = "1.14.5"
 
 [package.dependencies]
 pycparser = "*"
 
 [[package]]
-category = "main"
-description = "Universal encoding detector for Python 2 and 3"
 name = "chardet"
+version = "4.0.0"
+description = "Universal encoding detector for Python 2 and 3"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "4.0.0"
 
 [[package]]
-category = "main"
-description = "Citations and bibliography formatter"
 name = "citeproc-py"
+version = "0.5.1"
+description = "Citations and bibliography formatter"
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.5.1"
 
 [package.dependencies]
 lxml = "*"
 
 [[package]]
-category = "main"
-description = "Composable command line interface toolkit"
 name = "click"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "7.1.2"
-
-[[package]]
+description = "Composable command line interface toolkit"
 category = "main"
-description = "Cross-platform colored terminal text."
-marker = "sys_platform == \"win32\" or sys_platform == \"win32\""
-name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.4"
 
 [[package]]
-category = "dev"
-description = "Code coverage measurement for Python"
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "coverage"
+version = "5.4"
+description = "Code coverage measurement for Python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "5.4"
 
 [package.extras]
 toml = ["toml"]
 
 [[package]]
-category = "main"
-description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 name = "cryptography"
+version = "3.4.6"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "3.4.6"
 
 [package.dependencies]
 cffi = ">=1.12"
 
 [package.extras]
-docs = ["sphinx (>=1.6.5,<1.8.0 || >1.8.0,<3.1.0 || >3.1.0,<3.1.1 || >3.1.1)", "sphinx-rtd-theme"]
+docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
 docstest = ["doc8", "pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools-rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,<3.79.2 || >3.79.2)"]
+test = ["pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
-category = "main"
-description = "XML bomb protection for Python stdlib modules"
 name = "defusedxml"
+version = "0.6.0"
+description = "XML bomb protection for Python stdlib modules"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.6.0"
 
 [[package]]
-category = "main"
-description = "A set of disposable email domains"
 name = "disposable-email-domains"
+version = "0.0.64"
+description = "A set of disposable email domains"
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.0.64"
 
 [package.extras]
 dev = ["check-manifest"]
 
 [[package]]
-category = "main"
-description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
 name = "django"
+version = "3.1.6"
+description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "3.1.6"
 
 [package.dependencies]
 asgiref = ">=3.2.10,<4"
@@ -324,41 +311,38 @@ argon2 = ["argon2-cffi (>=16.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
-category = "main"
-description = "Integrated set of Django applications addressing authentication, registration, account management as well as 3rd party (social) account authentication."
 name = "django-allauth"
+version = "0.44.0"
+description = "Integrated set of Django applications addressing authentication, registration, account management as well as 3rd party (social) account authentication."
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.44.0"
 
 [package.dependencies]
 Django = ">=2.0"
+pyjwt = {version = ">=1.7", extras = ["crypto"]}
 python3-openid = ">=3.0.8"
 requests = "*"
 requests-oauthlib = ">=0.3.0"
 
-[package.dependencies.pyjwt]
-extras = ["crypto"]
-version = ">=1.7"
-
 [[package]]
-category = "main"
-description = "A helper class for handling configuration defaults of packaged apps gracefully."
 name = "django-appconf"
+version = "1.0.4"
+description = "A helper class for handling configuration defaults of packaged apps gracefully."
+category = "main"
 optional = false
 python-versions = "*"
-version = "1.0.4"
 
 [package.dependencies]
 django = "*"
 
 [[package]]
-category = "main"
-description = "Fresh autocompletes for Django"
 name = "django-autocomplete-light"
+version = "3.8.1"
+description = "Fresh autocompletes for Django"
+category = "main"
 optional = false
 python-versions = "*"
-version = "3.8.1"
 
 [package.dependencies]
 six = "*"
@@ -370,26 +354,26 @@ nested = ["django-nested-admin (>=3.0.21)"]
 tags = ["django-taggit"]
 
 [[package]]
-category = "main"
-description = "Database-backed Periodic Tasks."
 name = "django-celery-beat"
+version = "2.2.0"
+description = "Database-backed Periodic Tasks."
+category = "main"
 optional = false
 python-versions = "*"
-version = "2.2.0"
 
 [package.dependencies]
-Django = ">=2.2,<4.0"
 celery = ">=4.4,<6.0"
+Django = ">=2.2,<4.0"
 django-timezone-field = ">=4.1.0,<5.0"
 python-crontab = ">=2.3.4"
 
 [[package]]
-category = "main"
-description = "An async Django email backend using celery"
 name = "django-celery-email"
+version = "3.0.0"
+description = "An async Django email backend using celery"
+category = "main"
 optional = false
 python-versions = "*"
-version = "3.0.0"
 
 [package.dependencies]
 celery = ">=4.0"
@@ -397,34 +381,34 @@ django = ">=2.2"
 django-appconf = "*"
 
 [[package]]
-category = "main"
-description = "Celery result backends for Django."
 name = "django-celery-results"
+version = "2.0.1"
+description = "Celery result backends for Django."
+category = "main"
 optional = false
 python-versions = "*"
-version = "2.0.1"
 
 [package.dependencies]
 celery = ">=4.4,<6.0"
 
 [[package]]
-category = "main"
-description = "django-cors-headers is a Django application for handling the server headers required for Cross-Origin Resource Sharing (CORS)."
 name = "django-cors-headers"
+version = "3.7.0"
+description = "django-cors-headers is a Django application for handling the server headers required for Cross-Origin Resource Sharing (CORS)."
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "3.7.0"
 
 [package.dependencies]
 Django = ">=2.2"
 
 [[package]]
-category = "main"
-description = "Provides a country field for Django models."
 name = "django-countries"
+version = "7.0"
+description = "Provides a country field for Django models."
+category = "main"
 optional = false
 python-versions = "*"
-version = "7.0"
 
 [package.extras]
 dev = ["tox", "black", "django", "pytest", "pytest-django", "djangorestframework", "graphene-django"]
@@ -432,89 +416,89 @@ maintainer = ["transifex-client", "zest.releaser", "django"]
 test = ["pytest", "pytest-django", "pytest-cov", "graphene-django"]
 
 [[package]]
-category = "main"
-description = "Best way to have Django DRY forms"
 name = "django-crispy-forms"
+version = "1.11.0"
+description = "Best way to have Django DRY forms"
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "1.11.0"
 
 [[package]]
-category = "dev"
-description = "A configurable set of panels that display various debug information about the current request/response."
 name = "django-debug-toolbar"
+version = "3.2"
+description = "A configurable set of panels that display various debug information about the current request/response."
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "3.2"
 
 [package.dependencies]
 Django = ">=2.2"
 sqlparse = ">=0.2.0"
 
 [[package]]
-category = "main"
-description = "Extensions for Django"
 name = "django-extensions"
+version = "3.1.1"
+description = "Extensions for Django"
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "3.1.1"
 
 [[package]]
-category = "main"
-description = "Django-filter is a reusable Django application for allowing users to filter querysets dynamically."
 name = "django-filter"
-optional = false
-python-versions = ">=3.5"
 version = "2.4.0"
-
-[package.dependencies]
-Django = ">=2.2"
-
-[[package]]
+description = "Django-filter is a reusable Django application for allowing users to filter querysets dynamically."
 category = "main"
-description = "Implementation of per object permissions for Django."
-name = "django-guardian"
 optional = false
 python-versions = ">=3.5"
+
+[package.dependencies]
+Django = ">=2.2"
+
+[[package]]
+name = "django-guardian"
 version = "2.3.0"
+description = "Implementation of per object permissions for Django."
+category = "main"
+optional = false
+python-versions = ">=3.5"
 
 [package.dependencies]
 Django = ">=2.2"
 
 [[package]]
-category = "main"
-description = "Pluggable search for Django."
 name = "django-haystack"
+version = "3.0b1"
+description = "Pluggable search for Django."
+category = "main"
 optional = false
 python-versions = "*"
-version = "3.0b1"
 
 [package.dependencies]
 Django = ">=2.2"
 
 [[package]]
-category = "main"
-description = "A Django utility application that returns client's real IP address"
 name = "django-ipware"
-optional = false
-python-versions = "*"
 version = "3.0.2"
-
-[[package]]
+description = "A Django utility application that returns client's real IP address"
 category = "main"
-description = "script tag with additional attributes for django.forms.Media"
-name = "django-js-asset"
 optional = false
 python-versions = "*"
-version = "1.2.2"
 
 [[package]]
+name = "django-js-asset"
+version = "1.2.2"
+description = "script tag with additional attributes for django.forms.Media"
 category = "main"
-description = "A Django forum engine for building powerful community driven websites."
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "django-machina"
+version = "1.1.4"
+description = "A Django forum engine for building powerful community driven websites."
+category = "main"
 optional = false
 python-versions = ">=3.5,<4.0"
-version = "1.1.4"
 
 [package.dependencies]
 django = ">=2.2"
@@ -525,12 +509,12 @@ markdown2 = ">=2.3"
 pillow = ">=2.2"
 
 [[package]]
-category = "main"
-description = "A comprehensive Markdown editor built for Django."
 name = "django-markdownx"
+version = "3.0.1"
+description = "A comprehensive Markdown editor built for Django."
+category = "main"
 optional = false
 python-versions = "*"
-version = "3.0.1"
 
 [package.dependencies]
 Django = "*"
@@ -538,36 +522,36 @@ Markdown = "*"
 Pillow = "*"
 
 [[package]]
-category = "main"
-description = "Utilities for implementing Modified Preorder Tree Traversal with your Django Models and working with trees of Model instances."
 name = "django-mptt"
+version = "0.11.0"
+description = "Utilities for implementing Modified Preorder Tree Traversal with your Django Models and working with trees of Model instances."
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "0.11.0"
 
 [package.dependencies]
 Django = ">=1.11"
 django-js-asset = "*"
 
 [[package]]
-category = "main"
-description = "Full featured redis cache backend for Django."
 name = "django-redis"
+version = "4.12.1"
+description = "Full featured redis cache backend for Django."
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "4.12.1"
 
 [package.dependencies]
 Django = ">=2.2"
 redis = ">=3.0.0"
 
 [[package]]
-category = "main"
-description = "Authentication for django rest framework"
 name = "django-rest-knox"
+version = "4.1.0"
+description = "Authentication for django rest framework"
+category = "main"
 optional = false
 python-versions = "*"
-version = "4.1.0"
 
 [package.dependencies]
 cryptography = "*"
@@ -575,12 +559,12 @@ django = "*"
 djangorestframework = "*"
 
 [[package]]
-category = "main"
-description = "Select2 option fields for Django"
 name = "django-select2"
+version = "7.6.1"
+description = "Select2 option fields for Django"
+category = "main"
 optional = false
 python-versions = "*"
-version = "7.6.1"
 
 [package.dependencies]
 django = ">=2.2"
@@ -590,23 +574,23 @@ django-appconf = ">=0.6.0"
 test = ["pytest", "pytest-cov", "pytest-django", "selenium"]
 
 [[package]]
-category = "main"
-description = "Store model history and view/revert changes from admin site."
 name = "django-simple-history"
+version = "2.12.0"
+description = "Store model history and view/revert changes from admin site."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.12.0"
 
 [package.dependencies]
 six = "*"
 
 [[package]]
-category = "main"
-description = "Support for many storage backends in Django"
 name = "django-storages"
+version = "1.11.1"
+description = "Support for many storage backends in Django"
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "1.11.1"
 
 [package.dependencies]
 Django = ">=2.2"
@@ -620,23 +604,23 @@ libcloud = ["apache-libcloud"]
 sftp = ["paramiko"]
 
 [[package]]
-category = "main"
-description = "Summernote plugin for Django"
 name = "django-summernote"
+version = "0.8.11.6"
+description = "Summernote plugin for Django"
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.8.11.6"
 
 [package.dependencies]
 django = "*"
 
 [[package]]
-category = "main"
-description = "A Django app providing database and form fields for pytz timezone objects."
 name = "django-timezone-field"
+version = "4.1.1"
+description = "A Django app providing database and form fields for pytz timezone objects."
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "4.1.1"
 
 [package.dependencies]
 django = ">=2.2"
@@ -646,31 +630,31 @@ pytz = "*"
 rest_framework = ["djangorestframework (>=3.0.0)"]
 
 [[package]]
-category = "main"
-description = "Tweak the form field rendering in templates, not in python-level form definitions."
 name = "django-widget-tweaks"
+version = "1.4.8"
+description = "Tweak the form field rendering in templates, not in python-level form definitions."
+category = "main"
 optional = false
 python-versions = "*"
-version = "1.4.8"
 
 [[package]]
-category = "main"
-description = "Web APIs for Django, made easy."
 name = "djangorestframework"
+version = "3.12.2"
+description = "Web APIs for Django, made easy."
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "3.12.2"
 
 [package.dependencies]
 django = ">=2.2"
 
 [[package]]
-category = "main"
-description = "CSV Tools for Django REST Framework"
 name = "djangorestframework-csv"
+version = "2.1.0"
+description = "CSV Tools for Django REST Framework"
+category = "main"
 optional = false
 python-versions = "*"
-version = "2.1.0"
 
 [package.dependencies]
 djangorestframework = "*"
@@ -678,12 +662,12 @@ six = "*"
 unicodecsv = "*"
 
 [[package]]
-category = "main"
-description = "django-guardian support for Django REST Framework"
 name = "djangorestframework-guardian"
+version = "0.3.0"
+description = "django-guardian support for Django REST Framework"
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.3.0"
 
 [package.dependencies]
 django = "*"
@@ -691,15 +675,15 @@ django-guardian = "*"
 djangorestframework = "*"
 
 [[package]]
-category = "main"
-description = "A Python library for the Docker Engine API."
 name = "docker"
+version = "4.4.2"
+description = "A Python library for the Docker Engine API."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "4.4.2"
 
 [package.dependencies]
-pywin32 = "227"
+pywin32 = {version = "227", markers = "sys_platform == \"win32\""}
 requests = ">=2.14.2,<2.18.0 || >2.18.0"
 six = ">=1.4.0"
 websocket-client = ">=0.32.0"
@@ -709,56 +693,56 @@ ssh = ["paramiko (>=2.4.2)"]
 tls = ["pyOpenSSL (>=17.5.0)", "cryptography (>=1.3.4)", "idna (>=2.0.0)"]
 
 [[package]]
-category = "dev"
-description = "Docutils -- Python Documentation Utilities"
 name = "docutils"
+version = "0.16"
+description = "Docutils -- Python Documentation Utilities"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.16"
 
 [[package]]
-category = "main"
-description = "Sane and flexible OpenAPI 3 schema generation for Django REST framework"
 name = "drf-spectacular"
+version = "0.13.2"
+description = "Sane and flexible OpenAPI 3 schema generation for Django REST framework"
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "0.13.2"
 
 [package.dependencies]
 Django = ">=2.2"
-PyYAML = ">=5.1"
 djangorestframework = ">=3.10"
 inflection = ">=0.3.1"
 jsonschema = ">=2.6.0"
+PyYAML = ">=5.1"
 uritemplate = ">=2.0.0"
 
 [[package]]
-category = "main"
-description = "Easy thumbnails for Django"
 name = "easy-thumbnails"
+version = "2.7.1"
+description = "Easy thumbnails for Django"
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "2.7.1"
 
 [package.dependencies]
 django = ">=1.11,<4.0"
 pillow = "*"
 
 [[package]]
-category = "main"
-description = "An implementation of lxml.xmlfile for the standard library"
 name = "et-xmlfile"
+version = "1.0.1"
+description = "An implementation of lxml.xmlfile for the standard library"
+category = "main"
 optional = false
 python-versions = "*"
-version = "1.0.1"
 
 [[package]]
-category = "dev"
-description = "execnet: rapid multi-Python deployment"
 name = "execnet"
+version = "1.8.0"
+description = "execnet: rapid multi-Python deployment"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "1.8.0"
 
 [package.dependencies]
 apipkg = ">=1.4"
@@ -767,12 +751,12 @@ apipkg = ">=1.4"
 testing = ["pre-commit"]
 
 [[package]]
-category = "dev"
-description = "A versatile test fixtures replacement based on thoughtbot's factory_bot for Ruby."
 name = "factory-boy"
+version = "3.2.0"
+description = "A versatile test fixtures replacement based on thoughtbot's factory_bot for Ruby."
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "3.2.0"
 
 [package.dependencies]
 Faker = ">=0.7.0"
@@ -782,35 +766,32 @@ dev = ["coverage", "django", "flake8", "isort", "pillow", "sqlalchemy", "mongoen
 doc = ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
 
 [[package]]
-category = "dev"
-description = "Faker is a Python package that generates fake data for you."
 name = "faker"
+version = "6.1.1"
+description = "Faker is a Python package that generates fake data for you."
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "6.1.1"
 
 [package.dependencies]
 python-dateutil = ">=2.4"
 text-unidecode = "1.3"
 
 [[package]]
-category = "main"
-description = "A platform independent file lock."
 name = "filelock"
+version = "3.0.12"
+description = "A platform independent file lock."
+category = "main"
 optional = false
 python-versions = "*"
-version = "3.0.12"
 
 [[package]]
-category = "main"
-description = "WSGI HTTP Server for UNIX"
 name = "gunicorn"
+version = "20.0.4"
+description = "WSGI HTTP Server for UNIX"
+category = "main"
 optional = false
 python-versions = ">=3.4"
-version = "20.0.4"
-
-[package.dependencies]
-setuptools = ">=3.0"
 
 [package.extras]
 eventlet = ["eventlet (>=0.9.7)"]
@@ -819,66 +800,61 @@ setproctitle = ["setproctitle"]
 tornado = ["tornado (>=0.2)"]
 
 [[package]]
-category = "main"
-description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 name = "h11"
+version = "0.12.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "0.12.0"
 
 [[package]]
-category = "main"
-description = "A comprehensive HTTP client library."
 name = "httplib2"
+version = "0.19.0"
+description = "A comprehensive HTTP client library."
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.19.0"
 
 [package.dependencies]
 pyparsing = ">=2.4.2,<3"
 
 [[package]]
-category = "main"
-description = "A collection of framework independent HTTP protocol utils."
-marker = "sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\""
 name = "httptools"
+version = "0.1.1"
+description = "A collection of framework independent HTTP protocol utils."
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.1.1"
 
 [package.extras]
-test = ["Cython (0.29.14)"]
+test = ["Cython (==0.29.14)"]
 
 [[package]]
-category = "main"
-description = "Python humanize utilities"
 name = "humanize"
+version = "3.2.0"
+description = "Python humanize utilities"
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "3.2.0"
-
-[package.dependencies]
-setuptools = "*"
 
 [package.extras]
 tests = ["freezegun", "pytest", "pytest-cov"]
 
 [[package]]
-category = "main"
-description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
+version = "2.10"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.10"
 
 [[package]]
-category = "main"
-description = "Image transformation, compression, and decompression codecs"
-marker = "platform_system == \"Windows\""
 name = "imagecodecs"
+version = "2021.1.28"
+description = "Image transformation, compression, and decompression codecs"
+category = "main"
 optional = false
 python-versions = ">=3.7"
-version = "2021.1.28"
 
 [package.dependencies]
 numpy = ">=1.15.1"
@@ -887,44 +863,44 @@ numpy = ">=1.15.1"
 all = ["matplotlib (>=3.2)", "tifffile (>=2021.1.11)"]
 
 [[package]]
-category = "dev"
-description = "Getting image size from png/jpeg/jpeg2000/gif file"
 name = "imagesize"
+version = "1.2.0"
+description = "Getting image size from png/jpeg/jpeg2000/gif file"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.2.0"
 
 [[package]]
-category = "main"
-description = "A port of Ruby on Rails inflector to Python"
 name = "inflection"
+version = "0.5.1"
+description = "A port of Ruby on Rails inflector to Python"
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "0.5.1"
 
 [[package]]
-category = "dev"
-description = "iniconfig: brain-dead simple config-ini parsing"
 name = "iniconfig"
-optional = false
-python-versions = "*"
 version = "1.1.1"
-
-[[package]]
-category = "main"
-description = "Julian dates from proleptic Gregorian and Julian calendars."
-name = "jdcal"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "1.4.1"
 
 [[package]]
+name = "jdcal"
+version = "1.4.1"
+description = "Julian dates from proleptic Gregorian and Julian calendars."
 category = "main"
-description = "A very fast and expressive template engine."
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "jinja2"
+version = "2.11.3"
+description = "A very fast and expressive template engine."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.11.3"
 
 [package.dependencies]
 MarkupSafe = ">=0.23"
@@ -933,33 +909,32 @@ MarkupSafe = ">=0.23"
 i18n = ["Babel (>=0.8)"]
 
 [[package]]
-category = "main"
-description = "JSON Matching Expressions"
 name = "jmespath"
+version = "0.10.0"
+description = "JSON Matching Expressions"
+category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "0.10.0"
 
 [[package]]
-category = "main"
-description = "Lightweight pipelining with Python functions"
 name = "joblib"
+version = "1.0.1"
+description = "Lightweight pipelining with Python functions"
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "1.0.1"
 
 [[package]]
-category = "main"
-description = "An implementation of JSON Schema validation for Python"
 name = "jsonschema"
+version = "3.2.0"
+description = "An implementation of JSON Schema validation for Python"
+category = "main"
 optional = false
 python-versions = "*"
-version = "3.2.0"
 
 [package.dependencies]
 attrs = ">=17.4.0"
 pyrsistent = ">=0.14.0"
-setuptools = "*"
 six = ">=1.11.0"
 
 [package.extras]
@@ -967,12 +942,12 @@ format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors
 format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator (>0.1.0)", "rfc3339-validator"]
 
 [[package]]
-category = "main"
-description = "Messaging library for Python."
 name = "kombu"
+version = "4.6.11"
+description = "Messaging library for Python."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "4.6.11"
 
 [package.dependencies]
 amqp = ">=2.6.0,<2.7"
@@ -989,32 +964,29 @@ qpid = ["qpid-python (>=0.26)", "qpid-tools (>=0.26)"]
 redis = ["redis (>=3.3.11)"]
 slmq = ["softlayer-messaging (>=1.0.3)"]
 sqlalchemy = ["sqlalchemy"]
-sqs = ["boto3 (>=1.4.4)", "pycurl (7.43.0.2)"]
+sqs = ["boto3 (>=1.4.4)", "pycurl (==7.43.0.2)"]
 yaml = ["PyYAML (>=3.10)"]
 zookeeper = ["kazoo (>=1.3.1)"]
 
 [[package]]
-category = "dev"
-description = "Python LiveReload is an awesome tool for web developers"
 name = "livereload"
+version = "2.6.3"
+description = "Python LiveReload is an awesome tool for web developers"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "2.6.3"
 
 [package.dependencies]
 six = "*"
-
-[package.dependencies.tornado]
-python = ">=2.8"
-version = "*"
+tornado = {version = "*", markers = "python_version > \"2.7\""}
 
 [[package]]
-category = "main"
-description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
 name = "lxml"
+version = "4.6.2"
+description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
-version = "4.6.2"
 
 [package.extras]
 cssselect = ["cssselect (>=0.7)"]
@@ -1023,58 +995,58 @@ htmlsoup = ["beautifulsoup4"]
 source = ["Cython (>=0.29.7)"]
 
 [[package]]
-category = "main"
-description = "Python implementation of Markdown."
 name = "markdown"
+version = "3.3.3"
+description = "Python implementation of Markdown."
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "3.3.3"
 
 [package.extras]
 testing = ["coverage", "pyyaml"]
 
 [[package]]
-category = "main"
-description = "A fast and complete Python implementation of Markdown"
 name = "markdown2"
+version = "2.4.0"
+description = "A fast and complete Python implementation of Markdown"
+category = "main"
 optional = false
 python-versions = ">=3.5, <4"
-version = "2.4.0"
 
 [[package]]
-category = "main"
-description = "Safely add untrusted strings to HTML/XML markup."
 name = "markupsafe"
+version = "1.1.1"
+description = "Safely add untrusted strings to HTML/XML markup."
+category = "main"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
-version = "1.1.1"
 
 [[package]]
-category = "main"
-description = "NumPy is the fundamental package for array computing with Python."
 name = "numpy"
+version = "1.20.1"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "main"
 optional = false
 python-versions = ">=3.7"
-version = "1.20.1"
 
 [[package]]
-category = "main"
-description = "library for OAuth version 1.9"
 name = "oauth2"
+version = "1.9.0.post1"
+description = "library for OAuth version 1.9"
+category = "main"
 optional = false
 python-versions = "*"
-version = "1.9.0.post1"
 
 [package.dependencies]
 httplib2 = "*"
 
 [[package]]
-category = "main"
-description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
 name = "oauthlib"
+version = "3.1.0"
+description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "3.1.0"
 
 [package.extras]
 rsa = ["cryptography"]
@@ -1082,46 +1054,46 @@ signals = ["blinker"]
 signedtoken = ["cryptography", "pyjwt (>=1.0.0)"]
 
 [[package]]
-category = "main"
-description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
 name = "openpyxl"
+version = "3.0.6"
+description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
+category = "main"
 optional = false
 python-versions = ">=3.6,"
-version = "3.0.6"
 
 [package.dependencies]
 et-xmlfile = "*"
 jdcal = "*"
 
 [[package]]
-category = "main"
-description = "Python interface to OpenSlide"
 name = "openslide-python"
+version = "1.1.2"
+description = "Python interface to OpenSlide"
+category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.1.2"
 
 [package.dependencies]
 Pillow = "*"
 
 [[package]]
-category = "main"
-description = "Core utilities for Python packages"
 name = "packaging"
+version = "20.9"
+description = "Core utilities for Python packages"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.9"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
 
 [[package]]
-category = "main"
-description = "Powerful data structures for data analysis, time series, and statistics"
 name = "pandas"
+version = "1.2.2"
+description = "Powerful data structures for data analysis, time series, and statistics"
+category = "main"
 optional = false
 python-versions = ">=3.7.1"
-version = "1.2.2"
 
 [package.dependencies]
 numpy = ">=1.16.5"
@@ -1132,146 +1104,159 @@ pytz = ">=2017.3"
 test = ["pytest (>=5.0.1)", "pytest-xdist", "hypothesis (>=3.58)"]
 
 [[package]]
-category = "main"
-description = "Python Imaging Library (Fork)"
 name = "pillow"
+version = "8.1.0"
+description = "Python Imaging Library (Fork)"
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "8.1.0"
 
 [[package]]
-category = "main"
-description = "Interface Python with pkg-config"
 name = "pkgconfig"
+version = "1.5.1"
+description = "Interface Python with pkg-config"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.5.1"
 
 [[package]]
-category = "dev"
-description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
+version = "0.13.1"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.13.1"
 
 [package.extras]
 dev = ["pre-commit", "tox"]
 
 [[package]]
-category = "main"
-description = "Python client for the Prometheus monitoring system."
 name = "prometheus-client"
+version = "0.9.0"
+description = "Python client for the Prometheus monitoring system."
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.9.0"
 
 [package.extras]
 twisted = ["twisted"]
 
 [[package]]
-category = "main"
-description = "psycopg2 - Python-PostgreSQL Database Adapter"
 name = "psycopg2"
+version = "2.8.6"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
+category = "main"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
-version = "2.8.6"
 
 [[package]]
-category = "dev"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
 name = "py"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.10.0"
-
-[[package]]
-category = "main"
-description = "C parser in Python"
-name = "pycparser"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.20"
 
 [[package]]
+name = "pycparser"
+version = "2.20"
+description = "C parser in Python"
 category = "main"
-description = "PycURL -- A Python Interface To The cURL library"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "pycurl"
+version = "7.43.0.5"
+description = "PycURL -- A Python Interface To The cURL library"
+category = "main"
 optional = false
 python-versions = "*"
-version = "7.43.0.5"
 
 [[package]]
+name = "pydantic"
+version = "1.8.1"
+description = "Data validation and settings management using python 3.6 type hinting"
 category = "main"
-description = "Pure python package for DICOM medical file reading and writing"
-name = "pydicom"
 optional = false
 python-versions = ">=3.6.1"
-version = "2.1.2"
-
-[[package]]
-category = "dev"
-description = "Pygments is a syntax highlighting package written in Python."
-name = "pygments"
-optional = false
-python-versions = ">=3.5"
-version = "2.8.0"
-
-[[package]]
-category = "main"
-description = "JSON Web Token implementation in Python"
-name = "pyjwt"
-optional = false
-python-versions = ">=3.6"
-version = "2.0.1"
 
 [package.dependencies]
-[package.dependencies.cryptography]
-optional = true
-version = ">=3.3.1,<4.0.0"
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
+
+[[package]]
+name = "pydicom"
+version = "2.1.2"
+description = "Pure python package for DICOM medical file reading and writing"
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+
+[[package]]
+name = "pygments"
+version = "2.8.0"
+description = "Pygments is a syntax highlighting package written in Python."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "pyjwt"
+version = "2.0.1"
+description = "JSON Web Token implementation in Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+cryptography = {version = ">=3.3.1,<4.0.0", optional = true, markers = "extra == \"crypto\""}
 
 [package.extras]
 crypto = ["cryptography (>=3.3.1,<4.0.0)"]
-dev = ["sphinx", "sphinx-rtd-theme", "zope.interface", "cryptography (>=3.3.1,<4.0.0)", "pytest (>=6.0.0,<7.0.0)", "coverage (5.0.4)", "mypy", "pre-commit"]
+dev = ["sphinx", "sphinx-rtd-theme", "zope.interface", "cryptography (>=3.3.1,<4.0.0)", "pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)", "mypy", "pre-commit"]
 docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["pytest (>=6.0.0,<7.0.0)", "coverage (5.0.4)"]
+tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
 
 [[package]]
-category = "main"
-description = "Python parsing module"
 name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.7"
 
 [[package]]
-category = "main"
-description = "Persistent/Functional/Immutable data structures"
 name = "pyrsistent"
+version = "0.17.3"
+description = "Persistent/Functional/Immutable data structures"
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "0.17.3"
 
 [[package]]
-category = "main"
-description = "Python wrapper for JetBrains/swot."
 name = "pyswot"
+version = "0.1.3"
+description = "Python wrapper for JetBrains/swot."
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "0.1.3"
 
 [[package]]
-category = "dev"
-description = "pytest: simple powerful testing with Python"
 name = "pytest"
+version = "6.2.2"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "6.2.2"
 
 [package.dependencies]
-atomicwrites = ">=1.0"
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
-colorama = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<1.0.0a1"
@@ -1282,27 +1267,27 @@ toml = "*"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-category = "dev"
-description = "Pytest plugin for measuring coverage."
 name = "pytest-cov"
+version = "2.11.1"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.11.1"
 
 [package.dependencies]
 coverage = ">=5.2.1"
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
+testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
-category = "dev"
-description = "A Django plugin for pytest."
 name = "pytest-django"
+version = "4.1.0"
+description = "A Django plugin for pytest."
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "4.1.0"
 
 [package.dependencies]
 pytest = ">=5.4.0"
@@ -1312,24 +1297,24 @@ docs = ["sphinx", "sphinx-rtd-theme"]
 testing = ["django", "django-configurations (>=2.0)"]
 
 [[package]]
-category = "dev"
-description = "run tests in isolated forked subprocesses"
 name = "pytest-forked"
+version = "1.3.0"
+description = "run tests in isolated forked subprocesses"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "1.3.0"
 
 [package.dependencies]
 py = "*"
 pytest = ">=3.10"
 
 [[package]]
-category = "dev"
-description = "Thin-wrapper around the mock package for easier use with pytest"
 name = "pytest-mock"
+version = "3.5.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "3.5.1"
 
 [package.dependencies]
 pytest = ">=5.0"
@@ -1338,23 +1323,23 @@ pytest = ">=5.0"
 dev = ["pre-commit", "tox", "pytest-asyncio"]
 
 [[package]]
-category = "dev"
-description = "Pytest plugin to randomly order tests and control random.seed."
 name = "pytest-randomly"
+version = "3.5.0"
+description = "Pytest plugin to randomly order tests and control random.seed."
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "3.5.0"
 
 [package.dependencies]
 pytest = "*"
 
 [[package]]
-category = "dev"
-description = "pytest xdist plugin for distributed testing and loop-on-failing modes"
 name = "pytest-xdist"
+version = "2.2.1"
+description = "pytest xdist plugin for distributed testing and loop-on-failing modes"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "2.2.1"
 
 [package.dependencies]
 execnet = ">=1.1"
@@ -1366,12 +1351,12 @@ psutil = ["psutil (>=3.0)"]
 testing = ["filelock"]
 
 [[package]]
-category = "main"
-description = "Python Crontab API"
 name = "python-crontab"
+version = "2.5.1"
+description = "Python Crontab API"
+category = "main"
 optional = false
 python-versions = "*"
-version = "2.5.1"
 
 [package.dependencies]
 python-dateutil = "*"
@@ -1381,42 +1366,42 @@ cron-description = ["cron-descriptor"]
 cron-schedule = ["croniter"]
 
 [[package]]
-category = "main"
-description = "Extensions to the standard Python datetime module"
 name = "python-dateutil"
+version = "2.8.1"
+description = "Extensions to the standard Python datetime module"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-version = "2.8.1"
 
 [package.dependencies]
 six = ">=1.5"
 
 [[package]]
-category = "main"
-description = "Add .env support to your django/flask apps in development and deployments"
 name = "python-dotenv"
+version = "0.15.0"
+description = "Add .env support to your django/flask apps in development and deployments"
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.15.0"
 
 [package.extras]
 cli = ["click (>=5.0)"]
 
 [[package]]
-category = "main"
-description = "File type identification using libmagic"
 name = "python-magic"
+version = "0.4.22"
+description = "File type identification using libmagic"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.22"
 
 [[package]]
-category = "main"
-description = "OpenID support for modern servers and consumers."
 name = "python3-openid"
+version = "3.2.0"
+description = "OpenID support for modern servers and consumers."
+category = "main"
 optional = false
 python-versions = "*"
-version = "3.2.0"
 
 [package.dependencies]
 defusedxml = "*"
@@ -1426,31 +1411,31 @@ mysql = ["mysql-connector-python"]
 postgresql = ["psycopg2"]
 
 [[package]]
-category = "main"
-description = "World timezone definitions, modern and historical"
 name = "pytz"
+version = "2021.1"
+description = "World timezone definitions, modern and historical"
+category = "main"
 optional = false
 python-versions = "*"
-version = "2021.1"
 
 [[package]]
-category = "dev"
-description = "A tool to automatically upgrade syntax for newer versions."
 name = "pyupgrade"
+version = "2.10.0"
+description = "A tool to automatically upgrade syntax for newer versions."
+category = "dev"
 optional = false
 python-versions = ">=3.6.1"
-version = "2.10.0"
 
 [package.dependencies]
 tokenize-rt = ">=3.2.0"
 
 [[package]]
-category = "main"
-description = "binding for the libvips image processing library, API mode"
 name = "pyvips"
+version = "2.1.14"
+description = "binding for the libvips image processing library, API mode"
+category = "main"
 optional = false
 python-versions = "*"
-version = "2.1.14"
 
 [package.dependencies]
 cffi = ">=1.0.0"
@@ -1461,40 +1446,39 @@ doc = ["sphinx", "sphinx-rtd-theme"]
 test = ["cffi (>=1.0.0)", "pyperf", "pytest", "pytest-flake8", "pytest-runner"]
 
 [[package]]
-category = "main"
-description = "Python for Window Extensions"
-marker = "sys_platform == \"win32\""
 name = "pywin32"
+version = "227"
+description = "Python for Window Extensions"
+category = "main"
 optional = false
 python-versions = "*"
-version = "227"
 
 [[package]]
-category = "main"
-description = "YAML parser and emitter for Python"
 name = "pyyaml"
+version = "5.4.1"
+description = "YAML parser and emitter for Python"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-version = "5.4.1"
 
 [[package]]
-category = "main"
-description = "Python client for Redis key-value store"
 name = "redis"
+version = "3.5.3"
+description = "Python client for Redis key-value store"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "3.5.3"
 
 [package.extras]
 hiredis = ["hiredis (>=0.1.3)"]
 
 [[package]]
-category = "main"
-description = "Python HTTP for Humans."
 name = "requests"
+version = "2.25.1"
+description = "Python HTTP for Humans."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.25.1"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
@@ -1504,53 +1488,53 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 
 [[package]]
-category = "main"
-description = "File transport adapter for Requests"
 name = "requests-file"
+version = "1.5.1"
+description = "File transport adapter for Requests"
+category = "main"
 optional = false
 python-versions = "*"
-version = "1.5.1"
 
 [package.dependencies]
 requests = ">=1.0.0"
 six = "*"
 
 [[package]]
-category = "main"
-description = "OAuthlib authentication support for Requests."
 name = "requests-oauthlib"
+version = "1.3.0"
+description = "OAuthlib authentication support for Requests."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.3.0"
 
 [package.dependencies]
 oauthlib = ">=3.0.0"
 requests = ">=2.0.0"
 
 [package.extras]
-rsa = ["oauthlib (>=3.0.0)"]
+rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
-category = "main"
-description = "An Amazon S3 Transfer Manager"
 name = "s3transfer"
+version = "0.3.4"
+description = "An Amazon S3 Transfer Manager"
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.3.4"
 
 [package.dependencies]
 botocore = ">=1.12.36,<2.0a.0"
 
 [[package]]
-category = "main"
-description = "A set of python modules for machine learning and data mining"
 name = "scikit-learn"
+version = "0.24.1"
+description = "A set of python modules for machine learning and data mining"
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "0.24.1"
 
 [package.dependencies]
 joblib = ">=0.11"
@@ -1565,23 +1549,23 @@ examples = ["matplotlib (>=2.1.1)", "scikit-image (>=0.13)", "pandas (>=0.25.0)"
 tests = ["matplotlib (>=2.1.1)", "scikit-image (>=0.13)", "pandas (>=0.25.0)", "pytest (>=5.0.1)", "pytest-cov (>=2.9.0)", "flake8 (>=3.8.2)", "mypy (>=0.770)", "pyamg (>=4.0.0)"]
 
 [[package]]
-category = "main"
-description = "SciPy: Scientific Library for Python"
 name = "scipy"
+version = "1.6.0"
+description = "SciPy: Scientific Library for Python"
+category = "main"
 optional = false
 python-versions = ">=3.7"
-version = "1.6.0"
 
 [package.dependencies]
 numpy = ">=1.16.5"
 
 [[package]]
-category = "main"
-description = "Python client for Sentry (https://sentry.io)"
 name = "sentry-sdk"
+version = "0.20.2"
+description = "Python client for Sentry (https://sentry.io)"
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.20.2"
 
 [package.dependencies]
 certifi = "*"
@@ -1604,57 +1588,55 @@ sqlalchemy = ["sqlalchemy (>=1.2)"]
 tornado = ["tornado (>=5)"]
 
 [[package]]
-category = "main"
-description = "SimpleITK is a simplified interface to the Insight Toolkit (ITK) for image registration and segmentation"
 name = "simpleitk"
+version = "2.0.2"
+description = "SimpleITK is a simplified interface to the Insight Toolkit (ITK) for image registration and segmentation"
+category = "main"
 optional = false
 python-versions = "*"
-version = "2.0.2"
 
 [[package]]
-category = "main"
-description = "Python 2 and 3 compatibility utilities"
 name = "six"
+version = "1.15.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.15.0"
 
 [[package]]
-category = "dev"
-description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
 name = "snowballstemmer"
+version = "2.1.0"
+description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "2.1.0"
 
 [[package]]
-category = "main"
-description = "A modern CSS selector implementation for Beautiful Soup."
-marker = "python_version >= \"3.0\""
 name = "soupsieve"
+version = "2.2"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "2.2"
 
 [[package]]
-category = "dev"
-description = "Python documentation generator"
 name = "sphinx"
+version = "3.5.1"
+description = "Python documentation generator"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "3.5.1"
 
 [package.dependencies]
-Jinja2 = ">=2.3"
-Pygments = ">=2.0"
 alabaster = ">=0.7,<0.8"
 babel = ">=1.3"
-colorama = ">=0.3.5"
+colorama = {version = ">=0.3.5", markers = "sys_platform == \"win32\""}
 docutils = ">=0.12"
 imagesize = "*"
+Jinja2 = ">=2.3"
 packaging = "*"
+Pygments = ">=2.0"
 requests = ">=2.5.0"
-setuptools = "*"
 snowballstemmer = ">=1.1"
 sphinxcontrib-applehelp = "*"
 sphinxcontrib-devhelp = "*"
@@ -1669,12 +1651,12 @@ lint = ["flake8 (>=3.5.0)", "isort", "mypy (>=0.800)", "docutils-stubs"]
 test = ["pytest", "pytest-cov", "html5lib", "cython", "typed-ast"]
 
 [[package]]
-category = "dev"
-description = "Rebuild Sphinx documentation on changes, with live-reload in the browser."
 name = "sphinx-autobuild"
+version = "2020.9.1"
+description = "Rebuild Sphinx documentation on changes, with live-reload in the browser."
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "2020.9.1"
 
 [package.dependencies]
 livereload = "*"
@@ -1684,12 +1666,12 @@ sphinx = "*"
 test = ["pytest", "pytest-cov"]
 
 [[package]]
-category = "dev"
-description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
 name = "sphinx-autodoc-typehints"
+version = "1.11.1"
+description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
+category = "dev"
 optional = false
 python-versions = ">=3.5.2"
-version = "1.11.1"
 
 [package.dependencies]
 Sphinx = ">=3.0"
@@ -1699,12 +1681,12 @@ test = ["pytest (>=3.1.0)", "typing-extensions (>=3.5)", "sphobjinv (>=2.0)", "S
 type_comments = ["typed-ast (>=1.4.0)"]
 
 [[package]]
-category = "dev"
-description = "Read the Docs theme for Sphinx"
 name = "sphinx-rtd-theme"
+version = "0.5.1"
+description = "Read the Docs theme for Sphinx"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.5.1"
 
 [package.dependencies]
 sphinx = "*"
@@ -1713,133 +1695,133 @@ sphinx = "*"
 dev = ["transifex-client", "sphinxcontrib-httpdomain", "bump2version"]
 
 [[package]]
-category = "dev"
-description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
 name = "sphinxcontrib-applehelp"
+version = "1.0.2"
+description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "1.0.2"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
-category = "dev"
-description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
 name = "sphinxcontrib-devhelp"
+version = "1.0.2"
+description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "1.0.2"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
-category = "dev"
-description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 name = "sphinxcontrib-htmlhelp"
+version = "1.0.3"
+description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "1.0.3"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest", "html5lib"]
 
 [[package]]
-category = "dev"
-description = "A sphinx extension which renders display math in HTML via JavaScript"
 name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+description = "A sphinx extension which renders display math in HTML via JavaScript"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "1.0.1"
 
 [package.extras]
 test = ["pytest", "flake8", "mypy"]
 
 [[package]]
-category = "dev"
-description = "Sphinx \"plantuml\" extension"
 name = "sphinxcontrib-plantuml"
+version = "0.19"
+description = "Sphinx \"plantuml\" extension"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.19"
 
 [package.dependencies]
 Sphinx = ">=1.6"
 
 [[package]]
-category = "dev"
-description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
 name = "sphinxcontrib-qthelp"
-optional = false
-python-versions = ">=3.5"
 version = "1.0.3"
+description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
-category = "dev"
-description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
 name = "sphinxcontrib-serializinghtml"
+version = "1.1.4"
+description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "1.1.4"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
-category = "main"
-description = "A non-validating SQL parser."
 name = "sqlparse"
+version = "0.4.1"
+description = "A non-validating SQL parser."
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "0.4.1"
 
 [[package]]
-category = "dev"
-description = "The most basic Text::Unidecode port"
 name = "text-unidecode"
+version = "1.3"
+description = "The most basic Text::Unidecode port"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "1.3"
 
 [[package]]
-category = "main"
-description = "threadpoolctl"
 name = "threadpoolctl"
+version = "2.1.0"
+description = "threadpoolctl"
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "2.1.0"
 
 [[package]]
-category = "main"
-description = "Read and write TIFF(r) files"
 name = "tifffile"
+version = "2019.1.4"
+description = "Read and write TIFF(r) files"
+category = "main"
 optional = false
 python-versions = ">=2.7"
-version = "2019.1.4"
 
 [package.dependencies]
-imagecodecs = ">=2019.1.1"
+imagecodecs = {version = ">=2019.1.1", markers = "platform_system == \"Windows\""}
 numpy = ">=1.11.3"
 
 [package.extras]
 all = ["matplotlib (>=2.2)", "imagecodecs (>=2019.1.1)"]
 
 [[package]]
-category = "main"
-description = "Accurately separate the TLD from the registered domain and subdomains of a URL, using the Public Suffix List. By default, this includes the public ICANN TLDs and their exceptions. You can optionally support the Public Suffix List's private domains as well."
 name = "tldextract"
+version = "3.1.0"
+description = "Accurately separate the TLD from the registered domain and subdomains of a URL, using the Public Suffix List. By default, this includes the public ICANN TLDs and their exceptions. You can optionally support the Public Suffix List's private domains as well."
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "3.1.0"
 
 [package.dependencies]
 filelock = ">=3.0.8"
@@ -1848,118 +1830,103 @@ requests = ">=2.1.0"
 requests-file = ">=1.4"
 
 [[package]]
-category = "dev"
-description = "A wrapper around the stdlib `tokenize` which roundtrips."
 name = "tokenize-rt"
+version = "4.1.0"
+description = "A wrapper around the stdlib `tokenize` which roundtrips."
+category = "dev"
 optional = false
 python-versions = ">=3.6.1"
-version = "4.1.0"
 
 [[package]]
-category = "dev"
-description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "0.10.2"
 
 [[package]]
-category = "dev"
-description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
-marker = "python_version > \"2.7\""
 name = "tornado"
+version = "6.1"
+description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
+category = "dev"
 optional = false
 python-versions = ">= 3.5"
-version = "6.1"
 
 [[package]]
+name = "typing-extensions"
+version = "3.7.4.3"
+description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
-description = "Python port of Browserscope's user agent parser"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "ua-parser"
-optional = false
-python-versions = "*"
 version = "0.10.0"
-
-[[package]]
+description = "Python port of Browserscope's user agent parser"
 category = "main"
-description = "Python2's stdlib csv module is nice, but it doesn't support unicode. This module is a drop-in replacement which *does*."
-name = "unicodecsv"
 optional = false
 python-versions = "*"
-version = "0.14.1"
 
 [[package]]
+name = "unicodecsv"
+version = "0.14.1"
+description = "Python2's stdlib csv module is nice, but it doesn't support unicode. This module is a drop-in replacement which *does*."
 category = "main"
-description = "URI templates"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "uritemplate"
+version = "3.0.1"
+description = "URI templates"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "3.0.1"
 
 [[package]]
-category = "main"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
 name = "urllib3"
+version = "1.26.3"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.26.3"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
-category = "main"
-description = "The lightning-fast ASGI server."
 name = "uvicorn"
+version = "0.13.4"
+description = "The lightning-fast ASGI server."
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.13.3"
 
 [package.dependencies]
 click = ">=7.0.0,<8.0.0"
+colorama = {version = ">=0.4", optional = true, markers = "sys_platform == \"win32\" and extra == \"standard\""}
 h11 = ">=0.8"
-
-[package.dependencies.PyYAML]
-optional = true
-version = ">=5.1"
-
-[package.dependencies.colorama]
-optional = true
-version = ">=0.4"
-
-[package.dependencies.httptools]
-optional = true
-version = ">=0.1.0,<0.2.0"
-
-[package.dependencies.python-dotenv]
-optional = true
-version = ">=0.13"
-
-[package.dependencies.uvloop]
-optional = true
-version = ">=0.14.0"
-
-[package.dependencies.watchgod]
-optional = true
-version = ">=0.6,<0.7"
-
-[package.dependencies.websockets]
-optional = true
-version = ">=8.0.0,<9.0.0"
+httptools = {version = ">=0.1.0,<0.2.0", optional = true, markers = "sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\" and extra == \"standard\""}
+python-dotenv = {version = ">=0.13", optional = true, markers = "extra == \"standard\""}
+PyYAML = {version = ">=5.1", optional = true, markers = "extra == \"standard\""}
+uvloop = {version = ">=0.14.0,<0.15.0 || >0.15.0,<0.15.1 || >0.15.1", optional = true, markers = "sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\" and extra == \"standard\""}
+watchgod = {version = ">=0.6", optional = true, markers = "extra == \"standard\""}
+websockets = {version = ">=8.0.0,<9.0.0", optional = true, markers = "extra == \"standard\""}
 
 [package.extras]
-standard = ["websockets (>=8.0.0,<9.0.0)", "watchgod (>=0.6,<0.7)", "python-dotenv (>=0.13)", "PyYAML (>=5.1)", "httptools (>=0.1.0,<0.2.0)", "uvloop (>=0.14.0)", "colorama (>=0.4)"]
+standard = ["websockets (>=8.0.0,<9.0.0)", "watchgod (>=0.6)", "python-dotenv (>=0.13)", "PyYAML (>=5.1)", "httptools (>=0.1.0,<0.2.0)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "colorama (>=0.4)"]
 
 [[package]]
-category = "main"
-description = "Fast implementation of asyncio event loop on top of libuv"
-marker = "sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\""
 name = "uvloop"
+version = "0.15.2"
+description = "Fast implementation of asyncio event loop on top of libuv"
+category = "main"
 optional = false
-python-versions = "*"
-version = "0.15.1"
+python-versions = ">=3.7"
 
 [package.extras]
 dev = ["Cython (>=0.29.20,<0.30.0)", "pytest (>=3.6.0)", "Sphinx (>=1.7.3,<1.8.0)", "sphinxcontrib-asyncio (>=0.2.0,<0.3.0)", "sphinx-rtd-theme (>=0.2.4,<0.3.0)", "aiohttp", "flake8 (>=3.8.4,<3.9.0)", "psutil", "pycodestyle (>=2.6.0,<2.7.0)", "pyOpenSSL (>=19.0.0,<19.1.0)", "mypy (>=0.800)"]
@@ -1967,91 +1934,89 @@ docs = ["Sphinx (>=1.7.3,<1.8.0)", "sphinxcontrib-asyncio (>=0.2.0,<0.3.0)", "sp
 test = ["aiohttp", "flake8 (>=3.8.4,<3.9.0)", "psutil", "pycodestyle (>=2.6.0,<2.7.0)", "pyOpenSSL (>=19.0.0,<19.1.0)", "mypy (>=0.800)"]
 
 [[package]]
-category = "main"
-description = "Promises, promises, promises."
 name = "vine"
+version = "1.3.0"
+description = "Promises, promises, promises."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.3.0"
 
 [[package]]
-category = "dev"
-description = "Filesystem events monitoring"
 name = "watchdog"
+version = "2.0.0"
+description = "Filesystem events monitoring"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "2.0.0"
 
 [package.extras]
 watchmedo = ["PyYAML (>=3.10)", "argh (>=0.24.1)"]
 
 [[package]]
-category = "main"
-description = "Simple, modern file watching and code reload in python."
 name = "watchgod"
+version = "0.6"
+description = "Simple, modern file watching and code reload in python."
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "0.6"
 
 [[package]]
-category = "main"
-description = "Character encoding aliases for legacy web content"
 name = "webencodings"
+version = "0.5.1"
+description = "Character encoding aliases for legacy web content"
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.5.1"
 
 [[package]]
-category = "main"
-description = "WebSocket client for Python. hybi13 is supported."
 name = "websocket-client"
+version = "0.57.0"
+description = "WebSocket client for Python. hybi13 is supported."
+category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.57.0"
 
 [package.dependencies]
 six = "*"
 
 [[package]]
-category = "main"
-description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 name = "websockets"
+version = "8.1"
+description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
+category = "main"
 optional = false
 python-versions = ">=3.6.1"
-version = "8.1"
 
 [[package]]
-category = "dev"
-description = "The comprehensive WSGI web application library."
 name = "werkzeug"
+version = "1.0.1"
+description = "The comprehensive WSGI web application library."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "1.0.1"
 
 [package.dependencies]
-[package.dependencies.watchdog]
-optional = true
-version = "*"
+watchdog = {version = "*", optional = true, markers = "extra == \"watchdog\""}
 
 [package.extras]
 dev = ["pytest", "pytest-timeout", "coverage", "tox", "sphinx", "pallets-sphinx-themes", "sphinx-issues"]
 watchdog = ["watchdog"]
 
 [[package]]
-category = "main"
-description = "Radically simplified static file serving for WSGI applications"
 name = "whitenoise"
+version = "5.2.0"
+description = "Radically simplified static file serving for WSGI applications"
+category = "main"
 optional = false
 python-versions = ">=3.5, <4"
-version = "5.2.0"
 
 [package.extras]
 brotli = ["brotli"]
 
 [metadata]
-content-hash = "89459f99ede89bc3ae0f484a053ff85a11eef5797ebdc9edf221b2b5259f94fb"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "^3.8"
+content-hash = "113abfb1823dc72ebd3dd2904ef3c19343169196989bad993c738f6a65e3f394"
 
 [metadata.files]
 alabaster = [
@@ -2763,6 +2728,30 @@ pycurl = [
     {file = "pycurl-7.43.0.5.win32-py3.7.exe", hash = "sha256:b58e4d7888edd74dce40b9481962f0537dc77a44d99b5cc3385c3ffdaf2abf93"},
     {file = "pycurl-7.43.0.5.win32-py3.8.exe", hash = "sha256:b6512b864466b242ffc3997e982d4590e035d056d37e63136fa137a4044ce2f1"},
 ]
+pydantic = [
+    {file = "pydantic-1.8.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0c40162796fc8d0aa744875b60e4dc36834db9f2a25dbf9ba9664b1915a23850"},
+    {file = "pydantic-1.8.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:fff29fe54ec419338c522b908154a2efabeee4f483e48990f87e189661f31ce3"},
+    {file = "pydantic-1.8.1-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:fbfb608febde1afd4743c6822c19060a8dbdd3eb30f98e36061ba4973308059e"},
+    {file = "pydantic-1.8.1-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:eb8ccf12295113ce0de38f80b25f736d62f0a8d87c6b88aca645f168f9c78771"},
+    {file = "pydantic-1.8.1-cp36-cp36m-win_amd64.whl", hash = "sha256:20d42f1be7c7acc352b3d09b0cf505a9fab9deb93125061b376fbe1f06a5459f"},
+    {file = "pydantic-1.8.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:dde4ca368e82791de97c2ec019681ffb437728090c0ff0c3852708cf923e0c7d"},
+    {file = "pydantic-1.8.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:3bbd023c981cbe26e6e21c8d2ce78485f85c2e77f7bab5ec15b7d2a1f491918f"},
+    {file = "pydantic-1.8.1-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:830ef1a148012b640186bf4d9789a206c56071ff38f2460a32ae67ca21880eb8"},
+    {file = "pydantic-1.8.1-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:fb77f7a7e111db1832ae3f8f44203691e15b1fa7e5a1cb9691d4e2659aee41c4"},
+    {file = "pydantic-1.8.1-cp37-cp37m-win_amd64.whl", hash = "sha256:3bcb9d7e1f9849a6bdbd027aabb3a06414abd6068cb3b21c49427956cce5038a"},
+    {file = "pydantic-1.8.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2287ebff0018eec3cc69b1d09d4b7cebf277726fa1bd96b45806283c1d808683"},
+    {file = "pydantic-1.8.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:4bbc47cf7925c86a345d03b07086696ed916c7663cb76aa409edaa54546e53e2"},
+    {file = "pydantic-1.8.1-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:6388ef4ef1435364c8cc9a8192238aed030595e873d8462447ccef2e17387125"},
+    {file = "pydantic-1.8.1-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:dd4888b300769ecec194ca8f2699415f5f7760365ddbe243d4fd6581485fa5f0"},
+    {file = "pydantic-1.8.1-cp38-cp38-win_amd64.whl", hash = "sha256:8fbb677e4e89c8ab3d450df7b1d9caed23f254072e8597c33279460eeae59b99"},
+    {file = "pydantic-1.8.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2f2736d9a996b976cfdfe52455ad27462308c9d3d0ae21a2aa8b4cd1a78f47b9"},
+    {file = "pydantic-1.8.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:3114d74329873af0a0e8004627f5389f3bb27f956b965ddd3e355fe984a1789c"},
+    {file = "pydantic-1.8.1-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:258576f2d997ee4573469633592e8b99aa13bda182fcc28e875f866016c8e07e"},
+    {file = "pydantic-1.8.1-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:c17a0b35c854049e67c68b48d55e026c84f35593c66d69b278b8b49e2484346f"},
+    {file = "pydantic-1.8.1-cp39-cp39-win_amd64.whl", hash = "sha256:e8bc082afef97c5fd3903d05c6f7bb3a6af9fc18631b4cc9fedeb4720efb0c58"},
+    {file = "pydantic-1.8.1-py3-none-any.whl", hash = "sha256:e3f8790c47ac42549dc8b045a67b0ca371c7f66e73040d0197ce6172b385e520"},
+    {file = "pydantic-1.8.1.tar.gz", hash = "sha256:26cf3cb2e68ec6c0cfcb6293e69fb3450c5fd1ace87f46b64f678b0d29eac4c3"},
+]
 pydicom = [
     {file = "pydicom-2.1.2-py3-none-any.whl", hash = "sha256:d97f53a7b269dbd7414d18342f1b70f80d7d35dc4e479316bab146daac0e0c15"},
     {file = "pydicom-2.1.2.tar.gz", hash = "sha256:65f36820c5fec24b4e7ca45b7dae93e054ed269d55f92681863d39d30459e2fd"},
@@ -3106,6 +3095,11 @@ tornado = [
     {file = "tornado-6.1-cp39-cp39-win_amd64.whl", hash = "sha256:548430be2740e327b3fe0201abe471f314741efcb0067ec4f2d7dcfb4825f3e4"},
     {file = "tornado-6.1.tar.gz", hash = "sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791"},
 ]
+typing-extensions = [
+    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
+    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
+    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+]
 ua-parser = [
     {file = "ua-parser-0.10.0.tar.gz", hash = "sha256:47b1782ed130d890018d983fac37c2a80799d9e0b9c532e734c67cf70f185033"},
     {file = "ua_parser-0.10.0-py2.py3-none-any.whl", hash = "sha256:46ab2e383c01dbd2ab284991b87d624a26a08f72da4d7d413f5bfab8b9036f8a"},
@@ -3122,20 +3116,20 @@ urllib3 = [
     {file = "urllib3-1.26.3.tar.gz", hash = "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"},
 ]
 uvicorn = [
-    {file = "uvicorn-0.13.3-py3-none-any.whl", hash = "sha256:1079c50a06f6338095b4f203e7861dbff318dde5f22f3a324fc6e94c7654164c"},
-    {file = "uvicorn-0.13.3.tar.gz", hash = "sha256:ef1e0bb5f7941c6fe324e06443ddac0331e1632a776175f87891c7bd02694355"},
+    {file = "uvicorn-0.13.4-py3-none-any.whl", hash = "sha256:7587f7b08bd1efd2b9bad809a3d333e972f1d11af8a5e52a9371ee3a5de71524"},
+    {file = "uvicorn-0.13.4.tar.gz", hash = "sha256:3292251b3c7978e8e4a7868f4baf7f7f7bb7e40c759ecc125c37e99cdea34202"},
 ]
 uvloop = [
-    {file = "uvloop-0.15.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:9541dc3f391941796ae95c9c3bb16b813acf9e3d4beebfd3b623f1acb22d318d"},
-    {file = "uvloop-0.15.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:e178c255622d928d464187e3ceba94db88465f6b17909c651483fb73af8d8b85"},
-    {file = "uvloop-0.15.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:47ec567151070ed770211d359ad9250b59368548c60212c7ef6dda3f5b1778f6"},
-    {file = "uvloop-0.15.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:66881fe8a2187334c4dd5010c56310bdf32fe426613f9ca727f090bc31280624"},
-    {file = "uvloop-0.15.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:e72779681f839b6a069d7e7a9f7962a1d1927612c5c2e33071415478bdc1b91b"},
-    {file = "uvloop-0.15.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:ed073d24e0c383c24d17d3a2bb209b999ff0a8130e89b7c3f033db9e0c3bd04f"},
-    {file = "uvloop-0.15.1-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:236a3c31096e0845029856f7bc07a938340c2cdb35d9d39b38c9253b672bf948"},
-    {file = "uvloop-0.15.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ca8a9e982f0bfbe331f41902cdd721c6e749e4685a403685e792b86a584f5969"},
-    {file = "uvloop-0.15.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:1ae1ad731c8c0dcee80e0ecf06274f0f7293244d2cef81fa2747321a370a6aba"},
-    {file = "uvloop-0.15.1.tar.gz", hash = "sha256:7846828112bfb49abc5fdfc47d0e4dfd7402115c9fde3c14c31818cfbeeb63dc"},
+    {file = "uvloop-0.15.2-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:19fa1d56c91341318ac5d417e7b61c56e9a41183946cc70c411341173de02c69"},
+    {file = "uvloop-0.15.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:e5e5f855c9bf483ee6cd1eb9a179b740de80cb0ae2988e3fa22309b78e2ea0e7"},
+    {file = "uvloop-0.15.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:42eda9f525a208fbc4f7cecd00fa15c57cc57646c76632b3ba2fe005004f051d"},
+    {file = "uvloop-0.15.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:90e56f17755e41b425ad19a08c41dc358fa7bf1226c0f8e54d4d02d556f7af7c"},
+    {file = "uvloop-0.15.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:7ae39b11a5f4cec1432d706c21ecc62f9e04d116883178b09671aa29c46f7a47"},
+    {file = "uvloop-0.15.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:b45218c99795803fb8bdbc9435ff7f54e3a591b44cd4c121b02fa83affb61c7c"},
+    {file = "uvloop-0.15.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:114543c84e95df1b4ff546e6e3a27521580466a30127f12172a3278172ad68bc"},
+    {file = "uvloop-0.15.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:44cac8575bf168601424302045234d74e3561fbdbac39b2b54cc1d1d00b70760"},
+    {file = "uvloop-0.15.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:6de130d0cb78985a5d080e323b86c5ecaf3af82f4890492c05981707852f983c"},
+    {file = "uvloop-0.15.2.tar.gz", hash = "sha256:2bb0624a8a70834e54dde8feed62ed63b50bad7a1265c40d6403a2ac447bce01"},
 ]
 vine = [
     {file = "vine-1.3.0-py2.py3-none-any.whl", hash = "sha256:ea4947cc56d1fd6f2095c8d543ee25dad966f78692528e68b4fada11ba3f98af"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ jinja2 = "^2.11.3"
 openpyxl = "^3.0.6"
 requests = "^2.25.1"
 django_rest_knox = "^4.1.0"
+pydantic = "^1.8.1"
 
 [tool.poetry.dev-dependencies]
 pytest-django = "*"


### PR DESCRIPTION
Adds pydantic to do runtime validation of the panimg models, removes some more dependencies on grand challenge in the tests, and switches to pathlib for the tiff locations. Adds an extra argument to `panimg.convert` to determine where to put the output files, this is controlled by the user who manages the lifecycle. Changes the input to use directories, we then recursively visit each subdirectory and load all the files within, assuming that all the files for one image are located in the same directory - not an issue on grand challenge as the input directory is flat.

This PR is merging into #1759, so review that one first, then this, then merge this into #1759, and then #1759 into master.