### PR TITLE
Adds list and create views for publications

### DIFF
--- a/app/config/urls/root.py
+++ b/app/config/urls/root.py
@@ -139,6 +139,10 @@ urlpatterns = [
         ),
     ),
     path("forums/", include(machina_urls)),
+    path(
+        "publications/",
+        include("grandchallenge.publications.urls", namespace="publications"),
+    ),
 ]
 
 if settings.DEBUG and settings.ENABLE_DEBUG_TOOLBAR:

--- a/app/grandchallenge/publications/__init__.py
+++ b/app/grandchallenge/publications/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "grandchallenge.publications.apps.PublicationsConfig"

--- a/app/grandchallenge/publications/apps.py
+++ b/app/grandchallenge/publications/apps.py
@@ -14,9 +14,6 @@ def init_publication_permissions(*_, **__):
     assign_perm(
         f"{Publication._meta.app_label}.add_{Publication._meta.model_name}", g
     )
-    assign_perm(
-        f"{Publication._meta.app_label}.view_{Publication._meta.model_name}", g
-    )
 
 
 class PublicationsConfig(AppConfig):

--- a/app/grandchallenge/publications/apps.py
+++ b/app/grandchallenge/publications/apps.py
@@ -1,0 +1,26 @@
+from django.apps import AppConfig
+from django.conf import settings
+from django.db.models.signals import post_migrate
+
+
+def init_publication_permissions(*_, **__):
+    from django.contrib.auth.models import Group
+    from guardian.shortcuts import assign_perm
+    from grandchallenge.publications.models import Publication
+
+    g, _ = Group.objects.get_or_create(
+        name=settings.REGISTERED_USERS_GROUP_NAME
+    )
+    assign_perm(
+        f"{Publication._meta.app_label}.add_{Publication._meta.model_name}", g
+    )
+    assign_perm(
+        f"{Publication._meta.app_label}.view_{Publication._meta.model_name}", g
+    )
+
+
+class PublicationsConfig(AppConfig):
+    name = "grandchallenge.publications"
+
+    def ready(self):
+        post_migrate.connect(init_publication_permissions, sender=self)

--- a/app/grandchallenge/publications/filters.py
+++ b/app/grandchallenge/publications/filters.py
@@ -1,0 +1,18 @@
+from django_filters import CharFilter, FilterSet
+
+from grandchallenge.core.filters import FilterForm
+from grandchallenge.publications.models import Publication
+
+
+class PublicationFilter(FilterSet):
+    year = CharFilter(label="Year",)
+    authors = CharFilter(label="Author", method="search_filter",)
+
+    class Meta:
+        model = Publication
+        form = FilterForm
+        fields = ("year",)
+        search_fields = ("year", "authors")
+
+    def search_filter(self, queryset, name, value):
+        return queryset.filter(citation__icontains=value)

--- a/app/grandchallenge/publications/filters.py
+++ b/app/grandchallenge/publications/filters.py
@@ -1,18 +1,24 @@
-from django_filters import CharFilter, FilterSet
+from django_filters import CharFilter, Filter, FilterSet
 
 from grandchallenge.core.filters import FilterForm
 from grandchallenge.publications.models import Publication
 
 
+class AuthorFilter(Filter):
+    def filter(self, qs, value):
+        if value:
+            pub_list = [row.id for row in qs if value in row.authors]
+            return qs.filter(pk__in=pub_list)
+        else:
+            return qs
+
+
 class PublicationFilter(FilterSet):
     year = CharFilter(label="Year",)
-    authors = CharFilter(label="Author", method="search_filter",)
+    authors = AuthorFilter(label="Author last name")
 
     class Meta:
         model = Publication
         form = FilterForm
         fields = ("year",)
         search_fields = ("year", "authors")
-
-    def search_filter(self, queryset, name, value):
-        return queryset.filter(citation__icontains=value)

