### PR TITLE
Only add image to answer where the sessions match

### DIFF
--- a/app/grandchallenge/reader_studies/tasks.py
+++ b/app/grandchallenge/reader_studies/tasks.py
@@ -52,4 +52,10 @@ def add_image_to_answer(*, upload_session_pk, answer_pk):
     image = Image.objects.get(origin_id=upload_session_pk)
     answer = Answer.objects.get(pk=answer_pk)
 
-    add_image(answer, image)
+    if (
+        str(answer.answer["upload_session_pk"]).casefold()
+        == str(upload_session_pk).casefold()
+    ):
+        add_image(answer, image)
+    else:
+        raise ValueError("Upload session for answer does not match")


### PR DESCRIPTION
As answer image types are editable it could be the case that there are multiple pending upload sessions for an answer at the same time. The value of the latest upload session pk is always stored in the answer. As the upload sessions may be processed out of order (no FIFO guarantees) this PR only allows the image to be assigned to the answer if it originates from the session expected by the answer. Older versions of the `answer_image` are still saved and tracable through the answer history.