### PR TITLE
Add icon to show page visibility

### DIFF
--- a/app/grandchallenge/pages/migrations/0001_initial.py
+++ b/app/grandchallenge/pages/migrations/0001_initial.py
@@ -31,7 +31,7 @@ class Migration(migrations.Migration):
                     models.CharField(
                         choices=[
                             ("ALL", "All"),
-                            ("REG", "Registered users only"),
+                            ("REG", "Participants only"),
                             ("ADM", "Administrators only"),
                         ],
                         default="ALL",

--- a/app/grandchallenge/pages/migrations/0003_historicalpage.py
+++ b/app/grandchallenge/pages/migrations/0003_historicalpage.py
@@ -33,7 +33,7 @@ class Migration(migrations.Migration):
                     models.CharField(
                         choices=[
                             ("ALL", "All"),
-                            ("REG", "Registered users only"),
+                            ("REG", "Participants only"),
                             ("ADM", "Administrators only"),
                         ],
                         default="ALL",

--- a/app/grandchallenge/pages/models.py
+++ b/app/grandchallenge/pages/models.py
@@ -24,11 +24,10 @@ class Page(models.Model):
     ALL = "ALL"
     REGISTERED_ONLY = "REG"
     ADMIN_ONLY = "ADM"
-    STAFF_ONLY = "STF"
 
     PERMISSIONS_CHOICES = (
         (ALL, "All"),
-        (REGISTERED_ONLY, "Registered users only"),
+        (REGISTERED_ONLY, "Participants only"),
         (ADMIN_ONLY, "Administrators only"),
     )
 

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -33,6 +33,13 @@
                     <li class="nav-item">
                         <a class="nav-link px-4 py-1 mb-1 {% if page == currentpage %}active{% endif %}"
                            href="{{ page.get_absolute_url }}">
+                            {% if page.permission_level == page.REGISTERED_ONLY %}
+                                <i class="fas fa-lock fa-fw" title="Page is only visible by participants of this challenge"></i>
+                            {% elif page.permission_level == page.ADMIN_ONLY %}
+                                <i class="fas fa-lock fa-fw text-danger" title="Page is only visible by admins of this challenge"></i>
+                            {% else %}
+                                <i class="fa fa-fw"></i>
+                            {% endif %}
                             {% filter title %}
                                 {% firstof page.display_title page.title %}
                             {% endfilter %}


### PR DESCRIPTION
This PR adds a lock icon to show what pages are visible in the menu with tooltips. Uses danger for admin only views, and has a blank placeholder for alignment (maybe we can add a page icon option later). 

![image](https://user-images.githubusercontent.com/12661555/129872419-68ff6afd-ab56-4caf-9a8f-66adf2ec9d5d.png)
