### PR TITLE
Add task do debug a worker

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -788,10 +788,21 @@ CORS_ALLOW_CREDENTIALS = True
 #
 ###############################################################################
 
+CELERY_TASK_DECORATOR_KWARGS = {
+    "acks-late-2xlarge": {
+        "acks_late": True,
+        "reject_on_worker_lost": True,
+        "queue": "acks-late-2xlarge",
+    }
+}
+
 CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", "django-db")
 CELERY_RESULT_PERSISTENT = True
 CELERY_TASK_ACKS_LATE = strtobool(
     os.environ.get("CELERY_TASK_ACKS_LATE", "False")
+)
+CELERY_WORKER_PREFETCH_MULTIPLIER = int(
+    os.environ.get("CELERY_WORKER_PREFETCH_MULTIPLIER", "1")
 )
 CELERY_TASK_SOFT_TIME_LIMIT = int(
     os.environ.get("CELERY_TASK_SOFT_TIME_LIMIT", "7200")

--- a/app/grandchallenge/core/tasks.py
+++ b/app/grandchallenge/core/tasks.py
@@ -1,6 +1,15 @@
+from time import sleep
+
 from celery import shared_task
+from django.conf import settings
 from django.contrib.sitemaps import ping_google as _ping_google
+from django.contrib.sites.models import Site
 from django.core.management import call_command
+
+from grandchallenge.core.storage import (
+    private_s3_storage,
+    protected_s3_storage,
+)
 
 
 @shared_task
@@ -12,3 +21,29 @@ def clear_sessions():
 @shared_task
 def ping_google():
     _ping_google()
+
+
+@shared_task(
+    bind=True, **settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-2xlarge"]
+)
+def debug_task_queue_worker(self, duration=120, check_connectivity=True):
+    """Debug task for checking workers on a queue"""
+    print(f"{self.acks_late=}")
+    print(f"{self.reject_on_worker_lost=}")
+
+    print(f"Sleeping {duration=}")
+    sleep(duration)
+    print("Awake")
+
+    if check_connectivity:
+        print("Checking db connectivity")
+        site = Site.objects.get_current()
+        print(f"{site=}")
+
+        print("Checking private S3 storage connectivity")
+        private_storage_object_exists = private_s3_storage.exists("test")
+        print(f"{private_storage_object_exists=}")
+
+        print("Checking protected S3 storage connectivity")
+        protected_storage_object_exists = protected_s3_storage.exists("test")
+        print(f"{protected_storage_object_exists=}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,7 +150,7 @@ services:
       WORKBENCH_SECRET_KEY: "${WORKBENCH_SECRET_KEY-}"
       WORKBENCH_API_URL: "${WORKBENCH_API_URL-}"
     restart: always
-    command: "celery -A config worker -l info -c 1"
+    command: "celery -A config worker -c 1 -Q celery,workstations-eu-central-1"
     scale: 1
     hostname: "celery-worker"
     depends_on:
@@ -172,9 +172,10 @@ services:
       <<: *postgresenv
       <<: *private_storage_credentials
       <<: *protected_storage_credentials
+      REMAP_SIGTERM: 'SIGQUIT'
       PYTHONDONTWRITEBYTECODE: 1
     restart: always
-    command: "celery -A config worker -l info -Q evaluation,images,workstations-eu-central-1 -c 1"
+    command: "celery -A config worker -c 1 -Q evaluation,images,gpu,acks-late-2xlarge"
     scale: 1
     hostname: "celery-worker-evaluation"
     depends_on:
@@ -196,34 +197,6 @@ services:
     group_add:
       - ${DOCKER_GID-1001}
 
-  celery_worker_gpu:
-    image: grandchallenge/web-test:latest
-    environment:
-      <<: *postgresenv
-      <<: *private_storage_credentials
-      <<: *protected_storage_credentials
-      PYTHONDONTWRITEBYTECODE: 1
-    restart: always
-    command: "celery -A config worker -l info -Q gpu -c 1"
-    scale: 1
-    hostname: "celery-worker-gpu"
-    depends_on:
-      web:
-        condition: service_started
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_started
-    volumes:
-      # The docker socket is only needed for testing
-      - type: bind
-        source: /var/run/docker.sock
-        target: /var/run/docker.sock
-      # Bind the app directory for live reloading in development
-      - type: bind
-        source: ./app
-        target: /app/
-
   celery_beat:
     image: grandchallenge/web-test:latest
     environment:
@@ -232,7 +205,7 @@ services:
     command: >-
         bash -c "
         rm -f /tmp/celerybeat.pid
-        && celery -A config beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler --pidfile=\"/tmp/celerybeat.pid\"
+        && celery -A config beat --scheduler django_celery_beat.schedulers:DatabaseScheduler --pidfile=\"/tmp/celerybeat.pid\"
         "
     depends_on:
       web:


### PR DESCRIPTION
This PR adds a task that prints some information about a worker, and adds a new queue for long running, idempotent tasks that require significant memory, based on the t3.2xlarge instances on AWS. The exact configuration TBC. 

Removes the separately running GPU worker, and splits the queues into ones that will consume acks-late tasks. Adds `REMAP_SIGTERM: 'SIGQUIT'` to stop the running tasks as-is.