### PR TITLE
Adds 'about us' template and reorganizes footer

### DIFF
--- a/app/config/urls/root.py
+++ b/app/config/urls/root.py
@@ -13,7 +13,7 @@ from grandchallenge.archives.sitemaps import ArchivesSitemap
 from grandchallenge.blogs.sitemaps import PostsSitemap
 from grandchallenge.challenges.sitemaps import ChallengesSitemap
 from grandchallenge.core.sitemaps import CoreSitemap, FlatPagesSitemap
-from grandchallenge.core.views import HomeTemplate
+from grandchallenge.core.views import AboutTemplate, HomeTemplate
 from grandchallenge.pages.sitemaps import PagesSitemap
 from grandchallenge.policies.sitemaps import PoliciesSitemap
 from grandchallenge.products.sitemaps import CompaniesSitemap, ProductsSitemap
@@ -45,6 +45,7 @@ sitemaps = {
 
 urlpatterns = [
     path("", HomeTemplate.as_view(), name="home"),
+    path("about/", AboutTemplate.as_view(), name="about"),
     path(
         "robots.txt",
         TemplateView.as_view(

--- a/app/grandchallenge/core/templates/about.html
+++ b/app/grandchallenge/core/templates/about.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+{% load url %}
+
+{% block title %}About us - {{ block.super }}{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item active">About</li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <h1>Contributors</h1>
+    <p>This website was co-authored by
+        <a href="https://www.diagnijmegen.nl/people/bram-van-ginneken/?name=Bram_van_Ginneken">Bram van Ginneken</a>,
+        <a href="https://www.diagnijmegen.nl/people/sjoerd-kerkstra/?name=Sjoerd_Kerkstra">Sjoerd Kerkstra</a>, and
+        <a href="https://www.jmsmkn.com/">James Meakin</a> and is maintained by the
+        <a href="https://rse.diagnijmegen.nl/">Research Software Engineering Team</a> within the
+        <a href="https://www.diagnijmegen.nl/">Diagnostic Image Analysis Group</a> at
+        Radboud University Medical Center in Nijmegen, The Netherlands.
+    </p>
+    <p>The studies described on this web site have been made possible through a massive investment of time and effort
+        by many members of the medical image analysis research community. Organizing a challenge is complex and very
+        time consuming. The organizers of all challenges are mentioned at the web sites on the All Challenges page. On
+        this site, images from these web sites have been used as illustrations.
+    </p>
+    <p>Clinical collaborators have made it possible to collect, annotate and distribute the data sets used in all these
+        comparative studies. Many clinicians have actively participated in the definition and design of these
+        challenges. They are the users of the algorithms we develop and they are instrumental in pointing algorithm
+        developers to the right problem.
+    </p>
+    <p>Many companies in medical image analysis have supported and funded these events (and actively participated
+        as well). Without this support, it would be impossible to award prizes.
+    </p>
+    <p><a href="http://www.miccai.org/">MICCAI</a>, <a href="https://biomedicalimaging.org/2021/">ISBI</a>, and
+        <a href="https://spie.org/about-spie">SPIE Medical Imaging</a>, amongst others, have hosted challenge events.
+        Leading journals such as <a href="http://www.ieee-tmi.org/">IEEE Transactions on Medical Imaging</a> and
+        <a href="https://www.sciencedirect.com/journal/medical-image-analysis">Medical Image Analysis</a> have
+        welcomed overview papers that described the results of individual challenges.
+    </p>
+    <p>Finally, we'd like to thank all the participants. So many groups from all over the world have mustered the
+        courage to participate and see how their algorithm fares in a direct comparison with others. Their enthusiasm
+        is the most important factor that makes grand challenges in medical image analysis possible.
+    </p>
+{% endblock %}

--- a/app/grandchallenge/core/templates/grandchallenge/partials/footer.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/footer.html
@@ -9,8 +9,14 @@
             <hr class="m-0">
             <div class="row small">
                 <div class="col-sm-6 col-md-3 p-3">
-                    <h6>About</h6>
+                    <h6>Grand Challenge</h6>
                     <ul class="list-unstyled">
+                        <li class="my-1">
+                            <a class="text-muted"
+                               href="{% url 'about' %}">
+                                About us
+                            </a>
+                        </li>
                         {% for page in flatpages %}
                             <li class="my-1">
                                 {# Manual construction of url is used here due to flatpage redirect errors #}
@@ -72,20 +78,6 @@
                                href="https://comic.github.io/grand-challenge.org/"
                                title="Read the developer documentation">
                                 Developer Documentation
-                            </a>
-                        </li>
-                        <li class="my-1">
-                            <a class="text-muted"
-                               href="https://rse.diagnijmegen.nl"
-                               title="Research Software Engineering Team, Diagnostic Image Analysis Group, Radboud University Medical Center">
-                                rse.diagnijmegen.nl
-                            </a>
-                        </li>
-                        <li class="my-1">
-                            <a class="text-muted"
-                               href="http://diagnijmegen.nl/"
-                               title="Diagnostic Image Analysis Group, Radboud University Medical Center">
-                                diagnijmegen.nl
                             </a>
                         </li>
                         <li class="my-1">

--- a/app/grandchallenge/core/views.py
+++ b/app/grandchallenge/core/views.py
@@ -204,3 +204,7 @@ class PermissionRequestUpdate(
             f"{self.redirect_namespace}:permission-request-list",
             kwargs={"slug": self.base_object.slug},
         )
+
+
+class AboutTemplate(TemplateView):
+    template_name = "about.html"

--- a/scripts/development_fixtures.py
+++ b/scripts/development_fixtures.py
@@ -102,8 +102,8 @@ def run():
 
 def _create_flatpages(site):
     page = FlatPage.objects.create(
-        url="/about/",
-        title="About",
+        url="/example-flatpage/",
+        title="Example Flatpage",
         content="<p>You can add flatpages via django admin</p>",
     )
     page.sites.add(site)


### PR DESCRIPTION
Another small step towards redesigning the home page. This creates an About Us template page with the contents of the current 'contributors' flatpage. Once this is merged, the contributors flatpage should be removed. 

This also moves some of the links from the developer section to the new About Us page. 

The blog posts section will eventually be removed from the footer as well, but only once we add the link to the navigation bar so that the blogs remain accessible. 