### PR TITLE
Fix pytest cache sharing between container runs and add check for breakpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,7 @@ docs/**/?/
 
 # Pytest cache
 .pytest_cache/
-
+app/scripts/
 app/celerybeat-schedule
 
 # No coverage files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     rev: v3.4.0
     hooks:
       - id: check-docstring-first
+      - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace

--- a/app/pytest.ini
+++ b/app/pytest.ini
@@ -3,7 +3,7 @@ DJANGO_SETTINGS_MODULE = tests.settings
 testpaths = tests
 python_files = tests.py test_*.py *_tests.py
 addopts = --strict-markers --showlocals -n auto --dist loadscope
-cache_dir = /tmp/pytest_cache
+cache_dir = /tmp/.pytest_cache
 markers =
     integration: integration tests
 filterwarnings =

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,9 @@ services:
       - type: bind
         source: /var/run/docker.sock
         target: /var/run/docker.sock
+      - type: volume
+        source: pytest-cache
+        target: /tmp/.pytest_cache
     group_add:
       - ${DOCKER_GID-1001} # The docker group is only needed for testing
 
@@ -283,3 +286,6 @@ services:
 networks:
   default:
   workstations:
+
+volumes:
+  pytest-cache:

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -23,6 +23,7 @@ COPY --chown=django:django setup.cfg /home/django
 
 USER django:django
 WORKDIR /app
+RUN mkdir /tmp/.pytest_cache
 COPY --chown=django:django ./app/ /app/
 COPY --from=npm --chown=django:django /src/dist/ /opt/static/vendor/
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1363,18 +1363,6 @@ toml = "*"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-name = "pytest-cache"
-version = "1.0"
-description = "pytest plugin with mechanisms for caching across test runs"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-execnet = ">=1.1.dev1"
-pytest = ">=2.2"
-
-[[package]]
 name = "pytest-cov"
 version = "2.11.1"
 description = "Pytest plugin for measuring coverage."
@@ -2139,7 +2127,7 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "ac5f0a16837c9dbfb752aaf60cdd3393a5be086dbefbb7c4b21e91f3ea6c20d2"
+content-hash = "95501a9dcf0d9d1d90066afc173f8967ad7b7a97d200f153d61d9414ce01fa6f"
 
 [metadata.files]
 alabaster = [
@@ -2928,9 +2916,6 @@ pyswot = [
 pytest = [
     {file = "pytest-6.2.4-py3-none-any.whl", hash = "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"},
     {file = "pytest-6.2.4.tar.gz", hash = "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b"},
-]
-pytest-cache = [
-    {file = "pytest-cache-1.0.tar.gz", hash = "sha256:be7468edd4d3d83f1e844959fd6e3fd28e77a481440a7118d430130ea31b07a9"},
 ]
 pytest-cov = [
     {file = "pytest-cov-2.11.1.tar.gz", hash = "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1363,6 +1363,18 @@ toml = "*"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-cache"
+version = "1.0"
+description = "pytest plugin with mechanisms for caching across test runs"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+execnet = ">=1.1.dev1"
+pytest = ">=2.2"
+
+[[package]]
 name = "pytest-cov"
 version = "2.11.1"
 description = "Pytest plugin for measuring coverage."
@@ -2101,7 +2113,7 @@ python-versions = ">=3.6.1"
 
 [[package]]
 name = "werkzeug"
-version = "2.0.0"
+version = "2.0.1"
 description = "The comprehensive WSGI web application library."
 category = "dev"
 optional = false
@@ -2127,7 +2139,7 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "a53735b2645665d4337fd84a41505544d800984b33da054ce2f434e11458d09d"
+content-hash = "ac5f0a16837c9dbfb752aaf60cdd3393a5be086dbefbb7c4b21e91f3ea6c20d2"
 
 [metadata.files]
 alabaster = [
@@ -2917,6 +2929,9 @@ pytest = [
     {file = "pytest-6.2.4-py3-none-any.whl", hash = "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"},
     {file = "pytest-6.2.4.tar.gz", hash = "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b"},
 ]
+pytest-cache = [
+    {file = "pytest-cache-1.0.tar.gz", hash = "sha256:be7468edd4d3d83f1e844959fd6e3fd28e77a481440a7118d430130ea31b07a9"},
+]
 pytest-cov = [
     {file = "pytest-cov-2.11.1.tar.gz", hash = "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7"},
     {file = "pytest_cov-2.11.1-py2.py3-none-any.whl", hash = "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"},
@@ -3337,8 +3352,8 @@ websockets = [
     {file = "websockets-8.1.tar.gz", hash = "sha256:5c65d2da8c6bce0fca2528f69f44b2f977e06954c8512a952222cea50dad430f"},
 ]
 werkzeug = [
-    {file = "Werkzeug-2.0.0-py3-none-any.whl", hash = "sha256:64c02f6495ba01eddd6625b3675f357cd358a73f1e38458a56ad86c5baa30b53"},
-    {file = "Werkzeug-2.0.0.tar.gz", hash = "sha256:3389bbfe6d40c6dd25e6d3f974155163c8b3de5bbda6a89342d4ab93fae80ba0"},
+    {file = "Werkzeug-2.0.1-py3-none-any.whl", hash = "sha256:6c1ec500dcdba0baa27600f6a22f6333d8b662d22027ff9f6202e3367413caa8"},
+    {file = "Werkzeug-2.0.1.tar.gz", hash = "sha256:1de1db30d010ff1af14a009224ec49ab2329ad2cde454c8a708130642d579c42"},
 ]
 whitenoise = [
     {file = "whitenoise-5.2.0-py2.py3-none-any.whl", hash = "sha256:05d00198c777028d72d8b0bbd234db605ef6d60e9410125124002518a48e515d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,4 +108,3 @@ sphinxcontrib-plantuml = "*"
 pytest-randomly = "*"
 sphinxcontrib-django = "*"
 django-capture-on-commit-callbacks = "*"  # Backport from Django 3.2, can be removed
-pytest-cache = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,4 +107,5 @@ sphinx-rtd-theme = "*"
 sphinxcontrib-plantuml = "*"
 pytest-randomly = "*"
 sphinxcontrib-django = "*"
-django-capture-on-commit-callbacks = "^1.4.0"  # Backport from Django 3.2, can be removed
+django-capture-on-commit-callbacks = "*"  # Backport from Django 3.2, can be removed
+pytest-cache = "*"


### PR DESCRIPTION
Fixes the pytest cache to allow re-running of the last failed tests with `--lf`, or running with the failing test first with `--ff``.