### PR TITLE
Integrate challenge forums into challenge layout

### DIFF
--- a/app/grandchallenge/core/templates/challenge.html
+++ b/app/grandchallenge/core/templates/challenge.html
@@ -17,115 +17,12 @@
 {% endblock %}
 
 {% block messages %}
-    {% if challenge.banner %}
-        <div class="row mb-3">
-            <div class="col-12">
-                <a style="width: 100%;"
-                   href="{% url 'pages:home' challenge_short_name=challenge.short_name %}">
-                    <img alt="{% firstof challenge.title challenge.short_name %} Banner"
-                         class="rounded w-100"
-                         src="{{ challenge.banner.x20.url }}"
-                         srcset="{{ challenge.banner.x10.url }} 1x,
-                                 {{ challenge.banner.x15.url }} 1.5x,
-                                 {{ challenge.banner.x20.url }} 2x"
-                    >
-                </a>
-            </div>
-        </div>
-    {% endif %}
-
+    {% include 'grandchallenge/partials/challenge_banner.html' with challenge=challenge %}
     {{ block.super }}
 {% endblock %}
 
 {% block topbar %}
-    {% if challenge %}
-        <div class="row mb-3 mx-0 border-bottom">
-            <div class="col-11 px-0">
-                <div class="nav-tab-dropdown-container">
-                    <a class="d-lg-none btn btn-outline-dark mb-1"
-                       data-toggle="dropdown"
-                       href="#"
-                       role="button"
-                       aria-expanded="false"><i class="fas fa-bars"></i></a>
-                    <ul class="nav nav-tabs border-0">
-                        <li class="nav-item">
-                            <a class="nav-link {% if request.resolver_match.view_name == 'pages:home' or request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"
-                               href="{% url 'pages:home' challenge_short_name=challenge.short_name %}">
-                                <i class="fas fa-info fa-fw"></i>&nbsp;&nbsp;Info
-                            </a>
-                        </li>
-
-                        {% if challenge.display_forum_link %}
-                            <li class="nav-item">
-                                <a class="nav-link"
-                                   href="{% url 'forum:forum' slug=challenge.forum.slug pk=challenge.forum.pk %}">
-                                    <i class="fas fa-comments fa-fw"></i>&nbsp;&nbsp;Forum
-                                </a>
-                            </li>
-                        {% endif %}
-
-                        {% if challenge.use_evaluation %}
-                            {% if challenge.use_teams %}
-                                {% if "change_challenge" in challenge_perms or user_is_participant %}
-                                    <li class="nav-item">
-                                        <a class="nav-link {% if request.resolver_match.app_name == 'teams' %}active{% endif %}"
-                                           href="{% url 'teams:list' challenge_short_name=challenge.short_name %}"> <i class="fas fa-users fa-fw"></i>&nbsp;&nbsp;Teams</a>
-                                    </li>
-                                {% endif %}
-                            {% endif %}
-
-                            {% if "change_challenge" in challenge_perms or user_is_participant %}
-                                {% if challenge.use_workspaces %}
-                                    <li class="nav-item">
-                                        <a class="nav-link {% if request.resolver_match.app_name == "workspaces" %}active{% endif %}"
-                                           href="{% url 'workspaces:create' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
-                                           <i class="fas fa-tools fa-fw"></i>&nbsp;Workspaces</a>
-                                    </li>
-                                {% endif %}
-                                <li class="nav-item">
-                                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' or request.resolver_match.view_name == 'evaluation:submission-list' or request.resolver_match.view_name == 'evaluation:submission-detail' %}active{% endif %}"
-                                       href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
-                                         <i class="fas fa-upload fa-fw"></i>&nbsp;&nbsp;Submit</a>
-                                </li>
-                                <li class="nav-item">
-                                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' or request.resolver_match.view_name == 'evaluation:list' or request.resolver_match.view_name == 'evaluation:detail' or request.resolver_match.view_name == 'evaluation:update' %}active{% endif %}"
-                                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
-                                         <i class="fas fa-trophy fa-fw"></i>&nbsp;&nbsp;Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
-                                </li>
-                            {% elif not challenge.hidden %}
-                                <li class="nav-item">
-                                    <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' or request.resolver_match.view_name == 'evaluation:list' or request.resolver_match.view_name == 'evaluation:detail' or request.resolver_match.view_name == 'evaluation:update' %}active{% endif %}"
-                                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
-                                         <i class="fas fa-trophy fa-fw"></i>&nbsp;&nbsp;Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
-                                </li>
-                            {% endif %}
-                        {% endif %}
-                        {% if "change_challenge" in challenge_perms %}
-                            <div class="nav-item">
-                                <a class="nav-link {% if request.resolver_match.view_name == 'pages:update' or request.resolver_match.view_name == 'pages:delete' or request.resolver_match.view_name == 'pages:create' or request.resolver_match.view_name == 'update' or request.resolver_match.view_name == 'pages:list' or request.resolver_match.app_name == 'admins' or request.resolver_match.view_name == 'participants:list' or request.resolver_match.view_name == 'participants:registration-list' or request.resolver_match.view_name == 'evaluation:phase-update' or request.resolver_match.view_name == 'evaluation:create' or request.resolver_match.view_name == 'evaluation:method-list' or request.resolver_match.view_name == 'evaluation:method-create' %}active{% endif %}"
-                                   href="{% url 'update' challenge_short_name=challenge.short_name %}">
-                                    <i class="fas fa-cog fa-fw"></i>
-                                    Admin
-                                </a>
-                            </div>
-                        {% endif %}
-                    </ul>
-                </div>
-            </div>
-
-            <div class="col-1 py-0 px-0 d-flex justify-content-end">
-                {% if challenge.use_registration_page %}
-                    <div>
-                        <a class="btn btn-success"
-                           href="{% url 'participants:registration-create' challenge_short_name=challenge.short_name %}"
-                           role="button">
-                            Join
-                        </a>
-                    </div>
-                {% endif %}
-            </div>
-        </div>
-    {% endif %}
+    {% include 'grandchallenge/partials/challenge_topbar.html' with challenge=challenge %}
 {% endblock %}
 
 {% block script %}

