### PR TITLE
Push images to public ECR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,21 +44,6 @@ jobs:
       - name: Build the test container
         run: |
           make build_web_test
-      - name: Build and push to ECR
-        run: |
-          make build
-          aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT}
-          make push_web_ecr
-          aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT}
-          make push_http_ecr
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT: ${{ secrets.GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT }}
-          GRAND_CHALLENGE_HTTP_REPOSITORY_URI: ${{ secrets.GRAND_CHALLENGE_HTTP_REPOSITORY_URI }}
-          GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT: ${{ secrets.GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT }}
-          GRAND_CHALLENGE_WEB_REPOSITORY_URI: ${{ secrets.GRAND_CHALLENGE_WEB_REPOSITORY_URI }}
       - name: Run the django tests
         run: |
           docker pull crccheck/hello-world
@@ -113,3 +98,17 @@ jobs:
         env:
           DOCKER_USER: grandchallenge
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Push to ECR
+        run: |
+          aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT}
+          make push_web_ecr
+          aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT}
+          make push_http_ecr
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT: ${{ secrets.GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT }}
+          GRAND_CHALLENGE_HTTP_REPOSITORY_URI: ${{ secrets.GRAND_CHALLENGE_HTTP_REPOSITORY_URI }}
+          GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT: ${{ secrets.GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT }}
+          GRAND_CHALLENGE_WEB_REPOSITORY_URI: ${{ secrets.GRAND_CHALLENGE_WEB_REPOSITORY_URI }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,20 @@ jobs:
   django-tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Login to ECR
+        run: |
+          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT}
+          docker image search --list-tags ${GRAND_CHALLENGE_HTTP_REPOSITORY_URI}
+          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT}
+          docker image search --list-tags ${GRAND_CHALLENGE_WEB_REPOSITORY_URI
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT: ${{ secrets.GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT }}
+          GRAND_CHALLENGE_HTTP_REPOSITORY_URI: ${{ secrets.GRAND_CHALLENGE_HTTP_REPOSITORY_URI }}
+          GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT: ${{ secrets.GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT }}
+          GRAND_CHALLENGE_WEB_REPOSITORY_URI: ${{ secrets.GRAND_CHALLENGE_WEB_REPOSITORY_URI }}
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,9 @@ jobs:
         run: |
           make build
           aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT}
-          docker tag grandchallenge/web:latest ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}:latest
-          docker push ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}:latest
+          make push_web_ecr
           aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT}
-          docker tag grandchallenge/http:latest ${GRAND_CHALLENGE_HTTP_REPOSITORY_URI}:latest
-          docker push ${GRAND_CHALLENGE_HTTP_REPOSITORY_URI}:latest
+          make push_http_ecr
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
         run: |
           make build
           aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT}
-          docker tag grand-challenge/web:latest ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}:latest
+          docker tag grandchallenge/web:latest ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}:latest
           docker push ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}:latest
           aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT}
-          docker tag grand-challenge/web:latest ${GRAND_CHALLENGE_HTTP_REPOSITORY_URI}:latest
+          docker tag grandchallenge/http:latest ${GRAND_CHALLENGE_HTTP_REPOSITORY_URI}:latest
           docker push ${GRAND_CHALLENGE_HTTP_REPOSITORY_URI}:latest
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,20 +26,6 @@ jobs:
   django-tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Login to ECR
-        run: |
-          aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT}
-          docker image search --list-tags ${GRAND_CHALLENGE_HTTP_REPOSITORY_URI}
-          aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT}
-          docker image search --list-tags ${GRAND_CHALLENGE_WEB_REPOSITORY_URI
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT: ${{ secrets.GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT }}
-          GRAND_CHALLENGE_HTTP_REPOSITORY_URI: ${{ secrets.GRAND_CHALLENGE_HTTP_REPOSITORY_URI }}
-          GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT: ${{ secrets.GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT }}
-          GRAND_CHALLENGE_WEB_REPOSITORY_URI: ${{ secrets.GRAND_CHALLENGE_WEB_REPOSITORY_URI }}
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2
         with:
@@ -58,6 +44,22 @@ jobs:
       - name: Build the test container
         run: |
           make build_web_test
+      - name: Login to ECR
+        run: |
+          aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT}
+          docker tag grand-challenge/web:latest ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}:latest
+          docker push ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}:latest
+          aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT}
+          docker tag grand-challenge/web:latest ${GRAND_CHALLENGE_HTTP_REPOSITORY_URI}:latest
+          docker push ${GRAND_CHALLENGE_HTTP_REPOSITORY_URI}:latest
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT: ${{ secrets.GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT }}
+          GRAND_CHALLENGE_HTTP_REPOSITORY_URI: ${{ secrets.GRAND_CHALLENGE_HTTP_REPOSITORY_URI }}
+          GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT: ${{ secrets.GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT }}
+          GRAND_CHALLENGE_WEB_REPOSITORY_URI: ${{ secrets.GRAND_CHALLENGE_WEB_REPOSITORY_URI }}
       - name: Run the django tests
         run: |
           docker pull crccheck/hello-world

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,10 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       - name: Push to ECR
         run: |
