### PR TITLE
Remove unused API attributes and endpoints

### DIFF
--- a/app/grandchallenge/algorithms/serializers.py
+++ b/app/grandchallenge/algorithms/serializers.py
@@ -19,32 +19,18 @@ from grandchallenge.components.serializers import (
 
 
 class AlgorithmSerializer(serializers.ModelSerializer):
-    algorithm_container_images = HyperlinkedRelatedField(
-        many=True, read_only=True, view_name="api:algorithms-image-detail"
-    )
-    latest_ready_image = SerializerMethodField()
     average_duration = SerializerMethodField()
 
     class Meta:
         model = Algorithm
         fields = [
-            "algorithm_container_images",
             "api_url",
             "description",
-            "latest_ready_image",
             "pk",
             "title",
             "slug",
             "average_duration",
         ]
-
-    def get_latest_ready_image(self, obj: Algorithm):
-        """Used by latest_container_image SerializerMethodField."""
-        ci = obj.latest_ready_image
-        if ci:
-            return ci.api_url
-        else:
-            return None
 
     def get_average_duration(self, obj: Algorithm) -> Optional[float]:
         """The average duration of successful jobs in seconds"""

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -37,12 +37,13 @@ from guardian.mixins import (
     PermissionRequiredMixin as ObjectPermissionRequiredMixin,
 )
 from guardian.shortcuts import get_perms
+from rest_framework import mixins
 from rest_framework.decorators import action
 from rest_framework.permissions import DjangoObjectPermissions
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.viewsets import (
-    ModelViewSet,
+    GenericViewSet,
     ReadOnlyModelViewSet,
 )
 from rest_framework_guardian.filters import ObjectPermissionsFilter
@@ -889,7 +890,13 @@ class QuestionViewSet(ReadOnlyModelViewSet):
     )
 
 
-class AnswerViewSet(ModelViewSet):
+class AnswerViewSet(
+    mixins.CreateModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.ListModelMixin,
+    GenericViewSet,
+):
     serializer_class = AnswerSerializer
     queryset = (
         Answer.objects.all()

--- a/app/tests/algorithms_tests/test_serializers.py
+++ b/app/tests/algorithms_tests/test_serializers.py
@@ -26,10 +26,8 @@ from tests.serializer_helpers import (
                 "factory": AlgorithmFactory,
                 "serializer": AlgorithmSerializer,
                 "fields": (
-                    "algorithm_container_images",
                     "api_url",
                     "description",
-                    "latest_ready_image",
                     "pk",
                     "title",
                     "slug",


### PR DESCRIPTION
This is no longer necessary as the image to use is decided internally. I have searched all DIAG code and this is not used.