### PR TITLE
Display correct input and output paths when uploading algorithm images

### DIFF
--- a/app/grandchallenge/algorithms/templates/algorithms/algorithmimage_form.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithmimage_form.html
@@ -33,10 +33,10 @@
             <li>
                 {{ interface }} at
                 {% if interface.is_image_kind %}
-                    <code>{{ interface.input_path }}/&lt;uuid&gt;.mha</code> or
-                    <code>{{ interface.input_path }}/&lt;uuid&gt;.tif</code>
+                    <code>/input/{{ interface.relative_path }}/&lt;uuid&gt;.mha</code> or
+                    <code>/input/{{ interface.relative_path }}/&lt;uuid&gt;.tif</code>
                 {% else %}
-                    <code>{{ interface.input_path }}</code>
+                    <code>/input/{{ interface.relative_path }}</code>
                 {% endif %}
             </li>
         {% endfor %}
@@ -51,10 +51,10 @@
             <li>
                 {{ interface }} to
                 {% if interface.is_image_kind %}
-                    <code>{{ interface.output_path }}/&lt;uuid&gt;.mha</code> or
-                    <code>{{ interface.output_path }}/&lt;uuid&gt;.tif</code>
+                    <code>/output/{{ interface.relative_path }}/&lt;uuid&gt;.mha</code> or
+                    <code>/output/{{ interface.relative_path }}/&lt;uuid&gt;.tif</code>
                 {% else %}
-                    <code>{{ interface.output_path }}</code>
+                    <code>/output/{{ interface.relative_path }}</code>
                 {% endif %}
             </li>
         {% endfor %}


### PR DESCRIPTION
Input and output paths are not correctly displayed at the moment:
![image](https://user-images.githubusercontent.com/773597/127843786-6db9b4fb-3b03-45e9-909d-a802f2dc2e2b.png)