--- a/app/grandchallenge/core/templates/grandchallenge/partials/challenge_banner.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/challenge_banner.html
@@ -1,0 +1,18 @@
+{% load url %}
+
+{% if challenge.banner %}
+    <div class="row mb-3">
+        <div class="col-12">
+            <a style="width: 100%;"
+               href="{% url 'pages:home' challenge_short_name=challenge.short_name %}">
+                <img alt="{% firstof challenge.title challenge.short_name %} Banner"
+                     class="rounded w-100"
+                     src="{{ challenge.banner.x20.url }}"
+                     srcset="{{ challenge.banner.x10.url }} 1x,
+                             {{ challenge.banner.x15.url }} 1.5x,
+                             {{ challenge.banner.x20.url }} 2x"
+                >
+            </a>
+        </div>
+    </div>
+{% endif %}

--- a/app/grandchallenge/core/templates/grandchallenge/partials/challenge_topbar.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/challenge_topbar.html
@@ -1,0 +1,90 @@
+{% load url %}
+
+{% if challenge %}
+    <div class="row mb-3 mx-0 border-bottom">
+        <div class="col-11 px-0">
+            <div class="nav-tab-dropdown-container">
+                <a class="d-lg-none btn btn-outline-dark mb-1"
+                   data-toggle="dropdown"
+                   href="#"
+                   role="button"
+                   aria-expanded="false"><i class="fas fa-bars"></i></a>
+                <ul class="nav nav-tabs border-0">
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.resolver_match.view_name == 'pages:home' or request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"
+                           href="{% url 'pages:home' challenge_short_name=challenge.short_name %}">
+                            <i class="fas fa-info fa-fw"></i>&nbsp;&nbsp;Info
+                        </a>
+                    </li>
+
+                    {% if challenge.display_forum_link %}
+                        <li class="nav-item">
+                            <a class="nav-link {% if request.resolver_match.view_name == 'forum:forum' or request.resolver_match.view_name == 'forum_conversation:topic' or request.resolver_match.view_name == 'forum_conversation:topic_create' or request.resolver_match.view_name == 'forum_tracking:mark_topics_read' or request.resolver_match.view_name == 'forum_conversation:topic_update' or request.resolver_match.view_name == 'forum_conversation:post_create' or request.resolver_match.view_name == 'forum_conversation:post_update' or request.resolver_match.view_name == 'forum_conversation:post_delete' %} show active {% endif %}"
+                               href="{% url 'forum:forum' slug=challenge.forum.slug pk=challenge.forum.pk %}">
+                                <i class="fas fa-comments fa-fw"></i>&nbsp;&nbsp;Forum
+                            </a>
+                        </li>
+                    {% endif %}
+
+                    {% if challenge.use_evaluation %}
+                        {% if challenge.use_teams %}
+                            {% if "change_challenge" in challenge_perms or user_is_participant %}
+                                <li class="nav-item">
+                                    <a class="nav-link {% if request.resolver_match.app_name == 'teams' %}active{% endif %}"
+                                       href="{% url 'teams:list' challenge_short_name=challenge.short_name %}"> <i class="fas fa-users fa-fw"></i>&nbsp;&nbsp;Teams</a>
+                                </li>
+                            {% endif %}
+                        {% endif %}
+
+                        {% if "change_challenge" in challenge_perms or user_is_participant %}
+                            {% if challenge.use_workspaces %}
+                                <li class="nav-item">
+                                    <a class="nav-link {% if request.resolver_match.app_name == "workspaces" %}active{% endif %}"
+                                       href="{% url 'workspaces:create' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
+                                        <i class="fas fa-tools fa-fw"></i>&nbsp;Workspaces</a>
+                                </li>
+                            {% endif %}
+                            <li class="nav-item">
+                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:submission-create' or request.resolver_match.view_name == 'evaluation:submission-list' or request.resolver_match.view_name == 'evaluation:submission-detail' %}active{% endif %}"
+                                   href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
+                                    <i class="fas fa-upload fa-fw"></i>&nbsp;&nbsp;Submit</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' or request.resolver_match.view_name == 'evaluation:list' or request.resolver_match.view_name == 'evaluation:detail' or request.resolver_match.view_name == 'evaluation:update' %}active{% endif %}"
+                                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
+                                    <i class="fas fa-trophy fa-fw"></i>&nbsp;&nbsp;Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
+                            </li>
+                        {% elif not challenge.hidden %}
+                            <li class="nav-item">
+                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' or request.resolver_match.view_name == 'evaluation:list' or request.resolver_match.view_name == 'evaluation:detail' or request.resolver_match.view_name == 'evaluation:update' %}active{% endif %}"
+                                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
+                                    <i class="fas fa-trophy fa-fw"></i>&nbsp;&nbsp;Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
+                            </li>
+                        {% endif %}
+                    {% endif %}
+                    {% if "change_challenge" in challenge_perms %}
+                        <div class="nav-item">
+                            <a class="nav-link {% if request.resolver_match.view_name == 'pages:update' or request.resolver_match.view_name == 'pages:delete' or request.resolver_match.view_name == 'pages:create' or request.resolver_match.view_name == 'update' or request.resolver_match.view_name == 'pages:list' or request.resolver_match.app_name == 'admins' or request.resolver_match.view_name == 'participants:list' or request.resolver_match.view_name == 'participants:registration-list' or request.resolver_match.view_name == 'evaluation:phase-update' or request.resolver_match.view_name == 'evaluation:create' or request.resolver_match.view_name == 'evaluation:method-list' or request.resolver_match.view_name == 'evaluation:method-create' %}active{% endif %}"
+                               href="{% url 'update' challenge_short_name=challenge.short_name %}">
+                                <i class="fas fa-cog fa-fw"></i>
+                                    Admin
+                            </a>
+                        </div>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+
+        <div class="col-1 py-0 px-0 d-flex justify-content-end">
+            {% if challenge.use_registration_page %}
+                <div>
+                    <a class="btn btn-success"
+                       href="{% url 'participants:registration-create' challenge_short_name=challenge.short_name %}"
+                       role="button">
+                            Join
+                    </a>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+{% endif %}