--- a/app/grandchallenge/publications/models.py
+++ b/app/grandchallenge/publications/models.py
@@ -150,8 +150,4 @@ class Publication(models.Model):
 
     @property
     def authors(self):
-        authors = []
-        match = re.search(r".+?\.", self.citation)
-        for author in re.split(",", match.group()):
-            authors.append(re.split(r"\s", re.sub(r"^\s", "", author))[0])
-        return authors
+        return [a["family"] for a in self.csl.get("author", [])]

--- a/app/grandchallenge/publications/models.py
+++ b/app/grandchallenge/publications/models.py
@@ -147,3 +147,11 @@ class Publication(models.Model):
         citation = re.sub(r"^1\. ", "", citation)
 
         return clean(citation)
+
+    @property
+    def authors(self):
+        authors = []
+        match = re.search(r".+?\.", self.citation)
+        for author in re.split(",", match.group()):
+            authors.append(re.split(r"\s", re.sub(r"^\s", "", author))[0])
+        return authors

--- a/app/grandchallenge/publications/templates/publications/publication_form.html
+++ b/app/grandchallenge/publications/templates/publications/publication_form.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% load crispy_forms_tags %}
+
+{% block title %}Add Publication{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% url 'publications:list' %}">Publications</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Add Publication</li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <h1>{% trans "Add a publication" %}</h1>
+    <form action="" enctype="multipart/form-data" method="post">
+        {% csrf_token %}
+        {{ form | crispy }}
+        <input class="btn btn-primary" type="submit" value="{% trans "Save publication" %}"/>
+    </form>
+{% endblock %}

