### PR TITLE
Switch to ECS by default

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -879,6 +879,9 @@ CELERY_EMAIL_TASK_CONFIG = {
     "ignore_result": False,
 }
 
+COMPONENTS_DEFAULT_BACKEND = (
+    "grandchallenge.components.backends.amazon_ecs.AmazonECSExecutor"
+)
 COMPONENTS_REGISTRY_URL = os.environ.get(
     "COMPONENTS_REGISTRY_URL", "registry:5000"
 )

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -811,27 +811,23 @@ class ComponentJob(models.Model):
                 "job_pk": self.pk,
                 "job_app_label": self._meta.app_label,
                 "job_model_name": self._meta.model_name,
-                "backend": "grandchallenge.components.backends.docker.DockerExecutor",
+                "backend": settings.COMPONENTS_DEFAULT_BACKEND,
             },
-            "options": {
-                # TODO: remove this
-                "queue": "evaluation",
-            },
+            "options": {},
             "immutable": True,
         }
 
-        if self.container.requires_gpu:
-            kwargs["options"].update({"queue": "gpu"})
+        if not self.container.requires_gpu:
+            # TODO move these to ECS
+            kwargs["options"].update({"queue": "evaluation"})
+            kwargs["kwargs"].update(
+                {
+                    "backend": "grandchallenge.components.backends.docker.DockerExecutor"
+                }
+            )
 
         if getattr(self.container, "queue_override", None):
             kwargs["options"].update({"queue": self.container.queue_override})
-
-            if self.container.queue_override == "acks-late-2xlarge":
-                kwargs["kwargs"].update(
-                    {
-                        "backend": "grandchallenge.components.backends.amazon_ecs.AmazonECSExecutor"
-                    }
-                )
 
         return (
             provision_job.signature(**kwargs)

--- a/app/tests/settings.py
+++ b/app/tests/settings.py
@@ -27,6 +27,11 @@ EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 CELERY_BROKER = "memory"
 CELERY_BROKER_URL = "memory://"
 
+# Test using the docker backend
+COMPONENTS_DEFAULT_BACKEND = (
+    "grandchallenge.components.backends.docker.DockerExecutor"
+)
+
 # Disable image resizing
 STDIMAGE_LOGO_VARIATIONS = {"x20": (None,)}
 STDIMAGE_SOCIAL_VARIATIONS = {"x20": (None,)}


### PR DESCRIPTION
A setting is added so that the integration tests can still run using the docker executor.