--- a/app/grandchallenge/forum_conversation/templatetags/forum_extras.py
+++ b/app/grandchallenge/forum_conversation/templatetags/forum_extras.py
@@ -51,3 +51,9 @@ def get_content_type(follow_object):
     except AttributeError:
         ct = None
     return ct
+
+
+@register.simple_tag()
+def is_participant(user, challenge):
+    if challenge.is_participant(user):
+        return True

--- a/app/grandchallenge/forums/templates/board_base.html
+++ b/app/grandchallenge/forums/templates/board_base.html
@@ -14,20 +14,7 @@
     {% include "grandchallenge/partials/navbar.html" with hide_userlinks=False %}
     {% include "partials/breadcrumb.html" %}
 <div class="my-5 container" id="main_container">
-    <div class="row">
-        <div class="col-12">
-            <div class="float-right controls-link-wrapper">
-                {% if not request.user.is_anonymous %}
-                    <a href="{% url 'notifications:follow-list' %}" class="d-inline-block ml-3"><i class="fas fa-bookmark">&nbsp;</i>{% trans "Subscriptions" %}</a>
-                    <a href="{% url 'forum_member:user_posts' request.user.id %}" class="d-inline-block ml-3"><i class="fas fa-comments">&nbsp;</i>{% trans "View my posts" %}</a>
-                {% endif %}
-                {% get_permission 'can_access_moderation_queue' request.user as can_access_moderation_queue %}
-                {% if can_access_moderation_queue %}
-                    <a href="{% url 'forum_moderation:queue' %}" class="d-inline-block ml-3"><i class="fas fa-gavel">&nbsp;</i>{% trans "Moderation queue" %}</a>
-                {% endif %}
-            </div>
-        </div>
-    </div>
+    {% include 'partials/forum_actions.html' %}
     <div class="row">
         <div class="col-12">
             <br />

