### PR TITLE
Allow auth token to last longer than the session

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -824,6 +824,8 @@ WORKSTATIONS_RENDERING_SUBDOMAINS = {
     "eu-nl-1",
     "eu-nl-2",
 }
+# Number of minutes grace period before the container is stopped
+WORKSTATIONS_GRACE_MINUTES = 5
 
 CELERY_BEAT_SCHEDULE = {
     "ping_google": {
@@ -859,7 +861,7 @@ CELERY_BEAT_SCHEDULE = {
                 "region": region,
             },
             "options": {"queue": f"workstations-{region}"},
-            "schedule": timedelta(minutes=5),
+            "schedule": timedelta(minutes=WORKSTATIONS_GRACE_MINUTES),
         }
         for region in WORKSTATIONS_ACTIVE_REGIONS
     },

--- a/app/grandchallenge/workstations/models.py
+++ b/app/grandchallenge/workstations/models.py
@@ -525,10 +525,10 @@ class Session(UUIDModel):
 
         if self.auth_token and self.auth_token.expiry != (
             self.expires_at
-            + timedelta(minutes=2 * settings.WORKSTATIONS_GRACE_MINUTES)
+            + timedelta(minutes=settings.WORKSTATIONS_GRACE_MINUTES)
         ):
             self.auth_token.expiry = self.expires_at + timedelta(
-                minutes=2 * settings.WORKSTATIONS_GRACE_MINUTES
+                minutes=settings.WORKSTATIONS_GRACE_MINUTES
             )
             self.auth_token.save(update_fields=("expiry",))
 

--- a/app/grandchallenge/workstations/models.py
+++ b/app/grandchallenge/workstations/models.py
@@ -523,8 +523,13 @@ class Session(UUIDModel):
 
         super().save(*args, **kwargs)
 
-        if self.auth_token and self.auth_token.expiry != self.expires_at:
-            self.auth_token.expiry = self.expires_at
+        if self.auth_token and self.auth_token.expiry != (
+            self.expires_at
+            + timedelta(minutes=2 * settings.WORKSTATIONS_GRACE_MINUTES)
+        ):
+            self.auth_token.expiry = self.expires_at + timedelta(
+                minutes=2 * settings.WORKSTATIONS_GRACE_MINUTES
+            )
             self.auth_token.save(update_fields=("expiry",))
 
         if created:

--- a/app/tests/workstations_tests/test_models.py
+++ b/app/tests/workstations_tests/test_models.py
@@ -51,7 +51,7 @@ def test_session_auth_token():
 
     assert s.auth_token.user == s.creator
     assert s.auth_token.expiry == s.expires_at + timedelta(
-        minutes=2 * WORKSTATIONS_GRACE_MINUTES
+        minutes=WORKSTATIONS_GRACE_MINUTES
     )
 
     # old tokens should be deleted
@@ -66,7 +66,7 @@ def test_session_auth_token():
     s.save()
 
     assert s.auth_token.expiry == s.expires_at + timedelta(
-        minutes=2 * WORKSTATIONS_GRACE_MINUTES
+        minutes=WORKSTATIONS_GRACE_MINUTES
     )
 
 

--- a/app/tests/workstations_tests/test_models.py
+++ b/app/tests/workstations_tests/test_models.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from docker.errors import NotFound
 from knox.models import AuthToken
 
+from config.settings import WORKSTATIONS_GRACE_MINUTES
 from grandchallenge.components.tasks import stop_expired_services
 from grandchallenge.workstations.models import Session, Workstation
 from tests.factories import (
@@ -49,7 +50,9 @@ def test_session_auth_token():
     _ = s.environment
 
     assert s.auth_token.user == s.creator
-    assert s.auth_token.expiry == s.expires_at
+    assert s.auth_token.expiry == s.expires_at + timedelta(
+        minutes=2 * WORKSTATIONS_GRACE_MINUTES
+    )
 
     # old tokens should be deleted
     old_pk = s.auth_token.pk
@@ -62,7 +65,9 @@ def test_session_auth_token():
     s.maximum_duration = timedelta(days=1)
     s.save()
 
-    assert s.auth_token.expiry == s.expires_at
+    assert s.auth_token.expiry == s.expires_at + timedelta(
+        minutes=2 * WORKSTATIONS_GRACE_MINUTES
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Sometimes it takes a few minutes for the system to kill a session,
which means that the auth token will be invalid whilst the session
is still usable. A minute grace period allows the user to finish
up during which time the container will be stopped by the
"grandchallenge.components.tasks.stop_expired_services" periodic task.