### PR TITLE
Add blog post create and update views

### DIFF
--- a/app/grandchallenge/archives/templates/archives/archive_form.html
+++ b/app/grandchallenge/archives/templates/archives/archive_form.html
@@ -3,7 +3,7 @@
 {% load url %}
 
 {% block title %}
-    New Archive - {{ block.super }}
+    {% if object %}Update{% else %}New{% endif %} Archive - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/grandchallenge/blogs/__init__.py
+++ b/app/grandchallenge/blogs/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "grandchallenge.blogs.apps.BlogsConfig"

--- a/app/grandchallenge/blogs/admin.py
+++ b/app/grandchallenge/blogs/admin.py
@@ -7,7 +7,7 @@ from grandchallenge.blogs.models import Post, Tag
 from grandchallenge.core.widgets import MarkdownEditorAdminWidget
 
 
-class PostForm(ModelForm):
+class AdminPostForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         for field in [
@@ -24,7 +24,7 @@ class PostForm(ModelForm):
 
 
 class PostAdmin(MarkdownxModelAdmin):
-    form = PostForm
+    form = AdminPostForm
     list_display = (
         "pk",
         "title",

--- a/app/grandchallenge/blogs/apps.py
+++ b/app/grandchallenge/blogs/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class BlogsConfig(AppConfig):
+    name = "grandchallenge.blogs"
+
+    def ready(self):
+        # noinspection PyUnresolvedReferences
+        import grandchallenge.blogs.signals  # noqa: F401

--- a/app/grandchallenge/blogs/filters.py
+++ b/app/grandchallenge/blogs/filters.py
@@ -17,7 +17,9 @@ class BlogFilter(FilterSet):
     )
     authors = ModelMultipleChoiceFilter(
         queryset=get_user_model()
-        .objects.filter(blog_authors__isnull=False)
+        .objects.filter(
+            blog_authors__isnull=False, blog_authors__published=True
+        )
         .distinct()
         .order_by("username"),
         widget=Select2MultipleWidget,
@@ -27,7 +29,7 @@ class BlogFilter(FilterSet):
     class Meta:
         model = Post
         form = FilterForm
-        fields = ("tags", "authors", "search")
+        fields = ("search", "authors", "tags")
         search_fields = ("title", "content")
 
     def search_filter(self, queryset, name, value):

--- a/app/grandchallenge/blogs/forms.py
+++ b/app/grandchallenge/blogs/forms.py
@@ -1,0 +1,30 @@
+from django import forms
+from django.contrib.auth import get_user_model
+from django_select2.forms import Select2Widget
+
+from grandchallenge.blogs.models import Post
+from grandchallenge.core.forms import SaveFormInitMixin
+
+
+class PostForm(SaveFormInitMixin, forms.ModelForm):
+    def __init__(self, *args, user, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["authors"].queryset = get_user_model().objects.filter(
+            pk=user.pk
+        )
+        self.fields["authors"].initial = [user]
+
+    class Meta:
+        model = Post
+        fields = (
+            "title",
+            "description",
+            "logo",
+            "authors",
+            "tags",
+        )
+        widgets = {
+            "tags": Select2Widget,
+            "authors": forms.MultipleHiddenInput,
+        }

--- a/app/grandchallenge/blogs/forms.py
+++ b/app/grandchallenge/blogs/forms.py
@@ -1,19 +1,25 @@
 from django import forms
-from django.contrib.auth import get_user_model
-from django_select2.forms import Select2Widget
+from django.core.exceptions import ValidationError
+from django_select2.forms import Select2MultipleWidget
+from guardian.utils import get_anonymous_user
 
 from grandchallenge.blogs.models import Post
 from grandchallenge.core.forms import SaveFormInitMixin
+from grandchallenge.core.widgets import MarkdownEditorWidget
 
 
 class PostForm(SaveFormInitMixin, forms.ModelForm):
-    def __init__(self, *args, user, **kwargs):
+    def __init__(self, *args, authors, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.fields["authors"].queryset = get_user_model().objects.filter(
-            pk=user.pk
-        )
-        self.fields["authors"].initial = [user]
+        self.fields["authors"].queryset = authors
+        self.fields["authors"].initial = authors
+
+    def clean_authors(self):
+        authors = self.cleaned_data["authors"]
+        if get_anonymous_user() in authors:
+            raise ValidationError("You cannot add this user!")
+        return authors
 
     class Meta:
         model = Post
@@ -25,6 +31,15 @@ class PostForm(SaveFormInitMixin, forms.ModelForm):
             "tags",
         )
         widgets = {
-            "tags": Select2Widget,
+            "tags": Select2MultipleWidget,
             "authors": forms.MultipleHiddenInput,
+        }
+
+
+class PostUpdateForm(PostForm):
+    class Meta(PostForm.Meta):
+        fields = (*PostForm.Meta.fields, "published", "content")
+        widgets = {
+            **PostForm.Meta.widgets,
+            "content": MarkdownEditorWidget,
         }

--- a/app/grandchallenge/blogs/forms.py
+++ b/app/grandchallenge/blogs/forms.py
@@ -15,6 +15,8 @@ class PostForm(SaveFormInitMixin, forms.ModelForm):
         self.fields["authors"].queryset = authors
         self.fields["authors"].initial = authors
 
+        self.fields["tags"].required = True
+
     def clean_authors(self):
         authors = self.cleaned_data["authors"]
         if get_anonymous_user() in authors:

--- a/app/grandchallenge/blogs/signals.py
+++ b/app/grandchallenge/blogs/signals.py
@@ -1,0 +1,37 @@
+from django.contrib.auth import get_user_model
+from django.db.models.signals import m2m_changed
+from django.dispatch import receiver
+from guardian.shortcuts import assign_perm, remove_perm
+
+from grandchallenge.blogs.models import Post
+
+
+@receiver(m2m_changed, sender=Post.authors.through)
+def update_permissions_on_authors_changed(
+    instance, action, reverse, pk_set, **_
+):
+    if action not in ["post_add", "post_remove", "pre_clear"]:
+        # nothing to do for the other actions
+        return
+
+    if reverse:
+        users = [instance]
+        if pk_set is None:
+            # When using a _clear action, pk_set is None
+            # https://docs.djangoproject.com/en/2.2/ref/signals/#m2m-changed
+            posts = instance.blog_authors.all()
+        else:
+            posts = Post.objects.filter(pk__in=pk_set)
+    else:
+        posts = Post.objects.get(pk=instance.pk)
+        if pk_set is None:
+            # When using a _clear action, pk_set is None
+            # https://docs.djangoproject.com/en/2.2/ref/signals/#m2m-changed
+            users = instance.authors.all()
+        else:
+            users = get_user_model().objects.filter(pk__in=pk_set)
+
+    op = assign_perm if "add" in action else remove_perm
+
+    for user in users:
+        op("change_post", user, posts)

--- a/app/grandchallenge/blogs/signals.py
+++ b/app/grandchallenge/blogs/signals.py
@@ -34,4 +34,5 @@ def update_permissions_on_authors_changed(
     op = assign_perm if "add" in action else remove_perm
 
     for user in users:
+        op("view_post", user, posts)
         op("change_post", user, posts)

--- a/app/grandchallenge/blogs/signals.py
+++ b/app/grandchallenge/blogs/signals.py
@@ -34,5 +34,4 @@ def update_permissions_on_authors_changed(
     op = assign_perm if "add" in action else remove_perm
 
     for user in users:
-        op("view_post", user, posts)
         op("change_post", user, posts)

--- a/app/grandchallenge/blogs/templates/blogs/post_detail.html
+++ b/app/grandchallenge/blogs/templates/blogs/post_detail.html
@@ -2,6 +2,7 @@
 {% load url %}
 {% load profiles %}
 {% load bleach %}
+{% load guardian_tags %}
 
 {% block title %}{{ object.title }} - Blogs - {{ block.super }}{% endblock %}
 
@@ -48,7 +49,8 @@
                     </ul>
                 </div>
             {% endif %}
-            {% if perms.blogs.change_post %}
+            {% get_obj_perms request.user for object as "object_perms" %}
+            {% if "change_post" in object_perms %}
                 <p>
                     <a href="{% url "blogs:update" slug=object.slug %}"
                        class="btn btn-primary">

--- a/app/grandchallenge/blogs/templates/blogs/post_detail.html
+++ b/app/grandchallenge/blogs/templates/blogs/post_detail.html
@@ -51,6 +51,10 @@
             {% endif %}
             {% get_obj_perms request.user for object as "object_perms" %}
             {% if "change_post" in object_perms %}
+                <div class="alert alert-warning" role="alert">
+                    This post is currently unpublished.
+                    Please bookmark this URL in case you want to come back to edit it.
+                </div>
                 <p>
                     <a href="{% url "blogs:update" slug=object.slug %}"
                        class="btn btn-primary">

--- a/app/grandchallenge/blogs/templates/blogs/post_detail.html
+++ b/app/grandchallenge/blogs/templates/blogs/post_detail.html
@@ -40,11 +40,21 @@
                     <ul class="list-group list-group-flush">
                         {% for tag in object.tags.all %}
                             <li class="list-group-item border-0">
-                                <a href="{% url 'blogs:list'%}?tags={{ tag.pk }}"><i class="fa fa-tags" aria-hidden="true"></i>&nbsp;&nbsp;{{ tag.name }}</a>
+                                <a href="{% url 'blogs:list' %}?tags={{ tag.pk }}"><i class="fa fa-tags"
+                                                                                      aria-hidden="true"></i>&nbsp;&nbsp;{{ tag.name }}
+                                </a>
                             </li>
                         {% endfor %}
                     </ul>
                 </div>
+            {% endif %}
+            {% if perms.blogs.change_post %}
+                <p>
+                    <a href="{% url "blogs:update" slug=object.slug %}"
+                       class="btn btn-primary">
+                        <i class="fa fa-edit"></i> Edit post
+                    </a>
+                </p>
             {% endif %}
         </div>
     </div>

--- a/app/grandchallenge/blogs/templates/blogs/post_form.html
+++ b/app/grandchallenge/blogs/templates/blogs/post_form.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags %}
+{% load url %}
+
+{% block title %}{% if object %}Update{% else %}New{% endif %} Post - {{ block.super }}{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% url 'blogs:list' %}">Blogs</a></li>
+        <li class="breadcrumb-item active">{% if object %}Update{% else %}New{% endif %} Post</li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <h2>{% if object %}Update{% else %}New{% endif %} Post</h2>
+
+    {% crispy form %}
+{% endblock %}

--- a/app/grandchallenge/blogs/templates/blogs/post_form.html
+++ b/app/grandchallenge/blogs/templates/blogs/post_form.html
@@ -2,17 +2,20 @@
 {% load crispy_forms_tags %}
 {% load url %}
 
-{% block title %}{% if object %}Update{% else %}New{% endif %} Post - {{ block.super }}{% endblock %}
+{% block title %}{% if object %}Update{% else %}Create{% endif %} Post - {{ block.super }}{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'blogs:list' %}">Blogs</a></li>
-        <li class="breadcrumb-item active">{% if object %}Update{% else %}New{% endif %} Post</li>
+        {% if object %}
+            <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{{ object }}</a></li>
+        {% endif %}
+        <li class="breadcrumb-item active">{% if object %}Update{% else %}Create{% endif %}</li>
     </ol>
 {% endblock %}
 
 {% block content %}
-    <h2>{% if object %}Update{% else %}New{% endif %} Post</h2>
+    <h2>{% if object %}Update{% else %}Create{% endif %} Post</h2>
 
     {% crispy form %}
 {% endblock %}

--- a/app/grandchallenge/blogs/templates/blogs/post_list.html
+++ b/app/grandchallenge/blogs/templates/blogs/post_list.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load url %}
 
 {% block title %}Blogs - {{ block.super }}{% endblock %}
 

--- a/app/grandchallenge/blogs/templates/blogs/post_list.html
+++ b/app/grandchallenge/blogs/templates/blogs/post_list.html
@@ -18,6 +18,15 @@
 
 {% block content %}
 
+    {% if perms.blogs.add_post %}
+        <p>
+            <a href="{% url "blogs:create" %}"
+               class="btn btn-primary">
+                <i class="fa fa-plus"></i> Add a new post
+            </a>
+        </p>
+    {% endif %}
+
     {% include "grandchallenge/partials/filters.html" with filter=filter filters_applied=filters_applied %}
 
     {% for object in object_list %}

--- a/app/grandchallenge/blogs/urls.py
+++ b/app/grandchallenge/blogs/urls.py
@@ -1,10 +1,17 @@
 from django.urls import path
 
-from grandchallenge.blogs.views import PostDetail, PostList
+from grandchallenge.blogs.views import (
+    PostCreate,
+    PostDetail,
+    PostList,
+    PostUpdate,
+)
 
 app_name = "blogs"
 
 urlpatterns = [
     path("", PostList.as_view(), name="list"),
+    path("create/", PostCreate.as_view(), name="create"),
     path("<slug>/", PostDetail.as_view(), name="detail"),
+    path("<slug>/update/", PostUpdate.as_view(), name="update"),
 ]

--- a/app/grandchallenge/blogs/views.py
+++ b/app/grandchallenge/blogs/views.py
@@ -1,6 +1,10 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from guardian.mixins import (
+    LoginRequiredMixin,
+    PermissionRequiredMixin as ObjectPermissionRequiredMixin,
+)
 
 from grandchallenge.blogs.filters import BlogFilter
 from grandchallenge.blogs.forms import PostForm, PostUpdateForm
@@ -23,10 +27,16 @@ class AuthorFormKwargsMixin:
         return form_kwargs
 
 
-class PostCreate(PermissionRequiredMixin, AuthorFormKwargsMixin, CreateView):
+class PostCreate(
+    LoginRequiredMixin,
+    PermissionRequiredMixin,
+    AuthorFormKwargsMixin,
+    CreateView,
+):
     model = Post
     form_class = PostForm
     permission_required = "blogs.add_post"
+    raise_exception = True
 
 
 class PostList(FilterMixin, ListView):
@@ -46,7 +56,13 @@ class PostDetail(DetailView):
         return qs
 
 
-class PostUpdate(PermissionRequiredMixin, AuthorFormKwargsMixin, UpdateView):
+class PostUpdate(
+    LoginRequiredMixin,
+    ObjectPermissionRequiredMixin,
+    AuthorFormKwargsMixin,
+    UpdateView,
+):
     model = Post
     form_class = PostUpdateForm
     permission_required = "blogs.change_post"
+    raise_exception = True

--- a/app/grandchallenge/blogs/views.py
+++ b/app/grandchallenge/blogs/views.py
@@ -1,25 +1,38 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
 
 from grandchallenge.blogs.filters import BlogFilter
-from grandchallenge.blogs.forms import PostForm
+from grandchallenge.blogs.forms import PostForm, PostUpdateForm
 from grandchallenge.blogs.models import Post
 from grandchallenge.core.filters import FilterMixin
-from grandchallenge.core.forms import UserFormKwargsMixin
 
 
-class PostCreate(UserFormKwargsMixin, CreateView):
+class AuthorFormKwargsMixin:
+    def get_form_kwargs(self, *args, **kwargs):
+        form_kwargs = super().get_form_kwargs(*args, **kwargs)
+
+        author_pks = {self.request.user.pk}
+
+        if self.object:
+            author_pks.add(*[a.pk for a in self.object.authors.all()])
+
+        authors = get_user_model().objects.filter(pk__in=author_pks)
+
+        form_kwargs.update({"authors": authors})
+        return form_kwargs
+
+
+class PostCreate(PermissionRequiredMixin, AuthorFormKwargsMixin, CreateView):
     model = Post
     form_class = PostForm
+    permission_required = "blogs.add_post"
 
 
 class PostList(FilterMixin, ListView):
     model = Post
     filter_class = BlogFilter
-
-    def get_queryset(self):
-        qs = super().get_queryset()
-        qs = qs.filter(published=True)
-        return qs
+    queryset = Post.objects.filter(published=True)
 
 
 class PostDetail(DetailView):
@@ -33,6 +46,7 @@ class PostDetail(DetailView):
         return qs
 
 
-class PostUpdate(UserFormKwargsMixin, UpdateView):
+class PostUpdate(PermissionRequiredMixin, AuthorFormKwargsMixin, UpdateView):
     model = Post
-    form_class = PostForm
+    form_class = PostUpdateForm
+    permission_required = "blogs.change_post"

--- a/app/grandchallenge/blogs/views.py
+++ b/app/grandchallenge/blogs/views.py
@@ -1,8 +1,15 @@
-from django.views.generic import DetailView, ListView
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
 
 from grandchallenge.blogs.filters import BlogFilter
+from grandchallenge.blogs.forms import PostForm
 from grandchallenge.blogs.models import Post
 from grandchallenge.core.filters import FilterMixin
+from grandchallenge.core.forms import UserFormKwargsMixin
+
+
+class PostCreate(UserFormKwargsMixin, CreateView):
+    model = Post
+    form_class = PostForm
 
 
 class PostList(FilterMixin, ListView):
@@ -24,3 +31,8 @@ class PostDetail(DetailView):
             "authors__user_profile", "authors__verification"
         )
         return qs
+
+
+class PostUpdate(UserFormKwargsMixin, UpdateView):
+    model = Post
+    form_class = PostForm

--- a/app/tests/blogs_tests/factory.py
+++ b/app/tests/blogs_tests/factory.py
@@ -1,0 +1,19 @@
+import factory
+
+from grandchallenge.blogs.models import Post
+from tests.factories import UserFactory
+
+
+class PostFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Post
+
+    @factory.post_generation
+    def authors(self, create, extracted, **kwargs):
+        # See https://factoryboy.readthedocs.io/en/latest/recipes.html#simple-many-to-many-relationship
+        if not create:
+            return
+        if extracted:
+            self.authors.set([*extracted])
+        if create and not extracted:
+            self.authors.set([UserFactory()])

--- a/app/tests/blogs_tests/test_permissions.py
+++ b/app/tests/blogs_tests/test_permissions.py
@@ -1,0 +1,41 @@
+import pytest
+from guardian.shortcuts import assign_perm, remove_perm
+
+from tests.blogs_tests.factory import PostFactory
+from tests.factories import UserFactory
+from tests.utils import get_view_for_user
+
+
+@pytest.mark.django_db
+class TestObjectPermissionRequiredViews:
+    def test_permission_required_views(self, client):
+        p = PostFactory()
+        u = UserFactory()
+
+        for view_name, kwargs, permission, obj in [
+            ("create", {}, "blogs.add_post", None),
+            (
+                "update",
+                {"slug": p.slug},
+                "blogs.change_post",
+                None,  # NOTE: Using global permissions for now
+            ),
+        ]:
+
+            def _get_view():
+                return get_view_for_user(
+                    client=client,
+                    viewname=f"blogs:{view_name}",
+                    reverse_kwargs=kwargs,
+                    user=u,
+                )
+
+            response = _get_view()
+            assert response.status_code == 403
+
+            assign_perm(permission, u, obj)
+
+            response = _get_view()
+            assert response.status_code == 200
+
+            remove_perm(permission, u, obj)

--- a/app/tests/blogs_tests/test_permissions.py
+++ b/app/tests/blogs_tests/test_permissions.py
@@ -14,12 +14,7 @@ class TestObjectPermissionRequiredViews:
 
         for view_name, kwargs, permission, obj in [
             ("create", {}, "blogs.add_post", None),
-            (
-                "update",
-                {"slug": p.slug},
-                "blogs.change_post",
-                None,  # NOTE: Using global permissions for now
-            ),
+            ("update", {"slug": p.slug}, "blogs.change_post", p,),
         ]:
 
             def _get_view():

--- a/app/tests/blogs_tests/test_signals.py
+++ b/app/tests/blogs_tests/test_signals.py
@@ -1,0 +1,45 @@
+import pytest
+
+from tests.blogs_tests.factory import PostFactory
+from tests.evaluation_tests.test_permissions import get_users_with_set_perms
+from tests.factories import UserFactory
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("reverse", [True, False])
+def test_post_authors_permissions_signal(client, reverse):
+    p1, p2 = PostFactory.create_batch(2)
+    u1, u2, u3, u4 = UserFactory.create_batch(4)
+
+    # Remove permissions from the default created user
+    p1.authors.clear()
+    p2.authors.clear()
+
+    if reverse:
+        for user in [u1, u2, u3, u4]:
+            user.blog_authors.add(p1, p2)
+        for user in [u3, u4]:
+            user.blog_authors.remove(p1, p2)
+        for user in [u1, u2]:
+            user.blog_authors.remove(p2)
+    else:
+        # Test that adding authors works
+        p1.authors.add(u1, u2, u3, u4)
+        # Test that removing authors works
+        p1.authors.remove(u3, u4)
+
+    assert get_users_with_set_perms(p1) == {
+        u1: {"change_post"},
+        u2: {"change_post"},
+    }
+    assert get_users_with_set_perms(p2) == {}
+
+    # Test clearing
+    if reverse:
+        u1.blog_authors.clear()
+        u2.blog_authors.clear()
+    else:
+        p1.authors.clear()
+
+    assert get_users_with_set_perms(p1) == {}
+    assert get_users_with_set_perms(p2) == {}

--- a/app/tests/blogs_tests/test_signals.py
+++ b/app/tests/blogs_tests/test_signals.py
@@ -29,8 +29,8 @@ def test_post_authors_permissions_signal(client, reverse):
         p1.authors.remove(u3, u4)
 
     assert get_users_with_set_perms(p1) == {
-        u1: {"change_post"},
-        u2: {"change_post"},
+        u1: {"change_post", "view_post"},
+        u2: {"change_post", "view_post"},
     }
     assert get_users_with_set_perms(p2) == {}
 

--- a/app/tests/blogs_tests/test_signals.py
+++ b/app/tests/blogs_tests/test_signals.py
@@ -29,8 +29,8 @@ def test_post_authors_permissions_signal(client, reverse):
         p1.authors.remove(u3, u4)
 
     assert get_users_with_set_perms(p1) == {
-        u1: {"change_post", "view_post"},
-        u2: {"change_post", "view_post"},
+        u1: {"change_post"},
+        u2: {"change_post"},
     }
     assert get_users_with_set_perms(p2) == {}
 

--- a/app/tests/evaluation_tests/test_permissions.py
+++ b/app/tests/evaluation_tests/test_permissions.py
@@ -30,6 +30,16 @@ def get_groups_with_set_perms(*args, **kwargs):
     return {k: {*v} for k, v in get_groups_with_perms(*args, **kwargs).items()}
 
 
+def get_users_with_set_perms(*args, **kwargs):
+    """
+    Executes get_users_with_perms with attach_perms=True, and converts the
+    resulting list for each group to a set for easier comparison in tests as
+    the ordering of permissions is not always consistent.
+    """
+    kwargs.update({"attach_perms": True})
+    return {k: {*v} for k, v in get_users_with_perms(*args, **kwargs).items()}
+
+
 class TestPhasePermissions(TestCase):
     def test_phase_permissions(self):
         """Only challenge admins should be able to view and change phases."""


### PR DESCRIPTION
Allows users with the global permissions to create a blog post, and for the blog post authors to edit that post. The user creating the post cannot add authors right now, but they can ask us to do it until that is implemented.