--- a/app/grandchallenge/forums/templates/challenge_forum_base.html
+++ b/app/grandchallenge/forums/templates/challenge_forum_base.html
@@ -1,0 +1,43 @@
+{% extends 'challenge.html' %}
+{% load static %}
+{% load url %}
+{% load guardian_tags %}
+{% load forum_extras %}
+
+{% block css %}
+{{ block.super }}
+    <link rel="stylesheet" href="{% static 'css/machina.board_theme.min.css' %}" />
+{% endblock %}
+
+{% block title %}{% block sub_title %}{% endblock sub_title %} - {{ forum.name }}{% endblock title %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% url 'challenges:list' %}">Challenges</a></li>
+        <li class="breadcrumb-item" ><a href="{% url 'pages:home' challenge_short_name=forum.challenge.short_name %}">
+            {% firstof forum.challenge.title forum.challenge.short_name %}</a></li>
+        {% if topic %}
+            <li class="breadcrumb-item"><a href="{% url 'forum:forum' forum.slug forum.id %}">Forum</a></li>
+            <li class="breadcrumb-item active" aria-current="page">
+                {{ topic.subject }}
+            </li>
+        {% else %}
+            <li class="breadcrumb-item active" aria-current="page"><a href="{% url 'forum:forum' forum.slug forum.id %}">Forum</a></li>
+        {% endif %}
+    </ol>
+{% endblock %}
+
+{% block messages %}
+    {% include 'grandchallenge/partials/challenge_banner.html' with challenge=forum.challenge %}
+    {{ block.super }}
+{% endblock %}
+
+{% block topbar %}
+    {% get_obj_perms request.user for forum.challenge as "user_perms" %}
+    {% is_participant request.user forum.challenge as is_challenge_participant %}
+    {% include 'grandchallenge/partials/challenge_topbar.html' with challenge=forum.challenge challenge_perms=user_perms user_is_participant=is_challenge_participant %}
+{% endblock %}
+
+{% block content %}
+    {% include 'partials/forum_actions.html' %}
+{% endblock %}

--- a/app/grandchallenge/forums/templates/forum/forum_detail.html
+++ b/app/grandchallenge/forums/templates/forum/forum_detail.html
@@ -1,4 +1,4 @@
-{% extends 'board_base.html' %}
+{% extends 'challenge_forum_base.html' %}
 {% load i18n %}
 {% load mptt_tags %}
 {% load forum_tags %}
@@ -8,14 +8,17 @@
 {% load activity_tags %}
 {% load forum_extras %}
 {% load crispy_forms_tags %}
+{% load guardian_tags %}
+{% load url %}
+{% load static %}
 
-
-{% block sub_title %}{{ forum.name }}{% endblock sub_title %}
+{% block title %}{{ forum.name }} - Forum{% endblock %}
 
 {% block content %}
+{{ block.super }}
 <div class="row">
   <div class="col-12">
-    <h1>{{ forum.name }}</h1>
+    <h1>{{ forum.name }} Forum</h1>
   </div>
 </div>
 {% if sub_forums %}