--- a/app/grandchallenge/publications/templates/publications/publication_list.html
+++ b/app/grandchallenge/publications/templates/publications/publication_list.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+{% load static %}
+{% load publication_extras %}
+{% load guardian_tags %}
+{% load url %}
+
+
+{% block title %}Publications - {{ block.super }}{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item active" aria-current="page">Publications</li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <div class="d-flex justify-content-between">
+        <h2>Publications</h2>
+        <a class="btn btn-primary my-3" href="{% url 'publications:create' %}" role="button">Add a publication</a>
+    </div>
+        <ul class="list-group">
+            {% for publication in object_list %}
+                <li class="list-group-item p-0">
+                    <div class="py-2 pl-3">
+                        {{ publication.citation|safe }}
+                    </div>
+                    <div class="pt-1 pb-2 pl-3">
+                        <a class="btn btn-outline-primary btn-sm mb-1 mr-1" href="{{ publication.url }}"><i class="fa fa-link"></i></a>
+                        {% with publication|get_associated_objects as publication_objects %}
+                            {% if publication_objects %}
+                                {% for obj, obj_model in publication_objects.items %}
+                                    {% get_obj_perms request.user for obj as "object_perms" %}
+                                    {% if "view_"|add:obj_model in object_perms %}
+                                        <a class="btn btn-outline-primary btn-sm mb-1 mr-1" href="{{ obj.get_absolute_url }}">{{ obj }}</a>
+                                    {% endif %}
+                                {% endfor %}
+                            {% endif %}
+                        {% endwith %}
+                    </div>
+                </li>
+                {% empty %}
+                <li class="list-group-item">No publications found.</li>
+            {% endfor %}
+        </ul>
+    <br>
+    {% include "grandchallenge/partials/pagination.html" %}
+{% endblock %}

--- a/app/grandchallenge/publications/templates/publications/publication_list.html
+++ b/app/grandchallenge/publications/templates/publications/publication_list.html
@@ -31,16 +31,12 @@
                     </div>
                     <div class="pt-1 pb-2 pl-3">
                         <a class="btn btn-outline-primary btn-sm mb-1 mr-1" href="{{ publication.url }}"><i class="fa fa-link"></i></a>
-                        {% with publication|get_associated_objects as publication_objects %}
-                            {% if publication_objects %}
-                                {% for obj, obj_model in publication_objects.items %}
-                                    {% get_obj_perms request.user for obj as "object_perms" %}
-                                    {% if "view_"|add:obj_model in object_perms %}
-                                        <a class="btn btn-outline-primary btn-sm mb-1 mr-1" href="{{ obj.get_absolute_url }}">{{ obj }}</a>
-                                    {% endif %}
-                                {% endfor %}
-                            {% endif %}
-                        {% endwith %}
+                        {% get_associated_objects publication=publication checker=checker as publication_objects %}
+                        {% if publication_objects %}
+                            {% for obj, obj_model in publication_objects.items %}
+                                <a class="btn btn-outline-primary btn-sm mb-1 mr-1" href="{{ obj.get_absolute_url }}">{{ obj }}</a>
+                            {% endfor %}
+                        {% endif %}
                     </div>
                 </li>
                 {% empty %}

--- a/app/grandchallenge/publications/templates/publications/publication_list.html
+++ b/app/grandchallenge/publications/templates/publications/publication_list.html
@@ -3,6 +3,7 @@
 {% load publication_extras %}
 {% load guardian_tags %}
 {% load url %}
+{% load bleach %}
 
 
 {% block title %}Publications - {{ block.super }}{% endblock %}
@@ -26,7 +27,7 @@
             {% for publication in object_list %}
                 <li class="list-group-item p-0">
                     <div class="py-2 pl-3">
-                        {{ publication.citation|safe }}
+                        {{ publication.citation|clean }}
                     </div>
                     <div class="pt-1 pb-2 pl-3">
                         <a class="btn btn-outline-primary btn-sm mb-1 mr-1" href="{{ publication.url }}"><i class="fa fa-link"></i></a>

--- a/app/grandchallenge/publications/templates/publications/publication_list.html
+++ b/app/grandchallenge/publications/templates/publications/publication_list.html
@@ -14,6 +14,7 @@
 {% endblock %}
 
 {% block content %}
+        {% include "grandchallenge/partials/filters.html" with filter=filter filters_applied=filters_applied %}
     <div>
         <h2>Publications</h2>
     </div>

--- a/app/grandchallenge/publications/templates/publications/publication_list.html
+++ b/app/grandchallenge/publications/templates/publications/publication_list.html
@@ -14,9 +14,12 @@
 {% endblock %}
 
 {% block content %}
-    <div class="d-flex justify-content-between">
+    <div>
         <h2>Publications</h2>
-        <a class="btn btn-primary my-3" href="{% url 'publications:create' %}" role="button">Add a publication</a>
+    </div>
+    <div class="d-flex justify-content-between my-3">
+        <h6 class="ml-1 mt-2">{{ num_publications }} publications | {{ num_citations }} citations </h6>
+        <a class="btn btn-primary" href="{% url 'publications:create' %}" role="button">Add a publication</a>
     </div>
         <ul class="list-group">
             {% for publication in object_list %}

--- a/app/grandchallenge/publications/templates/publications/publication_list.html
+++ b/app/grandchallenge/publications/templates/publications/publication_list.html
@@ -20,8 +20,10 @@
         <h2>Publications</h2>
     </div>
     <div class="d-flex justify-content-between my-3">
-        <h6 class="ml-1 mt-2">{{ num_publications }} publications | {{ num_citations }} citations </h6>
-        <a class="btn btn-primary" href="{% url 'publications:create' %}" role="button">Add a publication</a>
+        <h6 class="ml-1 mt-2">{{ paginator.count }} publications | {{ num_citations }} citations </h6>
+        {% if perms.publications.add_publication %}
+            <a class="btn btn-primary" href="{% url 'publications:create' %}" role="button">Add a publication</a>
+        {% endif %}
     </div>
         <ul class="list-group">
             {% for publication in object_list %}

--- a/app/grandchallenge/publications/templatetags/publication_extras.py
+++ b/app/grandchallenge/publications/templatetags/publication_extras.py
@@ -1,0 +1,43 @@
+from django import template
+
+from grandchallenge.algorithms.models import Algorithm
+from grandchallenge.archives.models import Archive
+from grandchallenge.challenges.models import Challenge, ExternalChallenge
+from grandchallenge.reader_studies.models import ReaderStudy
+
+register = template.Library()
+
+
+@register.filter
+def get_associated_objects(publication):
+    objects = {}
+    for archive in publication.archive_set.all():
+        objects[Archive.objects.filter(pk=archive.pk).get()] = (
+            Archive.objects.filter(pk=archive.pk).get()._meta.model_name
+        )
+
+    for algorithm in publication.algorithm_set.all():
+        objects[Algorithm.objects.filter(pk=algorithm.pk).get()] = (
+            Algorithm.objects.filter(pk=algorithm.pk).get()._meta.model_name
+        )
+
+    for readerstudy in publication.readerstudy_set.all():
+        objects[ReaderStudy.objects.filter(pk=readerstudy.pk).get()] = (
+            ReaderStudy.objects.filter(pk=readerstudy.pk)
+            .get()
+            ._meta.model_name
+        )
+
+    for challenge in publication.challenge_set.all():
+        objects[Challenge.objects.filter(pk=challenge.pk).get()] = (
+            Challenge.objects.filter(pk=challenge.pk).get()._meta.model_name
+        )
+
+    for extchallenge in publication.externalchallenge_set.all():
+        objects[ExternalChallenge.objects.filter(pk=extchallenge.pk).get()] = (
+            ExternalChallenge.objects.filter(pk=extchallenge.pk)
+            .get()
+            ._meta.model_name
+        )
+
+    return objects

--- a/app/grandchallenge/publications/templatetags/publication_extras.py
+++ b/app/grandchallenge/publications/templatetags/publication_extras.py
@@ -1,43 +1,26 @@
 from django import template
 
-from grandchallenge.algorithms.models import Algorithm
-from grandchallenge.archives.models import Archive
-from grandchallenge.challenges.models import Challenge, ExternalChallenge
-from grandchallenge.reader_studies.models import ReaderStudy
-
 register = template.Library()
 
 
 @register.filter
 def get_associated_objects(publication):
+
+    archives = publication.archive_set.all()
+    algorithms = publication.algorithm_set.all()
+    reader_studies = publication.readerstudy_set.all()
+    challenges = publication.challenge_set.all()
+    external_challenges = publication.externalchallenge_set.all()
+
+    object_list = [
+        *archives,
+        *reader_studies,
+        *challenges,
+        *external_challenges,
+        *algorithms,
+    ]
     objects = {}
-    for archive in publication.archive_set.all():
-        objects[Archive.objects.filter(pk=archive.pk).get()] = (
-            Archive.objects.filter(pk=archive.pk).get()._meta.model_name
-        )
-
-    for algorithm in publication.algorithm_set.all():
-        objects[Algorithm.objects.filter(pk=algorithm.pk).get()] = (
-            Algorithm.objects.filter(pk=algorithm.pk).get()._meta.model_name
-        )
-
-    for readerstudy in publication.readerstudy_set.all():
-        objects[ReaderStudy.objects.filter(pk=readerstudy.pk).get()] = (
-            ReaderStudy.objects.filter(pk=readerstudy.pk)
-            .get()
-            ._meta.model_name
-        )
-
-    for challenge in publication.challenge_set.all():
-        objects[Challenge.objects.filter(pk=challenge.pk).get()] = (
-            Challenge.objects.filter(pk=challenge.pk).get()._meta.model_name
-        )
-
-    for extchallenge in publication.externalchallenge_set.all():
-        objects[ExternalChallenge.objects.filter(pk=extchallenge.pk).get()] = (
-            ExternalChallenge.objects.filter(pk=extchallenge.pk)
-            .get()
-            ._meta.model_name
-        )
+    for obj in object_list:
+        objects[obj] = obj._meta.model_name
 
     return objects

--- a/app/grandchallenge/publications/templatetags/publication_extras.py
+++ b/app/grandchallenge/publications/templatetags/publication_extras.py
@@ -3,8 +3,8 @@ from django import template
 register = template.Library()
 
 
-@register.filter
-def get_associated_objects(publication):
+@register.simple_tag
+def get_associated_objects(*, publication, checker):
 
     archives = publication.archive_set.all()
     algorithms = publication.algorithm_set.all()
@@ -21,6 +21,7 @@ def get_associated_objects(publication):
     ]
     objects = {}
     for obj in object_list:
