### PR TITLE
Do not change the token expiry

### DIFF
--- a/app/tests/workstations_tests/test_models.py
+++ b/app/tests/workstations_tests/test_models.py
@@ -111,7 +111,7 @@ def test_session_start(http_image, docker_client, settings):
             # noinspection PyStatementEffect
             s.service.container
     finally:
-        s.stop()
+        stop_all_sessions()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Set the token expiry to the session duration limit to avoid situations
where the token has expired but the session has not.

See https://teams.microsoft.com/l/message/19:6daf914d105b412989baaffa5b066dfa@thread.tacv2/1625204744307?tenantId=b208fe69-471e-48c4-8d87-025e9b9a157f&groupId=97a88c45-447f-4147-9e80-5e7c013f7501&parentMessageId=1625146521729&teamName=DIAG&channelName=Grand%20Challenge&createdTime=1625204744307