--- a/app/grandchallenge/forums/templates/forum_conversation/post_create.html
+++ b/app/grandchallenge/forums/templates/forum_conversation/post_create.html
@@ -1,0 +1,88 @@
+{% extends 'challenge_forum_base.html' %}
+{% load i18n %}
+{% load forum_conversation_tags %}
+{% load forum_member_tags %}
+
+{% block sub_title %}{% trans "Post a reply" %}{% endblock sub_title %}
+
+{% block content %}
+{{ block.super }}
+<div class="row">
+  <div class="col-12">
+    <h1>{{ topic.subject }}</h1>
+  </div>
+</div>
+{% if preview %}
+  {% include "forum_conversation/post_preview.html" %}
+{% endif %}
+<div class="row">
+  <div class="col-12">
+    <div class="card post-edit">
+      <div class="card-header">
+        <h3 class="m-0 h5 card-title">{% trans "Post a reply" %}</h3>
+      </div>
+      <div class="card-body">
+        <form method="post" action="." class="form" enctype="multipart/form-data" novalidate>{% csrf_token %}
+          {% include "forum_conversation/partials/post_form.html" %}
+          <div class="form-actions">
+            <input type="submit" name="preview" class="btn btn-large btn-default" value="{% trans "Preview" %}" />&nbsp;
+            <input type="submit" class="btn btn-large btn-primary" value="{% trans "Submit" %}" />
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="mt-3 row">
+  <div class="col-12">
+    <div class="card topic-review">
+      <div class="card-header">
+        <h3 class="m-0 h5 card-title">{% trans "Topic review" %}&nbsp;&ndash;&nbsp;{{ topic.subject }}</h3>
+      </div>
+      <div class="card-body">
+        {% for post in previous_posts %}
+        <div class="row post-review">
+          <div class="col-md-10 post-content-wrapper">
+            <h4 class="subject">{{ post.subject }}</h4>
+            <p><small class="text-muted">
+            {% spaceless %}
+              <i class="fa fa-clock-o"></i>&nbsp;
+              {% if post.poster %}
+                {% url 'forum_member:profile' post.poster_id as poster_url %}
+                {% blocktrans trimmed with poster_url=poster_url username=post.poster|forum_member_display_name creation_date=post.created %}
+                  By: <a href="{{ poster_url }}">{{ username }}</a> on {{ creation_date }}
+                {% endblocktrans %}
+              {% else %}
+                {% blocktrans trimmed with poster_username=post.username creation_date=post.created %}
+                  By: {{ poster_username }} on {{ creation_date }}
+                {% endblocktrans %}
+              {% endif %}
+            {% endspaceless %}
+            </small></p>
+            <div class="post-content">
+              {{ post.content.rendered }}
+            </div>
+            {% include "forum_conversation/forum_attachments/attachments_detail.html" %}
+          </div>
+          <div class="col-md-2 post-sidebar">
+            <div class="username">{% if post.poster %}<a href="{% url 'forum_member:profile' post.poster_id %}"><b>{{ post.poster|forum_member_display_name }}</b></a>{% else %}<b>{{ post.username }}</b>{% endif %}</div>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}
+
+{% block onbodyload %}
+  machina.attachment.init();
+{% endblock onbodyload %}
+
+{% block extra_css %}
+  {{ post_form.media.css }}
+{% endblock extra_css %}
+
+{% block extra_js %}
+  {{ post_form.media.js }}
+{% endblock extra_js %}

--- a/app/grandchallenge/forums/templates/forum_conversation/post_delete.html
+++ b/app/grandchallenge/forums/templates/forum_conversation/post_delete.html
@@ -1,0 +1,26 @@
+{% extends 'challenge_forum_base.html' %}
+{% load i18n %}
+{% load forum_conversation_tags %}
+
+{% block sub_title %}{% trans "Delete post" %}{% endblock sub_title %}
+
+{% block content %}
+{{ block.super }}
+<div class="row mt-3">
+  <div class="col-12">
+    <div class="card post-delete">
+      <div class="card-header">
+        <h3 class="m-0 card-title h5">{% trans "Delete post" %}</h3>
+      </div>
+      <div class="card-body">
+        <div class="mb-3 warning-message">{% trans "Are you sure you want to delete this post?" %}</div>
+        <form action="" method="post">{% csrf_token %}
+          <input type="hidden" name="post" value="yes" />
+          <button role="submit" class="btn btn-warning">{% trans "Yes, I'm sure" %}</button>
+          <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}" class="btn btn-secondary">{% trans "No, take me back" %}</a>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/app/grandchallenge/forums/templates/forum_conversation/post_update.html
+++ b/app/grandchallenge/forums/templates/forum_conversation/post_update.html
@@ -1,0 +1,47 @@
+{% extends 'challenge_forum_base.html' %}
+{% load i18n %}
+{% load forum_conversation_tags %}
+
+{% block sub_title %}{% trans "Edit post" %}{% endblock sub_title %}
+
+{% block content %}
+{{ block.super }}
+<div class="row">
+  <div class="col-12">
+    <h1>{{ topic.subject }}</h1>
+  </div>
+</div>
+{% if preview %}
+  {% include "forum_conversation/post_preview.html" %}
+{% endif %}
+<div class="row">
+  <div class="col-12">
+    <div class="card post-edit">
+      <div class="card-header">
+        <h3 class="m-0 h5 card-title">{% trans "Edit post" %}</h3>
+      </div>
+      <div class="card-body">
+        <form method="post" action="." class="form" enctype="multipart/form-data" novalidate>{% csrf_token %}
+          {% include "forum_conversation/partials/post_form.html" %}
+          <div class="form-actions">
+            <input type="submit" name="preview" class="btn btn-large btn-default" value="{% trans "Preview" %}" />&nbsp;
+            <input type="submit" class="btn btn-large btn-primary" value="{% trans "Submit" %}" />
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}
+
+{% block onbodyload %}
+  machina.attachment.init();
+{% endblock onbodyload %}
+
+{% block extra_css %}
+  {{ post_form.media.css }}
+{% endblock extra_css %}
+
+{% block extra_js %}
+  {{ post_form.media.js }}
+{% endblock extra_js %}

