### PR TITLE
Allow blog editors to add authors

### DIFF
--- a/app/grandchallenge/blogs/forms.py
+++ b/app/grandchallenge/blogs/forms.py
@@ -1,8 +1,11 @@
 from django import forms
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 from django_select2.forms import Select2MultipleWidget
 from guardian.utils import get_anonymous_user
 
+from config import settings
 from grandchallenge.blogs.models import Post
 from grandchallenge.core.forms import SaveFormInitMixin
 from grandchallenge.core.widgets import MarkdownEditorWidget
@@ -12,7 +15,16 @@ class PostForm(SaveFormInitMixin, forms.ModelForm):
     def __init__(self, *args, authors, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.fields["authors"].queryset = authors
+        self.fields["authors"].queryset = (
+            get_user_model()
+            .objects.filter(
+                groups=Group.objects.get(
+                    name=settings.REGISTERED_USERS_GROUP_NAME
+                )
+            )
+            .all()
+            .order_by("username")
+        )
         self.fields["authors"].initial = authors
 
         self.fields["tags"].required = True
@@ -34,7 +46,7 @@ class PostForm(SaveFormInitMixin, forms.ModelForm):
         )
         widgets = {
             "tags": Select2MultipleWidget,
-            "authors": forms.MultipleHiddenInput,
+            "authors": Select2MultipleWidget,
         }
 
 

--- a/app/grandchallenge/blogs/forms.py
+++ b/app/grandchallenge/blogs/forms.py
@@ -1,30 +1,19 @@
 from django import forms
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 from django_select2.forms import Select2MultipleWidget
 from guardian.utils import get_anonymous_user
 
-from config import settings
 from grandchallenge.blogs.models import Post
 from grandchallenge.core.forms import SaveFormInitMixin
 from grandchallenge.core.widgets import MarkdownEditorWidget
+from grandchallenge.groups.forms import UserGroupForm
 
 
 class PostForm(SaveFormInitMixin, forms.ModelForm):
     def __init__(self, *args, authors, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.fields["authors"].queryset = (
-            get_user_model()
-            .objects.filter(
-                groups=Group.objects.get(
-                    name=settings.REGISTERED_USERS_GROUP_NAME
-                )
-            )
-            .all()
-            .order_by("username")
-        )
+        self.fields["authors"].queryset = authors
         self.fields["authors"].initial = authors
 
         self.fields["tags"].required = True
@@ -46,7 +35,7 @@ class PostForm(SaveFormInitMixin, forms.ModelForm):
         )
         widgets = {
             "tags": Select2MultipleWidget,
-            "authors": Select2MultipleWidget,
+            "authors": forms.MultipleHiddenInput,
         }
 
 
@@ -57,3 +46,7 @@ class PostUpdateForm(PostForm):
             **PostForm.Meta.widgets,
             "content": MarkdownEditorWidget,
         }
+
+
+class AuthorsForm(UserGroupForm):
+    role = "author"

--- a/app/grandchallenge/blogs/models.py
+++ b/app/grandchallenge/blogs/models.py
@@ -65,3 +65,6 @@ class Post(models.Model):
     @property
     def public(self):
         return self.published
+
+    def add_author(self, user):
+        self.authors.add(user)

--- a/app/grandchallenge/blogs/templates/blogs/authors_update_form.html
+++ b/app/grandchallenge/blogs/templates/blogs/authors_update_form.html
@@ -1,0 +1,10 @@
+{% extends "groups/groups_form_base.html" %}
+{% load url %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% url 'blogs:list' %}">Blogs</a></li>
+        <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{{ object.title }}</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Add author</li>
+    </ol>
+{% endblock %}

--- a/app/grandchallenge/blogs/templates/blogs/post_detail.html
+++ b/app/grandchallenge/blogs/templates/blogs/post_detail.html
@@ -33,6 +33,12 @@
                     {% endfor %}
                 </ul>
             </div>
+            {% get_obj_perms request.user for object as "object_perms" %}
+            {% if "change_post" in object_perms %}
+                <a class="btn btn-primary mb-3" href="{% url 'blogs:authors-update' slug=object.slug %}">
+                    <i class="fa fa-plus"></i> Add Author
+                </a>
+            {% endif %}
             {% if object.tags.count != 0 %}
                 <div class="row mb-1">
                     <h3>Tags</h3>
@@ -49,7 +55,6 @@
                     </ul>
                 </div>
             {% endif %}
-            {% get_obj_perms request.user for object as "object_perms" %}
             {% if "change_post" in object_perms %}
 	        {% if not object.published %}
                     <div class="alert alert-warning" role="alert">

--- a/app/grandchallenge/blogs/urls.py
+++ b/app/grandchallenge/blogs/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from grandchallenge.blogs.views import (
+    AuthorsUpdate,
     PostCreate,
     PostDetail,
     PostList,
@@ -12,6 +13,11 @@ app_name = "blogs"
 urlpatterns = [
     path("", PostList.as_view(), name="list"),
     path("create/", PostCreate.as_view(), name="create"),
+    path(
+        "<slug>/authors/update/",
+        AuthorsUpdate.as_view(),
+        name="authors-update",
+    ),
     path("<slug>/", PostDetail.as_view(), name="detail"),
     path("<slug>/update/", PostUpdate.as_view(), name="update"),
 ]

--- a/app/grandchallenge/blogs/views.py
+++ b/app/grandchallenge/blogs/views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.shortcuts import get_object_or_404
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
 from guardian.mixins import (
     LoginRequiredMixin,
@@ -7,9 +8,10 @@ from guardian.mixins import (
 )
 
 from grandchallenge.blogs.filters import BlogFilter
-from grandchallenge.blogs.forms import PostForm, PostUpdateForm
+from grandchallenge.blogs.forms import AuthorsForm, PostForm, PostUpdateForm
 from grandchallenge.blogs.models import Post
 from grandchallenge.core.filters import FilterMixin
+from grandchallenge.groups.views import UserGroupUpdateMixin
 
 
 class AuthorFormKwargsMixin:
@@ -66,3 +68,15 @@ class PostUpdate(
     form_class = PostUpdateForm
     permission_required = "blogs.change_post"
     raise_exception = True
+
+
+class AuthorsUpdate(UserGroupUpdateMixin):
+    model = Post
+    form_class = AuthorsForm
+    template_name = "blogs/authors_update_form.html"
+    permission_required = "blogs.change_post"
+    success_message = "Authors successfully updated"
+
+    @property
+    def obj(self):
+        return get_object_or_404(Post, slug=self.kwargs["slug"])


### PR DESCRIPTION
This allows blog post authors to add other authors. It would make collaborating on a blog post easier for users, although, of course, simultanously working on the blog post does not work. 

This only adds the possibility to add authors, not to remove authors. 

Closes #1955 