### PR TITLE
Add flexible inputs for archives

### DIFF
--- a/app/grandchallenge/algorithms/forms.py
+++ b/app/grandchallenge/algorithms/forms.py
@@ -1,12 +1,8 @@
 from crispy_forms.helper import FormHelper
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.forms import (
-    BooleanField,
-    CharField,
-    FloatField,
     Form,
     IntegerField,
-    JSONField,
     ModelForm,
     ModelMultipleChoiceField,
     TextInput,
@@ -20,8 +16,8 @@ from grandchallenge.algorithms.models import (
     AlgorithmPermissionRequest,
     Job,
 )
-from grandchallenge.cases.forms import IMAGE_UPLOAD_HELP_TEXT
-from grandchallenge.components.models import ComponentInterface, InterfaceKind
+from grandchallenge.components.form_fields import InterfaceFormField
+from grandchallenge.components.models import ComponentInterface
 from grandchallenge.core.forms import (
     PermissionRequestUpdateForm,
     SaveFormInitMixin,
@@ -29,95 +25,11 @@ from grandchallenge.core.forms import (
 )
 from grandchallenge.core.templatetags.bleach import clean
 from grandchallenge.core.validators import ExtensionValidator
-from grandchallenge.core.widgets import JSONEditorWidget, MarkdownEditorWidget
+from grandchallenge.core.widgets import MarkdownEditorWidget
 from grandchallenge.groups.forms import UserGroupForm
 from grandchallenge.jqfileupload.widgets import uploader
 from grandchallenge.jqfileupload.widgets.uploader import UploadedAjaxFileList
-from grandchallenge.reader_studies.models import ANSWER_TYPE_SCHEMA
 from grandchallenge.subdomains.utils import reverse_lazy
-
-file_upload_text = (
-    "The total size of all files uploaded in a single session "
-    "cannot exceed 10 GB.<br>"
-    "The following file formats are supported: "
-)
-
-
-def _join_with_br(a, b):
-    if a:
-        return f"{a}<br>{b}"
-    else:
-        return b
-
-
-class InterfaceFormField:
-    def __init__(
-        self,
-        *,
-        kind: InterfaceKind.InterfaceKindChoices,
-        initial=None,
-        user=None,
-        help_text="",
-    ):
-        field_type = field_for_interface(kind)
-
-        # bool can't be required
-        kwargs = {
-            "required": (kind != InterfaceKind.InterfaceKindChoices.BOOL),
-        }
-
-        extra_help = ""
-
-        if initial is not None:
-            kwargs["initial"] = initial
-        if kind in InterfaceKind.interface_type_annotation():
-            kwargs["widget"] = JSONEditorWidget(
-                schema=ANSWER_TYPE_SCHEMA["definitions"][kind]
-            )
-        if kind in InterfaceKind.interface_type_file():
-            kwargs["widget"] = uploader.AjaxUploadWidget(
-                multifile=False, auto_commit=False
-            )
-            kwargs["validators"] = [
-                ExtensionValidator(allowed_extensions=(f".{kind.lower()}",))
-            ]
-            extra_help = f"{file_upload_text} .{kind.lower()}"
-        if kind in InterfaceKind.interface_type_image():
-            kwargs["widget"] = uploader.AjaxUploadWidget(
-                multifile=True, auto_commit=False
-            )
-            extra_help = IMAGE_UPLOAD_HELP_TEXT
-
-        self._field = field_type(
-            help_text=_join_with_br(help_text, extra_help), **kwargs
-        )
-
-        if user:
-            self._field.widget.user = user
-
-    @property
-    def field(self):
-        return self._field
-
-
-def field_for_interface(i: InterfaceKind.InterfaceKindChoices):
-    fields = {}
-    for kind in InterfaceKind.interface_type_annotation():
-        fields[kind] = JSONField
-    for kind in (
-        InterfaceKind.interface_type_image()
-        + InterfaceKind.interface_type_file()
-    ):
-        fields[kind] = UploadedAjaxFileList
-    fields.update(
-        {
-            InterfaceKind.InterfaceKindChoices.BOOL: BooleanField,
-            InterfaceKind.InterfaceKindChoices.STRING: CharField,
-            InterfaceKind.InterfaceKindChoices.INTEGER: IntegerField,
-            InterfaceKind.InterfaceKindChoices.FLOAT: FloatField,
-        }
-    )
-    return fields[i]
 
 
 class AlgorithmInputsForm(SaveFormInitMixin, Form):

--- a/app/grandchallenge/algorithms/tasks.py
+++ b/app/grandchallenge/algorithms/tasks.py
@@ -279,7 +279,6 @@ def create_algorithm_jobs(  # noqa: C901
     default_input_interface = ComponentInterface.objects.get(
         slug=DEFAULT_INPUT_INTERFACE_SLUG
     )
-
     jobs = []
 
     if not images:
@@ -315,7 +314,7 @@ def create_algorithm_jobs(  # noqa: C901
         # Check if a Job with identical inputs already exists
         skip = False
         for job in Job.objects.filter(
-            inputs__in=job_inputs,
+            inputs__interface__in=input_interfaces,
             algorithm_image=algorithm_image,
             creator=creator,
         ):

--- a/app/grandchallenge/algorithms/tasks.py
+++ b/app/grandchallenge/algorithms/tasks.py
@@ -312,16 +312,18 @@ def create_algorithm_jobs(  # noqa: C901
     for archive_item in archive_items:
         job_inputs = archive_item.values.filter(interface__in=input_interfaces)
 
-        # Check if a JOb with identical inputs already exists
+        # Check if a Job with identical inputs already exists
         skip = False
         for job in Job.objects.filter(
             inputs__in=job_inputs,
             algorithm_image=algorithm_image,
             creator=creator,
         ):
-            if job.inputs.order_by("pk").values(
-                "value", "image", "file"
-            ) == job_inputs.order_by("pk").values("value", "image", "file"):
+            if list(
+                job.inputs.order_by("pk").values("value", "image", "file")
+            ) == list(
+                job_inputs.order_by("pk").values("value", "image", "file")
+            ):
                 skip = True
                 break
         if skip:

--- a/app/grandchallenge/algorithms/tasks.py
+++ b/app/grandchallenge/algorithms/tasks.py
@@ -312,21 +312,29 @@ def create_algorithm_jobs(  # noqa: C901
     for archive_item in archive_items:
         job_inputs = archive_item.values.filter(interface__in=input_interfaces)
 
-        # TODO: check that this filter works
-        if not Job.objects.filter(
+        # Check if a JOb with identical inputs already exists
+        skip = False
+        for job in Job.objects.filter(
             inputs__in=job_inputs,
             algorithm_image=algorithm_image,
             creator=creator,
-        ).exists():
-            j = Job.objects.create(
-                creator=creator, algorithm_image=algorithm_image
-            )
-            j.inputs.set(job_inputs)
+        ):
+            if job.inputs.order_by("pk").values(
+                "value", "image", "file"
+            ) == job_inputs.order_by("pk").values("value", "image", "file"):
+                skip = True
+                break
+        if skip:
+            continue
+        j = Job.objects.create(
+            creator=creator, algorithm_image=algorithm_image
+        )
+        j.inputs.set(job_inputs)
 
-            if extra_viewer_groups is not None:
-                j.viewer_groups.add(*extra_viewer_groups)
+        if extra_viewer_groups is not None:
+            j.viewer_groups.add(*extra_viewer_groups)
 
-            jobs.append(j)
+        jobs.append(j)
 
     for image in images:
         if not ComponentInterfaceValue.objects.filter(

--- a/app/grandchallenge/archives/forms.py
+++ b/app/grandchallenge/archives/forms.py
@@ -173,7 +173,7 @@ class ArchiveCasesToReaderStudyForm(SaveFormInitMixin, Form):
 class AddCasesForm(UploadRawImagesForm):
     interface = ModelChoiceField(
         queryset=ComponentInterface.objects.filter(
-            kind=InterfaceKind.InterfaceKindChoices.IMAGE
+            kind__in=InterfaceKind.interface_type_image()
         )
     )
 

--- a/app/grandchallenge/archives/forms.py
+++ b/app/grandchallenge/archives/forms.py
@@ -1,3 +1,4 @@
+from crispy_forms.helper import FormHelper
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.forms import (
     Form,
@@ -12,12 +13,20 @@ from guardian.shortcuts import get_objects_for_user
 
 from grandchallenge.algorithms.models import Algorithm
 from grandchallenge.archives.models import Archive, ArchivePermissionRequest
+from grandchallenge.cases.forms import UploadRawImagesForm
 from grandchallenge.cases.models import Image
+from grandchallenge.components.form_fields import InterfaceFormField
+from grandchallenge.components.models import (
+    ComponentInterface,
+    ComponentInterfaceValue,
+    InterfaceKind,
+)
 from grandchallenge.core.forms import (
     PermissionRequestUpdateForm,
     SaveFormInitMixin,
     WorkstationUserFilterMixin,
 )
+from grandchallenge.core.templatetags.bleach import clean
 from grandchallenge.core.widgets import MarkdownEditorWidget
 from grandchallenge.groups.forms import UserGroupForm
 from grandchallenge.reader_studies.models import ReaderStudy
@@ -159,3 +168,43 @@ class ArchiveCasesToReaderStudyForm(SaveFormInitMixin, Form):
             )
 
         return cleaned_data
+
+
+class AddCasesForm(UploadRawImagesForm):
+    interface = ModelChoiceField(
+        queryset=ComponentInterface.objects.filter(
+            kind=InterfaceKind.InterfaceKindChoices.IMAGE
+        )
+    )
+
+    def save(self, commit=True):
+        self._linked_task.kwargs.update(
+            {"interface_pk": self.cleaned_data["interface"].pk}
+        )
+        return super().save(commit=commit)
+
+
+class ArchiveItemForm(SaveFormInitMixin, Form):
+    def __init__(
+        self, *args, archive=None, user=None, archive_item=None, **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper()
+
+        if archive_item:
+            values = archive_item.values.all()
+        else:
+            values = ComponentInterfaceValue.objects.none()
+
+        for inp in ComponentInterface.objects.all():
+            initial = values.filter(interface=inp).first()
+            if initial:
+                initial = initial.value
+            self.fields[inp.slug] = InterfaceFormField(
+                kind=inp.kind,
+                initial=initial or inp.default_value,
+                required=False,
+                user=user,
+                help_text=clean(inp.description) if inp.description else "",
+            ).field

--- a/app/grandchallenge/archives/tasks.py
+++ b/app/grandchallenge/archives/tasks.py
@@ -38,5 +38,10 @@ def add_images_to_archive(*, upload_session_pk, archive_pk, interface_pk=None):
 @shared_task
 def add_values_to_archive_item(*, archive_item_pk, civ_pks):
     archive_item = ArchiveItem.objects.get(pk=archive_item_pk)
-    archive_item.values.clear()
     archive_item.values.add(*civ_pks)
+
+
+@shared_task
+def clear_values_from_archive_item(*, archive_item_pk):
+    archive_item = ArchiveItem.objects.get(pk=archive_item_pk)
+    archive_item.values.clear()

--- a/app/grandchallenge/archives/tasks.py
+++ b/app/grandchallenge/archives/tasks.py
@@ -9,11 +9,15 @@ from grandchallenge.components.models import (
 
 
 @shared_task
-def add_images_to_archive(*, upload_session_pk, archive_pk):
+def add_images_to_archive(*, upload_session_pk, archive_pk, interface_pk=None):
     images = Image.objects.filter(origin_id=upload_session_pk)
     archive = Archive.objects.get(pk=archive_pk)
-    # TODO: this should be configurable
-    interface = ComponentInterface.objects.get(slug="generic-medical-image")
+    if interface_pk is not None:
+        interface = ComponentInterface.objects.get(pk=interface_pk)
+    else:
+        interface = ComponentInterface.objects.get(
+            slug="generic-medical-image"
+        )
 
     for image in images:
         civ = ComponentInterfaceValue.objects.filter(
@@ -29,3 +33,10 @@ def add_images_to_archive(*, upload_session_pk, archive_pk):
             continue
         item = ArchiveItem.objects.create(archive=archive)
         item.values.set([civ])
+
+
+@shared_task
+def add_values_to_archive_item(*, archive_item_pk, civ_pks):
+    archive_item = ArchiveItem.objects.get(pk=archive_item_pk)
+    archive_item.values.clear()
+    archive_item.values.add(*civ_pks)

--- a/app/grandchallenge/archives/tasks.py
+++ b/app/grandchallenge/archives/tasks.py
@@ -36,12 +36,9 @@ def add_images_to_archive(*, upload_session_pk, archive_pk, interface_pk=None):
 
 
 @shared_task
-def add_values_to_archive_item(*, archive_item_pk, civ_pks):
+def update_archive_item_values(
+    *, archive_item_pk, civ_pks_to_remove, civ_pks_to_add,
+):
     archive_item = ArchiveItem.objects.get(pk=archive_item_pk)
-    archive_item.values.add(*civ_pks)
-
-
-@shared_task
-def clear_values_from_archive_item(*, archive_item_pk):
-    archive_item = ArchiveItem.objects.get(pk=archive_item_pk)
-    archive_item.values.clear()
+    archive_item.values.remove(*civ_pks_to_remove)
+    archive_item.values.add(*civ_pks_to_add)

--- a/app/grandchallenge/archives/templates/archives/archive_detail.html
+++ b/app/grandchallenge/archives/templates/archives/archive_detail.html
@@ -66,6 +66,10 @@
                 ><i class="fas fa-eye fa-fw"></i>&nbsp;View Cases
                 </a>
                 <a class="nav-link"
+                   href="{% url 'archives:items-list' slug=object.slug %}"
+                ><i class="fas fa-eye fa-fw"></i>&nbsp;View Items
+                </a>
+                <a class="nav-link"
                    href="{% url 'archives:cases-reader-study-update' slug=object.slug %}"
                 ><i class="fas fa-plus fa-fw"></i>&nbsp;Add to Reader Study
                 </a>

--- a/app/grandchallenge/archives/templates/archives/archive_item_form.html
+++ b/app/grandchallenge/archives/templates/archives/archive_item_form.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags %}
+{% load url %}
+{% load get_obj_perms from guardian_tags %}
+{% load bleach %}
+{% load random_encode %}
+{% load static %}
+
+{% block title %}
+    Edit item for {{ archive }} - {{ block.super }}
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    {{ form.media }}
+{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a
+                href="{% url 'archives:list' %}">Archives</a>
+        </li>
+        <li class="breadcrumb-item"><a
+                href="{{ archive.get_absolute_url }}">{{ archive.title }}
+        </a></li>
+        <li class="breadcrumb-item active"
+            aria-current="page">Edit item
+        </li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    {% get_obj_perms request.user for archive as "archive_perms" %}
+    <h2>Edit item</h2>
+
+
+            <form method="POST">
+                {% csrf_token %}
+                {{ form|crispy }}
+                <input type="submit" name="save" value="Submit" class="btn btn-primary" id="submit-id-save">
+            </form>
+
+{% endblock %}

--- a/app/grandchallenge/archives/templates/archives/archive_items_list.html
+++ b/app/grandchallenge/archives/templates/archives/archive_items_list.html
@@ -1,0 +1,18 @@
+{% extends "datatables/list_base.html" %}
+{% load guardian_tags %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% url 'archives:list' %}">Archives</a></li>
+        <li class="breadcrumb-item"><a href="{{ archive.get_absolute_url }}">{{ archive.title }}</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Items</li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <h2>Items for {{ archive.title }}</h2>
+
+    {% get_obj_perms request.user for archive as "archive_perms" %}
+
+    {{ block.super }}
+{% endblock %}

--- a/app/grandchallenge/archives/templates/archives/archive_items_row.html
+++ b/app/grandchallenge/archives/templates/archives/archive_items_row.html
@@ -1,0 +1,18 @@
+{% load humanize %}
+{% load profiles %}
+{% load workstations %}
+{% load pathlib %}
+
+<ul class="list-unstyled mb-0">
+    {% for civ in object.values.all %}
+        <li>{{ civ.interface.title }}: {{ civ.title }}</li>
+    {% endfor %}
+</ul>
+<split></split>
+
+<a href="{% url 'archives:item-edit' slug=object.archive.slug id=object.pk %}">
+    <span class="badge badge-primary">
+        <i class="fa fa-edit"></i> Edit
+    </span>
+</a>
+<split></split>

--- a/app/grandchallenge/archives/urls.py
+++ b/app/grandchallenge/archives/urls.py
@@ -5,7 +5,9 @@ from grandchallenge.archives.views import (
     ArchiveCasesToReaderStudyUpdate,
     ArchiveCreate,
     ArchiveDetail,
+    ArchiveEditArchiveItem,
     ArchiveEditorsUpdate,
+    ArchiveItemsList,
     ArchiveList,
     ArchivePermissionRequestCreate,
     ArchivePermissionRequestList,
@@ -54,10 +56,16 @@ urlpatterns = [
         name="permission-request-update",
     ),
     path("<slug>/cases/", ArchiveCasesList.as_view(), name="cases-list"),
+    path("<slug>/items/", ArchiveItemsList.as_view(), name="items-list"),
     path(
         "<slug>/cases/add/",
         ArchiveUploadSessionCreate.as_view(),
         name="cases-create",
+    ),
+    path(
+        "<slug>/items/<id>/edit",
+        ArchiveEditArchiveItem.as_view(),
+        name="item-edit",
     ),
     path(
         "<slug>/cases/reader-study/update/",

--- a/app/grandchallenge/archives/views.py
+++ b/app/grandchallenge/archives/views.py
@@ -1,3 +1,4 @@
+from celery import chord, group
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import (
@@ -5,11 +6,14 @@ from django.core.exceptions import (
     PermissionDenied,
     ValidationError,
 )
+from django.core.files import File
+from django.db.transaction import on_commit
 from django.forms.utils import ErrorList
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
 from django.utils.html import format_html
+from django.utils.text import get_valid_filename
 from django.utils.timezone import now
 from django.views.generic import (
     CreateView,
@@ -29,19 +33,39 @@ from rest_framework.settings import api_settings
 from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework_guardian.filters import ObjectPermissionsFilter
 
+from grandchallenge.algorithms.tasks import (
+    add_images_to_component_interface_value,
+)
 from grandchallenge.archives.filters import ArchiveFilter
 from grandchallenge.archives.forms import (
+    AddCasesForm,
     ArchiveCasesToReaderStudyForm,
     ArchiveForm,
+    ArchiveItemForm,
     ArchivePermissionRequestUpdateForm,
     UploadersForm,
     UsersForm,
 )
-from grandchallenge.archives.models import Archive, ArchivePermissionRequest
+from grandchallenge.archives.models import (
+    Archive,
+    ArchiveItem,
+    ArchivePermissionRequest,
+)
 from grandchallenge.archives.serializers import ArchiveSerializer
-from grandchallenge.archives.tasks import add_images_to_archive
-from grandchallenge.cases.forms import UploadRawImagesForm
-from grandchallenge.cases.models import Image, RawImageUploadSession
+from grandchallenge.archives.tasks import (
+    add_images_to_archive,
+    add_values_to_archive_item,
+)
+from grandchallenge.cases.models import (
+    Image,
+    RawImageFile,
+    RawImageUploadSession,
+)
+from grandchallenge.components.models import (
+    ComponentInterface,
+    ComponentInterfaceValue,
+    InterfaceKind,
+)
 from grandchallenge.core.filters import FilterMixin
 from grandchallenge.core.forms import UserFormKwargsMixin
 from grandchallenge.core.permissions.mixins import UserIsNotAnonMixin
@@ -299,7 +323,7 @@ class ArchiveUploadSessionCreate(
     CreateView,
 ):
     model = RawImageUploadSession
-    form_class = UploadRawImagesForm
+    form_class = AddCasesForm
     template_name = "archives/archive_upload_session_create.html"
     permission_required = (
         f"{Archive._meta.app_label}.upload_{Archive._meta.model_name}"
@@ -332,6 +356,148 @@ class ArchiveUploadSessionCreate(
         context = super().get_context_data(**kwargs)
         context.update({"archive": self.archive})
         return context
+
+
+class ArchiveEditArchiveItem(
+    UserFormKwargsMixin,
+    LoginRequiredMixin,
+    ObjectPermissionRequiredMixin,
+    FormView,
+):
+    form_class = ArchiveItemForm
+    template_name = "archives/archive_item_form.html"
+    permission_required = (
+        f"{Archive._meta.app_label}.upload_{Archive._meta.model_name}"
+    )
+    raise_exception = True
+
+    def get_permission_object(self):
+        return self.archive
+
+    @cached_property
+    def archive(self):
+        return get_object_or_404(Archive, slug=self.kwargs["slug"])
+
+    @cached_property
+    def archive_item(self):
+        return get_object_or_404(ArchiveItem, pk=self.kwargs["id"])
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs.update(
+            {"archive": self.archive, "archive_item": self.archive_item}
+        )
+        return kwargs
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context.update({"archive": self.archive})
+        return context
+
+    def form_valid(self, form):
+        def create_upload(image_files):
+            raw_files = []
+            upload_session = RawImageUploadSession.objects.create(
+                creator=self.request.user
+            )
+            for image_file in image_files:
+                raw_files.append(
+                    RawImageFile(
+                        upload_session=upload_session,
+                        filename=image_file.name,
+                        staged_file_id=image_file.uuid,
+                    )
+                )
+            RawImageFile.objects.bulk_create(list(raw_files))
+            return upload_session.pk
+
+        upload_pks = {}
+        civ_pks = set(self.archive_item.values.values_list("pk", flat=True))
+
+        for slug, value in form.cleaned_data.items():
+            if not value:
+                continue
+            ci = ComponentInterface.objects.get(slug=slug)
+            civ = self.archive_item.values.filter(interface=ci).first()
+            if not civ:
+                civ = ComponentInterfaceValue.objects.create(interface=ci)
+            if ci.kind in InterfaceKind.interface_type_image():
+                civ_pks.add(civ.pk)
+                upload_pks[civ.pk] = create_upload(value)
+            elif ci.kind in InterfaceKind.interface_type_file():
+                name = get_valid_filename(value[0].name)
+                with value[0].open() as f:
+                    civ.file = File(f, name=name)
+                    civ.save()
+                civ_pks.add(civ.pk)
+            else:
+                civ.value = value
+                civ.save()
+                civ_pks.add(civ.pk)
+
+        tasks = add_values_to_archive_item.signature(
+            kwargs={
+                "archive_item_pk": self.archive_item.pk,
+                "civ_pks": list(civ_pks),
+            },
+            immutable=True,
+        )
+        if len(upload_pks) > 0:
+            image_tasks = group(
+                add_images_to_component_interface_value.signature(
+                    kwargs={
+                        "component_interface_value_pk": civ_pk,
+                        "upload_pk": upload_pk,
+                    },
+                    immutable=True,
+                )
+                for civ_pk, upload_pk in upload_pks.items()
+            )
+            tasks = chord(image_tasks, tasks)
+
+        on_commit(tasks.apply_async)
+
+        return HttpResponseRedirect(
+            reverse(
+                "archives:items-list", kwargs={"slug": self.kwargs["slug"]},
+            )
+        )
+
+
+class ArchiveItemsList(
+    LoginRequiredMixin, ObjectPermissionRequiredMixin, PaginatedTableListView,
+):
+    model = ArchiveItem
+    permission_required = (
+        f"{Archive._meta.app_label}.use_{Archive._meta.model_name}"
+    )
+    raise_exception = True
+    template_name = "archives/archive_items_list.html"
+    row_template = "archives/archive_items_row.html"
+    search_fields = [
+        "pk",
+        "name",
+    ]
+    columns = [
+        Column(title="Values", sort_field="pk"),
+        Column(title="Edit", sort_field="pk"),
+    ]
+
+    @cached_property
+    def archive(self):
+        return get_object_or_404(Archive, slug=self.kwargs["slug"])
+
+    def get_permission_object(self):
+        return self.archive
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update({"archive": self.archive})
+        return context
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        return qs.filter(archive=self.archive)
 
 
 class ArchiveCasesList(

--- a/app/grandchallenge/archives/views.py
+++ b/app/grandchallenge/archives/views.py
@@ -394,7 +394,7 @@ class ArchiveEditArchiveItem(
         context.update({"archive": self.archive})
         return context
 
-    def form_valid(self, form):
+    def form_valid(self, form):  # noqa: C901
         def create_upload(image_files):
             raw_files = []
             upload_session = RawImageUploadSession.objects.create(
@@ -415,10 +415,15 @@ class ArchiveEditArchiveItem(
         civ_pks = set(self.archive_item.values.values_list("pk", flat=True))
 
         for slug, value in form.cleaned_data.items():
-            if not value:
+            if value is None:
                 continue
             ci = ComponentInterface.objects.get(slug=slug)
             civ = self.archive_item.values.filter(interface=ci).first()
+            if civ and civ.value is not None:
+                if civ.value == value:
+                    continue
+                civ_pks.remove(civ.pk)
+                civ = None
             if not civ:
                 civ = ComponentInterfaceValue.objects.create(interface=ci)
             if ci.kind in InterfaceKind.interface_type_image():

--- a/app/grandchallenge/archives/views.py
+++ b/app/grandchallenge/archives/views.py
@@ -509,7 +509,7 @@ class ArchiveItemsList(
 
     def get_queryset(self):
         qs = super().get_queryset()
-        return qs.filter(archive=self.archive)
+        return qs.filter(archive=self.archive).prefetch_related("values")
 
 
 class ArchiveCasesList(

--- a/app/grandchallenge/components/form_fields.py
+++ b/app/grandchallenge/components/form_fields.py
@@ -1,0 +1,104 @@
+from django.forms import (
+    BooleanField,
+    CharField,
+    FloatField,
+    IntegerField,
+    JSONField,
+)
+
+from grandchallenge.cases.forms import IMAGE_UPLOAD_HELP_TEXT
+from grandchallenge.components.models import InterfaceKind
+from grandchallenge.core.validators import ExtensionValidator
+from grandchallenge.core.widgets import JSONEditorWidget
+from grandchallenge.jqfileupload.widgets import uploader
+from grandchallenge.jqfileupload.widgets.uploader import UploadedAjaxFileList
+from grandchallenge.reader_studies.models import ANSWER_TYPE_SCHEMA
+
+file_upload_text = (
+    "The total size of all files uploaded in a single session "
+    "cannot exceed 10 GB.<br>"
+    "The following file formats are supported: "
+)
+
+
+def _join_with_br(a, b):
+    if a:
+        return f"{a}<br>{b}"
+    else:
+        return b
+
+
+class InterfaceFormField:
+    def __init__(
+        self,
+        *,
+        kind: InterfaceKind.InterfaceKindChoices,
+        initial=None,
+        user=None,
+        required=None,
+        help_text="",
+    ):
+        field_type = field_for_interface(kind)
+
+        # bool can't be required
+        required = (
+            required
+            if required is not None
+            else (kind != InterfaceKind.InterfaceKindChoices.BOOL)
+        )
+        kwargs = {
+            "required": required,
+        }
+
+        extra_help = ""
+
+        if initial is not None:
+            kwargs["initial"] = initial
+        if kind in InterfaceKind.interface_type_annotation():
+            kwargs["widget"] = JSONEditorWidget(
+                schema=ANSWER_TYPE_SCHEMA["definitions"][kind]
+            )
+        if kind in InterfaceKind.interface_type_file():
+            kwargs["widget"] = uploader.AjaxUploadWidget(
+                multifile=False, auto_commit=False
+            )
+            kwargs["validators"] = [
+                ExtensionValidator(allowed_extensions=(f".{kind.lower()}",))
+            ]
+            extra_help = f"{file_upload_text} .{kind.lower()}"
+        if kind in InterfaceKind.interface_type_image():
+            kwargs["widget"] = uploader.AjaxUploadWidget(
+                multifile=True, auto_commit=False
+            )
+            extra_help = IMAGE_UPLOAD_HELP_TEXT
+
+        self._field = field_type(
+            help_text=_join_with_br(help_text, extra_help), **kwargs
+        )
+
+        if user:
+            self._field.widget.user = user
+
+    @property
+    def field(self):
+        return self._field
+
+
+def field_for_interface(i: InterfaceKind.InterfaceKindChoices):
+    fields = {}
+    for kind in InterfaceKind.interface_type_annotation():
+        fields[kind] = JSONField
+    for kind in (
+        InterfaceKind.interface_type_image()
+        + InterfaceKind.interface_type_file()
+    ):
+        fields[kind] = UploadedAjaxFileList
+    fields.update(
+        {
+            InterfaceKind.InterfaceKindChoices.BOOL: BooleanField,
+            InterfaceKind.InterfaceKindChoices.STRING: CharField,
+            InterfaceKind.InterfaceKindChoices.INTEGER: IntegerField,
+            InterfaceKind.InterfaceKindChoices.FLOAT: FloatField,
+        }
+    )
+    return fields[i]

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -510,7 +510,7 @@ class ComponentInterfaceValue(models.Model):
 
     @property
     def title(self):
-        if self.value:
+        if self.value is not None:
             return str(self.value)
         if self.file:
             return self.file.name

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -509,6 +509,16 @@ class ComponentInterfaceValue(models.Model):
     )
 
     @property
+    def title(self):
+        if self.value:
+            return str(self.value)
+        if self.file:
+            return self.file.name
+        if self.image:
+            return self.image.name
+        return ""
+
+    @property
     def has_value(self):
         return self.value is not None or self.image or self.file
 

--- a/app/grandchallenge/jqfileupload/widgets/uploader.py
+++ b/app/grandchallenge/jqfileupload/widgets/uploader.py
@@ -309,8 +309,8 @@ class StagedAjaxFile:
 
 class UploadedAjaxFileList(forms.Field):
     def to_python(self, value):
-        if value is None:
-            value = ""
+        if value is None or value == "None":
+            return
         allowed_characters = "0123456789abcdefABCDEF-,"
         if any(c for c in value if c not in allowed_characters):
             raise ValidationError("UUID list includes invalid characters")

--- a/app/tests/algorithms_tests/test_forms.py
+++ b/app/tests/algorithms_tests/test_forms.py
@@ -277,10 +277,10 @@ def test_create_experiment_json_input_field_validation(
 @pytest.mark.parametrize(
     "slug, content_parts",
     (
-        (None, ['class="invalid-feedback"', "Not a valid UUID: %(string)s"]),
+        (None, ['class="invalid-feedback"', "This field is required."]),
         (
             "generic-overlay",
-            ['class="invalid-feedback"', "Not a valid UUID: %(string)s"],
+            ['class="invalid-feedback"', "This field is required."],
         ),
         ("string", ['class="invalid-feedback"', "This field is required."]),
         ("integer", ['class="invalid-feedback"', "This field is required."]),


### PR DESCRIPTION
This PR adds support for `ComponentInterfaces` other than generic medical images to Archives.

Images can still be added to an Archive the same way as before. The only difference being that the desired `ComponentInterface` for the images now needs to be selected in the form:

![Screenshot from 2021-06-01 12-12-50](https://user-images.githubusercontent.com/57257130/120307601-77e02b80-c2d3-11eb-9aa0-3356fd5b7e56.png)


After adding cases users can now view the uploaded cases in the same manner as before, but there is also a new menu item `View Items`:


![Screenshot from 2021-06-01 12-12-14](https://user-images.githubusercontent.com/57257130/120307733-9d6d3500-c2d3-11eb-9c03-e8b0ee02d13a.png)

This takes the user to an overview of all the archive's `Archive Items`:


![Screenshot from 2021-06-01 12-13-37](https://user-images.githubusercontent.com/57257130/120307981-e329fd80-c2d3-11eb-9fed-750903c9294b.png)


The user then has the option to edit an `ArchiveItem` using a form that lists all available `ComponentInterfaces`:


![Screenshot from 2021-06-01 12-14-15](https://user-images.githubusercontent.com/57257130/120308102-02c12600-c2d4-11eb-8e80-2fbf2a4931b9.png)

Any fields that are filled in the form will overwrite existing values for the `ComponentInterface` or create a new `ComponentInterfaceValue` in the `ArchiveItem` in case there are none yet for the chosen interface.

Some caveats in the form:

- It is currently not possible to completely remove a `ComponentInterfaceValue` from an `ArchiveItem`
- The current value for a `ComponentInterfaceValue` is only shown for non file or image interfaces. 

