### PR TITLE
Implemented topbar

### DIFF
--- a/app/grandchallenge/core/context_processors.py
+++ b/app/grandchallenge/core/context_processors.py
@@ -5,6 +5,7 @@ from guardian.shortcuts import get_perms
 from guardian.utils import get_anonymous_user
 
 from grandchallenge.blogs.models import Post
+from grandchallenge.participants.models import RegistrationRequest
 from grandchallenge.policies.models import Policy
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,11 @@ def challenge(request):
         "challenge_perms": get_perms(user, challenge),
         "user_is_participant": challenge.is_participant(user),
         "pages": challenge.page_set.all(),
+        "num_admins": challenge.get_admins().count(),
+        "num_participants": challenge.get_participants().count(),
+        "num_requests": challenge.registrationrequest_set.filter(
+            status=RegistrationRequest.PENDING
+        ).count(),
     }
 
 

--- a/app/grandchallenge/core/context_processors.py
+++ b/app/grandchallenge/core/context_processors.py
@@ -32,11 +32,9 @@ def challenge(request):
         "challenge_perms": get_perms(user, challenge),
         "user_is_participant": challenge.is_participant(user),
         "pages": challenge.page_set.all(),
-        "num_admins": challenge.get_admins().count(),
-        "num_participants": challenge.get_participants().count(),
-        "num_requests": challenge.registrationrequest_set.filter(
+        "pending_requests": challenge.registrationrequest_set.filter(
             status=RegistrationRequest.PENDING
-        ).count(),
+        ),
     }
 
 

--- a/app/grandchallenge/core/templates/base.html
+++ b/app/grandchallenge/core/templates/base.html
@@ -70,6 +70,7 @@
             {% endblock %}
 
             {% block outer_content %}
+                {% block topbar %}{% endblock %}
                 <div class="row">
                     {% block sidebar %}{% endblock %}
                     <div class="col overflow-auto">

--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -39,8 +39,9 @@
             <div class="col-md-10">
                 <div class="nav nav-tabs" role="tablist">
                     <li class="nav-item">
-                        <a class="nav-link {% if request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"
-                           href="{% url 'pages:detail' challenge_short_name=challenge.short_name page_title=challenge.page_set.first.title %}">
+                    <! -- Todo: Adjust the view_name before merging with master (include the page_title slug)-->
+                        <a class="nav-link {% if request.resolver_match.view_name == 'pages:home' or request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"
+                           href="{% url 'pages:home' challenge_short_name=challenge.short_name %}">
                             Info
                         </a>
                     </li>
@@ -73,13 +74,13 @@
                             <li class="nav-item">
                                 <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' %}active{% endif %}"
                                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
-                                    Leaderboard(s)</a>
+                                    Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
                             </li>
                         {% elif not challenge.hidden %}
                             <li class="nav-item">
                                 <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' %}active{% endif %}"
                                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
-                                    Leaderboard(s)</a>
+                                    Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
                             </li>
                         {% endif %}
                     {% endif %}

--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -33,79 +33,78 @@
     {{ block.super }}
 {% endblock %}
 
-{% block sidebar %}
+{% block topbar %}
     {% if challenge %}
-        <div class="col-12 col-md-3 col-lg-2 mb-3">
-            <ul class="nav nav-pills flex-column">
-                {% for page in pages %}
-                    {% if not page.hidden %}
+        <div class="row">
+            <div class="col-md-10">
+                <div class="nav nav-tabs" role="tablist">
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"
+                           href="{% url 'pages:detail' challenge_short_name=challenge.short_name page_title=challenge.page_set.first.title %}">
+                            Info
+                        </a>
+                    </li>
+
+                    {% if challenge.display_forum_link %}
                         <li class="nav-item">
-                            <a class="nav-link {% if page == currentpage %}active{% endif %}"
-                               href="{{ page.get_absolute_url }}">
-                                {% filter title %}
-                                    {% firstof page.display_title page.title %}
-                                {% endfilter %}
+                            <a class="nav-link"
+                               href="{% url 'forum:forum' slug=challenge.forum.slug pk=challenge.forum.pk %}">
+                                Forum
                             </a>
                         </li>
                     {% endif %}
-                {% endfor %}
 
-                {% if challenge.display_forum_link %}
-                    <li class="nav-item">
-                        <a class="nav-link"
-                           href="{% url 'forum:forum' slug=challenge.forum.slug pk=challenge.forum.pk %}">
-                            Forum
-                        </a>
-                    </li>
-                {% endif %}
-
-                {% if challenge.use_registration_page %}
-                    <li class="nav-item">
-                        <a class="nav-link {% if request.resolver_match.view_name == 'participants:registration-create' %}active{% endif %}"
-                           href="{% url 'participants:registration-create' challenge_short_name=challenge.short_name %}">
-                            Join
-                        </a>
-                    </li>
-                {% endif %}
-
-                {% if challenge.use_evaluation %}
-                    {% if challenge.use_teams %}
-                        {% if "change_challenge" in challenge_perms or user_is_participant %}
-                            <li class="nav-item">
-                                <a class="nav-link {% if request.resolver_match.view_name == 'teams:list' %}active{% endif %}"
-                                   href="{% url 'teams:list' challenge_short_name=challenge.short_name %}">Teams</a>
-                            </li>
+                    {% if challenge.use_evaluation %}
+                        {% if challenge.use_teams %}
+                            {% if "change_challenge" in challenge_perms or user_is_participant %}
+                                <li class="nav-item">
+                                    <a class="nav-link {% if request.resolver_match.view_name == 'teams:list' %}active{% endif %}"
+                                       href="{% url 'teams:list' challenge_short_name=challenge.short_name %}">Teams</a>
+                                </li>
+                            {% endif %}
                         {% endif %}
