### PR TITLE
Apply celery tasks only on commit

### DIFF
--- a/app/grandchallenge/algorithms/admin.py
+++ b/app/grandchallenge/algorithms/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.db.transaction import on_commit
 from guardian.admin import GuardedModelAdmin
 
 from grandchallenge.algorithms.models import (
@@ -21,7 +22,7 @@ def requeue_jobs(modeladmin, request, queryset):
     """
     queryset.update(status=Job.RETRY)
     for job in queryset:
-        job.signature.apply_async()
+        on_commit(job.signature.apply_async)
 
 
 requeue_jobs.short_description = "Requeue selected jobs"

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -10,6 +10,7 @@ from django.core.exceptions import (
     ValidationError,
 )
 from django.core.files import File
+from django.db.transaction import on_commit
 from django.forms.utils import ErrorList
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
@@ -487,7 +488,7 @@ class AlgorithmExperimentCreate(
             kwargs={"job_pk": job.pk, "upload_pks": upload_pks},
             immutable=True,
         )
-        run_job.apply_async()
+        on_commit(run_job.apply_async)
 
         return HttpResponseRedirect(
             reverse(

--- a/app/grandchallenge/cases/models.py
+++ b/app/grandchallenge/cases/models.py
@@ -10,6 +10,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import Q
 from django.db.models.signals import post_delete
+from django.db.transaction import on_commit
 from django.dispatch import receiver
 from django.utils.text import get_valid_filename
 from guardian.shortcuts import assign_perm, get_groups_with_perms, remove_perm
@@ -111,7 +112,7 @@ class RawImageUploadSession(UUIDModel):
             linked_task.kwargs.update(kwargs)
             workflow |= linked_task
 
-        workflow.apply_async()
+        on_commit(workflow.apply_async)
 
     def get_absolute_url(self):
         return reverse(

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -10,6 +10,7 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import validate_slug
 from django.db import models
 from django.db.models.signals import post_delete
+from django.db.transaction import on_commit
 from django.dispatch import receiver
 from django.template.loader import render_to_string
 from django.utils.html import format_html
@@ -353,8 +354,10 @@ class Challenge(ChallengeBase):
             send_challenge_created_email(self)
 
         if adding or self.hidden != self._hidden_orig:
-            assign_evaluation_permissions.apply_async(
-                kwargs={"challenge_pk": self.pk}
+            on_commit(
+                lambda: assign_evaluation_permissions.apply_async(
+                    kwargs={"challenge_pk": self.pk}
+                )
             )
             self.update_user_forum_permissions()
 

--- a/app/grandchallenge/evaluation/tasks.py
+++ b/app/grandchallenge/evaluation/tasks.py
@@ -3,6 +3,7 @@ from statistics import mean, median
 
 from celery import shared_task
 from django.apps import apps
+from django.db.transaction import on_commit
 
 from grandchallenge.evaluation.utils import Metric, rank_results
 
@@ -61,7 +62,7 @@ def set_evaluation_inputs(evaluation_pk, job_pks):
         )
 
         evaluation.inputs.set([civ])
-        evaluation.signature.apply_async()
+        on_commit(evaluation.signature.apply_async)
 
 
 def filter_by_creators_most_recent(*, evaluations):

--- a/app/pytest.ini
+++ b/app/pytest.ini
@@ -21,6 +21,7 @@ filterwarnings =
     ignore::django.utils.deprecation.RemovedInDjango40Warning:django_summernote
     ignore::django.utils.deprecation.RemovedInDjango40Warning:mptt
     ignore::django.utils.deprecation.RemovedInDjango40Warning:actstream
+    ignore::django.utils.deprecation.RemovedInDjango40Warning:knox
     ignore::DeprecationWarning:SimpleITK
     # https://github.com/comic/grand-challenge.org/issues/1110
     ignore::DeprecationWarning:itypes

--- a/app/pytest.ini
+++ b/app/pytest.ini
@@ -19,6 +19,8 @@ filterwarnings =
     ignore::django.utils.deprecation.RemovedInDjango40Warning:rest_framework
     ignore::django.utils.deprecation.RemovedInDjango40Warning:markdownx
     ignore::django.utils.deprecation.RemovedInDjango40Warning:django_summernote
+    ignore::django.utils.deprecation.RemovedInDjango40Warning:mptt
+    ignore::django.utils.deprecation.RemovedInDjango40Warning:actstream
     ignore::DeprecationWarning:SimpleITK
     # https://github.com/comic/grand-challenge.org/issues/1110
     ignore::DeprecationWarning:itypes

--- a/app/tests/cases_tests/test_background_tasks.py
+++ b/app/tests/cases_tests/test_background_tasks.py
@@ -9,6 +9,7 @@ import pytest
 from billiard.exceptions import SoftTimeLimitExceeded
 from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
+from django_capture_on_commit_callbacks import capture_on_commit_callbacks
 from panimg.image_builders.metaio_utils import (
     ADDITIONAL_HEADERS,
     EXPECTED_HEADERS,
@@ -55,7 +56,9 @@ def create_raw_upload_image_session(
         ).delete()
 
     upload_session.save()
-    upload_session.process_images(linked_task=linked_task)
+
+    with capture_on_commit_callbacks(execute=True):
+        upload_session.process_images(linked_task=linked_task)
 
     return upload_session, uploaded_images
 

--- a/app/tests/cases_tests/test_tasks.py
+++ b/app/tests/cases_tests/test_tasks.py
@@ -1,5 +1,6 @@
 import pytest
 from celery import shared_task
+from django_capture_on_commit_callbacks import capture_on_commit_callbacks
 
 from tests.factories import UploadSessionFactory
 
@@ -25,6 +26,7 @@ def test_linked_task_called_with_session_pk(settings):
     session.status = session.REQUEUED
     session.save()
 
-    session.process_images(linked_task=local_linked_task.signature())
+    with capture_on_commit_callbacks(execute=True):
+        session.process_images(linked_task=local_linked_task.signature())
 
     assert called == {"upload_session_pk": session.pk}

--- a/app/tests/evaluation_tests/test_permissions.py
+++ b/app/tests/evaluation_tests/test_permissions.py
@@ -2,6 +2,7 @@ import pytest
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.test import TestCase
+from django_capture_on_commit_callbacks import capture_on_commit_callbacks
 from guardian.shortcuts import get_groups_with_perms, get_users_with_perms
 
 from grandchallenge.evaluation.models import (
@@ -197,8 +198,9 @@ class TestEvaluationPermissions:
         settings.task_eager_propagates = (True,)
         settings.task_always_eager = (True,)
 
-        e.submission.phase.challenge.hidden = True
-        e.submission.phase.challenge.save()
+        with capture_on_commit_callbacks(execute=True):
+            e.submission.phase.challenge.hidden = True
+            e.submission.phase.challenge.save()
 
         assert get_groups_with_set_perms(e) == {
             e.submission.phase.challenge.admins_group: {
@@ -232,8 +234,9 @@ class TestEvaluationPermissions:
         settings.task_eager_propagates = (True,)
         settings.task_always_eager = (True,)
 
-        e.submission.phase.challenge.hidden = False
-        e.submission.phase.challenge.save()
+        with capture_on_commit_callbacks(execute=True):
+            e.submission.phase.challenge.hidden = False
+            e.submission.phase.challenge.save()
 
         assert get_groups_with_set_perms(e) == {
             e.submission.phase.challenge.admins_group: {

--- a/app/tests/reader_studies_tests/test_api.py
+++ b/app/tests/reader_studies_tests/test_api.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+from django_capture_on_commit_callbacks import capture_on_commit_callbacks
 
 from grandchallenge.reader_studies.models import Answer, Question
 from tests.cases_tests.factories import (
@@ -1048,15 +1049,16 @@ def test_assign_answer_image(client, settings, answer_type):
     )
     RawImageFileFactory(upload_session=us, staged_file_id=f.file_id)
 
-    response = get_view_for_user(
-        viewname="api:upload-session-process-images",
-        reverse_kwargs={"pk": us.pk},
-        user=reader,
-        client=client,
-        method=client.patch,
-        data={"answer": str(answer.pk)},
-        content_type="application/json",
-    )
+    with capture_on_commit_callbacks(execute=True):
+        response = get_view_for_user(
+            viewname="api:upload-session-process-images",
+            reverse_kwargs={"pk": us.pk},
+            user=reader,
+            client=client,
+            method=client.patch,
+            data={"answer": str(answer.pk)},
+            content_type="application/json",
+        )
 
     assert response.status_code == 200
 

--- a/app/tests/reader_studies_tests/test_models.py
+++ b/app/tests/reader_studies_tests/test_models.py
@@ -1,5 +1,6 @@
 import pytest
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django_capture_on_commit_callbacks import capture_on_commit_callbacks
 
 from grandchallenge.reader_studies.models import Answer, Question, ReaderStudy
 from tests.factories import ImageFactory, UserFactory
@@ -178,10 +179,11 @@ def test_leaderboard(reader_study_with_gt, settings):  # noqa: C901
     r1, r2 = rs.readers_group.user_set.all()
     e = rs.editors_group.user_set.first()
 
-    for question in rs.questions.all():
-        for im in rs.images.all():
-            ans = AnswerFactory(question=question, creator=r1, answer=True)
-            ans.images.add(im)
+    with capture_on_commit_callbacks(execute=True):
+        for question in rs.questions.all():
+            for im in rs.images.all():
+                ans = AnswerFactory(question=question, creator=r1, answer=True)
+                ans.images.add(im)
 
     leaderboard = rs.leaderboard
     assert Answer.objects.filter(is_ground_truth=False).count() == 6
@@ -193,12 +195,13 @@ def test_leaderboard(reader_study_with_gt, settings):  # noqa: C901
     assert user_score["score__sum"] == 6.0
     assert user_score["score__avg"] == 1.0
 
-    for i, question in enumerate(rs.questions.all()):
-        for j, im in enumerate(rs.images.all()):
-            ans = AnswerFactory(
-                question=question, creator=r2, answer=(i + j) % 2 == 0
-            )
-            ans.images.add(im)
+    with capture_on_commit_callbacks(execute=True):
+        for i, question in enumerate(rs.questions.all()):
+            for j, im in enumerate(rs.images.all()):
+                ans = AnswerFactory(
+                    question=question, creator=r2, answer=(i + j) % 2 == 0
+                )
+                ans.images.add(im)
 
     del rs.scores_by_user
     del rs.leaderboard
@@ -213,10 +216,11 @@ def test_leaderboard(reader_study_with_gt, settings):  # noqa: C901
         assert user_score["score__sum"] == 3.0
         assert user_score["score__avg"] == 0.5
 
-    for question in rs.questions.all():
-        for im in rs.images.all():
-            ans = AnswerFactory(question=question, creator=e, answer=True)
-            ans.images.add(im)
+    with capture_on_commit_callbacks(execute=True):
+        for question in rs.questions.all():
+            for im in rs.images.all():
+                ans = AnswerFactory(question=question, creator=e, answer=True)
+                ans.images.add(im)
 
     del rs.scores_by_user
     del rs.leaderboard
@@ -242,10 +246,11 @@ def test_statistics(reader_study_with_gt, settings):
 
     rs_questions = rs.questions.values_list("question_text", flat=True)
 
-    for question in rs.questions.all():
-        for im in rs.images.all():
-            ans = AnswerFactory(question=question, creator=r1, answer=True)
-            ans.images.add(im)
+    with capture_on_commit_callbacks(execute=True):
+        for question in rs.questions.all():
+            for im in rs.images.all():
+                ans = AnswerFactory(question=question, creator=r1, answer=True)
+                ans.images.add(im)
 
     statistics = rs.statistics
     assert Answer.objects.filter(is_ground_truth=False).count() == 6
@@ -268,11 +273,14 @@ def test_statistics(reader_study_with_gt, settings):
         assert score["score__avg"] == 1.0
     assert images == set()
 
-    for question in rs.questions.all():
-        for im in rs.images.all():
-            answer = question.question_text == "q1" and im.name == "im1"
-            ans = AnswerFactory(question=question, creator=r2, answer=answer)
-            ans.images.add(im)
+    with capture_on_commit_callbacks(execute=True):
+        for question in rs.questions.all():
+            for im in rs.images.all():
+                answer = question.question_text == "q1" and im.name == "im1"
+                ans = AnswerFactory(
+                    question=question, creator=r2, answer=answer
+                )
+                ans.images.add(im)
 
     del rs.statistics
     statistics = rs.statistics
@@ -306,12 +314,13 @@ def test_score_for_user(reader_study_with_gt, settings):
     rs = reader_study_with_gt
     r1 = rs.readers_group.user_set.first()
 
-    for i, question in enumerate(rs.questions.all()):
-        for j, im in enumerate(rs.images.all()):
-            ans = AnswerFactory(
-                question=question, creator=r1, answer=(i + j) % 2 == 0
-            )
-            ans.images.add(im)
+    with capture_on_commit_callbacks(execute=True):
+        for i, question in enumerate(rs.questions.all()):
+            for j, im in enumerate(rs.images.all()):
+                ans = AnswerFactory(
+                    question=question, creator=r1, answer=(i + j) % 2 == 0
+                )
+                ans.images.add(im)
 
     score = rs.score_for_user(r1)
     assert Answer.objects.filter(is_ground_truth=False).count() == 6

--- a/app/tests/reader_studies_tests/test_signals.py
+++ b/app/tests/reader_studies_tests/test_signals.py
@@ -1,4 +1,5 @@
 import pytest
+from django_capture_on_commit_callbacks import capture_on_commit_callbacks
 
 from grandchallenge.reader_studies.models import Question
 from tests.factories import ImageFactory, UserFactory
@@ -95,32 +96,41 @@ def test_assign_score(settings):
     rs.add_reader(r1)
     rs.add_reader(r2)
 
-    a1 = AnswerFactory(question=q1, creator=r1, answer="foo")
+    with capture_on_commit_callbacks(execute=True):
+        a1 = AnswerFactory(question=q1, creator=r1, answer="foo")
     a1.images.add(im)
     assert a1.score is None
 
-    gt = AnswerFactory(
-        question=q1, creator=e, answer="foo", is_ground_truth=True
-    )
-    gt.images.add(im)
+    with capture_on_commit_callbacks(execute=True):
+        gt = AnswerFactory(
+            question=q1, creator=e, answer="foo", is_ground_truth=True
+        )
+        gt.images.add(im)
     a1.refresh_from_db()
     assert a1.score == 1.0
 
-    a2 = AnswerFactory(question=q1, creator=r2, answer="foo")
-    a2.images.add(im)
+    with capture_on_commit_callbacks(execute=True):
+        a2 = AnswerFactory(question=q1, creator=r2, answer="foo")
+        a2.images.add(im)
     a2.refresh_from_db()
     assert a2.score == 1.0
 
-    a1 = AnswerFactory(question=q2, creator=r1, answer=[])
-    a1.images.add(im)
+    with capture_on_commit_callbacks(execute=True):
+        a1 = AnswerFactory(question=q2, creator=r1, answer=[])
+        a1.images.add(im)
+    a1.refresh_from_db()
     assert a1.score is None
 
-    gt = AnswerFactory(question=q2, creator=e, answer=[], is_ground_truth=True)
-    gt.images.add(im)
+    with capture_on_commit_callbacks(execute=True):
+        gt = AnswerFactory(
+            question=q2, creator=e, answer=[], is_ground_truth=True
+        )
+        gt.images.add(im)
     a1.refresh_from_db()
     assert a1.score == 1.0
 
-    a2 = AnswerFactory(question=q2, creator=r2, answer=[])
-    a2.images.add(im)
+    with capture_on_commit_callbacks(execute=True):
+        a2 = AnswerFactory(question=q2, creator=r2, answer=[])
+        a2.images.add(im)
     a2.refresh_from_db()
     assert a2.score == 1.0

--- a/app/tests/workstations_tests/test_models.py
+++ b/app/tests/workstations_tests/test_models.py
@@ -106,8 +106,9 @@ def test_session_start(http_image, docker_client, settings):
         assert len(networks) == 1
         assert settings.WORKSTATIONS_NETWORK_NAME in networks
 
-        s.user_finished = True
-        s.save()
+        with capture_on_commit_callbacks(execute=True):
+            s.user_finished = True
+            s.save()
 
         with pytest.raises(NotFound):
             # noinspection PyStatementEffect
@@ -129,10 +130,11 @@ def test_correct_session_stopped(http_image, docker_client, settings):
     settings.task_always_eager = (True,)
 
     try:
-        s1, s2 = (
-            SessionFactory(workstation_image=wsi),
-            SessionFactory(workstation_image=wsi),
-        )
+        with capture_on_commit_callbacks(execute=True):
+            s1, s2 = (
+                SessionFactory(workstation_image=wsi),
+                SessionFactory(workstation_image=wsi),
+            )
 
         assert s1.service.container
         assert s2.service.container
@@ -140,8 +142,9 @@ def test_correct_session_stopped(http_image, docker_client, settings):
         s2.refresh_from_db()
         auth_token_pk = s2.auth_token.pk
 
-        s2.user_finished = True
-        s2.save()
+        with capture_on_commit_callbacks(execute=True):
+            s2.user_finished = True
+            s2.save()
 
         assert s1.service.container
         with pytest.raises(NotFound):

--- a/poetry.lock
+++ b/poetry.lock
@@ -407,6 +407,17 @@ nested = ["django-nested-admin (>=3.0.21)"]
 tags = ["django-taggit"]
 
 [[package]]
+name = "django-capture-on-commit-callbacks"
+version = "1.4.0"
+description = "Capture and make assertions on transaction.on_commit() callbacks."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+Django = ">=2.2"
+
+[[package]]
 name = "django-celery-beat"
 version = "2.2.0"
 description = "Database-backed Periodic Tasks."
@@ -2114,7 +2125,7 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "494e46c127dfd20deb60a38277ac2f776d0f625bb7a3815c9b489a8f4fab03d8"
+content-hash = "678bcbbd3281e5be7bae6cb14d20d61b6ac92acf2c04a33016b02a2a978fb7de"
 
 [metadata.files]
 alabaster = [
@@ -2354,6 +2365,10 @@ django-appconf = [
 ]
 django-autocomplete-light = [
     {file = "django-autocomplete-light-3.8.1.tar.gz", hash = "sha256:4e84a6d95d272b0d7221614332e2bd54ffff15ec06e78947279398f6507ce225"},
+]
+django-capture-on-commit-callbacks = [
+    {file = "django-capture-on-commit-callbacks-1.4.0.tar.gz", hash = "sha256:03c8213286eafebbcaa306394434e4bb5178953e59f19481006e697daaacdad3"},
+    {file = "django_capture_on_commit_callbacks-1.4.0-py3-none-any.whl", hash = "sha256:4628cc795b6ba0ba970ecf07004cf7b9250136f910eb620f6981bcec73152c0d"},
 ]
 django-celery-beat = [
     {file = "django-celery-beat-2.2.0.tar.gz", hash = "sha256:b8a13afb15e7c53fc04f4f847ac71a6d32088959aba701eb7c4a59f0c28ba543"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,3 +107,4 @@ sphinx-rtd-theme = "*"
 sphinxcontrib-plantuml = "*"
 pytest-randomly = "*"
 sphinxcontrib-django = "*"
+django-capture-on-commit-callbacks = "^1.4.0"  # Backport from Django 3.2, can be removed


### PR DESCRIPTION
Only apply celery tasks on commit, adds `capture_on_commit_callbacks` backport to execute the tasks in tests rather than using transaction test cases. Removes unused return types. See https://adamj.eu/tech/2020/05/20/the-fast-way-to-test-django-transaction-on-commit-callbacks/ and https://adamj.eu/tech/2020/02/03/common-celery-issues-on-django-projects/.