--- a/app/grandchallenge/forums/templates/forum_conversation/topic_create.html
+++ b/app/grandchallenge/forums/templates/forum_conversation/topic_create.html
@@ -1,0 +1,45 @@
+{% extends 'challenge_forum_base.html' %}
+{% load i18n %}
+{% load forum_conversation_tags %}
+
+{% block sub_title %}{% trans "Post a new topic" %}{% endblock sub_title %}
+
+{% block content %}
+{{ block.super }}
+<div class="row">
+  <div class="col-12">
+    <h1>{{ forum.name }}</h1>
+  </div>
+</div>
+{% if poll_preview %}
+{% include "forum_conversation/forum_polls/poll_preview.html" %}
+{% endif %}
+{% if preview %}
+{% include "forum_conversation/post_preview.html" %}
+{% endif %}
+<div class="row">
+  <div class="col-12">
+    <div class="card post-edit">
+      <div class="card-header">
+        <h3 class="m-0 h5 card-title">{% trans "Post a new topic" %}</h3>
+      </div>
+      <div class="card-body">
+        {% include "forum_conversation/partials/topic_form.html" %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}
+
+{% block onbodyload %}
+machina.poll.init();
+machina.attachment.init();
+{% endblock onbodyload %}
+
+{% block extra_css %}
+{{ post_form.media.css }}
+{% endblock extra_css %}
+
+{% block extra_js %}
+{{ post_form.media.js }}
+{% endblock extra_js %}

