### PR TITLE
Add zero values to metrics

### DIFF
--- a/app/grandchallenge/core/tasks.py
+++ b/app/grandchallenge/core/tasks.py
@@ -53,16 +53,18 @@ def _get_metrics():
             )
 
         qs = model.objects.values(field).annotate(Count(field)).order_by(field)
+        counts = {q[field]: q[f"{field}__count"] for q in qs}
+
         metric_data.append(
             {
                 "Namespace": f"{site.domain}/{model._meta.app_label}",
                 "MetricData": [
                     {
-                        "MetricName": choice_to_name(q[field]),
-                        "Value": q[f"{field}__count"],
+                        "MetricName": choice_to_name(c),
+                        "Value": counts.get(c, 0),
                         "Unit": "Count",
                     }
-                    for q in qs
+                    for c in choice_to_display
                 ],
             }
         )

--- a/app/tests/core_tests/test_tasks.py
+++ b/app/tests/core_tests/test_tasks.py
@@ -17,11 +17,36 @@ def test_get_metrics():
 
     # Note, this is the format expected by CloudWatch,
     # consult the API when changing this
-    assert _get_metrics() == [
+    result = _get_metrics()
+
+    assert result == [
         {
             "Namespace": "testserver/algorithms",
             "MetricData": [
-                {"MetricName": "JobsQueued", "Value": 1, "Unit": "Count"}
+                {"MetricName": "JobsQueued", "Value": 1, "Unit": "Count"},
+                {"MetricName": "JobsStarted", "Value": 0, "Unit": "Count"},
+                {"MetricName": "JobsReQueued", "Value": 0, "Unit": "Count"},
+                {"MetricName": "JobsFailed", "Value": 0, "Unit": "Count"},
+                {"MetricName": "JobsSucceeded", "Value": 0, "Unit": "Count"},
+                {"MetricName": "JobsCancelled", "Value": 0, "Unit": "Count"},
+                {
+                    "MetricName": "JobsProvisioning",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
+                {"MetricName": "JobsProvisioned", "Value": 0, "Unit": "Count"},
+                {"MetricName": "JobsExecuting", "Value": 0, "Unit": "Count"},
+                {"MetricName": "JobsExecuted", "Value": 0, "Unit": "Count"},
+                {
+                    "MetricName": "JobsParsingOutputs",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
+                {
+                    "MetricName": "JobsExecutingAlgorithm",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
             ],
         },
         {
@@ -31,13 +56,72 @@ def test_get_metrics():
                     "MetricName": "EvaluationsQueued",
                     "Value": 1,
                     "Unit": "Count",
-                }
+                },
+                {
+                    "MetricName": "EvaluationsStarted",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
+                {
+                    "MetricName": "EvaluationsReQueued",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
+                {
+                    "MetricName": "EvaluationsFailed",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
+                {
+                    "MetricName": "EvaluationsSucceeded",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
+                {
+                    "MetricName": "EvaluationsCancelled",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
+                {
+                    "MetricName": "EvaluationsProvisioning",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
+                {
+                    "MetricName": "EvaluationsProvisioned",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
+                {
+                    "MetricName": "EvaluationsExecuting",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
+                {
+                    "MetricName": "EvaluationsExecuted",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
+                {
+                    "MetricName": "EvaluationsParsingOutputs",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
+                {
+                    "MetricName": "EvaluationsExecutingAlgorithm",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
             ],
         },
         {
             "Namespace": "testserver/workstations",
             "MetricData": [
-                {"MetricName": "SessionsQueued", "Value": 1, "Unit": "Count"}
+                {"MetricName": "SessionsQueued", "Value": 1, "Unit": "Count"},
+                {"MetricName": "SessionsStarted", "Value": 0, "Unit": "Count"},
+                {"MetricName": "SessionsRunning", "Value": 0, "Unit": "Count"},
+                {"MetricName": "SessionsFailed", "Value": 0, "Unit": "Count"},
+                {"MetricName": "SessionsStopped", "Value": 0, "Unit": "Count"},
             ],
         },
         {
@@ -49,8 +133,28 @@ def test_get_metrics():
                     "Unit": "Count",
                 },
                 {
+                    "MetricName": "RawImageUploadSessionsStarted",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
+                {
                     "MetricName": "RawImageUploadSessionsReQueued",
                     "Value": 1,
+                    "Unit": "Count",
+                },
+                {
+                    "MetricName": "RawImageUploadSessionsFailed",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
+                {
+                    "MetricName": "RawImageUploadSessionsSucceeded",
+                    "Value": 0,
+                    "Unit": "Count",
+                },
+                {
+                    "MetricName": "RawImageUploadSessionsCancelled",
+                    "Value": 0,
                     "Unit": "Count",
                 },
             ],


### PR DESCRIPTION
CloudWatch cannot seem to display missing data as zero, so let's push them.