-                    {% endif %}
-                    {% for phase in challenge.phase_set.all %}
+
                         {% if "change_challenge" in challenge_perms or user_is_participant %}
                             <li class="nav-item">
-                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
-                                   href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">Create {{ phase.title }}
-                                    Submission</a>
+                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' %}active{% endif %}"
+                                   href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
+                                    Submit</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
-                                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}
-                                    Leaderboard</a>
+                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' %}active{% endif %}"
+                                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
+                                    Leaderboard(s)</a>
                             </li>
                         {% elif not challenge.hidden %}
                             <li class="nav-item">
-                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
-                                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}
-                                    Leaderboard</a>
+                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' %}active{% endif %}"
+                                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
+                                    Leaderboard(s)</a>
                             </li>
                         {% endif %}
-                    {% endfor %}
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="col-md-2 d-flex justify-content-end">
+                {% if challenge.use_registration_page %}
+                    <div>
+                        <a class="btn btn-primary"
+                           href="{% url 'participants:registration-create' challenge_short_name=challenge.short_name %}"
+                           role="button">
+                            Join
+                        </a>
+                    </div>
                 {% endif %}
 
                 {% if "change_challenge" in challenge_perms %}
-                    <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" data-toggle="dropdown"
+                    <div class="dropdown px-1">
+                        <a class="btn btn-primary dropdown-toggle"
+                           data-toggle="dropdown"
                            href="#"
-                           role="button" aria-haspopup="true"
+                           role="button"
                            aria-expanded="false">Admin</a>
-                        <div class="dropdown-menu">
+                        <ul class="dropdown-menu" role="menu" aria-labelledby="admin">
                             <h6 class="dropdown-header">{% firstof challenge.title challenge.short_name %}</h6>
                             <a class="dropdown-item"
                                href="{% url 'update' challenge_short_name=challenge.short_name %}">
@@ -151,10 +150,10 @@
                                     Evaluations
                                 </a>
                             {% endif %}
-                        </div>
-                    </li>
+                        </ul>
+                    </div>
                 {% endif %}
-            </ul>
+            </div>
         </div>
     {% endif %}
 {% endblock %}

--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -109,7 +109,7 @@
                             <h6 class="dropdown-header">{% firstof challenge.title challenge.short_name %}</h6>
                             <a class="dropdown-item"
                                href="{% url 'update' challenge_short_name=challenge.short_name %}">
-                                <i class="fas fa-cog fa-fw"></i> Settings</a>
+                                <i class="fas fa-cog fa-fw"></i> General Settings</a>
                             <a class="dropdown-item"
                                href="{% url 'pages:list' challenge_short_name=challenge.short_name %}">
                                 <i class="far fa-file fa-fw"></i> Pages</a>
@@ -117,27 +117,30 @@
                             <h6 class="dropdown-header">Users</h6>
                             <a class="dropdown-item"
                                href="{% url 'admins:list' challenge_short_name=challenge.short_name %}">
-                                <i class="fas fa-user fa-fw"></i>&nbsp;Admins</a>
+                                <i class="fas fa-user fa-fw"></i>&nbsp;Admins <span
+                        class="badge badge-pill badge-secondary align-middle">{{ num_admins }}</span></a>
                             <a class="dropdown-item"
                                href="{% url 'participants:list' challenge_short_name=challenge.short_name %}">
-                                <i class="fas fa-users fa-fw"></i>&nbsp;Participants</a>
+                                <i class="fas fa-users fa-fw"></i>&nbsp;Participants <span
+                                    class="badge badge-pill badge-secondary align-middle">{{ num_participants }}</span></a>
                             <a class="dropdown-item"
                                href="{% url 'participants:registration-list' challenge_short_name=challenge.short_name %}">
-                                <i class="fas fa-question fa-fw"></i>&nbsp;Participation Requests</a>
+                                <i class="fas fa-question fa-fw"></i>&nbsp;Participation Requests {% if num_requests > 0 %}<span
+                                    class="badge badge-pill badge-secondary align-middle">{{ num_requests }}</span>{% endif %}</a>
+                            <hr>
+                            <h6 class="dropdown-header">Phases</h6>
                             {% if challenge.use_evaluation %}
                                 {% for phase in challenge.phase_set.all %}
-                                    <hr>
-                                    <h6 class="dropdown-header">{{ phase.title }} Evaluation</h6>
                                     <a class="dropdown-item"
                                        href="{% url 'evaluation:phase-update' challenge_short_name=challenge.short_name slug=phase.slug %}">
-                                        <i class="fas fa-cog fa-fw"></i> Settings
+                                        <i class="fas fa-cog fa-fw"></i> {{ phase.title }} Evaluation Settings
                                     </a>
                                 {% endfor %}
-                                <hr>
                                 <a class="dropdown-item"
                                    href="{% url 'evaluation:phase-create' challenge_short_name=challenge.short_name %}">
                                     <i class="fas fa-plus fa-fw"></i>&nbsp;Add a new Phase
                                 </a>
+                                <hr>
                                 <a class="dropdown-item"
                                    href="{% url 'evaluation:method-list' challenge_short_name=challenge.short_name %}">
                                     Methods

--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -117,16 +117,14 @@
                             <h6 class="dropdown-header">Users</h6>
                             <a class="dropdown-item"
                                href="{% url 'admins:list' challenge_short_name=challenge.short_name %}">
