### PR TITLE
Conditionally determine visibility of columns in datatables

### DIFF
--- a/app/grandchallenge/archives/views.py
+++ b/app/grandchallenge/archives/views.py
@@ -538,7 +538,14 @@ class ArchiveCasesList(
         Column(title="Created", sort_field="created"),
         Column(title="Creator", sort_field="origin__creator__username"),
         Column(title="View", sort_field="pk"),
-        Column(title="Algorithm Results", sort_field="pk"),
+        Column(
+            title="Algorithm Results",
+            sort_field="pk",
+            optional_condition=lambda o: any(
+                civ.algorithms_jobs_as_input.exists()
+                for civ in o.componentinterfacevalue_set.all()
+            ),
+        ),
         Column(title="Download", sort_field="pk"),
     ]
 

--- a/app/grandchallenge/datatables/static/js/datatables/list.js
+++ b/app/grandchallenge/datatables/static/js/datatables/list.js
@@ -8,6 +8,13 @@ $(document).ready(function () {
         serverSide: true,
         ajax: {
             url: "",
+            dataSrc: function ( json ) {
+                const table = $('#ajaxDataTable').DataTable();
+                for (const [index, visible] of json.showColumns.entries()) {
+                    table.column(index).visible(visible)
+                }
+                return json.data;
+            }
         },
         ordering: true,
     });

--- a/app/tests/core_tests/test_views.py
+++ b/app/tests/core_tests/test_views.py
@@ -39,4 +39,5 @@ def test_paginated_table_list_view():
         "recordsTotal": 0,
         "recordsFiltered": 0,
         "data": [],
+        "showColumns": [],
     }


### PR DESCRIPTION
This PR allows us to conditionally show / hide columns in a datatable. 

It works by defining an `optional_condition` callable on a `Column` definition for datatables. The `optional_condition` will be called with the object for that row as parameter for each visible row on the page. If non of the calls evaluate to `True`, the column will be hidden. The visibility is recalculated each time the table data changes: pagination changes, search changes, ordering changes, etc.

This will be useful when the fields in https://github.com/DIAGNijmegen/rse-panimg/pull/51 are implemented here and we want to show these columns in the archive cases list view, but hide the columns that contain empty values. 

As an example I made the "Algorithm Results" column in the cases list view only visible if it actually contains algorithm results.