### PR TITLE
Fix display of duplicate archive items

### DIFF
--- a/app/grandchallenge/archives/views.py
+++ b/app/grandchallenge/archives/views.py
@@ -498,7 +498,7 @@ class ArchiveItemsList(
         "values__file",
     ]
     columns = [
-        Column(title="Values", sort_field="values"),
+        Column(title="Values", sort_field="created"),
         Column(title="Edit", sort_field="pk"),
     ]
 


### PR DESCRIPTION
If default ordering is by a many to many attribute then items are duplicated by `self.filter_queryset(self.object_list, search, order_by)`

Fixes #2048