### PR TITLE
Remove job and reader study from image serializer

### DIFF
--- a/app/grandchallenge/algorithms/static/algorithms/js/session.js
+++ b/app/grandchallenge/algorithms/static/algorithms/js/session.js
@@ -60,7 +60,13 @@ function getJobsForImages(imageUrls) {
 
     Promise.all(imageUrls.map(url => fetch(url).then(response => response.json()))
     ).then(images => {
-        getJobStatus(images.map(i => i.job_set).flat());
+        let params = new URLSearchParams();
+        images.forEach(i => params.append("input_image", i.pk));
+        let jobUrl = `/api/v1/algorithms/jobs/?${params.toString()}`;
+
+        fetch(jobUrl)
+            .then(response => response.json())
+            .then(jobs => handleJobStatus(jobs.results))
     });
 }
 

--- a/app/grandchallenge/cases/filters.py
+++ b/app/grandchallenge/cases/filters.py
@@ -1,8 +1,10 @@
 from django_filters import FilterSet, ModelMultipleChoiceFilter
 from django_select2.forms import Select2MultipleWidget
 
+from grandchallenge.algorithms.models import Job
 from grandchallenge.archives.models import Archive
 from grandchallenge.cases.models import Image
+from grandchallenge.reader_studies.models import ReaderStudy
 
 
 class ImageFilterSet(FilterSet):
@@ -10,7 +12,32 @@ class ImageFilterSet(FilterSet):
         queryset=Archive.objects.all(),
         widget=Select2MultipleWidget,
         label="Archive",
+        help_text="Filter images that belong to an archive",
         field_name="componentinterfacevalue__archive_items__archive__pk",
+        to_field_name="pk",
+    )
+    job_input = ModelMultipleChoiceFilter(
+        queryset=Job.objects.all(),
+        widget=Select2MultipleWidget,
+        label="Job Input",
+        help_text="Filter images that are used as input to an algorithm job",
+        field_name="componentinterfacevalue__algorithm_jobs_as_input__pk",
+        to_field_name="pk",
+    )
+    job_output = ModelMultipleChoiceFilter(
+        queryset=Job.objects.all(),
+        widget=Select2MultipleWidget,
+        label="Job Output",
+        help_text="Filter images that are produced as output from an algorithm job",
+        field_name="componentinterfacevalue__algorithm_jobs_as_output__pk",
+        to_field_name="pk",
+    )
+    reader_study = ModelMultipleChoiceFilter(
+        queryset=ReaderStudy.objects.all(),
+        widget=Select2MultipleWidget,
+        label="Reader Study",
+        help_text="Filter images that belong to a reader study",
+        field_name="readerstudies__pk",
         to_field_name="pk",
     )
 
@@ -19,8 +46,9 @@ class ImageFilterSet(FilterSet):
         fields = (
             "study",
             "origin",
-            # TODO JM: Add algorithm jobs here and remove from serializer
+            "job_input",
+            "job_output",
             "archive",
-            "readerstudies",
+            "reader_study",
             "name",
         )

--- a/app/grandchallenge/cases/serializers.py
+++ b/app/grandchallenge/cases/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
-from rest_framework.fields import CharField, SerializerMethodField
+from rest_framework.fields import CharField
 from rest_framework.relations import (
     HyperlinkedRelatedField,
     PrimaryKeyRelatedField,
@@ -26,20 +26,6 @@ class ImageFileSerializer(serializers.ModelSerializer):
 
 class HyperlinkedImageSerializer(serializers.ModelSerializer):
     files = ImageFileSerializer(many=True, read_only=True)
-    job_set = SerializerMethodField()
-    reader_study_set = HyperlinkedRelatedField(
-        source="readerstudies",
-        read_only=True,
-        many=True,
-        view_name="api:reader-study-detail",
-    )
-
-    def get_job_set(self, obj):
-        return [
-            job.api_url
-            for civ in obj.componentinterfacevalue_set.all()
-            for job in civ.algorithms_jobs_as_input.all()
-        ]
 
     class Meta:
         model = Image
@@ -48,8 +34,6 @@ class HyperlinkedImageSerializer(serializers.ModelSerializer):
             "name",
             "study",
             "files",
-            "reader_study_set",
-            "job_set",
             "width",
             "height",
             "depth",

--- a/app/grandchallenge/cases/views.py
+++ b/app/grandchallenge/cases/views.py
@@ -102,11 +102,7 @@ class OSDImageDetail(
 
 class ImageViewSet(ReadOnlyModelViewSet):
     serializer_class = HyperlinkedImageSerializer
-    queryset = Image.objects.all().prefetch_related(
-        "files",
-        "componentinterfacevalue_set__algorithms_jobs_as_input",
-        "readerstudies",
-    )
+    queryset = Image.objects.all().prefetch_related("files")
     permission_classes = (DjangoObjectPermissions,)
     filter_backends = (
         DjangoFilterBackend,

--- a/app/tests/algorithms_tests/test_api.py
+++ b/app/tests/algorithms_tests/test_api.py
@@ -42,12 +42,16 @@ def test_keys_used_in_algorithm_session_js(client):
     assert response.json()["status"] == "Queued"
     assert response.json()["api_url"] == j.api_url
 
-    # Image API
+    # Job API
     response = get_view_for_user(
-        client=client, url=j.inputs.first().image.api_url, user=u
+        client=client,
+        viewname="api:algorithms-job-list",
+        user=u,
+        data={"input_image": str(j.inputs.first().image.pk)},
     )
     assert response.status_code == 200
-    assert response.json()["job_set"] == [j.api_url]
+    assert len(response.json()["results"]) == 1
+    assert response.json()["results"][0]["pk"] == str(j.pk)
 
 
 @pytest.mark.django_db

--- a/app/tests/cases_tests/test_serializers.py
+++ b/app/tests/cases_tests/test_serializers.py
@@ -44,8 +44,6 @@ class TestRetinaImageSerializers:
                     "voxel_width_mm",
                     "voxel_height_mm",
                     "voxel_depth_mm",
-                    "job_set",
-                    "reader_study_set",
                     "api_url",
                 ),
                 "no_valid_check": True,


### PR DESCRIPTION
Placing these related lookups on the serializer skips permissions checks, users cannot see the job details but it does leak that the job or reader study exists. Instead we add filers to the images/jobs.