-        objects[obj] = obj._meta.model_name
+        if checker.has_perm(f"view_{obj._meta.model_name}", obj):
+            objects[obj] = obj._meta.model_name
 
     return objects

--- a/app/grandchallenge/publications/urls.py
+++ b/app/grandchallenge/publications/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from grandchallenge.publications.views import (
+    PublicationCreate,
+    PublicationList,
+)
+
+app_name = "publications"
+
+urlpatterns = [
+    path("", PublicationList.as_view(), name="list"),
+    path("create/", PublicationCreate.as_view(), name="create",),
+]

--- a/app/grandchallenge/publications/views.py
+++ b/app/grandchallenge/publications/views.py
@@ -1,0 +1,31 @@
+from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.contrib.messages.views import SuccessMessageMixin
+from django.views.generic import CreateView, ListView
+from guardian.mixins import LoginRequiredMixin
+
+from grandchallenge.publications.forms import PublicationForm
+from grandchallenge.publications.models import Publication
+from grandchallenge.subdomains.utils import reverse
+
+
+class PublicationList(LoginRequiredMixin, ListView):
+    model = Publication
+    paginate_by = 50
+
+    def get_queryset(self):
+        return super().get_queryset().order_by("-created")
+
+
+class PublicationCreate(
+    LoginRequiredMixin,
+    PermissionRequiredMixin,
+    SuccessMessageMixin,
+    CreateView,
+):
+    model = Publication
+    form_class = PublicationForm
+    permission_required = "publications.add_publication"
+    success_message = "Publication successfully added"
+
+    def get_success_url(self):
+        return reverse("publications:list")

