### PR TITLE
Set ATOMIC_REQUESTS

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -26,8 +26,6 @@ def strtobool(val) -> bool:
 
 DEBUG = strtobool(os.environ.get("DEBUG", "True"))
 
-ATOMIC_REQUESTS = strtobool(os.environ.get("ATOMIC_REQUESTS", "True"))
-
 COMMIT_ID = os.environ.get("COMMIT_ID", "unknown")
 
 ADMINS = (
@@ -71,6 +69,9 @@ DATABASES = {
                 SITE_ROOT, "config", "certs", "rds-ca-2019-root.pem"
             ),
         },
+        "ATOMIC_REQUESTS": strtobool(
+            os.environ.get("ATOMIC_REQUESTS", "True")
+        ),
     }
 }
 

--- a/app/tests/groups_tests/test_views.py
+++ b/app/tests/groups_tests/test_views.py
@@ -181,7 +181,7 @@ class TestAutocompleteViews:
         )
 
         try:
-            with django_assert_num_queries(12):
+            with django_assert_num_queries(14):
                 method(url, **kwargs)
         finally:
             client.logout()


### PR DESCRIPTION
The `ATOMIC_REQUESTS` setting was not in the correct location, this is a database setting, not a global setting. See https://docs.djangoproject.com/en/3.1/ref/settings/#atomic-requests.