### PR TITLE
Fix algorithm job status check

### DIFF
--- a/app/grandchallenge/algorithms/static/algorithms/js/job_session.js
+++ b/app/grandchallenge/algorithms/static/algorithms/js/job_session.js
@@ -30,7 +30,7 @@ function handleJobStatus(job) {
 
     if (jobStatus === "succeeded") {
         setCardCompleteMessage(cards.job, "View Results");
-    } else if (["started", "provisioning", "provisioned", "executing", "executed", "parsing"].includes(jobStatus)) {
+    } else if (["started", "provisioning", "provisioned", "executing", "executed", "parsing outputs"].includes(jobStatus)) {
         setCardActiveMessage(cards.job, `Started, ${moment.duration(estimatedRemainingTime).humanize()} remaining`);
         setTimeout(function () {
             getJobStatus(job.api_url)

--- a/app/grandchallenge/algorithms/static/algorithms/js/session.js
+++ b/app/grandchallenge/algorithms/static/algorithms/js/session.js
@@ -91,7 +91,7 @@ function handleJobStatus(jobs) {
 
     if (jobStatuses.every(s => s === "succeeded")) {
         setCardCompleteMessage(cards.job, "View Results");
-    } else if (jobStatuses.some(s => ["started", "provisioning", "provisioned", "executing", "executed", "parsing"].includes(s))) {
+    } else if (jobStatuses.some(s => ["started", "provisioning", "provisioned", "executing", "executed", "parsing outputs"].includes(s))) {
         setCardActiveMessage(cards.job, `Started, ${moment.duration(estimatedRemainingTime).humanize()} remaining`);
         setTimeout(function () {
             getJobStatus(jobUrls)


### PR DESCRIPTION
When running a job, they currently always end up as "Errored":

![image](https://user-images.githubusercontent.com/773597/129332676-22d4cbc4-e1b4-4e69-bdbd-cc2a677167d3.png)

From checking the API requests that this page makes, it seems that the job status message that is returned via the API becomes "Parsing Outputs" when the job has finished. Since the Javascript expects "Parsing", it displays the "Errored" message.