### PR TITLE
Moved challenge submission list view to tab

### DIFF
--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -67,7 +67,7 @@
 
                         {% if "change_challenge" in challenge_perms or user_is_participant %}
                             <li class="nav-item">
-                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' %}active{% endif %}"
+                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' or request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
                                    href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
                                     Submit</a>
                             </li>

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -25,10 +25,15 @@
         {% if "change_challenge" in challenge_perms or user_is_participant %}
             {% for phase in challenge.phase_set.all %}
                 <li class="nav-item">
-                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-create-legacy' and request.resolver_match.kwargs.slug == phase.slug%}active{% endif %}"
                        href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
                 </li>
             {% endfor %}
+            <li>
+                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
+                    href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">View your submissions
+                </a>
+            </li>
         {% endif %}
     </div>
 {% endblock %}
@@ -96,11 +101,4 @@
         {% endif %}
 
     {% endif %}
-
-    <h3>View your submissions</h3>
-
-    <p>
-        <a href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Click
-            here</a>
-        to view your current submissions to this challenge.</p>
 {% endblock %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -31,7 +31,7 @@
             {% endfor %}
             <li>
                 <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
-                    href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">View your submissions
+                    href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
                 </a>
             </li>
         {% endif %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
@@ -13,6 +13,24 @@
     </ol>
 {% endblock %}
 
+{% block sidebar %}
+    <div class="nav nav-pills col-12 pl-3 mb-3">
+        {% if "change_challenge" in challenge_perms or user_is_participant %}
+            {% for phase in challenge.phase_set.all %}
+                <li class="nav-item">
+                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                       href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+                </li>
+            {% endfor %}
+            <li class="nav-item">
+                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
+                    href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">View your submissions
+                </a>
+            </li>
+        {% endif %}
+    </div>
+{% endblock %}
+
 {% block content %}
 
     <h2>Submissions</h2>

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
@@ -24,7 +24,7 @@
             {% endfor %}
             <li class="nav-item">
                 <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
-                    href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">View your submissions
+                    href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
                 </a>
             </li>
         {% endif %}


### PR DESCRIPTION
Users can now access a list of their submissions to a challenge through a seperate tab next to the phase-specific submission tabs. 

![image](https://user-images.githubusercontent.com/30069334/113256184-1d255600-92c9-11eb-9d69-c5d5f6c28283.png)