--- a/app/grandchallenge/publications/views.py
+++ b/app/grandchallenge/publications/views.py
@@ -15,6 +15,19 @@ class PublicationList(LoginRequiredMixin, ListView):
     def get_queryset(self):
         return super().get_queryset().order_by("-created")
 
+    def get_context_data(self, *, object_list=None, **kwargs):
+        context = super().get_context_data()
+        num_citations = 0
+        for pub in Publication.objects.all():
+            num_citations += pub.referenced_by_count
+        context.update(
+            {
+                "num_publications": Publication.objects.all().count(),
+                "num_citations": num_citations,
+            }
+        )
+        return context
+
 
 class PublicationCreate(
     LoginRequiredMixin,

--- a/app/grandchallenge/publications/views.py
+++ b/app/grandchallenge/publications/views.py
@@ -16,19 +16,30 @@ class PublicationList(LoginRequiredMixin, FilterMixin, ListView):
     filter_class = PublicationFilter
 
     def get_queryset(self):
-        return super().get_queryset().order_by("-created")
+        return (
+            super()
+            .get_queryset()
+            .prefetch_related(
+                "algorithm_set",
+                "archive_set",
+                "readerstudy_set",
+                "challenge_set",
+                "externalchallenge_set",
+            )
+            .order_by("-created")
+        )
 
     def get_context_data(self, *, object_list=None, **kwargs):
         context = super().get_context_data()
         num_citations = 0
-        for pub in Publication.objects.all():
+        for pub in context["object_list"]:
             try:
                 num_citations += pub.referenced_by_count
             except TypeError:
                 continue
         context.update(
             {
-                "num_publications": Publication.objects.all().count(),
+                "num_publications": context["object_list"].count(),
                 "num_citations": num_citations,
             }
         )

--- a/app/grandchallenge/publications/views.py
+++ b/app/grandchallenge/publications/views.py
@@ -22,7 +22,10 @@ class PublicationList(LoginRequiredMixin, FilterMixin, ListView):
         context = super().get_context_data()
         num_citations = 0
         for pub in Publication.objects.all():
-            num_citations += pub.referenced_by_count
+            try:
+                num_citations += pub.referenced_by_count
+            except TypeError:
+                continue
         context.update(
             {
                 "num_publications": Publication.objects.all().count(),

--- a/app/grandchallenge/publications/views.py
+++ b/app/grandchallenge/publications/views.py
@@ -3,14 +3,17 @@ from django.contrib.messages.views import SuccessMessageMixin
 from django.views.generic import CreateView, ListView
 from guardian.mixins import LoginRequiredMixin
 
+from grandchallenge.core.filters import FilterMixin
+from grandchallenge.publications.filters import PublicationFilter
 from grandchallenge.publications.forms import PublicationForm
 from grandchallenge.publications.models import Publication
 from grandchallenge.subdomains.utils import reverse
 
 
-class PublicationList(LoginRequiredMixin, ListView):
+class PublicationList(LoginRequiredMixin, FilterMixin, ListView):
     model = Publication
     paginate_by = 50
+    filter_class = PublicationFilter
 
     def get_queryset(self):
         return super().get_queryset().order_by("-created")

--- a/app/grandchallenge/publications/views.py
+++ b/app/grandchallenge/publications/views.py
@@ -10,7 +10,7 @@ from grandchallenge.publications.models import Publication
 from grandchallenge.subdomains.utils import reverse
 
 
-class PublicationList(LoginRequiredMixin, FilterMixin, ListView):
+class PublicationList(FilterMixin, ListView):
     model = Publication
     paginate_by = 50
     filter_class = PublicationFilter

--- a/app/tests/publications_tests/test_views.py
+++ b/app/tests/publications_tests/test_views.py
@@ -1,0 +1,43 @@
+import pytest
+from django.contrib.auth.models import Group
+from guardian.utils import get_anonymous_user
+
+from config import settings
+from grandchallenge.publications.models import Publication
+from tests.factories import UserFactory
+from tests.utils import get_view_for_user
+
+
+TEST_DOI = "10.1002/mrm.25227"
+
+
+@pytest.mark.django_db
+def test_publication_creation(client):
+    user1 = UserFactory()
+    user2 = get_anonymous_user()
+    g_reg = Group.objects.get(name=settings.REGISTERED_USERS_GROUP_NAME)
+
+    assert g_reg not in user2.groups.all()
+    assert Publication.objects.count() == 0
+
+    # only registered users can create a publication
+    response = get_view_for_user(
+        viewname="publications:create",
+        client=client,
+        method=client.post,
+        data={"identifier": TEST_DOI},
+        user=user2,
+    )
+    assert response.status_code == 302
+    assert "/accounts/login/" in response.url
+    assert Publication.objects.count() == 0
+
+    response = get_view_for_user(
+        viewname="publications:create",
+        client=client,
+        method=client.post,
+        data={"identifier": TEST_DOI},
+        user=user1,
+    )
+    assert response.status_code == 302
+    assert Publication.objects.count() == 1


### PR DESCRIPTION
- Users can view a list of all publications
- Publications can be filtered by author names and publication year 
- If a publication is associated with a reader study, algorithm, archive etc., these related objects are linked underneath the publication, but only if the viewing user has permission to view these objects
- Only registered users can add new publications 

Closes #1909 

![image](https://user-images.githubusercontent.com/30069334/124771998-e69c4e80-df3b-11eb-87a5-0b57ed5f822f.png)