--- a/app/grandchallenge/forums/templates/forum_conversation/topic_detail.html
+++ b/app/grandchallenge/forums/templates/forum_conversation/topic_detail.html
@@ -1,0 +1,118 @@
+{% extends 'challenge_forum_base.html' %}
+{% load i18n %}
+{% load forum_conversation_tags %}
+{% load forum_member_tags %}
+{% load forum_permission_tags %}
+
+{% block sub_title %}{{ topic.subject }}{% endblock %}
+
+{% block content %}
+{{ block.super }}
+<div class="row"><div class="col-12"><h1>{{ topic.subject }}</h1></div></div>
+<div class="row">
+  <div class="col-12 col-md-4 topic-actions-block">
+  {% include "forum_conversation/partials/topic_detail_actions.html" %}
+  </div>
+  <div class="col-12 col-md-8 pagination-block">
+  {% with "pagination-sm justify-content-end" as pagination_size %}
+  {% include "partials/pagination.html" %}
+  {% endwith %}
+  </div>
+</div>
+<div class="row">
+  <div class="col-12">
+  {% for post in posts %}
+    {% if forloop.first and post.is_topic_head and poll %}
+    {% include "forum_conversation/forum_polls/poll_detail.html" %}
+    {% endif %}
+    <div id="{{ post.id }}" class="my-3 card post">
+      <div class="card-body">
+        <div class="row">
+          <div class="col-md-10 post-content-wrapper">
+            <div class="float-right post-controls">
+              {% get_permission 'can_edit_post' post request.user as user_can_edit_post %}
+              {% if user_can_edit_post %}
+              <a href="{% if post.is_topic_head %}{% url 'forum_conversation:topic_update' forum.slug forum.pk topic.slug topic.pk %}{% else %}{% url 'forum_conversation:post_update' forum.slug forum.pk topic.slug topic.pk post.pk %}{% endif %}" class="btn btn-warning btn-sm" title="{% trans "Edit" %}"><i class="fas fa-edit"></i>&nbsp;{% trans "Edit" %}</a>
+              {% endif %}
+              {% get_permission 'can_delete_post' post request.user as user_can_delete_post %}
+              {% if user_can_delete_post %}
+              <a href="{% url 'forum_conversation:post_delete' forum.slug forum.pk topic.slug topic.pk post.pk %}" class="btn btn-danger btn-sm" title="{% trans "Delete" %}"><i class="fas fa-times"></i></a>
+              {% endif %}
+            </div>
+              {% spaceless %}
+              <h4 class="m-0 subject">
+                {{ post.subject }}
+                &nbsp;<a href="{% url 'forum_conversation:topic' forum.slug forum.pk topic.slug topic.pk %}?post={{ post.pk }}#{{ post.pk }}">&#182;</a>
+              </h4>
+              {% endspaceless %}
+              <p>
+                <small class="text-muted">
+                {% spaceless %}
+                <i class="fas fa-clock"></i>&nbsp;
+                {% if post.poster %}
+                {% url 'forum_member:profile' post.poster_id as poster_url %}
+                {% blocktrans trimmed with poster_url=poster_url username=post.poster|forum_member_display_name creation_date=post.created %}
+                  By: <a href="{{ poster_url }}">{{ username }}</a> on {{ creation_date }}
+                {% endblocktrans %}
+                {% else %}
+                {% blocktrans trimmed with poster_username=post.username creation_date=post.created %}
+                  By: {{ poster_username }} on {{ creation_date }}
+                {% endblocktrans %}
+                {% endif %}
+                {% endspaceless %}
+                </small>
+              </p>
+              <div class="post-content">
+                {{ post.content.rendered }}
+              </div>
+              {% include "forum_conversation/forum_attachments/attachments_detail.html" %}
+              {% if post.enable_signature and post.poster.forum_profile.signature %}
+              <div class="post-signature">
+                {{ post.poster.forum_profile.signature.rendered }}
+              </div>
+              {% endif %}
+              {% if post.updates_count %}
+              <div class="mt-4 edit-info">
+                <small class="text-muted">
+                  <i class="fas fa-edit"></i>&nbsp;{% if post.updated_by %}{% trans "Last edited by:" %}&nbsp;<a href="{% url 'forum_member:profile' post.updated_by_id %}">{{ post.updated_by|forum_member_display_name }}</a>&nbsp;{% else %}{% trans "Updated" %}&nbsp;{% endif %}{% trans "on" %}&nbsp;{{ post.updated }}, {% blocktrans count counter=post.updates_count %}edited {{counter }} time in total.{% plural %}edited {{counter }} times in total.{% endblocktrans %}
+                </small>
+                {% if post.update_reason %}
+                <br />
+                <small class="text-muted">
+                  <b>{% trans "Reason:" %}</b>&nbsp;{{ post.update_reason }}
+                </small>
+                {% endif %}
+              </div>
+              {% endif %}
+          </div>
+          <div class="col-md-2 d-none d-md-block post-sidebar">
+            {% if post.poster %}
+            <div class="avatar">
+              <a href="{% url 'forum_member:profile' post.poster_id %}">
+                {% include "partials/avatar.html" with profile=post.poster.forum_profile show_placeholder=True %}
+              </a>
+            </div>
+            <div class="username"><a href="{% url 'forum_member:profile' post.poster_id %}"><b>{{ post.poster|forum_member_display_name }}</b></a></div>
+            <div class="posts-count text-muted"><b>{% trans "Posts:" %}</b>&nbsp;{{ post.poster.forum_profile.posts_count }}</div>
+            {% else %}
+            <div class="username"><b>{{ post.username }}</b></div>
+            <div class="username text-muted">{% trans "Anonymous user" %}</div>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endfor %}
+  </div>
+</div>
+<div class="row">
+  <div class="col-6 col-md-4 topic-actions-block">
+    {% include "forum_conversation/partials/topic_detail_actions.html" %}
+  </div>
+  <div class="col-12 col-md-8">
+    {% with "pagination-sm justify-content-end" as pagination_size %}
+    {% include "partials/pagination.html" %}
+    {% endwith %}
+  </div>
+</div>
+{% endblock content %}

