### PR TITLE
Migrate from docker hub to ECR public

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,23 +91,16 @@ jobs:
       - name: Build the distributable containers
         run: |
           make build
-      - name: Push the containers
-        run: |
-          echo $DOCKER_PASSWORD | docker login --username $DOCKER_USER --password-stdin
-          make push
-        env:
-          DOCKER_USER: grandchallenge
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       - name: Push to ECR
         run: |
           aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_WEB_BASE_REGISTRY_ENDPOINT}
-          make push_web_base_ecr
+          make push_web_base
           aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_WEB_TEST_BASE_REGISTRY_ENDPOINT}
-          make push_web_test_base_ecr
+          make push_web_test_base
           aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_WEB_REGISTRY_ENDPOINT}
-          make push_web_ecr
+          make push_web
           aws ecr-public get-login-password | docker login --username AWS --password-stdin ${GRAND_CHALLENGE_HTTP_REGISTRY_ENDPOINT}
-          make push_http_ecr
+          make push_http
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/cycle_docker_compose.sh
+++ b/cycle_docker_compose.sh
@@ -7,6 +7,10 @@ sleep 1
 export GIT_COMMIT_ID=$(git describe --always --dirty)
 export GIT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD | sed "s/[^[:alnum:]]//g")
 export DOCKER_GID=$(getent group docker | cut -d: -f3)
+export GRAND_CHALLENGE_HTTP_REPOSITORY_URI=public.ecr.aws/m3y0m7n5/grand-challenge/http
+export GRAND_CHALLENGE_WEB_REPOSITORY_URI=public.ecr.aws/m3y0m7n5/grand-challenge/web
+export GRAND_CHALLENGE_WEB_BASE_REPOSITORY_URI=public.ecr.aws/m3y0m7n5/grand-challenge/web-base
+export GRAND_CHALLENGE_WEB_TEST_BASE_REPOSITORY_URI=public.ecr.aws/m3y0m7n5/grand-challenge/web-test-base
 
 make build_web_test
 make build_http

--- a/cycle_docker_compose.sh
+++ b/cycle_docker_compose.sh
@@ -7,10 +7,6 @@ sleep 1
 export GIT_COMMIT_ID=$(git describe --always --dirty)
 export GIT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD | sed "s/[^[:alnum:]]//g")
 export DOCKER_GID=$(getent group docker | cut -d: -f3)
-export GRAND_CHALLENGE_HTTP_REPOSITORY_URI=public.ecr.aws/m3y0m7n5/grand-challenge/http
-export GRAND_CHALLENGE_WEB_REPOSITORY_URI=public.ecr.aws/m3y0m7n5/grand-challenge/web
-export GRAND_CHALLENGE_WEB_BASE_REPOSITORY_URI=public.ecr.aws/m3y0m7n5/grand-challenge/web-base
-export GRAND_CHALLENGE_WEB_TEST_BASE_REPOSITORY_URI=public.ecr.aws/m3y0m7n5/grand-challenge/web-test-base
 
 make build_web_test
 make build_http

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     restart: always
 
   web:
-    image: ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}-test:latest
+    image: public.ecr.aws/m3y0m7n5/grand-challenge/web-test:latest
     environment:
       <<: *postgresenv
       <<: &private_storage_credentials
@@ -112,7 +112,7 @@ services:
       - ${DOCKER_GID-1001} # The docker group is only needed for testing
 
   http:
-    image: ${GRAND_CHALLENGE_HTTP_REPOSITORY_URI}:latest
+    image: public.ecr.aws/m3y0m7n5/grand-challenge/http:latest
     environment:
       SERVER_NAME: gc.localhost
       SENDFILE_STATUS: 'off'
@@ -141,7 +141,7 @@ services:
       - "6379:6379" # Only required for running django locally
 
   celery_worker:
-    image: ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}-test:latest
+    image: public.ecr.aws/m3y0m7n5/grand-challenge/web-test:latest
     environment:
       <<: *postgresenv
       <<: *private_storage_credentials
@@ -167,7 +167,7 @@ services:
         target: /app/
 
   celery_worker_evaluation:
