### PR TITLE
Fixes algorithm request notifications and notification clean up

### DIFF
--- a/app/grandchallenge/core/management/commands/adjust_algorithm_follows.py
+++ b/app/grandchallenge/core/management/commands/adjust_algorithm_follows.py
@@ -1,0 +1,26 @@
+from actstream.models import Follow
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import BaseCommand
+
+from grandchallenge.algorithms.models import Algorithm
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        updated_follows = 0
+        for algorithm in Algorithm.objects.all():
+            for admin in algorithm.editors_group.user_set.all():
+                f = Follow.objects.filter(
+                    user=admin,
+                    object_id=algorithm.pk,
+                    content_type=ContentType.objects.filter(
+                        model="algorithm"
+                    ).get(),
+                    flag="",
+                ).get()
+                f.flag = "access_request"
+                f.save()
+                if f:
+                    updated_follows += 1
+
+        print(f"{updated_follows} follows updated.")

--- a/app/grandchallenge/core/signals.py
+++ b/app/grandchallenge/core/signals.py
@@ -14,12 +14,24 @@ from django.db.models.signals import (
 )
 from django.dispatch import receiver
 from guardian.utils import get_anonymous_user
+from machina.apps.forum.models import Forum
+from machina.apps.forum_conversation.models import Topic
 
-from grandchallenge.algorithms.models import AlgorithmPermissionRequest
-from grandchallenge.archives.models import ArchivePermissionRequest
+from grandchallenge.algorithms.models import (
+    Algorithm,
+    AlgorithmPermissionRequest,
+)
+from grandchallenge.archives.models import Archive, ArchivePermissionRequest
+from grandchallenge.cases.models import RawImageUploadSession
+from grandchallenge.challenges.models import Challenge
 from grandchallenge.core.utils import disable_for_loaddata
+from grandchallenge.evaluation.models import Evaluation, Phase, Submission
 from grandchallenge.notifications.models import Notification, NotificationType
-from grandchallenge.reader_studies.models import ReaderStudyPermissionRequest
+from grandchallenge.participants.models import RegistrationRequest
+from grandchallenge.reader_studies.models import (
+    ReaderStudy,
+    ReaderStudyPermissionRequest,
+)
 
 
 @receiver(post_save, sender=get_user_model())
@@ -114,7 +126,7 @@ def update_editor_follows(  # noqa: C901
 
     for user in users:
         for obj in follow_objects:
-            if action == "post_add":
+            if action == "post_add" and obj._meta.model_name != "algorithm":
                 follow(
                     user=user, obj=obj, actor_only=False, send_action=False,
                 )
@@ -126,6 +138,14 @@ def update_editor_follows(  # noqa: C901
                         action_object=user,
                         target=obj,
                     )
+            elif action == "post_add" and obj._meta.model_name == "algorithm":
+                follow(
+                    user=user,
+                    obj=obj,
+                    actor_only=False,
+                    flag="access_request",
+                    send_action=False,
+                )
             elif action == "pre_remove" or action == "pre_clear":
                 unfollow(user=user, obj=obj, send_action=False)
 
@@ -137,4 +157,37 @@ def clean_up_user_follows(instance, **_):
     ).get()
     Follow.objects.filter(
         Q(object_id=instance.pk) | Q(user=instance.pk), content_type=ct
+    ).delete()
+    Notification.objects.filter(
+        Q(actor_object_id=instance.pk) & Q(actor_content_type=ct)
+        | Q(action_object_object_id=instance.pk)
+        & Q(action_object_content_type=ct)
+        | Q(target_object_id=instance.pk) & Q(target_content_type=ct)
+        | Q(user_id=instance.pk)
+    ).delete()
+
+
+@receiver(pre_delete, sender=AlgorithmPermissionRequest)
+@receiver(pre_delete, sender=ReaderStudyPermissionRequest)
+@receiver(pre_delete, sender=ArchivePermissionRequest)
+@receiver(pre_delete, sender=Archive)
+@receiver(pre_delete, sender=Algorithm)
+@receiver(pre_delete, sender=ReaderStudy)
+@receiver(pre_delete, sender=Challenge)
+@receiver(pre_delete, sender=Forum)
+@receiver(pre_delete, sender=Topic)
+@receiver(pre_delete, sender=RegistrationRequest)
+@receiver(pre_delete, sender=Evaluation)
+@receiver(pre_delete, sender=Phase)
+@receiver(pre_delete, sender=Submission)
+@receiver(pre_delete, sender=RawImageUploadSession)
+def clean_up_notifications(instance, **_):
+    ct = ContentType.objects.filter(
+        app_label=instance._meta.app_label, model=instance._meta.model_name
+    ).get()
+    Notification.objects.filter(
+        Q(actor_object_id=instance.pk) & Q(actor_content_type=ct)
+        | Q(action_object_object_id=instance.pk)
+        & Q(action_object_content_type=ct)
+        | Q(target_object_id=instance.pk) & Q(target_content_type=ct)
     ).delete()

--- a/app/grandchallenge/notifications/models.py
+++ b/app/grandchallenge/notifications/models.py
@@ -141,12 +141,12 @@ class Notification(UUIDModel):
         message = kwargs.pop("message", None)
         description = kwargs.pop("description", None)
         context_class = kwargs.pop("context_class", None)
-
         if (
             type == NotificationType.NotificationTypeChoices.FORUM_POST
             or type
             == NotificationType.NotificationTypeChoices.FORUM_POST_REPLY
             or type == NotificationType.NotificationTypeChoices.ACCESS_REQUEST
+            and target._meta.model_name != "algorithm"
             or type == NotificationType.NotificationTypeChoices.REQUEST_UPDATE
             or type == NotificationType.NotificationTypeChoices.MISSING_METHOD
         ):
@@ -158,6 +158,11 @@ class Notification(UUIDModel):
                 ]
             else:
                 receivers = followers(target)
+        elif (
+            type == NotificationType.NotificationTypeChoices.ACCESS_REQUEST
+            and target._meta.model_name == "algorithm"
+        ):
+            receivers = followers(target, flag="access_request")
         elif type == NotificationType.NotificationTypeChoices.NEW_ADMIN:
             receivers = [action_object]
         elif (


### PR DESCRIPTION
Algorithm access request notifications were sent not only to editors of the algorithm, but also to users who had submitted jobs to the algorithm. This is fixed now. Requires a management command to update existing algorithm follows for editors.

I also added a signal that takes care of deleting notifications when an object that is currently used for notifications (as actor, target or action object) is deleted. 