--- a/app/grandchallenge/forums/templates/forum_conversation/topic_update.html
+++ b/app/grandchallenge/forums/templates/forum_conversation/topic_update.html
@@ -1,0 +1,45 @@
+{% extends 'challenge_forum_base.html' %}
+{% load i18n %}
+{% load forum_conversation_tags %}
+
+{% block sub_title %}{% trans "Edit post" %}{% endblock sub_title %}
+
+{% block content %}
+{{ block.super }}
+<div class="row">
+  <div class="col-12">
+    <h1>{{ forum.name }}</h1>
+  </div>
+</div>
+{% if poll_preview %}
+{% include "forum_conversation/forum_polls/poll_preview.html" %}
+{% endif %}
+{% if preview %}
+{% include "forum_conversation/post_preview.html" %}
+{% endif %}
+<div class="row">
+  <div class="col-12">
+    <div class="card post-edit">
+      <div class="card-header">
+        <h3 class="m-0 h5 card-title">{% trans "Edit post" %}</h3>
+      </div>
+      <div class="card-body">
+        {% include "forum_conversation/partials/topic_form.html" %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}
+
+{% block onbodyload %}
+machina.poll.init();
+machina.attachment.init();
+{% endblock onbodyload %}
+
+{% block extra_css %}
+{{ post_form.media.css }}
+{% endblock extra_css %}
+
+{% block extra_js %}
+{{ post_form.media.js }}
+{% endblock extra_js %}

--- a/app/grandchallenge/forums/templates/forum_tracking/mark_topics_read.html
+++ b/app/grandchallenge/forums/templates/forum_tracking/mark_topics_read.html
@@ -1,0 +1,24 @@
+{% extends 'challenge_forum_base.html' %}
+{% load i18n %}
+{% load forum_conversation_tags %}
+
+{% block sub_title %}{% trans "Mark topics read" %}{% endblock sub_title %}
+
+{% block content %}
+{{ block.super }}
+<div class="row mt-3">
+  <div class="col-12">
+    <div class="card topic-delete">
+      <div class="card-header"><h3 class="m-0 card-title h5">{% trans "Mark topics read" %}</h3></div>
+      <div class="card-body">
+        <div class="mb-3 warning-message">{% trans "Are you sure you want to mark topics read?" %}</div>
+        <form action="" method="post">{% csrf_token %}
+          <input type="hidden" name="post" value="yes" />
+          <button role="submit" class="btn btn-warning">{% trans "Yes, I'm sure" %}</button>
+          <a href="{{ forum_url }}" class="btn btn-secondary">{% trans "No, take me back" %}</a>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/app/grandchallenge/forums/templates/partials/forum_actions.html
+++ b/app/grandchallenge/forums/templates/partials/forum_actions.html
@@ -1,0 +1,18 @@
+{% load url %}
+{% load forum_permission_tags %}
+{% load i18n %}
+
+<div class="row">
+    <div class="col-12">
+        <div class="float-right controls-link-wrapper">
+            {% if not request.user.is_anonymous %}
+                <a href="{% url 'notifications:follow-list' %}" class="d-inline-block ml-3"><i class="fas fa-bookmark">&nbsp;</i>{% trans "Subscriptions" %}</a>
+                <a href="{% url 'forum_member:user_posts' request.user.id %}" class="d-inline-block ml-3"><i class="fas fa-comments">&nbsp;</i>{% trans "View my posts" %}</a>
+            {% endif %}
+            {% get_permission 'can_access_moderation_queue' request.user as can_access_moderation_queue %}
+            {% if can_access_moderation_queue %}
+                <a href="{% url 'forum_moderation:queue' %}" class="d-inline-block ml-3"><i class="fas fa-gavel">&nbsp;</i>{% trans "Moderation queue" %}</a>
+            {% endif %}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
This integrates challenge forums into the challenge layout. The challenge navbar remains visible at all times and the breadcrumbs reflect the nesting of the forum under the challenge and allow easy backwards navigation to the other challenge pages. 

![image](https://user-images.githubusercontent.com/30069334/133584268-a97882b6-f5ab-49ef-9710-96ddfd6f2b07.png)

The forum-related pages that are common to all forums (i.e. not challenge specific) stay with their previous layout:
![image](https://user-images.githubusercontent.com/30069334/133584392-617c9a2f-b006-4783-826f-d0a77b7dbab0.png)


Closes #2017 