### PR TITLE
Refactor algorithm job creation

### DIFF
--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -440,8 +440,6 @@ class Job(UUIDModel, ComponentJob):
         return self.algorithm_image
 
     def get_path_and_value(self, inp):
-        if inp.file:
-            return [(inp.interface.relative_path, inp.file)]
         if inp.image:
             return [
                 (
@@ -453,7 +451,10 @@ class Job(UUIDModel, ComponentJob):
                 )
                 for im_file in inp.image.files.all()
             ]
-        return [(inp.interface.relative_path, inp.value)]
+        elif inp.file:
+            return [(inp.interface.relative_path, inp.file)]
+        else:
+            return [(inp.interface.relative_path, inp.value)]
 
     @property
     def input_files(self):

--- a/app/grandchallenge/algorithms/tasks.py
+++ b/app/grandchallenge/algorithms/tasks.py
@@ -337,10 +337,6 @@ def create_algorithm_jobs(  # noqa: C901
             creator=creator, algorithm_image=algorithm_image
         )
         j.inputs.set(job_inputs)
-
-        if extra_viewer_groups is not None:
-            j.viewer_groups.add(*extra_viewer_groups)
-
         jobs.append(j)
 
     for image in images:
@@ -360,11 +356,11 @@ def create_algorithm_jobs(  # noqa: C901
                     )
                 ]
             )
-
-            if extra_viewer_groups is not None:
-                j.viewer_groups.add(*extra_viewer_groups)
-
             jobs.append(j)
+
+    if extra_viewer_groups is not None:
+        for j in jobs:
+            j.viewer_groups.add(*extra_viewer_groups)
 
     return jobs
 

