### PR TITLE
Call deprovisioning directly

### DIFF
--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -23,7 +23,6 @@ from django_extensions.db.fields import AutoSlugField
 from grandchallenge.cases.models import Image, ImageFile
 from grandchallenge.components.schemas import INTERFACE_VALUE_SCHEMA
 from grandchallenge.components.tasks import (
-    deprovision_job,
     execute_job,
     parse_job_outputs,
     provision_job,
@@ -801,7 +800,6 @@ class ComponentJob(models.Model):
             provision_job.signature(**kwargs)
             | execute_job.signature(**kwargs)
             | parse_job_outputs.signature(**kwargs)
-            | deprovision_job.signature(**kwargs)
         )
 
     @property

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,6 +163,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
+      registry:
+        condition: service_started
     volumes:
       # Bind the app directory for live reloading in development
       - type: bind
@@ -188,6 +190,8 @@ services:
       postgres:
         condition: service_healthy
       redis:
+        condition: service_started
+      registry:
         condition: service_started
     volumes:
       # The docker socket is only needed for testing
@@ -248,6 +252,9 @@ services:
     networks:
       - default
       - workstations
+
+  registry:
+    image: registry:2.7
 
   flower:
     image: mher/flower


### PR DESCRIPTION
This PR adds direct calling of job deprovisioning to fix a bug where volumed would not be cleaned up on error. Was tricky to get this to work with celery errbacks so just calling this explicitly.