### PR TITLE
Add horizontal navigation bars to challenges

### DIFF
--- a/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
@@ -47,7 +47,7 @@
    title="Result Info">
     <i class="fa fa-file"></i>
     {% for input in object.inputs.all %}
-        {{ input.image.name }}
+        {{ input.image.name|truncatechars:15 }}
     {% endfor %}
     ({{ object.get_status_display }}{% if object.status == object.SUCCESS and object.stderr %}, with warnings{% endif %})
 </a>

--- a/app/grandchallenge/challenges/static/js/challenges/dropdown.js
+++ b/app/grandchallenge/challenges/static/js/challenges/dropdown.js
@@ -1,0 +1,53 @@
+
+function handle_nav_tab_dropdown() {
+    if (window.innerWidth < 992) {
+        // 992 px is the bootstrap breakpoint for lg
+        navs_to_dropdown();
+    } else {
+        navs_to_dropdown(true);
+    }
+}
+
+function navs_to_dropdown(reverse = false) {
+    // Get all elements that need to change class
+    const containers = document.getElementsByClassName("nav-tab-dropdown-container");
+
+    const ulDropdownClasses = ["dropdown-menu", "dropdown-menu-left"];
+    const ulTabClasses = ["nav", "nav-tabs", "border-0"];
+    const itemDropdownClasses = ["dropdown-item", "challengeDropdown"];
+    const itemTabClasses = ["nav-item"];
+
+    // Change the classes
+    for (let container of containers) {
+        let ul  = container.querySelector("ul");
+
+        if (reverse === true) {
+            container.classList.remove("dropdown");
+
+            ul.classList.add(...ulTabClasses);
+            ul.classList.remove(...ulDropdownClasses);
+        }
+        else {
+            container.classList.add("dropdown");
+
+            ul.classList.add(...ulDropdownClasses);
+            ul.classList.remove(...ulTabClasses);
+        }
+
+        let items = container.querySelectorAll("li");
+
+        for (let item of items) {
+            if (reverse === true) {
+                item.classList.add(...itemTabClasses);
+                item.classList.remove(...itemDropdownClasses);
+            } else {
+                item.classList.add(...itemDropdownClasses);
+                item.classList.remove(...itemTabClasses);
+            }
+        }
+    }
+}
+
+window.addEventListener('resize', handle_nav_tab_dropdown);
+
+handle_nav_tab_dropdown();

