### PR TITLE
Lock the upload session and files when importing

### DIFF
--- a/app/grandchallenge/cases/models.py
+++ b/app/grandchallenge/cases/models.py
@@ -101,6 +101,9 @@ class RawImageUploadSession(UUIDModel):
         # Local import to avoid circular dependency
         from grandchallenge.cases.tasks import build_images
 
+        if self.status != self.PENDING:
+            raise RuntimeError("Job is not in PENDING state")
+
         RawImageUploadSession.objects.filter(pk=self.pk).update(
             status=RawImageUploadSession.REQUEUED
         )

--- a/app/tests/cases_tests/test_background_tasks.py
+++ b/app/tests/cases_tests/test_background_tasks.py
@@ -454,7 +454,7 @@ def test_failed_dicom_files_are_retained(settings):
     images = [f"dicom/{x}.dcm" for x in range(1, 21)]
     session, _ = create_raw_upload_image_session(images=images)
     session.refresh_from_db()
-    session.process_images()
+
     assert Image.objects.count() == 1
     assert not any(
         RawImageFile.objects.values_list("staged_file_id", flat=True)
@@ -466,7 +466,7 @@ def test_failed_dicom_files_are_retained(settings):
     images = [f"dicom/{x}.dcm" for x in range(1, 22)]
     session, _ = create_raw_upload_image_session(images=images)
     session.refresh_from_db()
-    session.process_images()
+
     assert Image.objects.count() == 1
     assert not any(
         RawImageFile.objects.values_list("staged_file_id", flat=True)
@@ -480,7 +480,7 @@ def test_failed_dicom_files_are_retained(settings):
     g.user_set.add(user)
     session, _ = create_raw_upload_image_session(images=images, user=user)
     session.refresh_from_db()
-    session.process_images()
+
     assert Image.objects.count() == 1
     assert all(RawImageFile.objects.values_list("staged_file_id", flat=True))
     RawImageFile.objects.all().delete()

--- a/app/tests/cases_tests/test_tasks.py
+++ b/app/tests/cases_tests/test_tasks.py
@@ -19,13 +19,6 @@ def test_linked_task_called_with_session_pk(settings):
 
     session = UploadSessionFactory()
 
-    session.process_images()
-
-    assert called == {}
-
-    session.status = session.REQUEUED
-    session.save()
-
     with capture_on_commit_callbacks(execute=True):
         session.process_images(linked_task=local_linked_task.signature())
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,7 +152,7 @@ services:
       WORKBENCH_SECRET_KEY: "${WORKBENCH_SECRET_KEY-}"
       WORKBENCH_API_URL: "${WORKBENCH_API_URL-}"
     restart: always
-    command: "celery -A config worker -c 1 -Q celery,workstations-eu-central-1"
+    command: "celery -A config worker -l info -c 1 -Q celery,workstations-eu-central-1"
     scale: 1
     hostname: "celery-worker"
     depends_on:
@@ -178,7 +178,7 @@ services:
       DEBUG: 'true'
       PYTHONDONTWRITEBYTECODE: 1
     restart: always
-    command: "celery -A config worker -c 1 -Q evaluation,gpu,acks-late-2xlarge"
+    command: "celery -A config worker -l info -c 1 -Q evaluation,gpu,acks-late-2xlarge"
     scale: 1
     hostname: "celery-worker-evaluation"
     depends_on:


### PR DESCRIPTION
Makes a change to the `build_images` task so that the session and associated files are locked when being imported by the worker. This ensures that if many workers claim the tasks on only runs, and that jobs can be retried when rejected by a worker. Constructions are a little weird as locking must be applied to a queryset, and then can only be used within a transaction, so two transactions are created with atomic blocks to first update the job status, then update the images.