### PR TITLE
Nav-pill and nav-tab layout improvements

### DIFF
--- a/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
@@ -47,7 +47,7 @@
    title="Result Info">
     <i class="fa fa-file"></i>
     {% for input in object.inputs.all %}
-        {{ input.image.name }}
+        {{ input.image.name|truncatechars:15 }}
     {% endfor %}
     ({{ object.get_status_display }}{% if object.status == object.SUCCESS and object.stderr %}, with warnings{% endif %})
 </a>

--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -132,14 +132,14 @@ ul.socialaccount_providers > li {
          background-color: darkgray !important;
     }
 
-.nav-tabs > .active > a,.nav-tabs > .active > a:hover,
+.nav-tabs > li, .nav-tabs > .active > a,.nav-tabs > .active > a:hover,
     .nav-tabs > li > a {
             color: #000 !important;
             }
     .nav-tabs > li > a:hover {
             border:0;
             color: #000 !important;
-            font-weight: bold;
+            /*font-weight: bold;*/
             border-bottom-width: 4px;
             border-bottom-style: solid;
              }
@@ -147,6 +147,7 @@ ul.socialaccount_providers > li {
             border:0;
             color: #000 !important;
             font-weight: bold;
+            /*background-color: #ecf0f1 !important;*/
             border-bottom-width: 4px !important;
             border-bottom-style: solid;
             border-bottom-color: #2C3E50 !important;

--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -114,3 +114,40 @@ ul.socialaccount_providers {
 ul.socialaccount_providers > li {
     min-width: 300px;
 }
+
+.nav-pills > .active > a,.nav-pills > .active > a:hover,
+    .nav-pills > li > a {
+        color: #000 !important;
+        padding-top: 5px !important;
+        padding-bottom: 5px !important;
+        margin-bottom: 5px;
+        margin-right: 5px;
+    }
+    .nav-pills > li > a:hover {
+        border-radius: 25px;
+        background-color: #f0f0f0;
+    }
+    .nav-pills > li > a.active {
+         border-radius: 25px;
+         background-color: darkgray !important;
+    }
+
+.nav-tabs > .active > a,.nav-tabs > .active > a:hover,
+    .nav-tabs > li > a {
+            color: #000 !important;
+            }
+    .nav-tabs > li > a:hover {
+            border:0;
+            color: #000 !important;
+            font-weight: bold;
+            border-bottom-width: 4px;
+            border-bottom-style: solid;
+             }
+    .nav-tabs > li > a.active {
+            border:0;
+            color: #000 !important;
+            font-weight: bold;
+            border-bottom-width: 4px !important;
+            border-bottom-style: solid;
+            border-bottom-color: #2C3E50 !important;
+         }

--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -117,10 +117,6 @@ ul.socialaccount_providers > li {
 
 .nav-pills > li > .nav-link {
     color: #000;
-    padding-top: 5px;
-    padding-bottom: 5px;
-    margin-bottom: 5px;
-    margin-right: 5px;
 }
 .nav-pills > li > .nav-link:hover {
     border-radius: 25px;
@@ -142,4 +138,19 @@ ul.socialaccount_providers > li {
     border: inherit;
     font-weight: bold;
     border-bottom: 4px solid #2c3e50;
+}
+
+.phaseDropdown {
+    color: black;
+}
+.phaseDropdown:hover {
+    background-color: #f0f0f0;
+}
+
+.phaseButton {
+    background-color: darkgray;
+    border-radius: 20px;
+}
+.phaseButton:focus {
+    box-shadow:none !important;
 }

--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -120,11 +120,11 @@ ul.socialaccount_providers > li {
 }
 .nav-pills > li > .nav-link:hover {
     border-radius: 25px;
+    color: #000;
     background-color: #f0f0f0;
 }
 .nav-pills > li > .nav-link.active {
     border-radius: 25px;
-    background-color: darkgray;
 }
 
 .nav-tabs > .nav-item > .nav-link {
@@ -140,17 +140,18 @@ ul.socialaccount_providers > li {
     border-bottom: 4px solid #2c3e50;
 }
 
-.phaseDropdown {
-    color: black;
+.challengeDropdown > .nav-link {
+    color: #000;
 }
-.phaseDropdown:hover {
+.challengeDropdown:hover {
     background-color: #f0f0f0;
 }
 
 .phaseButton {
-    background-color: darkgray;
     border-radius: 20px;
+    color: #000;
+    padding-top: 3px;
+    padding-bottom: 3px;
 }
-.phaseButton:focus {
-    box-shadow:none !important;
-}
+.phaseButton:focus, .phaseButton:hover {
+    box-shadow:none !important;}

--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -115,51 +115,31 @@ ul.socialaccount_providers > li {
     min-width: 300px;
 }
 
-.nav-pills > .active > a,.nav-pills > .active > a:hover,
-    .nav-pills > li > a {
-        color: #000 !important;
-        padding-top: 5px !important;
-        padding-bottom: 5px !important;
-        margin-bottom: 5px;
-        margin-right: 5px;
-    }
-    .nav-pills > li > a:hover {
-        border-radius: 25px;
-        background-color: #f0f0f0;
-    }
-    .nav-pills > li > a.active {
-         border-radius: 25px;
-         background-color: darkgray !important;
-    }
-
-.nav-tabs > li, .nav-tabs > .active > a,.nav-tabs > .active > a:hover,
-    .nav-tabs > li > a {
-            color: #000 !important;
-            }
-    .nav-tabs > li > a:hover {
-            border:0;
-            color: #000 !important;
-            /*font-weight: bold;*/
-            border-bottom-width: 4px;
-            border-bottom-style: solid;
-             }
-    .nav-tabs > li > a.active {
-            border:0;
-            color: #000 !important;
-            font-weight: bold;
-            /*background-color: #ecf0f1 !important;*/
-            border-bottom-width: 4px !important;
-            border-bottom-style: solid;
-            border-bottom-color: #2C3E50 !important;
-         }
-
-@media (max-width: 800px) {
-    .tab-disappear {
-        display: none !important;
-    }
+.nav-pills > li > .nav-link {
+    color: #000;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    margin-bottom: 5px;
+    margin-right: 5px;
 }
-@media (min-width: 800px) {
-    .nav-disappear {
-        display: none !important;
-    }
+.nav-pills > li > .nav-link:hover {
+    border-radius: 25px;
+    background-color: #f0f0f0;
+}
+.nav-pills > li > .nav-link.active {
+    border-radius: 25px;
+    background-color: darkgray;
+}
+
+.nav-tabs > .nav-item > .nav-link {
+    color: #000;
+}
+.nav-tabs > .nav-item > .nav-link:hover {
+    border: inherit;
+    border-bottom: 4px solid #f0f0f0;
+}
+.nav-tabs > .nav-item > .nav-link.active {
+    border: inherit;
+    font-weight: bold;
+    border-bottom: 4px solid #2c3e50;
 }

--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -152,3 +152,14 @@ ul.socialaccount_providers > li {
             border-bottom-style: solid;
             border-bottom-color: #2C3E50 !important;
          }
+
+@media (max-width: 800px) {
+    .tab-disappear {
+        display: none !important;
+    }
+}
+@media (min-width: 800px) {
+    .nav-disappear {
+        display: none !important;
+    }
+}

--- a/app/grandchallenge/core/templates/base.html
+++ b/app/grandchallenge/core/templates/base.html
@@ -71,6 +71,7 @@
 
             {% block outer_content %}
                 {% block topbar %}{% endblock %}
+                {% block topbar2 %}{% endblock %}
                 <div class="row">
                     {% block sidebar %}{% endblock %}
                     <div class="col overflow-auto">

--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -95,17 +95,16 @@
                            role="button"
                            aria-expanded="false"><i class="fas fa-bars"></i></a>
                     <ul class="dropdown-menu dropdown-menu-left" role="menu">
-                        <li class="dropdown-item pl-0 text-dark">
-                            <! -- Todo: Adjust the view_name before merging with master (include the page_title slug)-->
-                            <a class="nav-link text-dark"
+                        <li class="dropdown-item px-0 py-0 challengeDropdown">
+                            <a class="nav-link"
                                href="{% url 'pages:home' challenge_short_name=challenge.short_name %}">
                                 Info
                             </a>
                         </li>
 
                         {% if challenge.display_forum_link %}
-                            <li class="dropdown-item pl-0 text-dark">
-                                <a class="nav-link text-dark"
+                            <li class="dropdown-item px-0 py-0 challengeDropdown">
+                                <a class="nav-link"
                                    href="{% url 'forum:forum' slug=challenge.forum.slug pk=challenge.forum.pk %}">
                                     Forum
                                 </a>
@@ -115,27 +114,27 @@
                         {% if challenge.use_evaluation %}
                             {% if challenge.use_teams %}
                                 {% if "change_challenge" in challenge_perms or user_is_participant %}
-                                    <li class="dropdown-item pl-0 text-dark">
-                                        <a class="nav-link text-dark"
+                                    <li class="dropdown-item px-0 py-0 challengeDropdown">
+                                        <a class="nav-link"
                                            href="{% url 'teams:list' challenge_short_name=challenge.short_name %}">Teams</a>
                                     </li>
                                 {% endif %}
                             {% endif %}
 
                             {% if "change_challenge" in challenge_perms or user_is_participant %}
-                                <li class="dropdown-item pl-0 text-dark">
-                                    <a class="nav-link text-dark"
+                                <li class="dropdown-item px-0 py-0 challengeDropdown">
+                                    <a class="nav-link"
                                        href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
                                         Submit</a>
                                 </li>
-                                <li class="dropdown-item pl-0 text-dark">
-                                    <a class="nav-link text-dark"
+                                <li class="dropdown-item px-0 py-0 challengeDropdown">
+                                    <a class="nav-link"
                                        href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
                                         Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
                                 </li>
                             {% elif not challenge.hidden %}
-                                <li class="dropdown-item pl-0 text-dark">
-                                    <a class="nav-link text-dark"
+                                <li class="dropdown-item px-0 py-0 challengeDropdown">
+                                    <a class="nav-link"
                                        href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
                                         Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
                                 </li>

--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -35,8 +35,8 @@
 
 {% block topbar %}
     {% if challenge %}
-        <div class="row mb-3 mx-1" style="border-bottom:1px solid #ecf0f1">
-            <div class="col-md-10 col-sm-8 col-6 px-0">
+        <div class="row mb-3 mx-0" style="border-bottom:1px solid #ecf0f1">
+            <div class="tab-disappear col-md-10 col-sm-8 col-6 px-0">
                 <div class="nav nav-tabs" role="tablist" style="border-bottom:none">
                     <li class="nav-item">
                     <! -- Todo: Adjust the view_name before merging with master (include the page_title slug)-->
@@ -87,6 +87,69 @@
                 </div>
             </div>
 
+            <div class="nav-disappear col-md-10 col-sm-8 col-6 px-0 pb-1">
+                <div class="dropdown" id="collapsibleTopbar">
+                    <a class="btn btn-outline-dark"
+                           data-toggle="dropdown"
+                           href="#"
+                           role="button"
+                           aria-expanded="false"><i class="fas fa-bars"></i></a>
+                    <ul class="dropdown-menu dropdown-menu-left" role="menu">
+                        <li class="dropdown-item" style="color: black; padding-left:0px;">
+                            <! -- Todo: Adjust the view_name before merging with master (include the page_title slug)-->
+                            <a class="nav-link {% if request.resolver_match.view_name == 'pages:home' or request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"
+                               href="{% url 'pages:home' challenge_short_name=challenge.short_name %}"
+                                style="color: black">
+                                Info
+                            </a>
+                        </li>
+
+                        {% if challenge.display_forum_link %}
+                            <li class="dropdown-item" style="color: black; padding-left:0px;">
+                                <a class="nav-link"
+                                   href="{% url 'forum:forum' slug=challenge.forum.slug pk=challenge.forum.pk %}"
+                                    style="color: black">
+                                    Forum
+                                </a>
+                            </li>
+                        {% endif %}
+
+                        {% if challenge.use_evaluation %}
+                            {% if challenge.use_teams %}
+                                {% if "change_challenge" in challenge_perms or user_is_participant %}
+                                    <li class="dropdown-item" style="color: black; padding-left:0px;">
+                                        <a class="nav-link {% if request.resolver_match.view_name == 'teams:list' %}active{% endif %}"
+                                           href="{% url 'teams:list' challenge_short_name=challenge.short_name %}"
+                                            style="color: black">Teams</a>
+                                    </li>
+                                {% endif %}
+                            {% endif %}
+
+                            {% if "change_challenge" in challenge_perms or user_is_participant %}
+                                <li class="dropdown-item" style="color: black; padding-left:0px;">
+                                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' or request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
+                                       href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}"
+                                        style="color: black">
+                                        Submit</a>
+                                </li>
+                                <li class="dropdown-item" style="color: black; padding-left:0px;">
+                                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' %}active{% endif %}"
+                                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}"
+                                        style="color: black">
+                                        Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
+                                </li>
+                            {% elif not challenge.hidden %}
+                                <li class="dropdown-item" style="color: black; padding-left:0px;">
+                                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' %}active{% endif %}"
+                                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}"
+                                        style="color: black">
+                                        Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
+                                </li>
+                            {% endif %}
+                        {% endif %}
+                    </ul>
+                </div>
+            </div>
             <div class="col-md-2 col-sm-4 col-6 py-0 px-0 d-flex justify-content-end">
                 {% if challenge.use_registration_page %}
                     <div>

--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -35,9 +35,9 @@
 
 {% block topbar %}
     {% if challenge %}
-        <div class="row mb-3">
-            <div class="col-md-10 col-sm-8 col-6">
-                <div class="nav nav-tabs" role="tablist">
+        <div class="row mb-3 mx-1" style="border-bottom:1px solid #ecf0f1">
+            <div class="col-md-10 col-sm-8 col-6 px-0">
+                <div class="nav nav-tabs" role="tablist" style="border-bottom:none">
                     <li class="nav-item">
                     <! -- Todo: Adjust the view_name before merging with master (include the page_title slug)-->
                         <a class="nav-link {% if request.resolver_match.view_name == 'pages:home' or request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"
@@ -87,7 +87,7 @@
                 </div>
             </div>
 
-            <div class="col-md-2 col-sm-4 col-6 py-1 d-flex justify-content-end">
+            <div class="col-md-2 col-sm-4 col-6 py-0 px-0 d-flex justify-content-end">
                 {% if challenge.use_registration_page %}
                     <div>
                         <a class="btn btn-success"

--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -35,11 +35,11 @@
 
 {% block topbar %}
     {% if challenge %}
-        <div class="row mb-3 mx-0" style="border-bottom:1px solid #ecf0f1">
-            <div class="tab-disappear col-md-10 col-sm-8 col-6 px-0">
-                <div class="nav nav-tabs" role="tablist" style="border-bottom:none">
+        <div class="row mb-3 mx-0 border-bottom">
+            <div class="d-none d-md-block col-md-10 col-sm-8 col-6 px-0">
+                <div class="nav nav-tabs border-0" role="tablist">
                     <li class="nav-item">
-                    <! -- Todo: Adjust the view_name before merging with master (include the page_title slug)-->
+                        <! -- Todo: Adjust the view_name before merging with master (include the page_title slug)-->
                         <a class="nav-link {% if request.resolver_match.view_name == 'pages:home' or request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"
                            href="{% url 'pages:home' challenge_short_name=challenge.short_name %}">
                             Info
@@ -87,28 +87,26 @@
                 </div>
             </div>
 
-            <div class="nav-disappear col-md-10 col-sm-8 col-6 px-0 pb-1">
-                <div class="dropdown" id="collapsibleTopbar">
+            <div class="d-block d-md-none col-md-10 col-sm-8 col-6 px-0 pb-1">
+                <div class="dropdown">
                     <a class="btn btn-outline-dark"
                            data-toggle="dropdown"
                            href="#"
                            role="button"
                            aria-expanded="false"><i class="fas fa-bars"></i></a>
                     <ul class="dropdown-menu dropdown-menu-left" role="menu">
-                        <li class="dropdown-item" style="color: black; padding-left:0px;">
+                        <li class="dropdown-item pl-0 text-dark">
                             <! -- Todo: Adjust the view_name before merging with master (include the page_title slug)-->
-                            <a class="nav-link {% if request.resolver_match.view_name == 'pages:home' or request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"
-                               href="{% url 'pages:home' challenge_short_name=challenge.short_name %}"
-                                style="color: black">
+                            <a class="nav-link text-dark"
+                               href="{% url 'pages:home' challenge_short_name=challenge.short_name %}">
                                 Info
                             </a>
                         </li>
 
                         {% if challenge.display_forum_link %}
-                            <li class="dropdown-item" style="color: black; padding-left:0px;">
-                                <a class="nav-link"
-                                   href="{% url 'forum:forum' slug=challenge.forum.slug pk=challenge.forum.pk %}"
-                                    style="color: black">
+                            <li class="dropdown-item pl-0 text-dark">
+                                <a class="nav-link text-dark"
+                                   href="{% url 'forum:forum' slug=challenge.forum.slug pk=challenge.forum.pk %}">
                                     Forum
                                 </a>
                             </li>
@@ -117,32 +115,28 @@
                         {% if challenge.use_evaluation %}
                             {% if challenge.use_teams %}
                                 {% if "change_challenge" in challenge_perms or user_is_participant %}
-                                    <li class="dropdown-item" style="color: black; padding-left:0px;">
-                                        <a class="nav-link {% if request.resolver_match.view_name == 'teams:list' %}active{% endif %}"
-                                           href="{% url 'teams:list' challenge_short_name=challenge.short_name %}"
-                                            style="color: black">Teams</a>
+                                    <li class="dropdown-item pl-0 text-dark">
+                                        <a class="nav-link text-dark"
+                                           href="{% url 'teams:list' challenge_short_name=challenge.short_name %}">Teams</a>
                                     </li>
                                 {% endif %}
                             {% endif %}
 
                             {% if "change_challenge" in challenge_perms or user_is_participant %}
-                                <li class="dropdown-item" style="color: black; padding-left:0px;">
-                                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' or request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
-                                       href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}"
-                                        style="color: black">
+                                <li class="dropdown-item pl-0 text-dark">
+                                    <a class="nav-link text-dark"
+                                       href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
                                         Submit</a>
                                 </li>
-                                <li class="dropdown-item" style="color: black; padding-left:0px;">
-                                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' %}active{% endif %}"
-                                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}"
-                                        style="color: black">
+                                <li class="dropdown-item pl-0 text-dark">
+                                    <a class="nav-link text-dark"
+                                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
                                         Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
                                 </li>
                             {% elif not challenge.hidden %}
-                                <li class="dropdown-item" style="color: black; padding-left:0px;">
-                                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' %}active{% endif %}"
-                                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}"
-                                        style="color: black">
+                                <li class="dropdown-item pl-0 text-dark">
+                                    <a class="nav-link text-dark"
+                                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
                                         Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
                                 </li>
                             {% endif %}

--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -87,10 +87,10 @@
                 </div>
             </div>
 
-            <div class="col-md-2 col-sm-4 col-6 d-flex justify-content-end">
+            <div class="col-md-2 col-sm-4 col-6 py-1 d-flex justify-content-end">
                 {% if challenge.use_registration_page %}
                     <div>
-                        <a class="btn btn-primary"
+                        <a class="btn btn-success"
                            href="{% url 'participants:registration-create' challenge_short_name=challenge.short_name %}"
                            role="button">
                             Join
@@ -100,7 +100,7 @@
 
                 {% if "change_challenge" in challenge_perms %}
                     <div class="dropdown px-1">
-                        <a class="btn btn-primary dropdown-toggle"
+                        <a class="btn btn-dark dropdown-toggle"
                            data-toggle="dropdown"
                            href="#"
                            role="button"

--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -36,7 +36,7 @@
 {% block topbar %}
     {% if challenge %}
         <div class="row mb-3 mx-0 border-bottom">
-            <div class="d-none d-md-block col-md-10 col-sm-8 col-6 px-0">
+            <div class="d-none d-lg-block col-md-10 col-sm-8 col-6 px-0">
                 <div class="nav nav-tabs border-0" role="tablist">
                     <li class="nav-item">
                         <! -- Todo: Adjust the view_name before merging with master (include the page_title slug)-->
@@ -87,7 +87,7 @@
                 </div>
             </div>
 
-            <div class="d-block d-md-none col-md-10 col-sm-8 col-6 px-0 pb-1">
+            <div class="d-block d-lg-none col-md-10 col-sm-8 col-6 px-0 pb-1">
                 <div class="dropdown">
                     <a class="btn btn-outline-dark"
                            data-toggle="dropdown"

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
@@ -14,14 +14,33 @@
 {% endblock %}
 
 {% block sidebar %}
-    <div class="nav nav-pills col-12 pl-3 mb-3">
+    <div class="nav nav-pills d-none {% if challenge.phase_set.count > 4 %}d-lg-inline-flex{% elif challenge.phase_set.count == 4 %}d-md-inline-flex{% else %}d-sm-inline-flex{% endif %} col-12 pl-3 mb-3">
         {% for phase in challenge.phase_set.all %}
             <li class="nav-item">
-                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
             </li>
         {% endfor %}
     </div>
+    <div class="nav nav-pills d-block {% if challenge.phase_set.count > 4 %}d-lg-none{% elif challenge.phase_set.count == 4 %}d-md-none{% else %}d-sm-none{% endif %} col-12 pl-3 mb-3">
+                <div class="dropdown">
+                    <a class="btn dropdown-toggle phaseButton mr-1 px-4 py-1"
+                           data-toggle="dropdown"
+                           href="#"
+                           role="button"
+                           aria-expanded="false">
+                            Choose a Phase</a>
+                    <ul class="dropdown-menu dropdown-menu-left" role="menu">
+                        {% for phase in challenge.phase_set.all %}
+                            <li class="dropdown-item phaseDropdown px-0">
+                                <a class="nav-link"
+                                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"
+                                   style="color: black">{{ phase.title }}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+        </div>
 {% endblock %}
 
 {% block content %}

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
@@ -17,30 +17,30 @@
     <div class="nav nav-pills d-none {% if challenge.phase_set.count > 4 %}d-lg-inline-flex{% elif challenge.phase_set.count == 4 %}d-md-inline-flex{% else %}d-sm-inline-flex{% endif %} col-12 pl-3 mb-3">
         {% for phase in challenge.phase_set.all %}
             <li class="nav-item">
-                <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                <a class="nav-link mr-1 px-3 py-1 {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
             </li>
         {% endfor %}
     </div>
     <div class="nav nav-pills d-block {% if challenge.phase_set.count > 4 %}d-lg-none{% elif challenge.phase_set.count == 4 %}d-md-none{% else %}d-sm-none{% endif %} col-12 pl-3 mb-3">
-                <div class="dropdown">
-                    <a class="btn dropdown-toggle phaseButton mr-1 px-4 py-1"
-                           data-toggle="dropdown"
-                           href="#"
-                           role="button"
-                           aria-expanded="false">
-                            Choose a Phase</a>
-                    <ul class="dropdown-menu dropdown-menu-left" role="menu">
-                        {% for phase in challenge.phase_set.all %}
-                            <li class="dropdown-item phaseDropdown px-0">
-                                <a class="nav-link"
-                                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"
-                                   style="color: black">{{ phase.title }}</a>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </div>
+        <div class="btn dropdown px-0 py-0">
+            <a class="btn btn-outline-dark dropdown-toggle phaseButton mr-1 px-4"
+               data-toggle="dropdown"
+               href="#"
+               role="button"
+               aria-expanded="false">
+                Choose a Phase</a>
+            <div class="dropdown-menu dropdown-menu-left" role="menu">
+                {% for phase in challenge.phase_set.all %}
+                    <li class="dropdown-item challengeDropdown px-0 py-0">
+                        <a class="nav-link py-1"
+                           href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"
+                           style="color: black">{{ phase.title }}</a>
+                    </li>
+                {% endfor %}
+            </div>
         </div>
+    </div>
 {% endblock %}
 
 {% block content %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -25,12 +25,12 @@
         {% if "change_challenge" in challenge_perms or user_is_participant %}
             {% for phase in challenge.phase_set.all %}
                 <li class="nav-item">
-                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-create-legacy' and request.resolver_match.kwargs.slug == phase.slug%}active{% endif %}"
+                    <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-create-legacy' and request.resolver_match.kwargs.slug == phase.slug%}active{% endif %}"
                        href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
                 </li>
             {% endfor %}
             <li>
-                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
+                <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
                     href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
                 </a>
             </li>

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block sidebar %}
-    <div class="nav nav-pills col-12 pl-3 mb-3">
+    <div class="nav nav-pills d-none {% if challenge.phase_set.count > 4 %}d-lg-inline-flex{% elif challenge.phase_set.count == 4 %}d-md-inline-flex{% else %}d-sm-inline-flex{% endif %} col-12 pl-3 mb-3">
         {% if "change_challenge" in challenge_perms or user_is_participant %}
             {% for phase in challenge.phase_set.all %}
                 <li class="nav-item">
@@ -32,6 +32,32 @@
             <li>
                 <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
                     href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
+                </a>
+            </li>
+        {% endif %}
+    </div>
+    <div class="nav nav-pills d-flex {% if challenge.phase_set.count > 4 %}d-lg-none{% elif challenge.phase_set.count == 4 %}d-md-none{% else %}d-sm-none{% endif %} col-12 pl-3 mb-3">
+        {% if "change_challenge" in challenge_perms or user_is_participant %}
+            <div class="btn dropdown border-0 px-0 py-0 mb-1">
+                <a class="btn btn-outline-dark dropdown-toggle phaseButton mr-1 px-4"
+                   data-toggle="dropdown"
+                   href="#"
+                   role="button"
+                   aria-expanded="false">
+                    Choose a Phase</a>
+                <div class="dropdown-menu dropdown-menu-left" role="menu">
+                    {% for phase in challenge.phase_set.all %}
+                        <li class="dropdown-item challengeDropdown px-0 py-0">
+                            <a class="nav-link mr-1 px-4 py-1"
+                           href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}"
+                            style="color: black">{{ phase.title }}</a>
+                        </li>
+                    {% endfor %}
+                </div>
+            </div>
+            <li>
+                <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
+                   href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
                 </a>
             </li>
         {% endif %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
@@ -18,12 +18,12 @@
         {% if "change_challenge" in challenge_perms or user_is_participant %}
             {% for phase in challenge.phase_set.all %}
                 <li class="nav-item">
-                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                    <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
                        href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
                 </li>
             {% endfor %}
             <li class="nav-item">
-                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
+                <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
                     href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
                 </a>
             </li>

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
@@ -14,17 +14,43 @@
 {% endblock %}
 
 {% block sidebar %}
-    <div class="nav nav-pills col-12 pl-3 mb-3">
+    <div class="nav nav-pills d-none {% if challenge.phase_set.count > 4 %}d-lg-inline-flex{% elif challenge.phase_set.count == 4 %}d-md-inline-flex{% else %}d-sm-inline-flex{% endif %} col-12 pl-3 mb-3">
         {% if "change_challenge" in challenge_perms or user_is_participant %}
             {% for phase in challenge.phase_set.all %}
                 <li class="nav-item">
-                    <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                    <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-create-legacy' and request.resolver_match.kwargs.slug == phase.slug%}active{% endif %}"
                        href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
                 </li>
             {% endfor %}
-            <li class="nav-item">
+            <li>
                 <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
                     href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
+                </a>
+            </li>
+        {% endif %}
+    </div>
+    <div class="nav nav-pills d-flex {% if challenge.phase_set.count > 4 %}d-lg-none{% elif challenge.phase_set.count == 4 %}d-md-none{% else %}d-sm-none{% endif %} col-12 pl-3 mb-3">
+        {% if "change_challenge" in challenge_perms or user_is_participant %}
+            <div class="btn dropdown border-0 px-0 py-0 mb-1">
+                <a class="btn btn-outline-dark dropdown-toggle phaseButton mr-1 px-4"
+                   data-toggle="dropdown"
+                   href="#"
+                   role="button"
+                   aria-expanded="false">
+                    Choose a Phase</a>
+                <div class="dropdown-menu dropdown-menu-left" role="menu">
+                    {% for phase in challenge.phase_set.all %}
+                        <li class="dropdown-item challengeDropdown px-0">
+                            <a class="nav-link mr-1 px-4 py-1"
+                           href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}"
+                            style="color: black">{{ phase.title }}</a>
+                        </li>
+                    {% endfor %}
+                </div>
+            </div>
+            <li>
+                <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
+                   href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
                 </a>
             </li>
         {% endif %}

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -25,12 +25,29 @@
     </ol>
 {% endblock %}
 
-{% block sidebar %}
-      <div class="nav nav-pills flex-column pl-3">
+{% block topbar2 %}
+    <div class="nav nav-pills pl-0 mb-3 d-flex d-sm-none">
         {% for page in pages %}
             {% if not page.hidden %}
                 <li class="nav-item">
-                    <a class="nav-link {% if page == currentpage %}active{% endif %}"
+                    <a class="nav-link py-1 px-3 mr-1 mb-1 {% if page == currentpage %}active{% endif %}"
+                       href="{{ page.get_absolute_url }}">
+                        {% filter title %}
+                            {% firstof page.display_title page.title %}
+                        {% endfilter %}
+                    </a>
+                </li>
+            {% endif %}
+        {% endfor %}
+    </div>
+{% endblock %}
+
+{% block sidebar %}
+      <div class="nav nav-pills flex-column pl-3 d-none d-sm-block">
+        {% for page in pages %}
+            {% if not page.hidden %}
+                <li class="nav-item">
+                    <a class="nav-link text-center px-4 py-1 mb-1 {% if page == currentpage %}active{% endif %}"
                        href="{{ page.get_absolute_url }}">
                         {% filter title %}
                             {% firstof page.display_title page.title %}


### PR DESCRIPTION
- In the challenge navigation, nav-tabs no longer have a top/left/right border, only a bottom border, which highlights the currently active tab (in dark blue). Hovering over other tabs makes their bottom border visible in grey.

- Nav-pills are now thinner and rounded, making them visibly different from other nav-pills on the website and from the buttons used on the page etc. The active pill has a dark blue background, hovering over other pills highlights them in light grey. 

- All text is now black and no longer blue. 

- The bottom border of the nav-bars now extends also to underneath the join/admin buttons.

- The Join button is now green and the Admin button is dark grey. 

- Top nav-bar and nav-pills for phases now collapse into a dropdown on small screens. The info pages nav-pills display horizontally (rather than vertically) on small screens now (i.e., mobile devices). 


https://user-images.githubusercontent.com/30069334/114397663-34a0f080-9b9f-11eb-8d52-a36517f9428b.mp4


I also tried changing the background color of the nav-tab-bar (topbar) to a light grey, but I'm not sure how much I like it. 
 
![image](https://user-images.githubusercontent.com/30069334/113981881-6edd5b80-9848-11eb-8bf9-d7d53562c7c3.png)

The above changes also affect the nav-bars and nav-pills in the admin window (not the ones in readerstudies and algorithms and so on though). Do we want this, or do we want the nav-tabs to display as they used to for those pages? 

Before:

![image](https://user-images.githubusercontent.com/30069334/113890135-2f6d2b80-97c4-11eb-89c8-a860b610e4bf.png)

Now: 

![image](https://user-images.githubusercontent.com/30069334/113982065-9c2a0980-9848-11eb-8bc3-8f6fb15c2f73.png)
