### PR TITLE
Allow NUMBER and CHOICE answer types to be null when not required

### DIFF
--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1279,7 +1279,7 @@ class Answer(UUIDModel):
         valid_options = question.options.values_list("id", flat=True)
         if question.answer_type == Question.AnswerType.CHOICE:
             if not question.required:
-                valid_options.append(None)
+                valid_options = (*valid_options, None)
             if answer not in valid_options:
                 raise ValidationError(
                     "Provided option is not valid for this question"

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1088,14 +1088,21 @@ class Question(UUIDModel):
             self.AnswerType.MULTIPLE_POLYGONS_IMAGE,
         ]
 
+    @property
+    def allow_null_types(self):
+        return [
+            *self.annotation_types,
+            self.AnswerType.CHOICE,
+            self.AnswerType.NUMBER,
+        ]
+
     def is_answer_valid(self, *, answer):
         """Validates ``answer`` against ``ANSWER_TYPE_SCHEMA``."""
         allowed_types = [
             {"$ref": f"#/definitions/{self.answer_type}"},
         ]
 
-        allow_null = self.answer_type in self.annotation_types
-        if allow_null:
+        if self.answer_type in self.allow_null_types:
             allowed_types.append({"$ref": "#/definitions/null"})
 
         try:

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1276,23 +1276,32 @@ class Answer(UUIDModel):
         if not creator.has_perm("read_readerstudy", question.reader_study):
             raise ValidationError("This user is not a reader for this study.")
 
-        if (
-            question.answer_type == Question.AnswerType.CHOICE
-            and answer not in question.options.values_list("id", flat=True)
-        ):
-            raise ValidationError(
-                "Provided option is not valid for this question"
-            )
+        valid_options = question.options.values_list("id", flat=True)
+        if question.answer_type == Question.AnswerType.CHOICE:
+            if not question.required:
+                valid_options.append(None)
+            if answer not in valid_options:
+                raise ValidationError(
+                    "Provided option is not valid for this question"
+                )
 
         if question.answer_type in (
             Question.AnswerType.MULTIPLE_CHOICE,
             Question.AnswerType.MULTIPLE_CHOICE_DROPDOWN,
         ):
-            options = question.options.values_list("id", flat=True)
-            if not all(x in options for x in answer):
+            if not all(x in valid_options for x in answer):
                 raise ValidationError(
                     "Provided options are not valid for this question"
                 )
+
+        if (
+            question.answer_type == Question.AnswerType.NUMBER
+            and question.required
+            and answer is None
+        ):
+            raise ValidationError(
+                "Answer for required question cannot be None"
+            )
 
     @property
     def answer_text(self):

--- a/app/tests/reader_studies_tests/validation_tests.py
+++ b/app/tests/reader_studies_tests/validation_tests.py
@@ -272,3 +272,30 @@ def test_new_answer_type_listed():
     q = Question(answer_type="TEST")
     with pytest.raises(RuntimeError):
         q.is_answer_valid(answer="foo")
+
+
+@pytest.mark.parametrize(
+    "answer_type,allow_null",
+    [
+        ["STXT", False],
+        ["MTXT", False],
+        ["BOOL", False],
+        ["NUMB", True],
+        ["2DBB", True],
+        ["M2DB", True],
+        ["DIST", True],
+        ["MDIS", True],
+        ["POIN", True],
+        ["MPOI", True],
+        ["POLY", True],
+        ["PIMG", True],
+        ["MPOL", True],
+        ["MPIM", True],
+        ["CHOI", True],
+        ["MCHO", False],
+        ["MCHD", False],
+    ],
+)
+def test_answer_type_allows_null(answer_type, allow_null):
+    q = Question(answer_type=answer_type)
+    assert q.is_answer_valid(answer=None) == allow_null


### PR DESCRIPTION
Currently questions with `AnswerType` `NUMBER` and `CHOICE`  are not allowed to be null. This means that setting the `required` field to `False` on the question will not have the intended effect. 

This PR enables users to "skip" these non-required questions and make a reader study work like described in the table in https://github.com/DIAGNijmegen/rse-cirrus-core/pull/1432. By allowing the answer to be `null` (JSON schema)/ `None` (python) when the question is not required.