### PR TITLE
Fix social media cards for subpages

### DIFF
--- a/app/grandchallenge/core/templates/grandchallenge/partials/meta_social.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/meta_social.html
@@ -1,31 +1,13 @@
-{% load url %}
-{% load static %}
-
-<meta property="og:type" content="website">
-<meta property="twitter:card" content="summary_large_image">
-<meta property="og:url" content="{{ request.build_absolute_uri }}">
-<meta property="og:site_name" content="{{ request.site }}">
-
-{% firstof social_info archive algorithm reader_study request.challenge object as meta_info %}
-
-{% if social_object %}
-    <meta name="title" content="{% firstof meta_info.title object.short_name %} - {{ request.site.name }}">
-    <meta property="og:title" content="{% firstof meta_info.title object.short_name %} - {{ request.site.name }}">
-
-    <meta name="description" content="{{ meta_info.description }}">
-    <meta property="og:description" content="{{ meta_info.description }}">
-
-    {% if object.social_image %}
-        <meta property="og:image" content="{{ meta_info.social_image.url }}">
-    {% elif object.logo %}
-        <meta property="og:image" content="{{ meta_info.logo.url }}">
-    {% endif %}
+{% if social_info %}
+    {% include "grandchallenge/partials/meta_social_kernel.html" with meta_info=social_info %}
+{% elif archive %}
+    {% include "grandchallenge/partials/meta_social_kernel.html" with meta_info=archive %}
+{% elif algorithm %}
+    {% include "grandchallenge/partials/meta_social_kernel.html" with meta_info=algorithm %}
+{% elif reader_study %}
+    {% include "grandchallenge/partials/meta_social_kernel.html" with meta_info=reader_study %}
+{% elif challenge %}
+    {% include "grandchallenge/partials/meta_social_kernel.html" with meta_info=challenge %}
 {% else %}
-    <meta name="title" content="{{ request.site.name }}">
-    <meta property="og:title" content="{{ request.site.name }}">
-
-    <meta name="description"
-          content="A platform for end-to-end development of machine learning solutions in biomedical imaging.">
-    <meta property="og:description"
-          content="A platform for end-to-end development of machine learning solutions in biomedical imaging.">
+    {% include "grandchallenge/partials/meta_social_kernel.html" with meta_info=object %}
 {% endif %}

--- a/app/grandchallenge/core/templates/grandchallenge/partials/meta_social.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/meta_social.html
@@ -6,22 +6,26 @@
 <meta property="og:url" content="{{ request.build_absolute_uri }}">
 <meta property="og:site_name" content="{{ request.site }}">
 
-{% if object %}
-    <meta name="title" content="{% firstof object.title object.short_name %} - {{ request.site.name }}">
-    <meta property="og:title" content="{% firstof object.title object.short_name %} - {{ request.site.name }}">
+{% firstof social_info archive algorithm reader_study request.challenge object as meta_info %}
 
-    <meta name="description" content="{{ object.description }}">
-    <meta property="og:description" content="{{ object.description }}">
+{% if social_object %}
+    <meta name="title" content="{% firstof meta_info.title object.short_name %} - {{ request.site.name }}">
+    <meta property="og:title" content="{% firstof meta_info.title object.short_name %} - {{ request.site.name }}">
+
+    <meta name="description" content="{{ meta_info.description }}">
+    <meta property="og:description" content="{{ meta_info.description }}">
 
     {% if object.social_image %}
-        <meta property="og:image" content="{{ object.social_image.url }}">
+        <meta property="og:image" content="{{ meta_info.social_image.url }}">
     {% elif object.logo %}
-        <meta property="og:image" content="{{ object.logo.url }}">
+        <meta property="og:image" content="{{ meta_info.logo.url }}">
     {% endif %}
 {% else %}
     <meta name="title" content="{{ request.site.name }}">
     <meta property="og:title" content="{{ request.site.name }}">
 
-    <meta name="description" content="A platform for end-to-end development of machine learning solutions in biomedical imaging.">
-    <meta property="og:description" content="A platform for end-to-end development of machine learning solutions in biomedical imaging.">
+    <meta name="description"
+          content="A platform for end-to-end development of machine learning solutions in biomedical imaging.">
+    <meta property="og:description"
+          content="A platform for end-to-end development of machine learning solutions in biomedical imaging.">
 {% endif %}

--- a/app/grandchallenge/core/templates/grandchallenge/partials/meta_social_kernel.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/meta_social_kernel.html
@@ -1,0 +1,29 @@
+{% load url %}
+{% load static %}
+
+<meta property="og:type" content="website">
+<meta property="twitter:card" content="summary_large_image">
+<meta property="og:url" content="{{ request.build_absolute_uri }}">
+<meta property="og:site_name" content="{{ request.site }}">
+
+{% if meta_info %}
+    <meta name="title" content="{% firstof meta_info.title meta_info.short_name %} - {{ request.site.name }}">
+    <meta property="og:title" content="{% firstof meta_info.title meta_info.short_name %} - {{ request.site.name }}">
+
+    <meta name="description" content="{{ meta_info.description }}">
+    <meta property="og:description" content="{{ meta_info.description }}">
+
+    {% if meta_info.social_image %}
+        <meta property="og:image" content="{{ meta_info.social_image.url }}">
+    {% elif meta_info.logo %}
+        <meta property="og:image" content="{{ meta_info.logo.url }}">
+    {% endif %}
+{% else %}
+    <meta name="title" content="{{ request.site.name }}">
+    <meta property="og:title" content="{{ request.site.name }}">
+
+    <meta name="description"
+          content="A platform for end-to-end development of machine learning solutions in biomedical imaging.">
+    <meta property="og:description"
+          content="A platform for end-to-end development of machine learning solutions in biomedical imaging.">
+{% endif %}


### PR DESCRIPTION
Object is only present for the archive, challenge, algorithm or reader study
detail pages. This information will be missing for subpages of that object.
Use firstof to get the containing object, allowing us to override this later
by setting a `social_info` object if we need something specific.