--- a/app/grandchallenge/challenges/static/js/challenges/dropdown.js
+++ b/app/grandchallenge/challenges/static/js/challenges/dropdown.js
@@ -1,77 +1,77 @@
 
 function handleNavTabDropdown() {
-    if (window.innerWidth < 576) {
-        // 576 px is the bootstrap breakpoint for sm
-        navsToDropdown(false, true);
-    } else if (window.innerWidth < 992) {
-        // 992 px is the bootstrap breakpoint for lg
-        navsToDropdown();
-    } else {
-        navsToDropdown(true);
-    }
+  if (window.innerWidth < 576) {
+    // 576 px is the bootstrap breakpoint for sm
+    navsToDropdown(false, true);
+  } else if (window.innerWidth < 992) {
+    // 992 px is the bootstrap breakpoint for lg
+    navsToDropdown();
+  } else {
+    navsToDropdown(true);
+  }
 }
 
 function navsToDropdown(reverse = false, horizPagePills = false) {
-    // Get all elements that need to change class
-    const containers = document.querySelectorAll('.nav-tab-dropdown-container,.nav-pill-dropdown-container');
-    const pageContainers = document.getElementsByClassName("nav-pill-pages-container");
+  // Get all elements that need to change class
+  const containers = document.querySelectorAll('.nav-tab-dropdown-container,.nav-pill-dropdown-container');
+  const pageContainers = document.getElementsByClassName("nav-pill-pages-container");
 
-    const ulDropdownClasses = ["dropdown-menu", "dropdown-menu-left"];
-    const ulTabClasses = ["nav", "nav-tabs", "border-0"];
-    const itemDropdownClasses = ["dropdown-item", "challengeDropdown"];
-    const itemTabPillClasses = ["nav-item"];
-    const ulPillClasses = ["nav", "nav-pills", "col-12", "mb-3"];
-    const ulHorizPagePillClasses = ["d-flex", "align-items-stretch", "mb-3"];
-    const ulVertPagePillClasses = ["flex-column"];
+  const ulDropdownClasses = ["dropdown-menu", "dropdown-menu-left"];
+  const ulTabClasses = ["nav", "nav-tabs", "border-0"];
+  const itemDropdownClasses = ["dropdown-item", "challengeDropdown"];
+  const itemTabPillClasses = ["nav-item"];
+  const ulPillClasses = ["nav", "nav-pills", "col-12", "mb-3"];
+  const ulHorizPagePillClasses = ["d-flex", "align-items-stretch", "mb-3"];
+  const ulVertPagePillClasses = ["flex-column"];
 
-    for (const pageContainer of pageContainers) {
-        const ulPages  = pageContainer.querySelector("ul");
+  for (const pageContainer of pageContainers) {
+    const ulPages  = pageContainer.querySelector("ul");
 
-        if (horizPagePills === true) {
-            ulPages.classList.remove(...ulVertPagePillClasses);
-            ulPages.classList.add(...ulHorizPagePillClasses);
-        } else {
-            ulPages.classList.add(...ulVertPagePillClasses);
-            ulPages.classList.remove(...ulHorizPagePillClasses);
-        }
+    if (horizPagePills === true) {
+      ulPages.classList.remove(...ulVertPagePillClasses);
+      ulPages.classList.add(...ulHorizPagePillClasses);
+    } else {
+      ulPages.classList.add(...ulVertPagePillClasses);
+      ulPages.classList.remove(...ulHorizPagePillClasses);
+    }
+  }
+
+  // Change the classes
+  for (const container of containers) {
+    const ul  = container.querySelector("ul");
+
+    if (reverse === true) {
+      container.classList.remove("dropdown");
+      ul.classList.remove(...ulDropdownClasses);
+
+      if (container.classList.contains("nav-tab-dropdown-container")) {
+        ul.classList.add(...ulTabClasses);
+      } else if (container.classList.contains("nav-pill-dropdown-container")) {
+        ul.classList.add(...ulPillClasses);
+      }
+    } else {
+      container.classList.add("dropdown");
+      ul.classList.add(...ulDropdownClasses);
+
+      if (container.classList.contains("nav-tab-dropdown-container")) {
+        ul.classList.remove(...ulTabClasses);
+      } else if (container.classList.contains("nav-pill-dropdown-container")) {
+        ul.classList.remove(...ulPillClasses);
+      }
     }
 
-    // Change the classes
-    for (const container of containers) {
-        const ul  = container.querySelector("ul");
+    const items = container.querySelectorAll("li");
 
-        if (reverse === true) {
-            container.classList.remove("dropdown");
-            ul.classList.remove(...ulDropdownClasses);
-
-            if (container.classList.contains("nav-tab-dropdown-container")) {
-                ul.classList.add(...ulTabClasses);
-            } else if (container.classList.contains("nav-pill-dropdown-container")) {
-                ul.classList.add(...ulPillClasses);
-            }
-        } else {
-            container.classList.add("dropdown");
-            ul.classList.add(...ulDropdownClasses);
-
-            if (container.classList.contains("nav-tab-dropdown-container")) {
-                ul.classList.remove(...ulTabClasses);
-            } else if (container.classList.contains("nav-pill-dropdown-container")) {
-                ul.classList.remove(...ulPillClasses);
-            }
-        }
-
-        const items = container.querySelectorAll("li");
-
-        for (const item of items) {
-            if (reverse === true) {
-                item.classList.add(...itemTabPillClasses);
-                item.classList.remove(...itemDropdownClasses);
-            } else {
-                item.classList.add(...itemDropdownClasses);
-                item.classList.remove(...itemTabPillClasses);
-            }
-        }
+    for (const item of items) {
+      if (reverse === true) {
+        item.classList.add(...itemTabPillClasses);
+        item.classList.remove(...itemDropdownClasses);
+      } else {
+        item.classList.add(...itemDropdownClasses);
+        item.classList.remove(...itemTabPillClasses);
+      }
     }
+  }
 }
 
 window.addEventListener('resize', handleNavTabDropdown);

--- a/app/grandchallenge/challenges/static/js/challenges/dropdown.js
+++ b/app/grandchallenge/challenges/static/js/challenges/dropdown.js
@@ -1,21 +1,40 @@
 
 function handle_nav_tab_dropdown() {
-    if (window.innerWidth < 992) {
+    if (window.innerWidth < 576) {
+        // 576 px is the bootstrap breakpoint for sm
+        navs_to_dropdown(false, true);
+    } else if (window.innerWidth < 992) {
         // 992 px is the bootstrap breakpoint for lg
         navs_to_dropdown();
     } else {
         navs_to_dropdown(true);
-    }
+        }
 }
 
-function navs_to_dropdown(reverse = false) {
+function navs_to_dropdown(reverse = false, horiz_page_pills = false) {
     // Get all elements that need to change class
-    const containers = document.getElementsByClassName("nav-tab-dropdown-container");
+    const containers = document.querySelectorAll('.nav-tab-dropdown-container,.nav-pill-dropdown-container');
+    const page_containers = document.getElementsByClassName("nav-pill-pages-container");
 
     const ulDropdownClasses = ["dropdown-menu", "dropdown-menu-left"];
     const ulTabClasses = ["nav", "nav-tabs", "border-0"];
     const itemDropdownClasses = ["dropdown-item", "challengeDropdown"];
-    const itemTabClasses = ["nav-item"];
+    const itemTabPillClasses = ["nav-item"];
+    const ulPillClasses = ["nav", "nav-pills", "col-12", "mb-3"];
+    const ulHorizPagePillClasses = ["d-flex", "align-items-stretch", "mb-3"];
+    const ulVertPagePillClasses = ["flex-column"];
+
+    for (let page_container of page_containers) {
+        let ul_pages  = page_container.querySelector("ul");
+
+        if (horiz_page_pills === true) {
+            ul_pages.classList.remove(...ulVertPagePillClasses);
+            ul_pages.classList.add(...ulHorizPagePillClasses);
+        } else {
+            ul_pages.classList.add(...ulVertPagePillClasses);
+            ul_pages.classList.remove(...ulHorizPagePillClasses);
+        }
+    }
 
     // Change the classes
     for (let container of containers) {
@@ -23,29 +42,38 @@ function navs_to_dropdown(reverse = false) {
 
         if (reverse === true) {
             container.classList.remove("dropdown");
-
-            ul.classList.add(...ulTabClasses);
             ul.classList.remove(...ulDropdownClasses);
+
+            if (container.classList.contains("nav-tab-dropdown-container")) {
+                ul.classList.add(...ulTabClasses);
+            } else if (container.classList.contains("nav-pill-dropdown-container")) {
+                ul.classList.add(...ulPillClasses);
+            }
         }
         else {
             container.classList.add("dropdown");
-
             ul.classList.add(...ulDropdownClasses);
-            ul.classList.remove(...ulTabClasses);
+
+            if (container.classList.contains("nav-tab-dropdown-container")) {
+                ul.classList.remove(...ulTabClasses);
+            } else if (container.classList.contains("nav-pill-dropdown-container")) {
+                ul.classList.remove(...ulPillClasses);
+            }
         }
 
         let items = container.querySelectorAll("li");
 
         for (let item of items) {
             if (reverse === true) {
-                item.classList.add(...itemTabClasses);
+                item.classList.add(...itemTabPillClasses);
                 item.classList.remove(...itemDropdownClasses);
             } else {
                 item.classList.add(...itemDropdownClasses);
-                item.classList.remove(...itemTabClasses);
+                item.classList.remove(...itemTabPillClasses);
             }
         }
     }
+
 }
 
 window.addEventListener('resize', handle_nav_tab_dropdown);

--- a/app/grandchallenge/challenges/static/js/challenges/dropdown.js
+++ b/app/grandchallenge/challenges/static/js/challenges/dropdown.js
@@ -1,20 +1,20 @@
 
-function handle_nav_tab_dropdown() {
+function handleNavTabDropdown() {
     if (window.innerWidth < 576) {
         // 576 px is the bootstrap breakpoint for sm
-        navs_to_dropdown(false, true);
+        navsToDropdown(false, true);
     } else if (window.innerWidth < 992) {
         // 992 px is the bootstrap breakpoint for lg
-        navs_to_dropdown();
+        navsToDropdown();
     } else {
-        navs_to_dropdown(true);
-        }
+        navsToDropdown(true);
+    }
 }
 
-function navs_to_dropdown(reverse = false, horiz_page_pills = false) {
+function navsToDropdown(reverse = false, horizPagePills = false) {
     // Get all elements that need to change class
     const containers = document.querySelectorAll('.nav-tab-dropdown-container,.nav-pill-dropdown-container');
-    const page_containers = document.getElementsByClassName("nav-pill-pages-container");
+    const pageContainers = document.getElementsByClassName("nav-pill-pages-container");
 
     const ulDropdownClasses = ["dropdown-menu", "dropdown-menu-left"];
     const ulTabClasses = ["nav", "nav-tabs", "border-0"];
@@ -24,21 +24,21 @@ function navs_to_dropdown(reverse = false, horiz_page_pills = false) {
     const ulHorizPagePillClasses = ["d-flex", "align-items-stretch", "mb-3"];
     const ulVertPagePillClasses = ["flex-column"];
 
-    for (let page_container of page_containers) {
-        let ul_pages  = page_container.querySelector("ul");
+    for (const pageContainer of pageContainers) {
+        const ulPages  = pageContainer.querySelector("ul");
 
-        if (horiz_page_pills === true) {
-            ul_pages.classList.remove(...ulVertPagePillClasses);
-            ul_pages.classList.add(...ulHorizPagePillClasses);
+        if (horizPagePills === true) {
+            ulPages.classList.remove(...ulVertPagePillClasses);
+            ulPages.classList.add(...ulHorizPagePillClasses);
         } else {
-            ul_pages.classList.add(...ulVertPagePillClasses);
-            ul_pages.classList.remove(...ulHorizPagePillClasses);
+            ulPages.classList.add(...ulVertPagePillClasses);
+            ulPages.classList.remove(...ulHorizPagePillClasses);
         }
     }
 
     // Change the classes
-    for (let container of containers) {
-        let ul  = container.querySelector("ul");
+    for (const container of containers) {
+        const ul  = container.querySelector("ul");
 
         if (reverse === true) {
             container.classList.remove("dropdown");
@@ -49,8 +49,7 @@ function navs_to_dropdown(reverse = false, horiz_page_pills = false) {
             } else if (container.classList.contains("nav-pill-dropdown-container")) {
                 ul.classList.add(...ulPillClasses);
             }
-        }
-        else {
+        } else {
             container.classList.add("dropdown");
             ul.classList.add(...ulDropdownClasses);
 
@@ -61,9 +60,9 @@ function navs_to_dropdown(reverse = false, horiz_page_pills = false) {
             }
         }
 
-        let items = container.querySelectorAll("li");
+        const items = container.querySelectorAll("li");
 
-        for (let item of items) {
+        for (const item of items) {
             if (reverse === true) {
                 item.classList.add(...itemTabPillClasses);
                 item.classList.remove(...itemDropdownClasses);
@@ -73,9 +72,8 @@ function navs_to_dropdown(reverse = false, horiz_page_pills = false) {
             }
         }
     }
-
 }
 
-window.addEventListener('resize', handle_nav_tab_dropdown);
+window.addEventListener('resize', handleNavTabDropdown);
 
-handle_nav_tab_dropdown();
+handleNavTabDropdown();

--- a/app/grandchallenge/core/context_processors.py
+++ b/app/grandchallenge/core/context_processors.py
@@ -5,6 +5,7 @@ from guardian.shortcuts import get_perms
 from guardian.utils import get_anonymous_user
 
 from grandchallenge.blogs.models import Post
+from grandchallenge.participants.models import RegistrationRequest
 from grandchallenge.policies.models import Policy
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,9 @@ def challenge(request):
         "challenge_perms": get_perms(user, challenge),
         "user_is_participant": challenge.is_participant(user),
         "pages": challenge.page_set.all(),
+        "pending_requests": challenge.registrationrequest_set.filter(
+            status=RegistrationRequest.PENDING
+        ),
     }
 
 

--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -114,3 +114,44 @@ ul.socialaccount_providers {
 ul.socialaccount_providers > li {
     min-width: 300px;
 }
+
+.nav-pills > li > .nav-link {
+    color: #000;
+}
+.nav-pills > li > .nav-link:hover {
+    border-radius: 25px;
+    color: #000;
+    background-color: #f0f0f0;
+}
+.nav-pills > li > .nav-link.active {
+    border-radius: 25px;
+}
+
+.nav-tabs > .nav-item > .nav-link {
+    color: #000;
+}
+.nav-tabs > .nav-item > .nav-link:hover {
+    border: inherit;
+    border-bottom: 4px solid #f0f0f0;
+}
+.nav-tabs > .nav-item > .nav-link.active {
+    border: inherit;
+    font-weight: bold;
+    border-bottom: 4px solid #2c3e50;
+}
+
+.challengeDropdown > .nav-link {
+    color: #000;
+}
+.challengeDropdown:hover {
+    background-color: #f0f0f0;
+}
+
+.phaseButton {
+    border-radius: 20px;
+    color: #000;
+    padding-top: 3px;
+    padding-bottom: 3px;
+}
+.phaseButton:focus, .phaseButton:hover {
+    box-shadow:none !important;}

--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -129,6 +129,10 @@ ul.socialaccount_providers > li {
 
 .nav-tabs > .nav-item > .nav-link {
     color: #000;
+    border-top: 0px transparent;
+    border-right: 0px transparent;
+    border-left: 0px transparent;
+    border-bottom: 4px transparent;
 }
 .nav-tabs > .nav-item > .nav-link:hover {
     border: inherit;

--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -129,24 +129,31 @@ ul.socialaccount_providers > li {
 
 .nav-tabs > .nav-item > .nav-link {
     color: #000;
-    border-top: 0px transparent;
-    border-right: 0px transparent;
-    border-left: 0px transparent;
+    border-top: 0 transparent;
+    border-right: 0 transparent;
+    border-left: 0 transparent;
     border-bottom: 4px transparent;
 }
+
 .nav-tabs > .nav-item > .nav-link:hover {
     border: inherit;
     border-bottom: 4px solid #f0f0f0;
 }
+
 .nav-tabs > .nav-item > .nav-link.active {
     border: inherit;
     font-weight: bold;
     border-bottom: 4px solid #2c3e50;
 }
 
+.challengeDropdown {
+    padding: 0;
+}
+
 .challengeDropdown > .nav-link {
     color: #000;
 }
+
 .challengeDropdown:hover {
     background-color: #f0f0f0;
 }
@@ -157,5 +164,7 @@ ul.socialaccount_providers > li {
     padding-top: 3px;
     padding-bottom: 3px;
 }
+
 .phaseButton:focus, .phaseButton:hover {
-    box-shadow:none !important;}
+    box-shadow:none !important;
+}

--- a/app/grandchallenge/core/templates/base.html
+++ b/app/grandchallenge/core/templates/base.html
@@ -71,6 +71,7 @@
 
             {% block outer_content %}
                 {% block topbar %}{% endblock %}
+                {% block topbar2 %}{% endblock %}
                 <div class="row">
                     {% block sidebar %}{% endblock %}
                     <div class="col overflow-auto">

--- a/app/grandchallenge/core/templates/base.html
+++ b/app/grandchallenge/core/templates/base.html
@@ -70,6 +70,7 @@
             {% endblock %}
 
             {% block outer_content %}
+                {% block topbar %}{% endblock %}
                 <div class="row">
                     {% block sidebar %}{% endblock %}
                     <div class="col overflow-auto">

--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -35,11 +35,11 @@
 
 {% block topbar %}
     {% if challenge %}
-        <div class="row mb-3">
-            <div class="col-md-10 col-sm-8 col-6">
-                <div class="nav nav-tabs" role="tablist">
+        <div class="row mb-3 mx-0 border-bottom">
+            <div class="d-none d-lg-block col-md-10 col-sm-8 col-6 px-0">
+                <div class="nav nav-tabs border-0" role="tablist">
                     <li class="nav-item">
-                    <! -- Todo: Adjust the view_name before merging with master (include the page_title slug)-->
+                        <! -- Todo: Adjust the view_name before merging with master (include the page_title slug)-->
                         <a class="nav-link {% if request.resolver_match.view_name == 'pages:home' or request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"
                            href="{% url 'pages:home' challenge_short_name=challenge.short_name %}">
                             Info
@@ -87,10 +87,66 @@
                 </div>
             </div>
 
-            <div class="col-md-2 col-sm-4 col-6 d-flex justify-content-end">
+            <div class="d-block d-lg-none col-md-10 col-sm-8 col-6 px-0 pb-1">
+                <div class="dropdown">
+                    <a class="btn btn-outline-dark"
+                           data-toggle="dropdown"
+                           href="#"
+                           role="button"
+                           aria-expanded="false"><i class="fas fa-bars"></i></a>
+                    <ul class="dropdown-menu dropdown-menu-left" role="menu">
+                        <li class="dropdown-item px-0 py-0 challengeDropdown">
+                            <a class="nav-link"
+                               href="{% url 'pages:home' challenge_short_name=challenge.short_name %}">
+                                Info
+                            </a>
+                        </li>
+
+                        {% if challenge.display_forum_link %}
+                            <li class="dropdown-item px-0 py-0 challengeDropdown">
+                                <a class="nav-link"
+                                   href="{% url 'forum:forum' slug=challenge.forum.slug pk=challenge.forum.pk %}">
+                                    Forum
+                                </a>
+                            </li>
+                        {% endif %}
+
+                        {% if challenge.use_evaluation %}
+                            {% if challenge.use_teams %}
+                                {% if "change_challenge" in challenge_perms or user_is_participant %}
+                                    <li class="dropdown-item px-0 py-0 challengeDropdown">
+                                        <a class="nav-link"
+                                           href="{% url 'teams:list' challenge_short_name=challenge.short_name %}">Teams</a>
+                                    </li>
+                                {% endif %}
+                            {% endif %}
+
+                            {% if "change_challenge" in challenge_perms or user_is_participant %}
+                                <li class="dropdown-item px-0 py-0 challengeDropdown">
+                                    <a class="nav-link"
+                                       href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
+                                        Submit</a>
+                                </li>
+                                <li class="dropdown-item px-0 py-0 challengeDropdown">
+                                    <a class="nav-link"
+                                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
+                                        Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
+                                </li>
+                            {% elif not challenge.hidden %}
+                                <li class="dropdown-item px-0 py-0 challengeDropdown">
+                                    <a class="nav-link"
+                                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
+                                        Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
+                                </li>
+                            {% endif %}
+                        {% endif %}
+                    </ul>
+                </div>
+            </div>
+            <div class="col-md-2 col-sm-4 col-6 py-0 px-0 d-flex justify-content-end">
                 {% if challenge.use_registration_page %}
                     <div>
-                        <a class="btn btn-primary"
+                        <a class="btn btn-success"
                            href="{% url 'participants:registration-create' challenge_short_name=challenge.short_name %}"
                            role="button">
                             Join
@@ -100,7 +156,7 @@
 
                 {% if "change_challenge" in challenge_perms %}
                     <div class="dropdown px-1">
-                        <a class="btn btn-primary dropdown-toggle"
+                        <a class="btn btn-dark dropdown-toggle"
                            data-toggle="dropdown"
                            href="#"
                            role="button"

--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -67,7 +67,7 @@
 
                         {% if "change_challenge" in challenge_perms or user_is_participant %}
                             <li class="nav-item">
-                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' %}active{% endif %}"
+                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' or request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
                                    href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
                                     Submit</a>
                             </li>

--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -2,6 +2,7 @@
 {% load url %}
 {% load guardian_tags %}
 {% load admin_urls %}
+{% load static %}
 
 {% block title %} {% firstof challenge.title challenge.short_name %} - {{ block.super }} {% endblock %}
 
@@ -36,74 +37,24 @@
 {% block topbar %}
     {% if challenge %}
         <div class="row mb-3 mx-0 border-bottom">
-            <div class="d-none d-lg-block col-md-10 col-sm-8 col-6 px-0">
-                <div class="nav nav-tabs border-0" role="tablist">
-                    <li class="nav-item">
-                        <! -- Todo: Adjust the view_name before merging with master (include the page_title slug)-->
-                        <a class="nav-link {% if request.resolver_match.view_name == 'pages:home' or request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"
-                           href="{% url 'pages:home' challenge_short_name=challenge.short_name %}">
-                            Info
-                        </a>
-                    </li>
-
-                    {% if challenge.display_forum_link %}
+            <div class="col-md-10 col-sm-8 col-6 px-0">
+                <div class="nav-tab-dropdown-container">
+                    <a class="d-lg-none btn btn-outline-dark mb-1"
+                       data-toggle="dropdown"
+                       href="#"
+                       role="button"
+                       aria-expanded="false"><i class="fas fa-bars"></i></a>
+                    <ul class="nav nav-tabs border-0">
                         <li class="nav-item">
-                            <a class="nav-link"
-                               href="{% url 'forum:forum' slug=challenge.forum.slug pk=challenge.forum.pk %}">
-                                Forum
-                            </a>
-                        </li>
-                    {% endif %}
-
-                    {% if challenge.use_evaluation %}
-                        {% if challenge.use_teams %}
-                            {% if "change_challenge" in challenge_perms or user_is_participant %}
-                                <li class="nav-item">
-                                    <a class="nav-link {% if request.resolver_match.view_name == 'teams:list' %}active{% endif %}"
-                                       href="{% url 'teams:list' challenge_short_name=challenge.short_name %}">Teams</a>
-                                </li>
-                            {% endif %}
-                        {% endif %}
-
-                        {% if "change_challenge" in challenge_perms or user_is_participant %}
-                            <li class="nav-item">
-                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' or request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
-                                   href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
-                                    Submit</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' %}active{% endif %}"
-                                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
-                                    Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
-                            </li>
-                        {% elif not challenge.hidden %}
-                            <li class="nav-item">
-                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' %}active{% endif %}"
-                                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
-                                    Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
-                            </li>
-                        {% endif %}
-                    {% endif %}
-                </div>
-            </div>
-
-            <div class="d-block d-lg-none col-md-10 col-sm-8 col-6 px-0 pb-1">
-                <div class="dropdown">
-                    <a class="btn btn-outline-dark"
-                           data-toggle="dropdown"
-                           href="#"
-                           role="button"
-                           aria-expanded="false"><i class="fas fa-bars"></i></a>
-                    <ul class="dropdown-menu dropdown-menu-left" role="menu">
-                        <li class="dropdown-item px-0 py-0 challengeDropdown">
-                            <a class="nav-link"
+                            <! -- Todo: Adjust the view_name before merging with master (include the page_title slug)-->
+                            <a class="nav-link {% if request.resolver_match.view_name == 'pages:home' or request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"
                                href="{% url 'pages:home' challenge_short_name=challenge.short_name %}">
                                 Info
                             </a>
                         </li>
 
                         {% if challenge.display_forum_link %}
-                            <li class="dropdown-item px-0 py-0 challengeDropdown">
+                            <li class="nav-item">
                                 <a class="nav-link"
                                    href="{% url 'forum:forum' slug=challenge.forum.slug pk=challenge.forum.pk %}">
                                     Forum
@@ -114,27 +65,27 @@
                         {% if challenge.use_evaluation %}
                             {% if challenge.use_teams %}
                                 {% if "change_challenge" in challenge_perms or user_is_participant %}
-                                    <li class="dropdown-item px-0 py-0 challengeDropdown">
-                                        <a class="nav-link"
+                                    <li class="nav-item">
+                                        <a class="nav-link {% if request.resolver_match.view_name == 'teams:list' %}active{% endif %}"
                                            href="{% url 'teams:list' challenge_short_name=challenge.short_name %}">Teams</a>
                                     </li>
                                 {% endif %}
                             {% endif %}
 
                             {% if "change_challenge" in challenge_perms or user_is_participant %}
-                                <li class="dropdown-item px-0 py-0 challengeDropdown">
-                                    <a class="nav-link"
+                                <li class="nav-item">
+                                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' or request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
                                        href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
                                         Submit</a>
                                 </li>
-                                <li class="dropdown-item px-0 py-0 challengeDropdown">
-                                    <a class="nav-link"
+                                <li class="nav-item">
+                                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' %}active{% endif %}"
                                        href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
                                         Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
                                 </li>
                             {% elif not challenge.hidden %}
-                                <li class="dropdown-item px-0 py-0 challengeDropdown">
-                                    <a class="nav-link"
+                                <li class="nav-item">
+                                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' %}active{% endif %}"
                                        href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
                                         Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
                                 </li>
@@ -143,6 +94,7 @@
                     </ul>
                 </div>
             </div>
+
             <div class="col-md-2 col-sm-4 col-6 py-0 px-0 d-flex justify-content-end">
                 {% if challenge.use_registration_page %}
                     <div>
@@ -173,14 +125,20 @@
                             <h6 class="dropdown-header">Users</h6>
                             <a class="dropdown-item"
                                href="{% url 'admins:list' challenge_short_name=challenge.short_name %}">
-                                <i class="fas fa-user fa-fw"></i>&nbsp;Admins <span class="badge badge-pill badge-secondary align-middle">{{ challenge.get_admins.count }}</span> </a>
+                                <i class="fas fa-user fa-fw"></i>&nbsp;Admins <span
+                                    class="badge badge-pill badge-secondary align-middle">{{ challenge.get_admins.count }}</span>
+                            </a>
                             <a class="dropdown-item"
                                href="{% url 'participants:list' challenge_short_name=challenge.short_name %}">
-                                <i class="fas fa-users fa-fw"></i>&nbsp;Participants <span class="badge badge-pill badge-secondary align-middle">{{ challenge.get_participants.count }}</span></a>
+                                <i class="fas fa-users fa-fw"></i>&nbsp;Participants <span
+                                    class="badge badge-pill badge-secondary align-middle">{{ challenge.get_participants.count }}</span></a>
                             <a class="dropdown-item"
                                href="{% url 'participants:registration-list' challenge_short_name=challenge.short_name %}">
-                                <i class="fas fa-question fa-fw"></i>&nbsp;Participation Requests {% if challenge.require_participant_review %} {% with num_requests=pending_requests.count %} <span
-                                    class="badge badge-pill badge-secondary align-middle">{{ num_requests }}</span>{% endwith %}{% endif %}</a>
+                                <i class="fas fa-question fa-fw"></i>&nbsp;Participation Requests
+                                {% if challenge.require_participant_review %}
+                                    {% with num_requests=pending_requests.count %} <span
+                                            class="badge badge-pill badge-secondary align-middle">{{ num_requests }}</span>
+                                    {% endwith %}{% endif %}</a>
                             <hr>
                             <h6 class="dropdown-header">Phases</h6>
                             {% if challenge.use_evaluation %}
@@ -214,4 +172,9 @@
             </div>
         </div>
     {% endif %}
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    <script src="{% static 'js/challenges/dropdown.js' %}" type="module"></script>
 {% endblock %}

--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -46,7 +46,6 @@
                        aria-expanded="false"><i class="fas fa-bars"></i></a>
                     <ul class="nav nav-tabs border-0">
                         <li class="nav-item">
-                            <! -- Todo: Adjust the view_name before merging with master (include the page_title slug)-->
                             <a class="nav-link {% if request.resolver_match.view_name == 'pages:home' or request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"
                                href="{% url 'pages:home' challenge_short_name=challenge.short_name %}">
                                 Info

--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -33,83 +33,83 @@
     {{ block.super }}
 {% endblock %}
 
-{% block sidebar %}
+{% block topbar %}
     {% if challenge %}
-        <div class="col-12 col-md-3 col-lg-2 mb-3">
-            <ul class="nav nav-pills flex-column">
-                {% for page in pages %}
-                    {% if not page.hidden %}
+        <div class="row mb-3">
+            <div class="col-md-10 col-sm-8 col-6">
+                <div class="nav nav-tabs" role="tablist">
+                    <li class="nav-item">
+                    <! -- Todo: Adjust the view_name before merging with master (include the page_title slug)-->
+                        <a class="nav-link {% if request.resolver_match.view_name == 'pages:home' or request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"
+                           href="{% url 'pages:home' challenge_short_name=challenge.short_name %}">
+                            Info
+                        </a>
+                    </li>
+
+                    {% if challenge.display_forum_link %}
                         <li class="nav-item">
-                            <a class="nav-link {% if page == currentpage %}active{% endif %}"
-                               href="{{ page.get_absolute_url }}">
-                                {% filter title %}
-                                    {% firstof page.display_title page.title %}
-                                {% endfilter %}
+                            <a class="nav-link"
+                               href="{% url 'forum:forum' slug=challenge.forum.slug pk=challenge.forum.pk %}">
+                                Forum
                             </a>
                         </li>
                     {% endif %}
-                {% endfor %}
 
-                {% if challenge.display_forum_link %}
-                    <li class="nav-item">
-                        <a class="nav-link"
-                           href="{% url 'forum:forum' slug=challenge.forum.slug pk=challenge.forum.pk %}">
-                            Forum
-                        </a>
-                    </li>
-                {% endif %}
-
-                {% if challenge.use_registration_page %}
-                    <li class="nav-item">
-                        <a class="nav-link {% if request.resolver_match.view_name == 'participants:registration-create' %}active{% endif %}"
-                           href="{% url 'participants:registration-create' challenge_short_name=challenge.short_name %}">
-                            Join
-                        </a>
-                    </li>
-                {% endif %}
-
-                {% if challenge.use_evaluation %}
-                    {% if challenge.use_teams %}
-                        {% if "change_challenge" in challenge_perms or user_is_participant %}
-                            <li class="nav-item">
-                                <a class="nav-link {% if request.resolver_match.view_name == 'teams:list' %}active{% endif %}"
-                                   href="{% url 'teams:list' challenge_short_name=challenge.short_name %}">Teams</a>
-                            </li>
+                    {% if challenge.use_evaluation %}
+                        {% if challenge.use_teams %}
+                            {% if "change_challenge" in challenge_perms or user_is_participant %}
+                                <li class="nav-item">
+                                    <a class="nav-link {% if request.resolver_match.view_name == 'teams:list' %}active{% endif %}"
+                                       href="{% url 'teams:list' challenge_short_name=challenge.short_name %}">Teams</a>
+                                </li>
+                            {% endif %}
                         {% endif %}
-                    {% endif %}
-                    {% for phase in challenge.phase_set.all %}
+
                         {% if "change_challenge" in challenge_perms or user_is_participant %}
                             <li class="nav-item">
-                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
-                                   href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">Create {{ phase.title }}
-                                    Submission</a>
+                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' %}active{% endif %}"
+                                   href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
+                                    Submit</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
-                                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}
-                                    Leaderboard</a>
+                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' %}active{% endif %}"
+                                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
+                                    Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
                             </li>
                         {% elif not challenge.hidden %}
                             <li class="nav-item">
-                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
-                                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}
-                                    Leaderboard</a>
+                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' %}active{% endif %}"
+                                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
+                                    Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
                             </li>
                         {% endif %}
-                    {% endfor %}
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="col-md-2 col-sm-4 col-6 d-flex justify-content-end">
+                {% if challenge.use_registration_page %}
+                    <div>
+                        <a class="btn btn-primary"
+                           href="{% url 'participants:registration-create' challenge_short_name=challenge.short_name %}"
+                           role="button">
+                            Join
+                        </a>
+                    </div>
                 {% endif %}
 
                 {% if "change_challenge" in challenge_perms %}
-                    <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" data-toggle="dropdown"
+                    <div class="dropdown px-1">
+                        <a class="btn btn-primary dropdown-toggle"
+                           data-toggle="dropdown"
                            href="#"
-                           role="button" aria-haspopup="true"
+                           role="button"
                            aria-expanded="false">Admin</a>
-                        <div class="dropdown-menu">
+                        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="admin">
                             <h6 class="dropdown-header">{% firstof challenge.title challenge.short_name %}</h6>
                             <a class="dropdown-item"
                                href="{% url 'update' challenge_short_name=challenge.short_name %}">
-                                <i class="fas fa-cog fa-fw"></i> Settings</a>
+                                <i class="fas fa-cog fa-fw"></i> General Settings</a>
                             <a class="dropdown-item"
                                href="{% url 'pages:list' challenge_short_name=challenge.short_name %}">
                                 <i class="far fa-file fa-fw"></i> Pages</a>
@@ -117,27 +117,28 @@
                             <h6 class="dropdown-header">Users</h6>
                             <a class="dropdown-item"
                                href="{% url 'admins:list' challenge_short_name=challenge.short_name %}">
-                                <i class="fas fa-user fa-fw"></i>&nbsp;Admins</a>
+                                <i class="fas fa-user fa-fw"></i>&nbsp;Admins <span class="badge badge-pill badge-secondary align-middle">{{ challenge.get_admins.count }}</span> </a>
                             <a class="dropdown-item"
                                href="{% url 'participants:list' challenge_short_name=challenge.short_name %}">
-                                <i class="fas fa-users fa-fw"></i>&nbsp;Participants</a>
+                                <i class="fas fa-users fa-fw"></i>&nbsp;Participants <span class="badge badge-pill badge-secondary align-middle">{{ challenge.get_participants.count }}</span></a>
                             <a class="dropdown-item"
                                href="{% url 'participants:registration-list' challenge_short_name=challenge.short_name %}">
-                                <i class="fas fa-question fa-fw"></i>&nbsp;Participation Requests</a>
+                                <i class="fas fa-question fa-fw"></i>&nbsp;Participation Requests {% if challenge.require_participant_review %} {% with num_requests=pending_requests.count %} <span
+                                    class="badge badge-pill badge-secondary align-middle">{{ num_requests }}</span>{% endwith %}{% endif %}</a>
+                            <hr>
+                            <h6 class="dropdown-header">Phases</h6>
                             {% if challenge.use_evaluation %}
                                 {% for phase in challenge.phase_set.all %}
-                                    <hr>
-                                    <h6 class="dropdown-header">{{ phase.title }} Evaluation</h6>
                                     <a class="dropdown-item"
                                        href="{% url 'evaluation:phase-update' challenge_short_name=challenge.short_name slug=phase.slug %}">
-                                        <i class="fas fa-cog fa-fw"></i> Settings
+                                        <i class="fas fa-cog fa-fw"></i> {{ phase.title }} Evaluation Settings
                                     </a>
                                 {% endfor %}
-                                <hr>
                                 <a class="dropdown-item"
                                    href="{% url 'evaluation:phase-create' challenge_short_name=challenge.short_name %}">
                                     <i class="fas fa-plus fa-fw"></i>&nbsp;Add a new Phase
                                 </a>
+                                <hr>
                                 <a class="dropdown-item"
                                    href="{% url 'evaluation:method-list' challenge_short_name=challenge.short_name %}">
                                     Methods
@@ -151,10 +152,10 @@
                                     Evaluations
                                 </a>
                             {% endif %}
-                        </div>
-                    </li>
+                        </ul>
+                    </div>
                 {% endif %}
-            </ul>
+            </div>
         </div>
     {% endif %}
 {% endblock %}

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
@@ -13,6 +13,17 @@
     </ol>
 {% endblock %}
 
+{% block sidebar %}
+    <div class="nav nav-pills col-12 pl-3 mb-3">
+        {% for phase in challenge.phase_set.all %}
+            <li class="nav-item">
+                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+            </li>
+        {% endfor %}
+    </div>
+{% endblock %}
+
 {% block content %}
     <h2>{{ phase.title }} Leaderboard {{ request.GET.date }}</h2>
 

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
@@ -14,13 +14,32 @@
 {% endblock %}
 
 {% block sidebar %}
-    <div class="nav nav-pills col-12 pl-3 mb-3">
+    <div class="nav nav-pills d-none {% if challenge.phase_set.count > 4 %}d-lg-inline-flex{% elif challenge.phase_set.count == 4 %}d-md-inline-flex{% else %}d-sm-inline-flex{% endif %} col-12 pl-3 mb-3">
         {% for phase in challenge.phase_set.all %}
             <li class="nav-item">
-                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                <a class="nav-link mr-1 px-3 py-1 {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
             </li>
         {% endfor %}
+    </div>
+    <div class="nav nav-pills d-block {% if challenge.phase_set.count > 4 %}d-lg-none{% elif challenge.phase_set.count == 4 %}d-md-none{% else %}d-sm-none{% endif %} col-12 pl-3 mb-3">
+        <div class="btn dropdown px-0 py-0">
+            <a class="btn btn-outline-dark dropdown-toggle phaseButton mr-1 px-4"
+               data-toggle="dropdown"
+               href="#"
+               role="button"
+               aria-expanded="false">
+                Choose a Phase</a>
+            <div class="dropdown-menu dropdown-menu-left" role="menu">
+                {% for phase in challenge.phase_set.all %}
+                    <li class="dropdown-item challengeDropdown px-0 py-0">
+                        <a class="nav-link py-1"
+                           href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"
+                           style="color: black">{{ phase.title }}</a>
+                    </li>
+                {% endfor %}
+            </div>
+        </div>
     </div>
 {% endblock %}
 

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
@@ -13,33 +13,22 @@
     </ol>
 {% endblock %}
 
-{% block sidebar %}
-    <div class="nav nav-pills d-none {% if challenge.phase_set.count > 4 %}d-lg-inline-flex{% elif challenge.phase_set.count == 4 %}d-md-inline-flex{% else %}d-sm-inline-flex{% endif %} col-12 pl-3 mb-3">
-        {% for phase in challenge.phase_set.all %}
-            <li class="nav-item">
-                <a class="nav-link mr-1 px-3 py-1 {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
-                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
-            </li>
-        {% endfor %}
-    </div>
-    <div class="nav nav-pills d-block {% if challenge.phase_set.count > 4 %}d-lg-none{% elif challenge.phase_set.count == 4 %}d-md-none{% else %}d-sm-none{% endif %} col-12 pl-3 mb-3">
-        <div class="btn dropdown px-0 py-0">
-            <a class="btn btn-outline-dark dropdown-toggle phaseButton mr-1 px-4"
-               data-toggle="dropdown"
-               href="#"
-               role="button"
-               aria-expanded="false">
-                Choose a Phase</a>
-            <div class="dropdown-menu dropdown-menu-left" role="menu">
-                {% for phase in challenge.phase_set.all %}
-                    <li class="dropdown-item challengeDropdown px-0 py-0">
-                        <a class="nav-link py-1"
-                           href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"
-                           style="color: black">{{ phase.title }}</a>
-                    </li>
-                {% endfor %}
-            </div>
-        </div>
+{% block topbar2 %}
+    <div class="nav-pill-dropdown-container">
+        <a class="d-lg-none btn btn-outline-dark dropdown-toggle phaseButton mr-1 mb-3 px-4"
+           data-toggle="dropdown"
+           href="#"
+           role="button"
+           aria-expanded="false">
+            Choose a Phase</a>
+        <ul class="nav nav-pills col-12 mb-3">
+            {% for phase in challenge.phase_set.all %}
+                <li class="nav-item">
+                    <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+                </li>
+            {% endfor %}
+        </ul>
     </div>
 {% endblock %}
 

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -25,10 +25,15 @@
         {% if "change_challenge" in challenge_perms or user_is_participant %}
             {% for phase in challenge.phase_set.all %}
                 <li class="nav-item">
-                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-create-legacy' and request.resolver_match.kwargs.slug == phase.slug%}active{% endif %}"
                        href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
                 </li>
             {% endfor %}
+            <li>
+                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
+                    href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
+                </a>
+            </li>
         {% endif %}
     </div>
 {% endblock %}
@@ -96,11 +101,4 @@
         {% endif %}
 
     {% endif %}
-
-    <h3>View your submissions</h3>
-
-    <p>
-        <a href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Click
-            here</a>
-        to view your current submissions to this challenge.</p>
 {% endblock %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -21,17 +21,43 @@
 {% endblock %}
 
 {% block sidebar %}
-    <div class="nav nav-pills col-12 pl-3 mb-3">
+    <div class="nav nav-pills d-none {% if challenge.phase_set.count > 4 %}d-lg-inline-flex{% elif challenge.phase_set.count == 4 %}d-md-inline-flex{% else %}d-sm-inline-flex{% endif %} col-12 pl-3 mb-3">
         {% if "change_challenge" in challenge_perms or user_is_participant %}
             {% for phase in challenge.phase_set.all %}
                 <li class="nav-item">
-                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-create-legacy' and request.resolver_match.kwargs.slug == phase.slug%}active{% endif %}"
+                    <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-create-legacy' and request.resolver_match.kwargs.slug == phase.slug%}active{% endif %}"
                        href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
                 </li>
             {% endfor %}
             <li>
-                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
+                <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
                     href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
+                </a>
+            </li>
+        {% endif %}
+    </div>
+    <div class="nav nav-pills d-flex {% if challenge.phase_set.count > 4 %}d-lg-none{% elif challenge.phase_set.count == 4 %}d-md-none{% else %}d-sm-none{% endif %} col-12 pl-3 mb-3">
+        {% if "change_challenge" in challenge_perms or user_is_participant %}
+            <div class="btn dropdown border-0 px-0 py-0 mb-1">
+                <a class="btn btn-outline-dark dropdown-toggle phaseButton mr-1 px-4"
+                   data-toggle="dropdown"
+                   href="#"
+                   role="button"
+                   aria-expanded="false">
+                    Choose a Phase</a>
+                <div class="dropdown-menu dropdown-menu-left" role="menu">
+                    {% for phase in challenge.phase_set.all %}
+                        <li class="dropdown-item challengeDropdown px-0 py-0">
+                            <a class="nav-link mr-1 px-4 py-1"
+                           href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}"
+                            style="color: black">{{ phase.title }}</a>
+                        </li>
+                    {% endfor %}
+                </div>
+            </div>
+            <li>
+                <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
+                   href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
                 </a>
             </li>
         {% endif %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -20,46 +20,28 @@
     </ol>
 {% endblock %}
 
-{% block sidebar %}
-    <div class="nav nav-pills d-none {% if challenge.phase_set.count > 4 %}d-lg-inline-flex{% elif challenge.phase_set.count == 4 %}d-md-inline-flex{% else %}d-sm-inline-flex{% endif %} col-12 pl-3 mb-3">
+{% block topbar2 %}
+    <div class="nav-pill-dropdown-container">
+        <a class="d-lg-none btn btn-outline-dark dropdown-toggle phaseButton mr-1 mb-3 px-4"
+           data-toggle="dropdown"
+           href="#"
+           role="button"
+           aria-expanded="false">
+            Choose a Phase</a>
         {% if "change_challenge" in challenge_perms or user_is_participant %}
-            {% for phase in challenge.phase_set.all %}
+            <ul class="nav nav-pills col-12 mb-3">
+                {% for phase in challenge.phase_set.all %}
+                    <li class="nav-item">
+                        <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-create-legacy' and request.resolver_match.kwargs.slug == phase.slug%}active{% endif %}"
+                           href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+                    </li>
+                {% endfor %}
                 <li class="nav-item">
-                    <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-create-legacy' and request.resolver_match.kwargs.slug == phase.slug%}active{% endif %}"
-                       href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+                    <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
+                       href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
+                    </a>
                 </li>
-            {% endfor %}
-            <li>
-                <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
-                    href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
-                </a>
-            </li>
-        {% endif %}
-    </div>
-    <div class="nav nav-pills d-flex {% if challenge.phase_set.count > 4 %}d-lg-none{% elif challenge.phase_set.count == 4 %}d-md-none{% else %}d-sm-none{% endif %} col-12 pl-3 mb-3">
-        {% if "change_challenge" in challenge_perms or user_is_participant %}
-            <div class="btn dropdown border-0 px-0 py-0 mb-1">
-                <a class="btn btn-outline-dark dropdown-toggle phaseButton mr-1 px-4"
-                   data-toggle="dropdown"
-                   href="#"
-                   role="button"
-                   aria-expanded="false">
-                    Choose a Phase</a>
-                <div class="dropdown-menu dropdown-menu-left" role="menu">
-                    {% for phase in challenge.phase_set.all %}
-                        <li class="dropdown-item challengeDropdown px-0 py-0">
-                            <a class="nav-link mr-1 px-4 py-1"
-                           href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}"
-                            style="color: black">{{ phase.title }}</a>
-                        </li>
-                    {% endfor %}
-                </div>
-            </div>
-            <li>
-                <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
-                   href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
-                </a>
-            </li>
+            </ul>
         {% endif %}
     </div>
 {% endblock %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -20,8 +20,20 @@
     </ol>
 {% endblock %}
 
-{% block content %}
+{% block sidebar %}
+    <div class="nav nav-pills col-12 pl-3 mb-3">
+        {% if "change_challenge" in challenge_perms or user_is_participant %}
+            {% for phase in challenge.phase_set.all %}
+                <li class="nav-item">
+                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                       href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+                </li>
+            {% endfor %}
+        {% endif %}
+    </div>
+{% endblock %}
 
+{% block content %}
     <h2>{{ phase.title }} Submission</h2>
 
     {{ phase.submission_page_html|clean }}
@@ -91,5 +103,4 @@
         <a href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Click
             here</a>
         to view your current submissions to this challenge.</p>
-
 {% endblock %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
@@ -13,46 +13,28 @@
     </ol>
 {% endblock %}
 
-{% block sidebar %}
-    <div class="nav nav-pills d-none {% if challenge.phase_set.count > 4 %}d-lg-inline-flex{% elif challenge.phase_set.count == 4 %}d-md-inline-flex{% else %}d-sm-inline-flex{% endif %} col-12 pl-3 mb-3">
+{% block topbar2 %}
+    <div class="nav-pill-dropdown-container">
+        <a class="d-lg-none btn btn-outline-dark dropdown-toggle phaseButton mr-1 mb-3 px-4"
+           data-toggle="dropdown"
+           href="#"
+           role="button"
+           aria-expanded="false">
+            Choose a Phase</a>
         {% if "change_challenge" in challenge_perms or user_is_participant %}
-            {% for phase in challenge.phase_set.all %}
+            <ul class="nav nav-pills col-12 mb-3">
+                {% for phase in challenge.phase_set.all %}
+                    <li class="nav-item">
+                        <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-create-legacy' and request.resolver_match.kwargs.slug == phase.slug%}active{% endif %}"
+                           href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+                    </li>
+                {% endfor %}
                 <li class="nav-item">
-                    <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-create-legacy' and request.resolver_match.kwargs.slug == phase.slug%}active{% endif %}"
-                       href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+                    <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
+                       href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
+                    </a>
                 </li>
-            {% endfor %}
-            <li>
-                <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
-                    href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
-                </a>
-            </li>
-        {% endif %}
-    </div>
-    <div class="nav nav-pills d-flex {% if challenge.phase_set.count > 4 %}d-lg-none{% elif challenge.phase_set.count == 4 %}d-md-none{% else %}d-sm-none{% endif %} col-12 pl-3 mb-3">
-        {% if "change_challenge" in challenge_perms or user_is_participant %}
-            <div class="btn dropdown border-0 px-0 py-0 mb-1">
-                <a class="btn btn-outline-dark dropdown-toggle phaseButton mr-1 px-4"
-                   data-toggle="dropdown"
-                   href="#"
-                   role="button"
-                   aria-expanded="false">
-                    Choose a Phase</a>
-                <div class="dropdown-menu dropdown-menu-left" role="menu">
-                    {% for phase in challenge.phase_set.all %}
-                        <li class="dropdown-item challengeDropdown px-0">
-                            <a class="nav-link mr-1 px-4 py-1"
-                           href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}"
-                            style="color: black">{{ phase.title }}</a>
-                        </li>
-                    {% endfor %}
-                </div>
-            </div>
-            <li>
-                <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
-                   href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
-                </a>
-            </li>
+            </ul>
         {% endif %}
     </div>
 {% endblock %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
@@ -14,17 +14,43 @@
 {% endblock %}
 
 {% block sidebar %}
-    <div class="nav nav-pills col-12 pl-3 mb-3">
+    <div class="nav nav-pills d-none {% if challenge.phase_set.count > 4 %}d-lg-inline-flex{% elif challenge.phase_set.count == 4 %}d-md-inline-flex{% else %}d-sm-inline-flex{% endif %} col-12 pl-3 mb-3">
         {% if "change_challenge" in challenge_perms or user_is_participant %}
             {% for phase in challenge.phase_set.all %}
                 <li class="nav-item">
-                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                    <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-create-legacy' and request.resolver_match.kwargs.slug == phase.slug%}active{% endif %}"
                        href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
                 </li>
             {% endfor %}
-            <li class="nav-item">
-                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
+            <li>
+                <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
                     href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
+                </a>
+            </li>
+        {% endif %}
+    </div>
+    <div class="nav nav-pills d-flex {% if challenge.phase_set.count > 4 %}d-lg-none{% elif challenge.phase_set.count == 4 %}d-md-none{% else %}d-sm-none{% endif %} col-12 pl-3 mb-3">
+        {% if "change_challenge" in challenge_perms or user_is_participant %}
+            <div class="btn dropdown border-0 px-0 py-0 mb-1">
+                <a class="btn btn-outline-dark dropdown-toggle phaseButton mr-1 px-4"
+                   data-toggle="dropdown"
+                   href="#"
+                   role="button"
+                   aria-expanded="false">
+                    Choose a Phase</a>
+                <div class="dropdown-menu dropdown-menu-left" role="menu">
+                    {% for phase in challenge.phase_set.all %}
+                        <li class="dropdown-item challengeDropdown px-0">
+                            <a class="nav-link mr-1 px-4 py-1"
+                           href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}"
+                            style="color: black">{{ phase.title }}</a>
+                        </li>
+                    {% endfor %}
+                </div>
+            </div>
+            <li>
+                <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
+                   href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
                 </a>
             </li>
         {% endif %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
@@ -13,6 +13,24 @@
     </ol>
 {% endblock %}
 
+{% block sidebar %}
+    <div class="nav nav-pills col-12 pl-3 mb-3">
+        {% if "change_challenge" in challenge_perms or user_is_participant %}
+            {% for phase in challenge.phase_set.all %}
+                <li class="nav-item">
+                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                       href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+                </li>
+            {% endfor %}
+            <li class="nav-item">
+                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-list' %}active{% endif %}"
+                    href="{% url 'evaluation:submission-list' challenge_short_name=challenge.short_name %}">Your Submissions
+                </a>
+            </li>
+        {% endif %}
+    </div>
+{% endblock %}
+
 {% block content %}
 
     <h2>Submissions</h2>

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -25,12 +25,29 @@
     </ol>
 {% endblock %}
 
-{% block sidebar %}
-      <div class="nav nav-pills flex-column pl-3">
+{% block topbar2 %}
+    <div class="nav nav-pills pl-0 mb-3 d-flex d-sm-none">
         {% for page in pages %}
             {% if not page.hidden %}
                 <li class="nav-item">
-                    <a class="nav-link {% if page == currentpage %}active{% endif %}"
+                    <a class="nav-link py-1 px-3 mr-1 mb-1 {% if page == currentpage %}active{% endif %}"
+                       href="{{ page.get_absolute_url }}">
+                        {% filter title %}
+                            {% firstof page.display_title page.title %}
+                        {% endfilter %}
+                    </a>
+                </li>
+            {% endif %}
+        {% endfor %}
+    </div>
+{% endblock %}
+
+{% block sidebar %}
+      <div class="nav nav-pills flex-column pl-3 d-none d-sm-block">
+        {% for page in pages %}
+            {% if not page.hidden %}
+                <li class="nav-item">
+                    <a class="nav-link text-center px-4 py-1 mb-1 {% if page == currentpage %}active{% endif %}"
                        href="{{ page.get_absolute_url }}">
                         {% filter title %}
                             {% firstof page.display_title page.title %}

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -13,9 +13,7 @@
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a
-                href="{% url 'challenges:list' %}">Challenges</a>
-        </li>
+        <li class="breadcrumb-item"><a href="{% url 'challenges:list' %}">Challenges</a></li>
         <li class="breadcrumb-item"><a
                 href="{{ challenge.get_absolute_url }}">{% firstof challenge.title challenge.short_name %}</a></li>
         <li class="breadcrumb-item active"
@@ -27,28 +25,47 @@
     </ol>
 {% endblock %}
 
+{% block sidebar %}
+      <div class="nav nav-pills flex-column pl-3">
+        {% for page in pages %}
+            {% if not page.hidden %}
+                <li class="nav-item">
+                    <a class="nav-link {% if page == currentpage %}active{% endif %}"
+                       href="{{ page.get_absolute_url }}">
+                        {% filter title %}
+                            {% firstof page.display_title page.title %}
+                        {% endfilter %}
+                    </a>
+                </li>
+            {% endif %}
+        {% endfor %}
+    </div>
+{% endblock %}
+
 {% block content %}
-    {% if challenge.disclaimer %}
-        <div class="disclaimer alert alert-warning" role="alert">
-            {{ challenge.disclaimer|clean }}
-        </div>
-    {% endif %}
+    <div class="mx-3">
+        {% if challenge.disclaimer %}
+            <div class="disclaimer alert alert-warning" role="alert">
+                {{ challenge.disclaimer|clean }}
+            </div>
+        {% endif %}
 
-    <div id=pageContainer>{{ currentpage.cleaned_html }}</div>
+        <div id=pageContainer>{{ currentpage.cleaned_html }}</div>
 
-    {% if not currentpage.is_error_page %}
-        {% if currentpage.pk %}
-            {% if "change_challenge" in challenge_perms %}
-                <br>
-                <a class="btn btn-primary"
-                   href="{% url 'pages:update' challenge_short_name=currentpage.challenge.short_name page_title=currentpage.title %}"
-                   title="Edit this page"
-                >
-                    <i class="fas fa-edit"></i>
-                </a>
+        {% if not currentpage.is_error_page %}
+            {% if currentpage.pk %}
+                {% if "change_challenge" in challenge_perms %}
+                    <br>
+                    <a class="btn btn-primary"
+                       href="{% url 'pages:update' challenge_short_name=currentpage.challenge.short_name page_title=currentpage.title %}"
+                       title="Edit this page"
+                    >
+                        <i class="fas fa-edit"></i>
+                    </a>
+                {% endif %}
             {% endif %}
         {% endif %}
-    {% endif %}
+    </div>
 {% endblock %}
 
 {% block script %}
@@ -56,13 +73,11 @@
     {# For displaying equations on the site, the safe config is important #}
     <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML,Safe'
             async></script>
-
     {# geocharts #}
     <script type="text/javascript"
             src="https://www.gstatic.com/charts/loader.js"></script>
     <script type="text/javascript"
             src="{% static "js/render_geocharts.js" %}"></script>
-
     {# make the tables sortable #}
     <script type="text/javascript"
             src="{% static "js/sort_tables.js" %}"></script>

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -70,6 +70,7 @@
     </div>
 {% endblock %}
 
+
 {% block script %}
     {{ block.super }}
     {# For displaying equations on the site, the safe config is important #}

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -25,37 +25,22 @@
     </ol>
 {% endblock %}
 
-{% block topbar2 %}
-    <div class="nav nav-pills pl-0 mb-3 d-flex d-sm-none">
-        {% for page in pages %}
-            {% if not page.hidden %}
-                <li class="nav-item">
-                    <a class="nav-link py-1 px-3 mr-1 mb-1 {% if page == currentpage %}active{% endif %}"
-                       href="{{ page.get_absolute_url }}">
-                        {% filter title %}
-                            {% firstof page.display_title page.title %}
-                        {% endfilter %}
-                    </a>
-                </li>
-            {% endif %}
-        {% endfor %}
-    </div>
-{% endblock %}
-
 {% block sidebar %}
-      <div class="nav nav-pills flex-column pl-3 d-none d-sm-block">
-        {% for page in pages %}
-            {% if not page.hidden %}
-                <li class="nav-item">
-                    <a class="nav-link text-center px-4 py-1 mb-1 {% if page == currentpage %}active{% endif %}"
-                       href="{{ page.get_absolute_url }}">
-                        {% filter title %}
-                            {% firstof page.display_title page.title %}
-                        {% endfilter %}
-                    </a>
-                </li>
-            {% endif %}
-        {% endfor %}
+    <div class="nav-pill-pages-container col-12 col-sm-5 col-md-4 col-lg-3 pl-3">
+          <ul class="nav nav-pills flex-column">
+            {% for page in pages %}
+                {% if not page.hidden %}
+                    <li class="nav-item">
+                        <a class="nav-link px-4 py-1 mb-1 {% if page == currentpage %}active{% endif %}"
+                           href="{{ page.get_absolute_url }}">
+                            {% filter title %}
+                                {% firstof page.display_title page.title %}
+                            {% endfilter %}
+                        </a>
+                    </li>
+                {% endif %}
+            {% endfor %}
+          </ul>
     </div>
 {% endblock %}
 


### PR DESCRIPTION
We redesigned the layout of challenge pages. Previously, navigation was possible through a sidebar that contained links to all sub-pages (info pages, submission forms, etc.). With multiple phases, this list could get very long and confusing. We now implemented a horizontal navigation bar which groups related pages together: all info pages can be accessed through the Info tab, the submission forms and leaderboards for all phases can be accessed through the Submit and Leaderboard tabs respectively. You can then navigate to the phase-specific submission form / leaderboard through the subtabs. The subtabs for the phases are also displayed horizontally now, leaving more space for the leaderboard tables. Finally, the Join and Admin buttons are now separated from the rest of the navigation and hence easier to spot. We hope this design will make navigation through the challenge page more intuitive for users. Let us know what you think! 

Screenshot to demonstrate will be added here soon

Part of pitch: https://github.com/DIAGNijmegen/rse-roadmap/issues/24

Closes #1786 
Closes #1789