--- a/app/grandchallenge/algorithms/tasks.py
+++ b/app/grandchallenge/algorithms/tasks.py
@@ -365,6 +365,38 @@ def create_algorithm_jobs(  # noqa: C901
     return jobs
 
 
+def filter_civs_for_algorithm(*, civ_sets, algorithm_image):
+    """
+    Removes sets of civs that are invalid for new jobs
+
+    Parameters
+    ----------
+    civ_sets
+        Iterable of sets of ComponentInterfaceValues that are candidate for
+        new Jobs
+    algorithm_image
+        The algorithm image to use for new job
+
+    Returns
+    -------
+    Filters set of ComponentInterfaceValues
+    """
+    input_interfaces = {*algorithm_image.algorithm.inputs.all()}
+
+    valid_job_inputs = []
+
+    for civ_set in civ_sets:
+
+        # Check interfaces match
+        civ_interfaces = {civ.interface for civ in civ_set}
+        if civ_interfaces != input_interfaces:
+            continue
+
+        valid_job_inputs.append(civ_set)
+
+    return valid_job_inputs
+
+
 def remaining_jobs(*, creator, algorithm_image):
     user_credit = Credit.objects.get(user=creator)
     jobs = Job.credits_set.spent_credits(user=creator)

--- a/app/tests/algorithms_tests/resources/docker/run_algorithm.py
+++ b/app/tests/algorithms_tests/resources/docker/run_algorithm.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+from pathlib import Path
 from typing import Union
 from warnings import warn
 
@@ -17,7 +18,8 @@ if __name__ == "__main__":
     # What the user uploads will be placed directly in /input/, but the admin
     # is free to determine the file type. The only limitation is that this will
     # be a single file.
-    input_file = "/input/input_file.tif"
+
+    input_file = next(Path("/input/").glob("*.tif"))
     os.makedirs("/output/images")
     shutil.copyfile(input_file, "/output/images/output.tif")
 

--- a/app/tests/algorithms_tests/test_permissions.py
+++ b/app/tests/algorithms_tests/test_permissions.py
@@ -304,7 +304,9 @@ class TestJobPermissions(TestCase):
         im = ImageFactory()
         s.image_set.set([im])
 
-        civ = ComponentInterfaceValueFactory(image=im)
+        civ = ComponentInterfaceValueFactory(
+            image=im, interface=ai.algorithm.inputs.get()
+        )
         archive_item = ArchiveItemFactory(archive=archive)
         with capture_on_commit_callbacks(execute=True):
             archive_item.values.add(civ)
@@ -348,7 +350,9 @@ class TestJobPermissions(TestCase):
         im = ImageFactory()
         s.image_set.set([im])
 
-        civ = ComponentInterfaceValueFactory(image=im)
+        civ = ComponentInterfaceValueFactory(
+            image=im, interface=ai.algorithm.inputs.get()
+        )
         archive_item = ArchiveItemFactory(archive=archive)
         with capture_on_commit_callbacks(execute=True):
             archive_item.values.add(civ)

--- a/app/tests/algorithms_tests/test_tasks.py
+++ b/app/tests/algorithms_tests/test_tasks.py
@@ -46,7 +46,7 @@ class TestCreateAlgorithmJobs:
 
     def test_no_images_does_nothing(self):
         ai = AlgorithmImageFactory()
-        create_algorithm_jobs(algorithm_image=ai, images=[])
+        create_algorithm_jobs(algorithm_image=ai, civ_sets=[])
         assert Job.objects.count() == 0
 
     def test_civ_existing_does_nothing(self):
@@ -64,8 +64,11 @@ class TestCreateAlgorithmJobs:
     def test_creates_job_correctly(self):
         ai = AlgorithmImageFactory()
         image = ImageFactory()
+        civ = ComponentInterfaceValueFactory(
+            image=image, interface=ai.algorithm.inputs.get()
+        )
         assert Job.objects.count() == 0
-        jobs = create_algorithm_jobs(algorithm_image=ai, images=[image])
+        jobs = create_algorithm_jobs(algorithm_image=ai, civ_sets=[{civ}])
         assert Job.objects.count() == 1
         j = Job.objects.first()
         assert j.algorithm_image == ai
@@ -79,30 +82,42 @@ class TestCreateAlgorithmJobs:
     def test_is_idempotent(self):
         ai = AlgorithmImageFactory()
         image = ImageFactory()
+        civ = ComponentInterfaceValueFactory(
+            image=image, interface=ai.algorithm.inputs.get()
+        )
         assert Job.objects.count() == 0
-        create_algorithm_jobs(algorithm_image=ai, images=[image])
+        create_algorithm_jobs(algorithm_image=ai, civ_sets=[{civ}])
         assert Job.objects.count() == 1
-        jobs = create_algorithm_jobs(algorithm_image=ai, images=[image])
+        jobs = create_algorithm_jobs(algorithm_image=ai, civ_sets=[{civ}])
         assert Job.objects.count() == 1
         assert len(jobs) == 0
 
     def test_gets_creator_from_session(self):
+        ai = AlgorithmImageFactory()
         riu = RawImageUploadSessionFactory()
         riu.image_set.add(ImageFactory(), ImageFactory())
+        civ_sets = [
+            {
+                ComponentInterfaceValueFactory(
+                    image=image, interface=ai.algorithm.inputs.get()
+                )
+            }
+            for image in riu.image_set.all()
+        ]
         create_algorithm_jobs(
-            algorithm_image=AlgorithmImageFactory(),
-            images=riu.image_set.all(),
-            creator=riu.creator,
+            algorithm_image=ai, civ_sets=civ_sets, creator=riu.creator,
         )
         j = Job.objects.first()
         assert j.creator == riu.creator
 
     def test_extra_viewer_groups(self):
         ai = AlgorithmImageFactory()
-        image = ImageFactory()
+        civ = ComponentInterfaceValueFactory(
+            interface=ai.algorithm.inputs.get()
+        )
         groups = (GroupFactory(), GroupFactory(), GroupFactory())
         jobs = create_algorithm_jobs(
-            algorithm_image=ai, images=[image], extra_viewer_groups=groups
+            algorithm_image=ai, civ_sets=[{civ}], extra_viewer_groups=groups
         )
         for g in groups:
             assert jobs[0].viewer_groups.filter(pk=g.pk).exists()
@@ -124,16 +139,20 @@ class TestCreateAlgorithmJobs:
                 ImageFactory(origin=riu),
 
             riu.save()
-            return riu
+
+            interface = algorithm_image.algorithm.inputs.get()
+
+            return [
+                {ComponentInterfaceValueFactory(image=im, interface=interface)}
+                for im in riu.image_set.all()
+            ]
 
         assert Job.objects.count() == 0
 
         # Create an upload session as editor; should not be limited
         upload = create_upload(editor)
         create_algorithm_jobs(
-            algorithm_image=algorithm_image,
-            images=upload.image_set.all(),
-            creator=upload.creator,
+            algorithm_image=algorithm_image, civ_sets=upload, creator=editor,
         )
 
         assert Job.objects.count() == 3
@@ -141,9 +160,7 @@ class TestCreateAlgorithmJobs:
         # Create an upload session as user; should be limited
         upload_2 = create_upload(user)
         create_algorithm_jobs(
-            algorithm_image=algorithm_image,
-            images=upload_2.image_set.all(),
-            creator=upload_2.creator,
+            algorithm_image=algorithm_image, civ_sets=upload_2, creator=user,
         )
 
         # An additional 2 jobs should be created (standard nr of credits is 1000
@@ -155,9 +172,7 @@ class TestCreateAlgorithmJobs:
 
         # The job that was skipped on the previous run should now be accepted
         create_algorithm_jobs(
-            algorithm_image=algorithm_image,
-            images=upload_2.image_set.all(),
-            creator=upload_2.creator,
+            algorithm_image=algorithm_image, civ_sets=upload_2, creator=user,
         )
         assert Job.objects.count() == 6
 
@@ -166,14 +181,22 @@ class TestCreateJobsWorkflow(TestCase):
     def test_no_jobs_workflow(self):
         ai = AlgorithmImageFactory()
         with capture_on_commit_callbacks() as callbacks:
-            execute_jobs(algorithm_image=ai, images=[])
+            execute_jobs(algorithm_image=ai, civ_sets=[])
         assert len(callbacks) == 0
 
     def test_jobs_workflow(self):
         ai = AlgorithmImageFactory()
         images = [ImageFactory(), ImageFactory()]
+        civ_sets = [
+            {
+                ComponentInterfaceValueFactory(
+                    image=im, interface=ai.algorithm.inputs.get()
+                )
+            }
+            for im in images
+        ]
         with capture_on_commit_callbacks() as callbacks:
-            execute_jobs(algorithm_image=ai, images=images)
+            execute_jobs(algorithm_image=ai, civ_sets=civ_sets)
         assert len(callbacks) == 1
 
 
@@ -197,11 +220,15 @@ def test_algorithm(client, algorithm_image, settings):
 
     # Run the algorithm, it will create a results.json and an output.tif
     image_file = ImageFileFactory(
-        file__from_path=Path(__file__).parent / "resources" / "input_file.tif"
+        file__from_path=Path(__file__).parent / "resources" / "input_file.tif",
     )
+    civ = ComponentInterfaceValueFactory(
+        image=image_file.image, interface=alg.algorithm.inputs.get(), file=None
+    )
+    assert civ.interface.slug == "generic-medical-image"
 
     with capture_on_commit_callbacks(execute=True):
-        execute_jobs(algorithm_image=alg, images=[image_file.image])
+        execute_jobs(algorithm_image=alg, civ_sets=[{civ}])
 
     jobs = Job.objects.filter(algorithm_image=alg).all()
 
@@ -243,9 +270,12 @@ def test_algorithm(client, algorithm_image, settings):
     image_file = ImageFileFactory(
         file__from_path=Path(__file__).parent / "resources" / "input_file.tif"
     )
+    civ = ComponentInterfaceValueFactory(
+        image=image_file.image, interface=alg.algorithm.inputs.get(), file=None
+    )
 
     with capture_on_commit_callbacks(execute=True):
-        execute_jobs(algorithm_image=alg, images=[image_file.image])
+        execute_jobs(algorithm_image=alg, civ_sets=[{civ}])
 
     jobs = Job.objects.filter(
         algorithm_image=alg, inputs__image=image_file.image
@@ -287,9 +317,12 @@ def test_algorithm_with_invalid_output(client, algorithm_image, settings):
     image_file = ImageFileFactory(
         file__from_path=Path(__file__).parent / "resources" / "input_file.tif"
     )
+    civ = ComponentInterfaceValueFactory(
+        image=image_file.image, interface=alg.algorithm.inputs.get(), file=None
+    )
 
     with capture_on_commit_callbacks(execute=True):
-        execute_jobs(algorithm_image=alg, images=[image_file.image])
+        execute_jobs(algorithm_image=alg, civ_sets=[{civ}])
 
     jobs = Job.objects.filter(
         algorithm_image=alg, inputs__image=image_file.image, status=Job.FAILURE


### PR DESCRIPTION
This PR simplifies the algorithm job creation to work with sets of interface values rather than archive items and images, and adds some query optimisation.

Partial fix of #1903 
Closes #1866