-                                <i class="fas fa-user fa-fw"></i>&nbsp;Admins <span
-                        class="badge badge-pill badge-secondary align-middle">{{ num_admins }}</span></a>
+                                <i class="fas fa-user fa-fw"></i>&nbsp;Admins <span class="badge badge-pill badge-secondary align-middle">{{ challenge.get_admins.count }}</span> </a>
                             <a class="dropdown-item"
                                href="{% url 'participants:list' challenge_short_name=challenge.short_name %}">
-                                <i class="fas fa-users fa-fw"></i>&nbsp;Participants <span
-                                    class="badge badge-pill badge-secondary align-middle">{{ num_participants }}</span></a>
+                                <i class="fas fa-users fa-fw"></i>&nbsp;Participants <span class="badge badge-pill badge-secondary align-middle">{{ challenge.get_participants.count }}</span></a>
                             <a class="dropdown-item"
                                href="{% url 'participants:registration-list' challenge_short_name=challenge.short_name %}">
-                                <i class="fas fa-question fa-fw"></i>&nbsp;Participation Requests {% if num_requests > 0 %}<span
-                                    class="badge badge-pill badge-secondary align-middle">{{ num_requests }}</span>{% endif %}</a>
+                                <i class="fas fa-question fa-fw"></i>&nbsp;Participation Requests {% if challenge.require_participant_review %} {% with num_requests=pending_requests.count %} <span
+                                    class="badge badge-pill badge-secondary align-middle">{{ num_requests }}</span>{% endwith %}{% endif %}</a>
                             <hr>
                             <h6 class="dropdown-header">Phases</h6>
                             {% if challenge.use_evaluation %}

--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -35,8 +35,8 @@
 
 {% block topbar %}
     {% if challenge %}
-        <div class="row">
-            <div class="col-md-10">
+        <div class="row mb-3">
+            <div class="col-md-10 col-sm-8 col-6">
                 <div class="nav nav-tabs" role="tablist">
                     <li class="nav-item">
                     <! -- Todo: Adjust the view_name before merging with master (include the page_title slug)-->
@@ -87,7 +87,7 @@
                 </div>
             </div>
 
-            <div class="col-md-2 d-flex justify-content-end">
+            <div class="col-md-2 col-sm-4 col-6 d-flex justify-content-end">
                 {% if challenge.use_registration_page %}
                     <div>
                         <a class="btn btn-primary"
@@ -105,7 +105,7 @@
                            href="#"
                            role="button"
                            aria-expanded="false">Admin</a>
-                        <ul class="dropdown-menu" role="menu" aria-labelledby="admin">
+                        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="admin">
                             <h6 class="dropdown-header">{% firstof challenge.title challenge.short_name %}</h6>
                             <a class="dropdown-item"
                                href="{% url 'update' challenge_short_name=challenge.short_name %}">

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block sidebar %}
-    <div class="nav nav-pills col-12 pl-3 mt-3">
+    <div class="nav nav-pills col-12 pl-3 my-3">
         {% for phase in challenge.phase_set.all %}
             <li class="nav-item">
                 <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
@@ -25,7 +25,6 @@
 {% endblock %}
 
 {% block content %}
-    <div class="mt-3">
         <h2>{{ phase.title }} Leaderboard {{ request.GET.date }}</h2>
 
         {% if phase.evaluation_comparison_observable_url %}
@@ -120,7 +119,6 @@
                 </div>
             </div>
         {% endif %}
-    </div>
 {% endblock %}
 
 {% block script %}

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block sidebar %}
-    <div class="nav nav-pills col-12 pl-3 my-3">
+    <div class="nav nav-pills col-12 pl-3 mb-3">
         {% for phase in challenge.phase_set.all %}
             <li class="nav-item">
                 <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
@@ -79,8 +79,7 @@
             <p>
                 <a class="btn btn-primary"
                    href="{% url 'api:evaluation-list' %}?format=csv&submission__phase={{ phase.pk }}&offset={{ offset }}&limit={{ limit }}"
-                   download="{{ phase.challenge.short_name }}_{{ phase.slug }}_evaluations_{{ offset|add:1 }}_
-                           {{ offset|add:limit }}_{{ now }}.csv">
+                   download="{{ phase.challenge.short_name }}_{{ phase.slug }}_evaluations_{{ offset|add:1 }}_{{ offset|add:limit }}_{{ now }}.csv">
                     <i class="fas fa-file-csv"></i> Evaluations ({{ offset|add:1 }} to {{ offset|add:limit }})
                 </a>
             </p>

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
@@ -13,101 +13,114 @@
     </ol>
 {% endblock %}
 
