### PR TITLE
Run build images in correct queue and fix error handling

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1101,6 +1101,7 @@ if DEBUG:
         }
     )
     DEMO_ALGORITHM_IMAGE_PATH = os.path.join(SITE_ROOT, "algorithm.tar.gz")
+    DEMO_ALGORITHM_SHA256 = "sha256:5e81cef3738b7dbffc12c101990eb3b97f17642c09a2e0b64d5b3d4dd144e79b"
 
     if ENABLE_DEBUG_TOOLBAR:
         INSTALLED_APPS += ("debug_toolbar",)

--- a/app/tests/algorithms_tests/test_tasks.py
+++ b/app/tests/algorithms_tests/test_tasks.py
@@ -1,6 +1,5 @@
 import re
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 from django.test import TestCase
@@ -374,9 +373,8 @@ def test_algorithm_multiple_inputs(
 
 
 @pytest.mark.django_db
-@patch("grandchallenge.algorithms.tasks.build_images", return_value=None)
 def test_algorithm_input_image_multiple_files(
-    build_images, client, algorithm_io_image, settings, component_interfaces
+    client, algorithm_io_image, settings, component_interfaces
 ):
     # Override the celery settings
     settings.task_eager_propagates = (True,)
@@ -435,7 +433,7 @@ def test_add_images_to_component_interface_value():
 
     with pytest.raises(ValueError) as err:
         add_images_to_component_interface_value(
-            component_interface_value_pk=civ.pk, upload_pk=us.pk
+            component_interface_value_pk=civ.pk, upload_session_pk=us.pk
         )
     assert "Image imports should result in a single image" in str(err)
     assert civ.image is None
@@ -444,7 +442,7 @@ def test_add_images_to_component_interface_value():
     image = ImageFactory(origin=us2)
     civ2 = ComponentInterfaceValueFactory(interface=ci, image=None)
     add_images_to_component_interface_value(
-        component_interface_value_pk=civ2.pk, upload_pk=us2.pk
+        component_interface_value_pk=civ2.pk, upload_session_pk=us2.pk
     )
     civ2.refresh_from_db()
     assert civ2.image == image

--- a/scripts/development_fixtures.py
+++ b/scripts/development_fixtures.py
@@ -342,10 +342,12 @@ def _create_algorithm_demo(users):
     algorithm_image = AlgorithmImage(
         creator=users["algorithm"], algorithm=algorithm
     )
+
     if os.path.isfile(settings.DEMO_ALGORITHM_IMAGE_PATH):
         with open(settings.DEMO_ALGORITHM_IMAGE_PATH, "rb") as f:
             container = File(f)
             algorithm_image.image.save("test_algorithm.tar", container)
+            algorithm_image.image_sha256 = settings.DEMO_ALGORITHM_SHA256
     else:
         container = ContentFile(base64.b64decode(b""))
         algorithm_image.image.save("test_algorithm.tar", container)


### PR DESCRIPTION
Celery tasks should not be called directly from within other tasks for routing reasons, this changes the setup to use a workflow.

Closes #1911