-    image: ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}-test:latest
+    image: public.ecr.aws/m3y0m7n5/grand-challenge/web-test:latest
     environment:
       <<: *postgresenv
       <<: *private_storage_credentials
@@ -198,7 +198,7 @@ services:
       - ${DOCKER_GID-1001}
 
   celery_beat:
-    image: ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}-test:latest
+    image: public.ecr.aws/m3y0m7n5/grand-challenge/web-test:latest
     environment:
       <<: *postgresenv
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     restart: always
 
   web:
-    image: grandchallenge/web-test:latest
+    image: ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}-test:latest
     environment:
       <<: *postgresenv
       <<: &private_storage_credentials
@@ -112,7 +112,7 @@ services:
       - ${DOCKER_GID-1001} # The docker group is only needed for testing
 
   http:
-    image: grandchallenge/http:latest
+    image: ${GRAND_CHALLENGE_HTTP_REPOSITORY_URI}:latest
     environment:
       SERVER_NAME: gc.localhost
       SENDFILE_STATUS: 'off'
@@ -141,7 +141,7 @@ services:
       - "6379:6379" # Only required for running django locally
 
   celery_worker:
-    image: grandchallenge/web-test:latest
+    image: ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}-test:latest
     environment:
       <<: *postgresenv
       <<: *private_storage_credentials
@@ -167,7 +167,7 @@ services:
         target: /app/
 
   celery_worker_evaluation:
-    image: grandchallenge/web-test:latest
+    image: ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}-test:latest
     environment:
       <<: *postgresenv
       <<: *private_storage_credentials
@@ -198,7 +198,7 @@ services:
       - ${DOCKER_GID-1001}
 
   celery_beat:
-    image: grandchallenge/web-test:latest
+    image: ${GRAND_CHALLENGE_WEB_REPOSITORY_URI}-test:latest
     environment:
       <<: *postgresenv
     restart: always

--- a/dockerfiles/http/Dockerfile
+++ b/dockerfiles/http/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.17
+FROM nginx:1.20
 
 RUN apt-get update && \
     apt-get install -y \

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -2,6 +2,8 @@
 ARG PYTHON_VERSION
 ARG GDCM_VERSION_TAG
 ARG POETRY_HASH
+ARG GRAND_CHALLENGE_WEB_TEST_BASE_REPOSITORY_URI
+ARG GRAND_CHALLENGE_WEB_BASE_REPOSITORY_URI
 
 #############
 # Vendor JS #
@@ -17,7 +19,7 @@ RUN npm install && npm run build
 ##################
 # Test Container #
 ##################
-FROM grandchallenge/web-test-base:${PYTHON_VERSION}-${GDCM_VERSION_TAG}-${POETRY_HASH} as test
+FROM ${GRAND_CHALLENGE_WEB_TEST_BASE_REPOSITORY_URI}:${PYTHON_VERSION}-${GDCM_VERSION_TAG}-${POETRY_HASH} as test
 
 COPY --chown=django:django setup.cfg /home/django
 
@@ -30,7 +32,7 @@ COPY --from=npm --chown=django:django /src/dist/ /opt/static/vendor/
 ##################
 # Dist Container #
 ##################
-FROM grandchallenge/web-base:${PYTHON_VERSION}-${GDCM_VERSION_TAG}-${POETRY_HASH} as dist
+FROM ${GRAND_CHALLENGE_WEB_BASE_REPOSITORY_URI}:${PYTHON_VERSION}-${GDCM_VERSION_TAG}-${POETRY_HASH} as dist
 
 USER django:django
 WORKDIR /app


### PR DESCRIPTION
Our containers now live on ECR at

```
GRAND_CHALLENGE_HTTP_REPOSITORY_URI = public.ecr.aws/m3y0m7n5/grand-challenge/http
GRAND_CHALLENGE_WEB_REPOSITORY_URI = public.ecr.aws/m3y0m7n5/grand-challenge/web
GRAND_CHALLENGE_WEB_BASE_REPOSITORY_URI = public.ecr.aws/m3y0m7n5/grand-challenge/web-base
GRAND_CHALLENGE_WEB_TEST_BASE_REPOSITORY_URI = public.ecr.aws/m3y0m7n5/grand-challenge/web-test-base
```