### PR TITLE
Add a timeout on the URL checker

### DIFF
--- a/app/grandchallenge/challenges/tasks.py
+++ b/app/grandchallenge/challenges/tasks.py
@@ -49,7 +49,7 @@ def check_external_challenge_urls():
             url = challenge.homepage
             if not url.startswith("http"):
                 url = "http://" + url
-            r = get(url)
+            r = get(url, timeout=60)
             # raise an exception when we receive a http error (e.g., 404)
             r.raise_for_status()
         except exceptions.RequestException as err:


### PR DESCRIPTION
Prevents indefinite hanging in the celery task.