+          aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_WEB_BASE_REGISTRY_ENDPOINT}
+          make push_web_base_ecr
+          aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_WEB_TEST_BASE_REGISTRY_ENDPOINT}
+          make push_web_test_base_ecr
           aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT}
           make push_web_ecr
           aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT}
@@ -112,3 +116,7 @@ jobs:
           GRAND_CHALLENGE_HTTP_REPOSITORY_URI: ${{ secrets.GRAND_CHALLENGE_HTTP_REPOSITORY_URI }}
           GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT: ${{ secrets.GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT }}
           GRAND_CHALLENGE_WEB_REPOSITORY_URI: ${{ secrets.GRAND_CHALLENGE_WEB_REPOSITORY_URI }}
+          GRAND_CHALLENGE_WEB_BASE_REGISTRY_ENDPOINT: ${{ secrets.GRAND_CHALLENGE_WEB_BASE_REGISTRY_ENDPOINT }}
+          GRAND_CHALLENGE_WEB_BASE_REPOSITORY_URI: ${{ secrets.GRAND_CHALLENGE_WEB_BASE_REPOSITORY_URI }}
+          GRAND_CHALLENGE_WEB_TEST_BASE_REGISTRY_ENDPOINT: ${{ secrets.GRAND_CHALLENGE_WEB_TEST_BASE_REGISTRY_ENDPOINT }}
+          GRAND_CHALLENGE_WEB_TEST_BASE_REPOSITORY_URI: ${{ secrets.GRAND_CHALLENGE_WEB_TEST_BASE_REPOSITORY_URI }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,9 @@ jobs:
       - name: Build the test container
         run: |
           make build_web_test
-      - name: Login to ECR
+      - name: Build and push to ECR
         run: |
+          make build
           aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT}
           docker tag grand-challenge/web:latest ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}:latest
           docker push ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
     steps:
       - name: Login to ECR
         run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT}
+          aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT}
           docker image search --list-tags ${GRAND_CHALLENGE_HTTP_REPOSITORY_URI}
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT}
+          aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT}
           docker image search --list-tags ${GRAND_CHALLENGE_WEB_REPOSITORY_URI
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,21 @@ push_web:
 	docker push grandchallenge/web:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)
 	docker push grandchallenge/web:latest
 
+push_web_ecr:
+	docker tag grandchallenge/web:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH) $(GRAND_CHALLENGE_WEB_REPOSITORY_URI):$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)
+	docker push $(GRAND_CHALLENGE_WEB_REPOSITORY_URI):$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)
+	docker tag grandchallenge/web:latest $(GRAND_CHALLENGE_WEB_REPOSITORY_URI):latest
+	docker push $(GRAND_CHALLENGE_WEB_REPOSITORY_URI):latest
+
 push_http:
 	docker push grandchallenge/http:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)
 	docker push grandchallenge/http:latest
+
+push_http_ecr:
+	docker tag grandchallenge/http:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH) $(GRAND_CHALLENGE_HTTP_REPOSITORY_URI):$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)
+	docker push $(GRAND_CHALLENGE_HTTP_REPOSITORY_URI):$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)
+	docker tag grandchallenge/http:latest $(GRAND_CHALLENGE_HTTP_REPOSITORY_URI):latest
+	docker push $(GRAND_CHALLENGE_HTTP_REPOSITORY_URI):latest
 
 build: build_web_test build_web_dist build_http
 

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,16 @@ build_http:
 push_web_base:
 	docker push grandchallenge/web-base:$(PYTHON_VERSION)-$(GDCM_VERSION_TAG)-$(POETRY_HASH)
 
+push_web_base_ecr:
+	docker tag grandchallenge/web-base:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH) $(GRAND_CHALLENGE_WEB_BASE_REPOSITORY_URI):$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)
+	docker push $(GRAND_CHALLENGE_WEB_BASE_REPOSITORY_URI):$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)
+
 push_web_test_base:
 	docker push grandchallenge/web-test-base:$(PYTHON_VERSION)-$(GDCM_VERSION_TAG)-$(POETRY_HASH)
+
+push_web_test_base_ecr:
+	docker tag grandchallenge/web-test-base:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH) $(GRAND_CHALLENGE_WEB_TEST_BASE_REPOSITORY_URI):$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)
+	docker push $(GRAND_CHALLENGE_WEB_TEST_BASE_REPOSITORY_URI):$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)
 
 push_web:
 	docker push grandchallenge/web:$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(POETRY_HASH)


### PR DESCRIPTION
We are running on ECS so it makes sense that our images are on ECR. This PR adds commands so that the final images are re-tagged and pushed to ECR, with all of the secrets being populated from Terraform to GitHub actions. A later one will follow once the production instances are migrated to use these.