-{% block content %}
-    <h2>{{ phase.title }} Leaderboard {{ request.GET.date }}</h2>
-
-    {% if phase.evaluation_comparison_observable_url %}
-        <div id="compare-warning-alert" class="alert alert-warning d-none" role="alert">
-            <h5>Attention</h5>
-            Selecting more than 6 results may affect the performance of the visualization
-        </div>
-    {% endif %}
-
-    {% include "datatables/partials/datatable.html" with columns=columns %}
-
-    {% if phase.result_display_choice == phase.BEST %}
-        <p class="small ml-3">
-            Only the best published result for each participant is listed.
-        </p>
-    {% elif phase.result_display_choice == phase.MOST_RECENT %}
-        <p class="small ml-3">
-            Only the most recent published result for each participant is listed.
-        </p>
-    {% else %}
-        <div class="modal fade" id="leaderboardDateModal" tabindex="-1" role="dialog"
-             aria-labelledby="leaderboardDateModalLabel"
-             aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="leaderboardDateModalLabel">Leaderboard History</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-
-                    <div class="modal-body">
-                        <p>
-                            Select a date to display the leaderboard as it was on that day.
-                        </p>
-                        <form class="form-inline" action="">
-                            <label class="mr-sm-2" for="leaderboardDate">Date:</label>
-                            <input class="mr-sm-2" type="date" id="leaderboardDate" name="date" required
-                                   value="{{ request.GET.date }}">
-                            <button type="submit" class="btn btn-primary btn-sm">Submit</button>
-                        </form>
-                    </div>
-                </div>
-            </div>
-        </div>
-    {% endif %}
-
-    {% if "change_challenge" in challenge_perms %}
-        <h3>Export</h3>
-        {% for offset in offsets %}
-            <p>
-                <a class="btn btn-primary"
-                   href="{% url 'api:evaluation-list' %}?format=csv&submission__phase={{ phase.pk }}&offset={{ offset }}&limit={{ limit }}"
-                   download="{{ phase.challenge.short_name }}_{{ phase.slug }}_evaluations_{{ offset|add:1 }}_{{ offset|add:limit }}_{{ now }}.csv">
-                    <i class="fas fa-file-csv"></i> Evaluations ({{ offset|add:1 }} to {{ offset|add:limit }})
-                </a>
-            </p>
+{% block sidebar %}
+    <div class="nav nav-pills col-12 pl-3 mt-3">
+        {% for phase in challenge.phase_set.all %}
+            <li class="nav-item">
+                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+            </li>
         {% endfor %}
-    {% endif %}
+    </div>
+{% endblock %}
 
-    {% if phase.evaluation_comparison_observable_url or phase.evaluation_detail_observable_url %}
-        <div class="modal fade" id="observableModal" tabindex="-1" role="dialog" aria-labelledby="observableModalLabel"
-             aria-hidden="true">
-            <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered modal-xl" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="observableModalLabel">Compare Results</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <iframe id="observableNotebook"
-                                class="border-0"
-                                style="height: 75vh; min-width: 100%;"
-                                sandbox="allow-scripts">
-                        </iframe>
+{% block content %}
+    <div class="mt-3">
+        <h2>{{ phase.title }} Leaderboard {{ request.GET.date }}</h2>
 
-                        {% if "change_challenge" in challenge_perms %}
+        {% if phase.evaluation_comparison_observable_url %}
+            <div id="compare-warning-alert" class="alert alert-warning d-none" role="alert">
+                <h5>Attention</h5>
+                Selecting more than 6 results may affect the performance of the visualization
+            </div>
+        {% endif %}
+
+        {% include "datatables/partials/datatable.html" with columns=columns %}
+
+        {% if phase.result_display_choice == phase.BEST %}
+            <p class="small ml-3">
+                Only the best published result for each participant is listed.
+            </p>
+        {% elif phase.result_display_choice == phase.MOST_RECENT %}
+            <p class="small ml-3">
+                Only the most recent published result for each participant is listed.
+            </p>
+        {% else %}
+            <div class="modal fade" id="leaderboardDateModal" tabindex="-1" role="dialog"
+                 aria-labelledby="leaderboardDateModalLabel"
+                 aria-hidden="true">
+                <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="leaderboardDateModalLabel">Leaderboard History</h5>
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                <span aria-hidden="true">&times;</span>
+                            </button>
+                        </div>
+
+                        <div class="modal-body">
                             <p>
-                                <a id="observableEditLink"
-                                   class="btn btn-primary"
-                                   title="Edit notebook in observable"
-                                   target="_blank">
-                                    <i class="fa fa-edit"></i>
-                                </a>
+                                Select a date to display the leaderboard as it was on that day.
                             </p>
-                        {% endif %}
+                            <form class="form-inline" action="">
+                                <label class="mr-sm-2" for="leaderboardDate">Date:</label>
+                                <input class="mr-sm-2" type="date" id="leaderboardDate" name="date" required
+                                       value="{{ request.GET.date }}">
+                                <button type="submit" class="btn btn-primary btn-sm">Submit</button>
+                            </form>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-    {% endif %}
+        {% endif %}
+
+        {% if "change_challenge" in challenge_perms %}
+            <h3>Export</h3>
+            {% for offset in offsets %}
+                <p>
+                    <a class="btn btn-primary"
+                       href="{% url 'api:evaluation-list' %}?format=csv&submission__phase={{ phase.pk }}&offset={{ offset }}&limit={{ limit }}"
+                       download="{{ phase.challenge.short_name }}_{{ phase.slug }}_evaluations_{{ offset|add:1 }}_{{ offset|add:limit }}_{{ now }}.csv">
+                        <i class="fas fa-file-csv"></i> Evaluations ({{ offset|add:1 }} to {{ offset|add:limit }})
+                    </a>
+                </p>
+            {% endfor %}
+        {% endif %}
+
+        {% if phase.evaluation_comparison_observable_url or phase.evaluation_detail_observable_url %}
+            <div class="modal fade" id="observableModal" tabindex="-1" role="dialog" aria-labelledby="observableModalLabel"
+                 aria-hidden="true">
+                <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered modal-xl" role="document">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="observableModalLabel">Compare Results</h5>
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                <span aria-hidden="true">&times;</span>
+                            </button>
+                        </div>
+                        <div class="modal-body">
+                            <iframe id="observableNotebook"
+                                    class="border-0"
+                                    style="height: 75vh; min-width: 100%;"
+                                    sandbox="allow-scripts">
+                            </iframe>
+
+                            {% if "change_challenge" in challenge_perms %}
+                                <p>
+                                    <a id="observableEditLink"
+                                       class="btn btn-primary"
+                                       title="Edit notebook in observable"
+                                       target="_blank">
+                                        <i class="fa fa-edit"></i>
+                                    </a>
+                                </p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+    </div>
 {% endblock %}
 
 {% block script %}

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
@@ -25,100 +25,101 @@
 {% endblock %}
 
 {% block content %}
