### PR TITLE
Replace google maps and chart js with vega lite

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -469,7 +469,6 @@ AUTHENTICATION_BACKENDS = [
     "guardian.backends.ObjectPermissionBackend",
 ]
 
-GOOGLE_MAPS_API_KEY = os.environ.get("GOOGLE_MAPS_API_KEY", "")
 GOOGLE_ANALYTICS_ID = os.environ.get("GOOGLE_ANALYTICS_ID", "GA_TRACKING_ID")
 
 ##############################################################################

--- a/app/grandchallenge/core/context_processors.py
+++ b/app/grandchallenge/core/context_processors.py
@@ -41,7 +41,6 @@ def challenge(request):
 def deployment_info(*_, **__):
     return {
         "google_analytics_id": settings.GOOGLE_ANALYTICS_ID,
-        "geochart_api_key": settings.GOOGLE_MAPS_API_KEY,
         "COMMIT_ID": settings.COMMIT_ID,
     }
 

--- a/app/grandchallenge/core/static/js/render_geocharts.js
+++ b/app/grandchallenge/core/static/js/render_geocharts.js
@@ -31,7 +31,7 @@ var spec = {
         "color": {
             "field": "participants",
             "type": "quantitative",
-            "scale": {"scheme": "viridis", "domainMin": 0},
+            "scale": {"scheme": "viridis", "domainMin": 1, "type": "log"},
             "legend": {"title": null, "type": "gradient"},
             "condition": {"test": "datum['participants'] === 0.01", "value": "#eee"}
         },

--- a/app/grandchallenge/core/static/js/render_geocharts.js
+++ b/app/grandchallenge/core/static/js/render_geocharts.js
@@ -1,49 +1,45 @@
 "use strict";
 
-$(document).ready(function () {
-    google.charts.load('current', {'packages': ['geochart']});
-    google.charts.setOnLoadCallback(drawGeoCharts);
-
-    function drawGeoCharts() {
-        google.visualization.mapsApiKey = '{{ geochart_api_key }}';
-        var charts = document.querySelectorAll('[data-geochart]');
-
-        for (var i = 0; i < charts.length; i++) {
-            try {
-                drawGeoChart(charts[i]);
-            } catch (err) {
-                console.log(err);
-            }
-        }
-    }
-
-    function drawGeoChart(element) {
-        var array = JSON.parse(element.dataset['geochart']);
-        var data = google.visualization.arrayToDataTable(array);
-        var options = {
-            colorAxis: {
-                colors: [
-                    '#440154',
-                    '#32658e',
-                    '#20a486',
-                    '#63cb5f',
-                    '#a8db34',
-                    '#d0e11c',
-                    '#e7e419',
-                    '#f1e51d',
-                    '#f8e621',
-                    '#fbe723',
-                    '#fbe723',
-                    '#fde725',
-                    '#fde725',
-                    '#fde725',
-                    '#fde725',
-                    '#fde725'
-                ]
+var countryParticipants = JSON.parse(document.getElementById("countryParticipants").textContent);
+var spec = {
+    "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+    "width": "container",
+    "height": "container",
+    "padding": 0,
+    "view": {
+        "stroke": "transparent",
+        "fill": "#c9eeff"
+    },
+    "data": {
+        "url": "https://cdn.jsdelivr.net/npm/world-atlas@2/countries-110m.json",
+        "format": {"type": "topojson", "feature": "countries"}
+    },
+    "transform": [
+        {
+            "lookup": "id",
+            "from": {
+                "data": {"values": countryParticipants},
+                "key": "id",
+                "fields": ["participants"]
             },
-            backgroundColor: '#c9eeff'
-        };
-        var chart = new google.visualization.GeoChart(element);
-        chart.draw(data, options);
+            "default": 0.01
+        }
+    ],
+    "projection": {"type": "equalEarth"},
+    "mark": {"type": "geoshape", "stroke": "#757575", "strokeWidth": 0.5},
+    "encoding": {
+        "color": {
+            "field": "participants",
+            "type": "quantitative",
+            "scale": {"scheme": "viridis", "domainMin": 0},
+            "legend": {"title": null, "type": "gradient"},
+            "condition": {"test": "datum['participants'] === 0.01", "value": "#eee"}
+        },
+        "tooltip": [
+            {"field": "properties.name", "type": "nominal", "title": "Country"},
+            {"field": "participants", "type": "quantitative", "title": "Participants", "format": ".0f"}
+        ]
     }
-});
+};
+
+vegaEmbed('#participantsGeoChart', spec, {"actions": false});

--- a/app/grandchallenge/core/static/js/render_geocharts.js
+++ b/app/grandchallenge/core/static/js/render_geocharts.js
@@ -1,7 +1,5 @@
-"use strict";
-
-var countryParticipants = JSON.parse(document.getElementById("countryParticipants").textContent);
-var spec = {
+const countryParticipants = JSON.parse(document.getElementById("countryParticipants").textContent);
+const spec = {
     "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
     "width": "container",
     "height": "container",
@@ -32,7 +30,7 @@ var spec = {
             "field": "participants",
             "type": "quantitative",
             "scale": {"scheme": "viridis", "domainMin": 1, "type": "log"},
-            "legend": {"title": null, "type": "gradient"},
+            "legend": null,
             "condition": {"test": "datum['participants'] === 0.01", "value": "#eee"}
         },
         "tooltip": [

--- a/app/grandchallenge/core/static/js/sort_tables.js
+++ b/app/grandchallenge/core/static/js/sort_tables.js
@@ -1,5 +1,3 @@
-"use strict";
-
 $(document).ready(function () {
     $('table.sortable').dataTable({
         "bJQueryUI": false,

--- a/app/grandchallenge/core/templates/grandchallenge/partials/geochart.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/geochart.html
@@ -1,6 +1,9 @@
-<div class="statistics">
-    {% if user_count %}
-        <p>Number of users: {{ user_count }}</p>
-    {% endif %}
-    <div data-geochart="{{ country_data }}"></div>
+{% if user_count %}
+    <p>Number of participants: {{ user_count }}</p>
+{% endif %}
+
+<div class="embed-responsive embed-responsive-21by9">
+    <div class="embed-responsive-item" id="participantsGeoChart"></div>
 </div>
+
+{{ country_data|json_script:"countryParticipants" }}

--- a/app/grandchallenge/core/templates/grandchallenge/partials/script.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/script.html
@@ -16,8 +16,3 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/blueimp-file-upload/9.31.0/js/jquery.fileupload.min.js"
         integrity="sha256-rFUfBX6nxajRE557glMx+ybBdfL9NXf8woMA1M1Tw0w="
         crossorigin="anonymous"></script>
-
-{# jquery cookies #}
-<script src="https://cdn.jsdelivr.net/npm/jquery.cookie@1.4.1/jquery.cookie.js"
-        integrity="sha256-uEFhyfv3UgzRTnAZ+SEgvYepKKB0FW6RqZLrqfyUNug="
-        crossorigin="anonymous"></script>

--- a/app/grandchallenge/pages/models.py
+++ b/app/grandchallenge/pages/models.py
@@ -118,13 +118,19 @@ class Page(models.Model):
         else:
             return user.has_perm(f"view_{self._meta.model_name}", self)
 
-    def cleaned_html(self):
-        out = clean(self.html)
+    @property
+    def detail_context(self):
+        context = {}
 
-        if "project_statistics" in out:
-            out = self._substitute_geochart(html=out)
+        cleaned_html = clean(self.html)
 
-        return out
+        if "project_statistics" in cleaned_html:
+            cleaned_html = self._substitute_geochart(html=cleaned_html)
+            context["includes_geochart"] = True
+
+        context["cleaned_html"] = cleaned_html
+
+        return context
 
     def _substitute_geochart(self, *, html):
         users = self.challenge.get_participants().select_related(

--- a/app/grandchallenge/pages/models.py
+++ b/app/grandchallenge/pages/models.py
@@ -1,10 +1,9 @@
-import json
-
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import Count, Max
 from django.template.loader import render_to_string
 from django.utils.html import format_html
+from django_countries import countries
 from guardian.shortcuts import assign_perm, remove_perm
 from simple_history.models import HistoricalRecords
 
@@ -142,9 +141,13 @@ class Page(models.Model):
             "grandchallenge/partials/geochart.html",
             {
                 "user_count": users.count(),
-                "country_data": json.dumps(
-                    [["Country", "#Participants"]] + list(country_data)
-                ),
+                "country_data": [
+                    {
+                        "id": countries.numeric(c[0], padded=True),
+                        "participants": c[1],
+                    }
+                    for c in country_data
+                ],
             },
         )
 

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -76,6 +76,9 @@
     {# For displaying equations on the site, the safe config is important #}
     <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML,Safe'
             async></script>
+    {# make the tables sortable #}
+    <script type="module"
+            src="{% static "js/sort_tables.js" %}"></script>
     {# geocharts #}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/vega/5.20.2/vega.min.js"
             integrity="sha512-cNxHgXBzKj+J32O+EhaG4v7CuZTVe7p+jBzu1N+QlUxFe/m3y0r1rAHTbBSFcQR5XagrXm43g/DfcmkFvvfIQQ=="
@@ -86,9 +89,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/6.17.0/vega-embed.min.js"
             integrity="sha512-APNk3zkoYiQb+AhF+HOkt3cj1u+xIymun1KTqKP32YZDRWgnN/sNmCeUL5QxecitZSgS0b/Wp0/WF0uFv1GO2A=="
             crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script type="text/javascript"
+    <script type="module"
             src="{% static "js/render_geocharts.js" %}"></script>
-    {# make the tables sortable #}
-    <script type="text/javascript"
-            src="{% static "js/sort_tables.js" %}"></script>
+
 {% endblock %}

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -27,7 +27,7 @@
 
 {% block sidebar %}
     <div class="nav-pill-pages-container col-12 col-sm-5 col-md-4 col-lg-3 pl-3">
-          <ul class="nav nav-pills flex-column">
+        <ul class="nav nav-pills flex-column">
             {% for page in pages %}
                 {% if not page.hidden %}
                     <li class="nav-item">
@@ -40,7 +40,7 @@
                     </li>
                 {% endif %}
             {% endfor %}
-          </ul>
+        </ul>
     </div>
 {% endblock %}
 
@@ -77,8 +77,15 @@
     <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML,Safe'
             async></script>
     {# geocharts #}
-    <script type="text/javascript"
-            src="https://www.gstatic.com/charts/loader.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega/5.20.2/vega.min.js"
+            integrity="sha512-cNxHgXBzKj+J32O+EhaG4v7CuZTVe7p+jBzu1N+QlUxFe/m3y0r1rAHTbBSFcQR5XagrXm43g/DfcmkFvvfIQQ=="
+            crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/5.1.0/vega-lite.min.js"
+            integrity="sha512-1FlIGoVpDTGmUpnMqFvsedEILJNp0mkDQ1JSuZwLR1yllAHzSSIPTl0cMp8S3F6UrmWFIeS4/Zr7ivVFAxAAQw=="
+            crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/6.17.0/vega-embed.min.js"
+            integrity="sha512-APNk3zkoYiQb+AhF+HOkt3cj1u+xIymun1KTqKP32YZDRWgnN/sNmCeUL5QxecitZSgS0b/Wp0/WF0uFv1GO2A=="
+            crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script type="text/javascript"
             src="{% static "js/render_geocharts.js" %}"></script>
     {# make the tables sortable #}

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -52,7 +52,7 @@
             </div>
         {% endif %}
 
-        <div id=pageContainer>{{ currentpage.cleaned_html }}</div>
+        <div id=pageContainer>{{ cleaned_html }}</div>
 
         {% if not currentpage.is_error_page %}
             {% if currentpage.pk %}
@@ -80,16 +80,17 @@
     <script type="module"
             src="{% static "js/sort_tables.js" %}"></script>
     {# geocharts #}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega/5.20.2/vega.min.js"
-            integrity="sha512-cNxHgXBzKj+J32O+EhaG4v7CuZTVe7p+jBzu1N+QlUxFe/m3y0r1rAHTbBSFcQR5XagrXm43g/DfcmkFvvfIQQ=="
-            crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/5.1.0/vega-lite.min.js"
-            integrity="sha512-1FlIGoVpDTGmUpnMqFvsedEILJNp0mkDQ1JSuZwLR1yllAHzSSIPTl0cMp8S3F6UrmWFIeS4/Zr7ivVFAxAAQw=="
-            crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/6.17.0/vega-embed.min.js"
-            integrity="sha512-APNk3zkoYiQb+AhF+HOkt3cj1u+xIymun1KTqKP32YZDRWgnN/sNmCeUL5QxecitZSgS0b/Wp0/WF0uFv1GO2A=="
-            crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script type="module"
-            src="{% static "js/render_geocharts.js" %}"></script>
-
+    {% if includes_geochart %}
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/vega/5.20.2/vega.min.js"
+                integrity="sha512-cNxHgXBzKj+J32O+EhaG4v7CuZTVe7p+jBzu1N+QlUxFe/m3y0r1rAHTbBSFcQR5XagrXm43g/DfcmkFvvfIQQ=="
+                crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/5.1.0/vega-lite.min.js"
+                integrity="sha512-1FlIGoVpDTGmUpnMqFvsedEILJNp0mkDQ1JSuZwLR1yllAHzSSIPTl0cMp8S3F6UrmWFIeS4/Zr7ivVFAxAAQw=="
+                crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/6.17.0/vega-embed.min.js"
+                integrity="sha512-APNk3zkoYiQb+AhF+HOkt3cj1u+xIymun1KTqKP32YZDRWgnN/sNmCeUL5QxecitZSgS0b/Wp0/WF0uFv1GO2A=="
+                crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        <script type="module"
+                src="{% static "js/render_geocharts.js" %}"></script>
+    {% endif %}
 {% endblock %}

--- a/app/grandchallenge/pages/views.py
+++ b/app/grandchallenge/pages/views.py
@@ -82,6 +82,11 @@ class PageDetail(
     def get_context_object_name(self, obj):
         return "currentpage"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(self.object.detail_context)
+        return context
+
 
 class ChallengeHome(PageDetail):
     def get_object(self, queryset=None):

--- a/app/grandchallenge/statistics/static/js/statistics/render_barchart.js
+++ b/app/grandchallenge/statistics/static/js/statistics/render_barchart.js
@@ -2,12 +2,12 @@ const challengeRegistrations = JSON.parse(document.getElementById("challengeRegi
 const challengeSubmissions = JSON.parse(document.getElementById("challengeSubmissions").textContent);
 const days = JSON.parse(document.getElementById("days").textContent);
 
-
 createStackedBarChart(challengeRegistrations, "num_registrations_period", `Number of registrations last ${days} days`, "#registrationsChart");
 createStackedBarChart(challengeSubmissions, "num_submissions_period", `Number of submissions last ${days} days`, "#submissionsChart");
 
 function createStackedBarChart(chartData, statisticLookup, statisticTitle, displayID) {
     const challengeNameLookup = "short_name";
+    const urlLookup = "absolute_url";
     const spec = {
         "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
         "width": "container",
@@ -28,7 +28,13 @@ function createStackedBarChart(chartData, statisticLookup, statisticTitle, displ
                 {"field": statisticLookup, "type": "quantitative", "title": statisticTitle, "format": ".0f"}
             ],
             "y": {"field": challengeNameLookup, "type": "nominal", "axis": {"labelAngle": 0}, "title": null},
-            "x": {"field": statisticLookup, "type": "quantitative", "title": statisticTitle}
+            "x": {
+                "field": statisticLookup,
+                "type": "quantitative",
+                "title": statisticTitle,
+                "axis": {"tickMinStep": "1", "format": ".0f"}
+            },
+            "href": {"field": urlLookup, "type": "nominal"}
         }
     }
 

--- a/app/grandchallenge/statistics/static/js/statistics/render_barchart.js
+++ b/app/grandchallenge/statistics/static/js/statistics/render_barchart.js
@@ -1,0 +1,28 @@
+
+var chartData = JSON.parse(document.getElementById("chartData").textContent);
+
+var spec = {
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "description": "A simple bar chart with embedded data.",
+  "data": {
+    "values": chartData
+  },
+  "mark": "bar",
+  "encoding": {
+    "color": {
+            "field": "a",
+            "type": "nominal",
+            "legend": null,
+            "scale": {"scheme": {"name": "viridis", "extent": [1, 0]}}
+        },
+        "tooltip": [
+            {"field": "a", "type": "nominal", "title": "Challenge"},
+            {"field": "b", "type": "quantitative", "title": "Number of Participants", "format": ".0f"}
+        ],
+    "y": {"field": "a", "type": "nominal", "axis": {"labelAngle": 0}, "title": null},
+    "x": {"field": "b", "type": "quantitative", "title": "Number of Participants"}
+  }
+}
+
+// TODO Update this and the source data
+vegaEmbed('#participantsGeoChart', spec, {"actions": false});

--- a/app/grandchallenge/statistics/static/js/statistics/render_barchart.js
+++ b/app/grandchallenge/statistics/static/js/statistics/render_barchart.js
@@ -1,28 +1,36 @@
+const challengeRegistrations = JSON.parse(document.getElementById("challengeRegistrations").textContent);
+const challengeSubmissions = JSON.parse(document.getElementById("challengeSubmissions").textContent);
+const days = JSON.parse(document.getElementById("days").textContent);
 
-var chartData = JSON.parse(document.getElementById("chartData").textContent);
 
-var spec = {
-  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
-  "description": "A simple bar chart with embedded data.",
-  "data": {
-    "values": chartData
-  },
-  "mark": "bar",
-  "encoding": {
-    "color": {
-            "field": "a",
-            "type": "nominal",
-            "legend": null,
-            "scale": {"scheme": {"name": "viridis", "extent": [1, 0]}}
+createStackedBarChart(challengeRegistrations, "num_registrations_period", `Number of registrations last ${days} days`, "#registrationsChart");
+createStackedBarChart(challengeSubmissions, "num_submissions_period", `Number of submissions last ${days} days`, "#submissionsChart");
+
+function createStackedBarChart(chartData, statisticLookup, statisticTitle, displayID) {
+    const challengeNameLookup = "short_name";
+    const spec = {
+        "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+        "width": "container",
+        "padding": 0,
+        "data": {
+            "values": chartData
         },
-        "tooltip": [
-            {"field": "a", "type": "nominal", "title": "Challenge"},
-            {"field": "b", "type": "quantitative", "title": "Number of Participants", "format": ".0f"}
-        ],
-    "y": {"field": "a", "type": "nominal", "axis": {"labelAngle": 0}, "title": null},
-    "x": {"field": "b", "type": "quantitative", "title": "Number of Participants"}
-  }
-}
+        "mark": "bar",
+        "encoding": {
+            "color": {
+                "field": challengeNameLookup,
+                "type": "nominal",
+                "legend": null,
+                "scale": {"scheme": {"name": "viridis", "extent": [1, 0]}}
+            },
+            "tooltip": [
+                {"field": challengeNameLookup, "type": "nominal", "title": "Challenge"},
+                {"field": statisticLookup, "type": "quantitative", "title": statisticTitle, "format": ".0f"}
+            ],
+            "y": {"field": challengeNameLookup, "type": "nominal", "axis": {"labelAngle": 0}, "title": null},
+            "x": {"field": statisticLookup, "type": "quantitative", "title": statisticTitle}
+        }
+    }
 
-// TODO Update this and the source data
-vegaEmbed('#participantsGeoChart', spec, {"actions": false});
+    vegaEmbed(displayID, spec, {"actions": false});
+}

--- a/app/grandchallenge/statistics/templates/statistics/statistics_detail.html
+++ b/app/grandchallenge/statistics/templates/statistics/statistics_detail.html
@@ -160,14 +160,22 @@
 
 {% block script %}
     {{ block.super }}
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega/5.20.2/vega.min.js"
+            integrity="sha512-cNxHgXBzKj+J32O+EhaG4v7CuZTVe7p+jBzu1N+QlUxFe/m3y0r1rAHTbBSFcQR5XagrXm43g/DfcmkFvvfIQQ=="
+            crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/5.1.0/vega-lite.min.js"
+            integrity="sha512-1FlIGoVpDTGmUpnMqFvsedEILJNp0mkDQ1JSuZwLR1yllAHzSSIPTl0cMp8S3F6UrmWFIeS4/Zr7ivVFAxAAQw=="
+            crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/6.17.0/vega-embed.min.js"
+            integrity="sha512-APNk3zkoYiQb+AhF+HOkt3cj1u+xIymun1KTqKP32YZDRWgnN/sNmCeUL5QxecitZSgS0b/Wp0/WF0uFv1GO2A=="
+            crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script type="text/javascript"
+            src="{% static "js/render_geocharts.js" %}"></script>
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js"
             integrity="sha256-CfcERD4Ov4+lKbWbYqXD6aFM9M51gN4GUEtDhkWABMo="
             crossorigin="anonymous"></script>
-
-    <script type="text/javascript"
-            src="https://www.gstatic.com/charts/loader.js"></script>
-    <script type="text/javascript"
-            src="{% static "js/render_geocharts.js" %}"></script>
 
     <script>
         var ctx = document.getElementById("registrationsChart");

--- a/app/grandchallenge/statistics/templates/statistics/statistics_detail.html
+++ b/app/grandchallenge/statistics/templates/statistics/statistics_detail.html
@@ -60,7 +60,7 @@
     <h4>Registrations to public challenges in the past {{ days }} days
         (top {{ max_num_results }})</h4>
 
-    <canvas id="registrationsChart"></canvas>
+    <div class="w-100" id="registrationsChart"></div>
 
     <br>
 
@@ -96,7 +96,7 @@
     <h4>Submissions to public challenges in the past {{ days }} days
         (top {{ max_num_results }})</h4>
 
-    <canvas id="submissionsChart"></canvas>
+    <div class="w-100" id="submissionsChart"></div>
 
     <br>
 
@@ -170,80 +170,10 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/6.17.0/vega-embed.min.js"
             integrity="sha512-APNk3zkoYiQb+AhF+HOkt3cj1u+xIymun1KTqKP32YZDRWgnN/sNmCeUL5QxecitZSgS0b/Wp0/WF0uFv1GO2A=="
             crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
     <script type="text/javascript"
             src="{% static "js/render_geocharts.js" %}"></script>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js"
-            integrity="sha256-CfcERD4Ov4+lKbWbYqXD6aFM9M51gN4GUEtDhkWABMo="
-            crossorigin="anonymous"></script>
-
-    <script>
-        var ctx = document.getElementById("registrationsChart");
-
-        var colormap = [
-            '#440154',
-            '#482979',
-            '#3e4c8a',
-            '#306a8e',
-            '#25858e',
-            '#1fa188',
-            '#3bbb75',
-            '#77d153',
-            '#c2df23',
-            '#fde725'
-        ].reverse();
-
-        var options = {
-            scales: {
-                xAxes: [{
-                    ticks: {
-                        beginAtZero: true
-                    }
-                }]
-            }
-        };
-
-        var registrationsChart = new Chart(ctx, {
-            type: 'horizontalBar',
-            data: {
-                labels: [
-                    {% for challenge in challenge_registrations_period %}
-                        "{{ challenge }}",
-                    {% endfor %}
-                ],
-                datasets: [{
-                    label: '# of Registrations (past {{ days }} days)',
-                    data: [
-                        {% for challenge in challenge_registrations_period %}
-                            {{ challenge.num_registrations_period }},
-                        {% endfor %}
-                    ],
-                    backgroundColor: colormap
-                }]
-            },
-            options: options
-        });
-
-        ctx = document.getElementById("submissionsChart");
-        var submissionsChart = new Chart(ctx, {
-            type: 'horizontalBar',
-            data: {
-                labels: [
-                    {% for challenge in challenge_submissions_period %}
-                        "{{ challenge }}",
-                    {% endfor %}
-                ],
-                datasets: [{
-                    label: '# of Submissions (past {{ days }} days)',
-                    data: [
-                        {% for challenge in challenge_submissions_period %}
-                            {{ challenge.num_submissions_period }},
-                        {% endfor %}
-                    ],
-                    backgroundColor: colormap
-                }]
-            },
-            options: options
-        });
-    </script>
+    <script type="text/javascript"
+            src="{% static "js/statistics/render_barchart.js" %}"></script>
 {% endblock %}

--- a/app/grandchallenge/statistics/templates/statistics/statistics_detail.html
+++ b/app/grandchallenge/statistics/templates/statistics/statistics_detail.html
@@ -171,9 +171,13 @@
             integrity="sha512-APNk3zkoYiQb+AhF+HOkt3cj1u+xIymun1KTqKP32YZDRWgnN/sNmCeUL5QxecitZSgS0b/Wp0/WF0uFv1GO2A=="
             crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
-    <script type="text/javascript"
+    <script type="module"
             src="{% static "js/render_geocharts.js" %}"></script>
 
-    <script type="text/javascript"
+    {{ challenge_registrations_period|json_script:"challengeRegistrations" }}
+    {{ challenge_submissions_period|json_script:"challengeSubmissions" }}
+    {{ days|json_script:"days" }}
+
+    <script type="module"
             src="{% static "js/statistics/render_barchart.js" %}"></script>
 {% endblock %}

--- a/app/grandchallenge/statistics/views.py
+++ b/app/grandchallenge/statistics/views.py
@@ -83,13 +83,18 @@ class StatisticsDetail(TemplateView):
                 .first()
             ),
             "challenge_registrations_period": (
-                public_challenges.filter(
-                    registrationrequest__created__gt=time_period
+                list(
+                    public_challenges.filter(
+                        registrationrequest__created__gt=time_period
+                    )
+                    .annotate(
+                        num_registrations_period=Count("registrationrequest")
+                    )
+                    .order_by("-num_registrations_period")
+                    .values("short_name", "num_registrations_period")[
+                        :max_num_results
+                    ]
                 )
-                .annotate(
-                    num_registrations_period=Count("registrationrequest")
-                )
-                .order_by("-num_registrations_period")[:max_num_results]
             ),
             "mp_challenge_submissions": (
                 public_challenges.annotate(
@@ -99,11 +104,18 @@ class StatisticsDetail(TemplateView):
                 .first()
             ),
             "challenge_submissions_period": (
-                public_challenges.filter(
-                    phase__submission__created__gt=time_period
+                list(
+                    public_challenges.filter(
+                        phase__submission__created__gt=time_period
+                    )
+                    .annotate(
+                        num_submissions_period=Count("phase__submission")
+                    )
+                    .order_by("-num_submissions_period")
+                    .values("short_name", "num_submissions_period")[
+                        :max_num_results
+                    ]
                 )
-                .annotate(num_submissions_period=Count("phase__submission"))
-                .order_by("-num_submissions_period")[:max_num_results]
             ),
             "latest_result": (
                 EvaluationJob.objects.filter(

--- a/app/grandchallenge/statistics/views.py
+++ b/app/grandchallenge/statistics/views.py
@@ -22,11 +22,25 @@ from grandchallenge.evaluation.models import (
 from grandchallenge.reader_studies.models import Answer, Question, ReaderStudy
 from grandchallenge.statistics import metrics
 from grandchallenge.statistics.renderers import PrometheusRenderer
+from grandchallenge.subdomains.utils import reverse
 from grandchallenge.workstations.models import Session, Workstation
 
 
 class StatisticsDetail(TemplateView):
     template_name = "statistics/statistics_detail.html"
+
+    @staticmethod
+    def _challenge_qs_to_list_with_url(challenge_list):
+        return [
+            {
+                **c,
+                "absolute_url": reverse(
+                    "pages:home",
+                    kwargs={"challenge_short_name": c["short_name"]},
+                ),
+            }
+            for c in challenge_list
+        ]
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -83,7 +97,7 @@ class StatisticsDetail(TemplateView):
                 .first()
             ),
             "challenge_registrations_period": (
-                list(
+                self._challenge_qs_to_list_with_url(
                     public_challenges.filter(
                         registrationrequest__created__gt=time_period
                     )
@@ -104,7 +118,7 @@ class StatisticsDetail(TemplateView):
                 .first()
             ),
             "challenge_submissions_period": (
-                list(
+                self._challenge_qs_to_list_with_url(
                     public_challenges.filter(
                         phase__submission__created__gt=time_period
                     )

--- a/app/grandchallenge/statistics/views.py
+++ b/app/grandchallenge/statistics/views.py
@@ -1,4 +1,3 @@
-import json
 from datetime import timedelta
 
 import prometheus_client
@@ -7,6 +6,7 @@ from django.contrib.auth.models import Group
 from django.db.models import Count, Sum
 from django.utils import timezone
 from django.views.generic import TemplateView
+from django_countries import countries
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -52,9 +52,13 @@ class StatisticsDetail(TemplateView):
             "days": days,
             "max_num_results": max_num_results,
             "number_of_users": User.objects.filter(is_active=True).count(),
-            "country_data": json.dumps(
-                [["Country", "#Participants"]] + list(country_data)
-            ),
+            "country_data": [
+                {
+                    "id": countries.numeric(c[0], padded=True),
+                    "participants": c[1],
+                }
+                for c in country_data
+            ],
             "new_users_period": (
                 User.objects.filter(date_joined__gt=time_period).count()
             ),

--- a/app/tests/pages_tests/test_substitutions.py
+++ b/app/tests/pages_tests/test_substitutions.py
@@ -66,5 +66,6 @@ def test_argument_substitution(inp, output):
 @pytest.mark.django_db
 def test_project_statistics():
     p = PageFactory(html="{% project_statistics %}")
-    html = p.cleaned_html()
-    assert "participantsGeoChart" in html
+    context = p.detail_context
+    assert "participantsGeoChart" in context["cleaned_html"]
+    assert context["includes_geochart"] is True

--- a/app/tests/pages_tests/test_substitutions.py
+++ b/app/tests/pages_tests/test_substitutions.py
@@ -67,4 +67,4 @@ def test_argument_substitution(inp, output):
 def test_project_statistics():
     p = PageFactory(html="{% project_statistics %}")
     html = p.cleaned_html()
-    assert "data-geochart" in html
+    assert "participantsGeoChart" in html

--- a/app/tests/statistics_tests/test_views.py
+++ b/app/tests/statistics_tests/test_views.py
@@ -15,7 +15,9 @@ def test_get_statistics(client):
 
     response = get_view_for_user(client=client, viewname="statistics:detail")
     assert response.status_code == 200
-    assert f"[&quot;NL&quot;, {n_dutch}]" in response.rendered_content
+    # String country IDs are used in the topojson file we download
+    # 528 is the ISO ID for the Netherlands
+    assert '{"id": "528", "participants": 3}' in response.rendered_content
 
 
 @pytest.mark.django_db

--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
     "datatables.net-bs4": "^1.10.18",
     "datatables.net-buttons-bs4": "^1.5.4",
     "blueimp-file-upload": "^9.31.0",
-    "jquery.cookie": "^1.4.1",
-    "mathjax": "^2.7.5",
-    "chart.js": "^2.7.2"
+    "mathjax": "^2.7.5"
   },
   "devDependencies": {
     "sass": "^1.25.0"


### PR DESCRIPTION
Consolidates the plotting libraries to use vega which we have already been using in observable (https://vega.github.io/vega-lite/docs/). Adds a link from the bar charts to the challenges. Uses an equal earth projection for the map (https://en.wikipedia.org/wiki/Equal_Earth_projection).