### PR TITLE
Run algorithm job creation on long task queue

### DIFF
--- a/app/grandchallenge/algorithms/tasks.py
+++ b/app/grandchallenge/algorithms/tasks.py
@@ -1,4 +1,5 @@
 from celery import chain, chord, group, shared_task
+from django.db import transaction
 from django.db.models import Count, Q
 from django.db.transaction import on_commit
 from guardian.shortcuts import assign_perm
@@ -160,7 +161,7 @@ def create_algorithm_jobs_for_session(
         for image in session.image_set.all()
     ]
 
-    new_jobs = execute_jobs(
+    new_jobs = create_algorithm_jobs(
         algorithm_image=algorithm_image,
         civ_sets=civ_sets,
         creator=session.creator,
@@ -214,7 +215,7 @@ def create_algorithm_jobs_for_archive(
             archive_items = archive.items.all()
 
         for algorithm in algorithms:
-            execute_jobs(
+            create_algorithm_jobs(
                 algorithm_image=algorithm.latest_ready_image,
                 civ_sets=[
                     {*ai.values.all()}
@@ -228,69 +229,6 @@ def create_algorithm_jobs_for_archive(
                 # to the algorithm editors
                 task_on_success=None,
             )
-
-
-def execute_jobs(
-    *,
-    algorithm_image,
-    civ_sets,
-    creator=None,
-    extra_viewer_groups=None,
-    extra_logs_viewer_groups=None,
-    task_on_success=None,
-    task_on_failure=None,
-    max_jobs=None,
-):
-    """
-    Execute an algorithm image on sets of component interface values.
-
-    The resulting jobs will be applied in parallel. Note that using
-    a chord here is not supported due to the message size limit of
-    SQS (https://github.com/celery/kombu/issues/279).
-
-    Parameters
-    ----------
-    algorithm_image
-        The algorithm image to use
-    civ_sets
-        The sets of component interface values that will be used as input
-        for the algorithm image
-    creator
-        The creator of the algorithm jobs
-    extra_viewer_groups
-        The groups that will also get permission to view the jobs
-    extra_logs_viewer_groups
-        The groups that will also get permission to view the logs for
-        the jobs
-    task_on_success
-        Celery task that is run on job success. This must be able
-        to handle being called more than once, and in parallel.
-    task_on_failure
-        Celery task that is run on job failure
-    max_jobs
-        The maximum number of jobs to schedule
-
-    Returns
-    -------
-    jobs
-        A list of Job objects that have been scheduled
-
-    """
-    jobs = create_algorithm_jobs(
-        algorithm_image=algorithm_image,
-        civ_sets=civ_sets,
-        creator=creator,
-        extra_viewer_groups=extra_viewer_groups,
-        extra_logs_viewer_groups=extra_logs_viewer_groups,
-        max_jobs=max_jobs,
-        task_on_success=task_on_success,
-        task_on_failure=task_on_failure,
-    )
-
-    for j in jobs:
-        on_commit(j.execute)
-
-    return jobs
 
 
 def create_algorithm_jobs(
@@ -352,22 +290,25 @@ def create_algorithm_jobs(
 
     jobs = []
     for civ_set in civ_sets:
-        j = Job.objects.create(
-            creator=creator,
-            algorithm_image=algorithm_image,
-            task_on_success=task_on_success,
-            task_on_failure=task_on_failure,
-        )
-        j.inputs.set(civ_set)
+        with transaction.atomic():
+            j = Job.objects.create(
+                creator=creator,
+                algorithm_image=algorithm_image,
+                task_on_success=task_on_success,
+                task_on_failure=task_on_failure,
+            )
+            j.inputs.set(civ_set)
 
-        if extra_viewer_groups is not None:
-            j.viewer_groups.add(*extra_viewer_groups)
+            if extra_viewer_groups is not None:
+                j.viewer_groups.add(*extra_viewer_groups)
 
-        if extra_logs_viewer_groups is not None:
-            for g in extra_logs_viewer_groups:
-                assign_perm("algorithms.view_logs", g, j)
+            if extra_logs_viewer_groups is not None:
+                for g in extra_logs_viewer_groups:
+                    assign_perm("algorithms.view_logs", g, j)
 
-        jobs.append(j)
+            jobs.append(j)
+
+            on_commit(j.execute)
 
     return jobs
 

--- a/app/grandchallenge/algorithms/tasks.py
+++ b/app/grandchallenge/algorithms/tasks.py
@@ -1,4 +1,5 @@
 from celery import chain, chord, group, shared_task
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Count, Q
 from django.db.transaction import on_commit
@@ -130,7 +131,7 @@ def execute_algorithm_job_for_inputs(*, job_pk):
         on_commit(job.execute)
 
 
-@shared_task
+@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-2xlarge"])
 def create_algorithm_jobs_for_session(
     *, upload_session_pk, algorithm_image_pk
 ):
@@ -152,46 +153,48 @@ def create_algorithm_jobs_for_session(
     default_input_interface = ComponentInterface.objects.get(
         slug=DEFAULT_INPUT_INTERFACE_SLUG
     )
-    civ_sets = [
-        {
-            ComponentInterfaceValue.objects.create(
-                interface=default_input_interface, image=image
+
+    with transaction.atomic():
+        civ_sets = [
+            {
+                ComponentInterfaceValue.objects.create(
+                    interface=default_input_interface, image=image
+                )
+            }
+            for image in session.image_set.all()
+        ]
+
+        new_jobs = create_algorithm_jobs(
+            algorithm_image=algorithm_image,
+            civ_sets=civ_sets,
+            creator=session.creator,
+            extra_viewer_groups=algorithm_editors,
+            extra_logs_viewer_groups=algorithm_editors,
+            task_on_success=task_on_success,
+        )
+
+        unscheduled_jobs = len(civ_sets) - len(new_jobs)
+
+        if session.creator is not None and unscheduled_jobs:
+            experiment_url = reverse(
+                "algorithms:execution-session-detail",
+                kwargs={
+                    "slug": algorithm_image.algorithm.slug,
+                    "pk": upload_session_pk,
+                },
             )
-        }
-        for image in session.image_set.all()
-    ]
-
-    new_jobs = create_algorithm_jobs(
-        algorithm_image=algorithm_image,
-        civ_sets=civ_sets,
-        creator=session.creator,
-        extra_viewer_groups=algorithm_editors,
-        extra_logs_viewer_groups=algorithm_editors,
-        task_on_success=task_on_success,
-    )
-
-    unscheduled_jobs = len(civ_sets) - len(new_jobs)
-
-    if session.creator is not None and unscheduled_jobs:
-        experiment_url = reverse(
-            "algorithms:execution-session-detail",
-            kwargs={
-                "slug": algorithm_image.algorithm.slug,
-                "pk": upload_session_pk,
-            },
-        )
-        Notification.send(
-            type=NotificationType.NotificationTypeChoices.JOB_STATUS,
-            actor=session.creator,
-            message=f"Unfortunately {unscheduled_jobs} of the jobs for algorithm "
-            f"{algorithm_image.algorithm.title} were not started because "
-            f"the number of allowed jobs was reached.",
-            target=algorithm_image.algorithm,
-            description=experiment_url,
-        )
+            Notification.send(
+                type=NotificationType.NotificationTypeChoices.JOB_STATUS,
+                actor=session.creator,
+                message=f"Unfortunately {unscheduled_jobs} of the jobs for algorithm "
+                f"{algorithm_image.algorithm.title} were not started because "
+                f"the number of allowed jobs was reached.",
+                target=algorithm_image.algorithm,
+                description=experiment_url,
+            )
 
 
-@shared_task
+@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-2xlarge"])
 def create_algorithm_jobs_for_archive(
     *, archive_pks, archive_item_pks=None, algorithm_pks=None
 ):

--- a/app/grandchallenge/evaluation/tasks.py
+++ b/app/grandchallenge/evaluation/tasks.py
@@ -4,6 +4,7 @@ from statistics import mean, median
 
 from celery import shared_task
 from django.apps import apps
+from django.conf import settings
 from django.core.files import File
 from django.db import transaction
 from django.db.models import Count, Q
@@ -111,7 +112,7 @@ def create_evaluation(*, submission_pk, max_initial_jobs=1):
         raise RuntimeError("No algorithm or predictions file found")
 
 
-@shared_task
+@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-2xlarge"])
 def create_algorithm_jobs_for_evaluation(*, evaluation_pk, max_jobs=1):
     """
     Creates the algorithm jobs for the evaluation

--- a/app/grandchallenge/evaluation/tasks.py
+++ b/app/grandchallenge/evaluation/tasks.py
@@ -9,7 +9,7 @@ from django.db import transaction
 from django.db.models import Count, Q
 from django.db.transaction import on_commit
 
-from grandchallenge.algorithms.tasks import execute_jobs
+from grandchallenge.algorithms.tasks import create_algorithm_jobs
 from grandchallenge.components.models import (
     ComponentInterface,
     ComponentInterfaceValue,
@@ -157,7 +157,7 @@ def create_algorithm_jobs_for_evaluation(*, evaluation_pk, max_jobs=1):
         kwargs={"evaluation_pk": str(evaluation.pk)}, immutable=True
     )
 
-    execute_jobs(
+    create_algorithm_jobs(
         algorithm_image=evaluation.submission.algorithm_image,
         civ_sets=[
             {*ai.values.all()}

--- a/app/tests/algorithms_tests/test_tasks.py
+++ b/app/tests/algorithms_tests/test_tasks.py
@@ -14,7 +14,6 @@ from grandchallenge.algorithms.tasks import (
     add_images_to_component_interface_value,
     create_algorithm_jobs,
     execute_algorithm_job_for_inputs,
-    execute_jobs,
     filter_civs_for_algorithm,
     run_algorithm_job_for_inputs,
     send_failed_job_notification,
@@ -189,7 +188,7 @@ class TestCreateJobsWorkflow(TestCase):
     def test_no_jobs_workflow(self):
         ai = AlgorithmImageFactory()
         with capture_on_commit_callbacks() as callbacks:
-            execute_jobs(algorithm_image=ai, civ_sets=[])
+            create_algorithm_jobs(algorithm_image=ai, civ_sets=[])
         assert len(callbacks) == 0
 
     def test_jobs_workflow(self):
@@ -204,7 +203,7 @@ class TestCreateJobsWorkflow(TestCase):
             for im in images
         ]
         with capture_on_commit_callbacks() as callbacks:
-            execute_jobs(algorithm_image=ai, civ_sets=civ_sets)
+            create_algorithm_jobs(algorithm_image=ai, civ_sets=civ_sets)
         assert len(callbacks) == 2
 
 
@@ -236,7 +235,7 @@ def test_algorithm(client, algorithm_image, settings):
     assert civ.interface.slug == "generic-medical-image"
 
     with capture_on_commit_callbacks() as callbacks:
-        execute_jobs(algorithm_image=alg, civ_sets=[{civ}])
+        create_algorithm_jobs(algorithm_image=alg, civ_sets=[{civ}])
     recurse_callbacks(callbacks=callbacks)
 
     jobs = Job.objects.filter(algorithm_image=alg).all()
@@ -284,7 +283,7 @@ def test_algorithm(client, algorithm_image, settings):
     )
 
     with capture_on_commit_callbacks() as callbacks:
-        execute_jobs(algorithm_image=alg, civ_sets=[{civ}])
+        create_algorithm_jobs(algorithm_image=alg, civ_sets=[{civ}])
     recurse_callbacks(callbacks=callbacks)
 
     jobs = Job.objects.filter(
@@ -332,7 +331,7 @@ def test_algorithm_with_invalid_output(client, algorithm_image, settings):
     )
 
     with capture_on_commit_callbacks() as callbacks:
-        execute_jobs(algorithm_image=alg, civ_sets=[{civ}])
+        create_algorithm_jobs(algorithm_image=alg, civ_sets=[{civ}])
     recurse_callbacks(callbacks=callbacks)
 
     jobs = Job.objects.filter(


### PR DESCRIPTION
Adds atomic blocks so that retries are ok, probably the session import should create CIVs, not `create_algorithm_jobs_for_session` but that is for another day.