### PR TITLE
Fix 404 for 5XX errors

### DIFF
--- a/dockerfiles/http/nginx.conf.template
+++ b/dockerfiles/http/nginx.conf.template
@@ -221,10 +221,5 @@ http {
       proxy_redirect off;
       proxy_pass http://app_server;
     }
-
-    error_page 500 502 503 504 /500.html;
-    location = /500.html {
-      root /http/;
-    }
   }
 }


### PR DESCRIPTION
Would be good to have nice error pages (including the one for sentry), but this is fine for now, more important to get the correct error codes.

Closes #1993 