-        <h2>{{ phase.title }} Leaderboard {{ request.GET.date }}</h2>
+    <h2>{{ phase.title }} Leaderboard {{ request.GET.date }}</h2>
 
-        {% if phase.evaluation_comparison_observable_url %}
-            <div id="compare-warning-alert" class="alert alert-warning d-none" role="alert">
-                <h5>Attention</h5>
-                Selecting more than 6 results may affect the performance of the visualization
+    {% if phase.evaluation_comparison_observable_url %}
+        <div id="compare-warning-alert" class="alert alert-warning d-none" role="alert">
+            <h5>Attention</h5>
+            Selecting more than 6 results may affect the performance of the visualization
+        </div>
+    {% endif %}
+
+    {% include "datatables/partials/datatable.html" with columns=columns %}
+
+    {% if phase.result_display_choice == phase.BEST %}
+        <p class="small ml-3">
+            Only the best published result for each participant is listed.
+        </p>
+    {% elif phase.result_display_choice == phase.MOST_RECENT %}
+        <p class="small ml-3">
+            Only the most recent published result for each participant is listed.
+        </p>
+    {% else %}
+        <div class="modal fade" id="leaderboardDateModal" tabindex="-1" role="dialog"
+             aria-labelledby="leaderboardDateModalLabel"
+             aria-hidden="true">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="leaderboardDateModalLabel">Leaderboard History</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+
+                    <div class="modal-body">
+                        <p>
+                            Select a date to display the leaderboard as it was on that day.
+                        </p>
+                        <form class="form-inline" action="">
+                            <label class="mr-sm-2" for="leaderboardDate">Date:</label>
+                            <input class="mr-sm-2" type="date" id="leaderboardDate" name="date" required
+                                   value="{{ request.GET.date }}">
+                            <button type="submit" class="btn btn-primary btn-sm">Submit</button>
+                        </form>
+                    </div>
+                </div>
             </div>
-        {% endif %}
+        </div>
+    {% endif %}
 
-        {% include "datatables/partials/datatable.html" with columns=columns %}
-
-        {% if phase.result_display_choice == phase.BEST %}
-            <p class="small ml-3">
-                Only the best published result for each participant is listed.
+    {% if "change_challenge" in challenge_perms %}
+        <h3>Export</h3>
+        {% for offset in offsets %}
+            <p>
+                <a class="btn btn-primary"
+                   href="{% url 'api:evaluation-list' %}?format=csv&submission__phase={{ phase.pk }}&offset={{ offset }}&limit={{ limit }}"
+                   download="{{ phase.challenge.short_name }}_{{ phase.slug }}_evaluations_{{ offset|add:1 }}_
+                           {{ offset|add:limit }}_{{ now }}.csv">
+                    <i class="fas fa-file-csv"></i> Evaluations ({{ offset|add:1 }} to {{ offset|add:limit }})
+                </a>
             </p>
-        {% elif phase.result_display_choice == phase.MOST_RECENT %}
-            <p class="small ml-3">
-                Only the most recent published result for each participant is listed.
-            </p>
-        {% else %}
-            <div class="modal fade" id="leaderboardDateModal" tabindex="-1" role="dialog"
-                 aria-labelledby="leaderboardDateModalLabel"
-                 aria-hidden="true">
-                <div class="modal-dialog" role="document">
-                    <div class="modal-content">
-                        <div class="modal-header">
-                            <h5 class="modal-title" id="leaderboardDateModalLabel">Leaderboard History</h5>
-                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                <span aria-hidden="true">&times;</span>
-                            </button>
-                        </div>
+        {% endfor %}
+    {% endif %}
 
-                        <div class="modal-body">
+    {% if phase.evaluation_comparison_observable_url or phase.evaluation_detail_observable_url %}
+        <div class="modal fade" id="observableModal" tabindex="-1" role="dialog" aria-labelledby="observableModalLabel"
+             aria-hidden="true">
+            <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered modal-xl" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="observableModalLabel">Compare Results</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <iframe id="observableNotebook"
+                                class="border-0"
+                                style="height: 75vh; min-width: 100%;"
+                                sandbox="allow-scripts">
+                        </iframe>
+
+                        {% if "change_challenge" in challenge_perms %}
                             <p>
-                                Select a date to display the leaderboard as it was on that day.
+                                <a id="observableEditLink"
+                                   class="btn btn-primary"
+                                   title="Edit notebook in observable"
+                                   target="_blank">
+                                    <i class="fa fa-edit"></i>
+                                </a>
                             </p>
-                            <form class="form-inline" action="">
-                                <label class="mr-sm-2" for="leaderboardDate">Date:</label>
-                                <input class="mr-sm-2" type="date" id="leaderboardDate" name="date" required
-                                       value="{{ request.GET.date }}">
-                                <button type="submit" class="btn btn-primary btn-sm">Submit</button>
-                            </form>
-                        </div>
+                        {% endif %}
                     </div>
                 </div>
             </div>
