### PR TITLE
Stay on current menu item in reader studies after page refresh

### DIFF
--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -18,7 +18,7 @@
 {% block sidebar %}
     {% get_obj_perms request.user for object as "readerstudy_perms" %}
     <div class="col-12 col-md-4 col-lg-3 mb-3">
-        <div class="nav nav-pills flex-column" id="v-pills-tab" role="tablist"
+        <ul class="nav nav-pills flex-column" id="v-pills-tab" role="tablist"
              aria-orientation="vertical">
             <a class="nav-link active" id="v-pills-home-tab" data-toggle="pill"
                href="#v-pills-home" role="tab" aria-controls="v-pills-home"
@@ -35,11 +35,11 @@
                    aria-selected="false"><i class="fas fa-users fa-fw"></i>&nbsp;Readers&nbsp;<span
                         class="badge badge-pill badge-secondary align-middle">{{ num_readers }}</span>
                 </a>
-                <a class="nav-link" id="v-pills-readers-tab"
+                <a class="nav-link" id="v-pills-users-progress-tab"
                    href="{% url 'reader-studies:users-progress' slug=object.slug %}"
                 ><i class="fas fa-tasks fa-fw"></i>&nbsp;Users Progress
                 </a>
-                <a class="nav-link"
+                <a class="nav-link" id="v-pills-requests-tab"
                    href="{% url 'reader-studies:permission-request-list' slug=object.slug %}"
                 ><i class="fas fa-question fa-fw"></i>&nbsp;Requests&nbsp;<span
                         class="badge badge-pill badge-secondary align-middle">{{ pending_permission_requests }}</span>
@@ -61,11 +61,12 @@
                    aria-selected="false"><i class="fas fa-check fa-fw"></i>&nbsp;Ground
                     Truth
                 </a>
-                <a class="nav-link"
+                <a class="nav-link" id="v-pills-leaderboard-tab" role="tab"
                    href="{% url 'reader-studies:leaderboard' slug=object.slug %}"><i
                         class="fas fa-trophy fa-fw"></i>&nbsp;Leaderboard
                 </a>
-                <a class="nav-link"
+                <a class="nav-link" id="v-pills-stats-tab" role="tab" aria-controls="v-pills-stats"
+                   aria-selected="true"
                    href="{% url 'reader-studies:statistics' slug=object.slug %}"><i
                         class="fas fa-chart-bar fa-fw"></i>&nbsp;Statistics
                 </a>
@@ -87,7 +88,7 @@
                     <i class="fa fa-question fa-fw"></i>&nbsp;Request Access
                 </a>
             {% endif %}
-        </div>
+        </ul>
     </div>
 {% endblock %}
 
@@ -476,6 +477,22 @@
             csrfHeaderName: "{{ csrf_header_name|default:'X-CSRFToken' }}",
             csrfToken: "{% if request %}{{ csrf_token }}{% endif %}"
         };
+
+        $('#v-pills-tab a').click(function () {
+            $(this).siblings().removeClass('active');
+            $(this).tab('active');
+        });
+
+        // store the currently selected tab in the hash value
+        $("ul.nav-pills > a").on("shown.bs.tab", function (e) {
+            var id = $(e.target).attr("href").substr(1);
+            window.location.hash = id;
+        });
+
+        // on load of the page: switch to the currently selected tab
+        var hash = window.location.hash;
+        $('#v-pills-tab a[href="' + hash + '"]').tab('show');
+        $('#v-pills-tab a[href="' + hash + '"]').siblings().removeClass('active');
 
         $(document).ready(() => {
 

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -22,7 +22,7 @@
              aria-orientation="vertical">
             <a class="nav-link active" id="v-pills-home-tab" data-toggle="pill"
                href="#v-pills-home" role="tab" aria-controls="v-pills-home"
-               aria-selected="true"><i
+               aria-selected="false" aria-expanded="false"><i
                     class="fas fa-info fa-fw"></i>&nbsp;Information
             </a>
             {% if "change_readerstudy" in readerstudy_perms %}
@@ -144,7 +144,7 @@
 
     <div class="tab-content" id="v-pills-tabContent">
 
-        <div class="tab-pane fade show active" id="v-pills-home" role="tabpanel"
+        <div class="tab-pane fade show" id="v-pills-home" role="tabpanel"
              aria-labelledby="v-pills-home-tab">
 
             <h2>{{ object.title }}</h2>
@@ -478,6 +478,10 @@
             csrfToken: "{% if request %}{{ csrf_token }}{% endif %}"
         };
 
+        if (window.location.hash == "" || window.location.hash == '#v-pills-home') {
+            $('#v-pills-home').addClass('active');
+        }
+
         $('#v-pills-tab a').click(function () {
             $(this).siblings().removeClass('active');
             $(this).tab('active');
@@ -487,12 +491,12 @@
         $("ul.nav-pills > a").on("shown.bs.tab", function (e) {
             var id = $(e.target).attr("href").substr(1);
             window.location.hash = id;
-        });
+         });
 
         // on load of the page: switch to the currently selected tab
         var hash = window.location.hash;
-        $('#v-pills-tab a[href="' + hash + '"]').tab('show');
         $('#v-pills-tab a[href="' + hash + '"]').siblings().removeClass('active');
+        $('#v-pills-tab a[href="' + hash + '"]').tab('show');
 
         $(document).ready(() => {
 


### PR DESCRIPTION
When refreshing a readerstudy page, the selected tab/menu item remains active and is displayed. The user no longer returns to the overview (i.e., the first tab) after refreshing.

Closes #1578 