-        {% endif %}
-
-        {% if "change_challenge" in challenge_perms %}
-            <h3>Export</h3>
-            {% for offset in offsets %}
-                <p>
-                    <a class="btn btn-primary"
-                       href="{% url 'api:evaluation-list' %}?format=csv&submission__phase={{ phase.pk }}&offset={{ offset }}&limit={{ limit }}"
-                       download="{{ phase.challenge.short_name }}_{{ phase.slug }}_evaluations_{{ offset|add:1 }}_{{ offset|add:limit }}_{{ now }}.csv">
-                        <i class="fas fa-file-csv"></i> Evaluations ({{ offset|add:1 }} to {{ offset|add:limit }})
-                    </a>
-                </p>
-            {% endfor %}
-        {% endif %}
-
-        {% if phase.evaluation_comparison_observable_url or phase.evaluation_detail_observable_url %}
-            <div class="modal fade" id="observableModal" tabindex="-1" role="dialog" aria-labelledby="observableModalLabel"
-                 aria-hidden="true">
-                <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered modal-xl" role="document">
-                    <div class="modal-content">
-                        <div class="modal-header">
-                            <h5 class="modal-title" id="observableModalLabel">Compare Results</h5>
-                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                <span aria-hidden="true">&times;</span>
-                            </button>
-                        </div>
-                        <div class="modal-body">
-                            <iframe id="observableNotebook"
-                                    class="border-0"
-                                    style="height: 75vh; min-width: 100%;"
-                                    sandbox="allow-scripts">
-                            </iframe>
-
-                            {% if "change_challenge" in challenge_perms %}
-                                <p>
-                                    <a id="observableEditLink"
-                                       class="btn btn-primary"
-                                       title="Edit notebook in observable"
-                                       target="_blank">
-                                        <i class="fa fa-edit"></i>
-                                    </a>
-                                </p>
-                            {% endif %}
-                        </div>
-                    </div>
-                </div>
-            </div>
-        {% endif %}
+        </div>
+    {% endif %}
 {% endblock %}
 
 {% block script %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -34,73 +34,73 @@
 {% endblock %}
 
 {% block content %}
-        <h2>{{ phase.title }} Submission</h2>
+    <h2>{{ phase.title }} Submission</h2>
 
-        {{ phase.submission_page_html|clean }}
+    {{ phase.submission_page_html|clean }}
 
-        <h3>Create a new submission</h3>
+    <h3>Create a new submission</h3>
 
-        {% if "change_challenge" in challenge_perms %}
+    {% if "change_challenge" in challenge_perms %}
 
-            {% if request.resolver_match.view_name != "evaluation:submission-create-legacy" %}
+        {% if request.resolver_match.view_name != "evaluation:submission-create-legacy" %}
 
-                <p>
-                    As an admin for this challenge you can make as many submissions as
-                    you like. Challenge participants will be allowed to make
-                    {{ phase.daily_submission_limit }}
-                    submission{{ phase.daily_submission_limit|pluralize }}
-                    per day to this phase. You can change the Daily Submission Limit in <a
-                        href="{% url 'evaluation:phase-update' challenge_short_name=challenge.short_name slug=phase.slug %}">
-                    Phase Settings</a>. Please use
-                    <a href="{% url 'evaluation:submission-create-legacy' challenge_short_name=challenge.short_name slug=phase.slug %}">
-                        this form</a>
-                    if you would like to create a submission on the behalf of one of the participants of this challenge.
-                </p>
-
-            {% endif %}
-
-            {% crispy form %}
-
-        {% else %}
-
-            {% if pending_evaluations %}
-
-                <p>
-                    You need to wait until all of your existing submissions have
-                    been evaluated before you can make another submission.
-                    <a href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">
-                        Click here
-                    </a>
-                    to see their status.
-                </p>
-
-            {% elif phase.daily_submission_limit == 0 %}
-
-                <p>Submissions are closed for this phase.</p>
-
-            {% elif remaining_submissions <= 0 %}
-
-                <p>
-                    You have reached your submission limit for today. You can make
-                    another submission in {{ next_submission_at|timeuntil }}.</p>
-
-            {% else %}
-
-                <p>
-                    You can make {{ remaining_submissions }} more
-                    submission{{ remaining_submissions|pluralize }} today.
-                </p>
-
-                {% crispy form %}
-
-            {% endif %}
+            <p>
+                As an admin for this challenge you can make as many submissions as
+                you like. Challenge participants will be allowed to make
+                {{ phase.daily_submission_limit }}
+                submission{{ phase.daily_submission_limit|pluralize }}
+                per day to this phase. You can change the Daily Submission Limit in <a
+                    href="{% url 'evaluation:phase-update' challenge_short_name=challenge.short_name slug=phase.slug %}">
+                Phase Settings</a>. Please use
+                <a href="{% url 'evaluation:submission-create-legacy' challenge_short_name=challenge.short_name slug=phase.slug %}">
+                    this form</a>
+                if you would like to create a submission on the behalf of one of the participants of this challenge.
+            </p>
 
         {% endif %}
 
-        <h3>View your submissions</h3>
+        {% crispy form %}
 
-        <p>
-            <a href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Click
-                here</a>
-            to view your current submissions to this challenge.</p>
+    {% else %}
+
+        {% if pending_evaluations %}
+
+            <p>
+                You need to wait until all of your existing submissions have
+                been evaluated before you can make another submission.
+                <a href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">
+                    Click here
+                </a>
+                to see their status.
+            </p>
+
+        {% elif phase.daily_submission_limit == 0 %}
+
+            <p>Submissions are closed for this phase.</p>
+
+        {% elif remaining_submissions <= 0 %}
+
+            <p>
+                You have reached your submission limit for today. You can make
+                another submission in {{ next_submission_at|timeuntil }}.</p>
+
+        {% else %}
+
+            <p>
+                You can make {{ remaining_submissions }} more
+                submission{{ remaining_submissions|pluralize }} today.
+            </p>
+
+            {% crispy form %}
+
+        {% endif %}
+
+    {% endif %}
+
+    <h3>View your submissions</h3>
+
+    <p>
+        <a href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Click
+            here</a>
+        to view your current submissions to this challenge.</p>
 {% endblock %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block sidebar %}
-    <div class="nav nav-pills col-12 pl-3 mt-3">
+    <div class="nav nav-pills col-12 pl-3 my-3">
         {% if "change_challenge" in challenge_perms or user_is_participant %}
             {% for phase in challenge.phase_set.all %}
                 <li class="nav-item">
@@ -34,7 +34,6 @@
 {% endblock %}
 
 {% block content %}
-    <div class="mt-3">
         <h2>{{ phase.title }} Submission</h2>
 
         {{ phase.submission_page_html|clean }}
@@ -104,5 +103,4 @@
             <a href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Click
                 here</a>
             to view your current submissions to this challenge.</p>
-    </div>
 {% endblock %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block sidebar %}
-    <div class="nav nav-pills col-12 pl-3 my-3">
+    <div class="nav nav-pills col-12 pl-3 mb-3">
         {% if "change_challenge" in challenge_perms or user_is_participant %}
             {% for phase in challenge.phase_set.all %}
                 <li class="nav-item">

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -20,76 +20,89 @@
     </ol>
 {% endblock %}
 
-{% block content %}
-
-    <h2>{{ phase.title }} Submission</h2>
-
-    {{ phase.submission_page_html|clean }}
-
-    <h3>Create a new submission</h3>
-
-    {% if "change_challenge" in challenge_perms %}
-
-        {% if request.resolver_match.view_name != "evaluation:submission-create-legacy" %}
-
-            <p>
-                As an admin for this challenge you can make as many submissions as
-                you like. Challenge participants will be allowed to make
-                {{ phase.daily_submission_limit }}
-                submission{{ phase.daily_submission_limit|pluralize }}
-                per day to this phase. You can change the Daily Submission Limit in <a
-                    href="{% url 'evaluation:phase-update' challenge_short_name=challenge.short_name slug=phase.slug %}">
-                Phase Settings</a>. Please use
-                <a href="{% url 'evaluation:submission-create-legacy' challenge_short_name=challenge.short_name slug=phase.slug %}">
-                    this form</a>
-                if you would like to create a submission on the behalf of one of the participants of this challenge.
-            </p>
-
+{% block sidebar %}
+    <div class="nav nav-pills col-12 pl-3 mt-3">
+        {% if "change_challenge" in challenge_perms or user_is_participant %}
+            {% for phase in challenge.phase_set.all %}
+                <li class="nav-item">
+                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                       href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+                </li>
+            {% endfor %}
         {% endif %}
+    </div>
+{% endblock %}
 
-        {% crispy form %}
+{% block content %}
+    <div class="mt-3">
+        <h2>{{ phase.title }} Submission</h2>
 
-    {% else %}
+        {{ phase.submission_page_html|clean }}
 
-        {% if pending_evaluations %}
+        <h3>Create a new submission</h3>
 
-            <p>
-                You need to wait until all of your existing submissions have
-                been evaluated before you can make another submission.
-                <a href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">
-                    Click here
-                </a>
-                to see their status.
-            </p>
+        {% if "change_challenge" in challenge_perms %}
 
-        {% elif phase.daily_submission_limit == 0 %}
+            {% if request.resolver_match.view_name != "evaluation:submission-create-legacy" %}
 
-            <p>Submissions are closed for this phase.</p>
+                <p>
+                    As an admin for this challenge you can make as many submissions as
+                    you like. Challenge participants will be allowed to make
+                    {{ phase.daily_submission_limit }}
+                    submission{{ phase.daily_submission_limit|pluralize }}
+                    per day to this phase. You can change the Daily Submission Limit in <a
+                        href="{% url 'evaluation:phase-update' challenge_short_name=challenge.short_name slug=phase.slug %}">
+                    Phase Settings</a>. Please use
+                    <a href="{% url 'evaluation:submission-create-legacy' challenge_short_name=challenge.short_name slug=phase.slug %}">
+                        this form</a>
+                    if you would like to create a submission on the behalf of one of the participants of this challenge.
+                </p>
 
-        {% elif remaining_submissions <= 0 %}
-
-            <p>
-                You have reached your submission limit for today. You can make
-                another submission in {{ next_submission_at|timeuntil }}.</p>
-
-        {% else %}
-
-            <p>
-                You can make {{ remaining_submissions }} more
-                submission{{ remaining_submissions|pluralize }} today.
-            </p>
+            {% endif %}
 
             {% crispy form %}
 
+        {% else %}
+
+            {% if pending_evaluations %}
+
+                <p>
+                    You need to wait until all of your existing submissions have
+                    been evaluated before you can make another submission.
+                    <a href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">
+                        Click here
+                    </a>
+                    to see their status.
+                </p>
+
+            {% elif phase.daily_submission_limit == 0 %}
+
+                <p>Submissions are closed for this phase.</p>
+
+            {% elif remaining_submissions <= 0 %}
+
+                <p>
+                    You have reached your submission limit for today. You can make
+                    another submission in {{ next_submission_at|timeuntil }}.</p>
+
+            {% else %}
+
+                <p>
+                    You can make {{ remaining_submissions }} more
+                    submission{{ remaining_submissions|pluralize }} today.
+                </p>
+
+                {% crispy form %}
+
+            {% endif %}
+
         {% endif %}
 
-    {% endif %}
+        <h3>View your submissions</h3>
 
-    <h3>View your submissions</h3>
-
-    <p>
-        <a href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Click
-            here</a>
-        to view your current submissions to this challenge.</p>
-
+        <p>
+            <a href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Click
+                here</a>
+            to view your current submissions to this challenge.</p>
+    </div>
 {% endblock %}

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -26,7 +26,7 @@
 {% endblock %}
 
 {% block sidebar %}
-      <div class="nav nav-pills flex-column pl-3 mt-3">
+      <div class="nav nav-pills flex-column pl-3">
         {% for page in pages %}
             {% if not page.hidden %}
                 <li class="nav-item">
@@ -43,7 +43,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="mt-3 mx-3">
+    <div class="mx-3">
         {% if challenge.disclaimer %}
             <div class="disclaimer alert alert-warning" role="alert">
                 {{ challenge.disclaimer|clean }}

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -4,6 +4,13 @@
 {% load bleach %}
 {% load static %}
 
+{% block title %}
+    {% filter title %}
+        {% firstof currentpage.display_title currentpage.title %}
+    {% endfilter %}
+    - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'challenges:list' %}">Challenges</a></li>
@@ -59,4 +66,22 @@
             {% endif %}
         {% endif %}
     </div>
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    {# For displaying equations on the site, the safe config is important #}
+    <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML,Safe'
+            async></script>
+    {# geocharts #}
+    <script type="text/javascript"
+            src="https://www.gstatic.com/charts/loader.js"></script>
+    <script type="text/javascript"
+            src="{% static "js/render_geocharts.js" %}"></script>
+    {# make the tables sortable #}
+    <script type="text/javascript"
+            src="{% static "js/sort_tables.js" %}"></script>
+    {# render embeddable google forums #}
+    <script type="text/javascript"
+            src="{% static "js/embed_forums.js" %}"></script>
 {% endblock %}

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -4,18 +4,9 @@
 {% load bleach %}
 {% load static %}
 
-{% block title %}
-    {% filter title %}
-        {% firstof currentpage.display_title currentpage.title %}
-    {% endfilter %}
-    - {{ block.super }}
-{% endblock %}
-
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a
-                href="{% url 'challenges:list' %}">Challenges</a>
-        </li>
+        <li class="breadcrumb-item"><a href="{% url 'challenges:list' %}">Challenges</a></li>
         <li class="breadcrumb-item"><a
                 href="{{ challenge.get_absolute_url }}">{% firstof challenge.title challenge.short_name %}</a></li>
         <li class="breadcrumb-item active"
@@ -27,46 +18,45 @@
     </ol>
 {% endblock %}
 
-{% block content %}
-    {% if challenge.disclaimer %}
-        <div class="disclaimer alert alert-warning" role="alert">
-            {{ challenge.disclaimer|clean }}
-        </div>
-    {% endif %}
-
-    <div id=pageContainer>{{ currentpage.cleaned_html }}</div>
-
-    {% if not currentpage.is_error_page %}
-        {% if currentpage.pk %}
-            {% if "change_challenge" in challenge_perms %}
-                <br>
-                <a class="btn btn-primary"
-                   href="{% url 'pages:update' challenge_short_name=currentpage.challenge.short_name page_title=currentpage.title %}"
-                   title="Edit this page"
-                >
-                    <i class="fas fa-edit"></i>
-                </a>
+{% block sidebar %}
+      <div class="nav nav-pills flex-column pl-3 mt-3">
+        {% for page in pages %}
+            {% if not page.hidden %}
+                <li class="nav-item">
+                    <a class="nav-link {% if page == currentpage %}active{% endif %}"
+                       href="{{ page.get_absolute_url }}">
+                        {% filter title %}
+                            {% firstof page.display_title page.title %}
+                        {% endfilter %}
+                    </a>
+                </li>
             {% endif %}
-        {% endif %}
-    {% endif %}
+        {% endfor %}
+    </div>
 {% endblock %}
 
-{% block script %}
-    {{ block.super }}
-    {# For displaying equations on the site, the safe config is important #}
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML,Safe'
-            async></script>
+{% block content %}
+    <div class="mt-3 mx-3">
+        {% if challenge.disclaimer %}
+            <div class="disclaimer alert alert-warning" role="alert">
+                {{ challenge.disclaimer|clean }}
+            </div>
+        {% endif %}
 
-    {# geocharts #}
-    <script type="text/javascript"
-            src="https://www.gstatic.com/charts/loader.js"></script>
-    <script type="text/javascript"
-            src="{% static "js/render_geocharts.js" %}"></script>
+        <div id=pageContainer>{{ currentpage.cleaned_html }}</div>
 
-    {# make the tables sortable #}
-    <script type="text/javascript"
-            src="{% static "js/sort_tables.js" %}"></script>
-    {# render embeddable google forums #}
-    <script type="text/javascript"
-            src="{% static "js/embed_forums.js" %}"></script>
+        {% if not currentpage.is_error_page %}
+            {% if currentpage.pk %}
+                {% if "change_challenge" in challenge_perms %}
+                    <br>
+                    <a class="btn btn-primary"
+                       href="{% url 'pages:update' challenge_short_name=currentpage.challenge.short_name page_title=currentpage.title %}"
+                       title="Edit this page"
+                    >
+                        <i class="fas fa-edit"></i>
+                    </a>
+                {% endif %}
+            {% endif %}
+        {% endif %}
+    </div>
 {% endblock %}


### PR DESCRIPTION
- this implements the topbar in base.html and challenge.html
- superordinate `Info`, `Submit`, and `Leaderboard` tabs currently only link to the `detail view` for the first `page` / `phase` respectively, no subordinate tabs/pills yet
- moves `join` and `admin` buttons to the right (they are buttons now, no longer tabs)
