### PR TITLE
Fixes gc card styling 

### DIFF
--- a/app/grandchallenge/core/templates/grandchallenge/partials/cards.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/cards.html
@@ -30,7 +30,7 @@
                         >
                 </div>
                 <div class="card-body d-flex flex-column">
-                    <h5 class="card-title text-truncate mb-0">
+                    <h5 class="card-title {% if 'challenge' in object|meta_attr:'model_name' %}text-truncate{% endif %} mb-0">
                         {% if 'challenge' in object|meta_attr:'model_name' %}
                             {% firstof object.title object.short_name %}
                         {% else %}

--- a/app/grandchallenge/core/templates/home.html
+++ b/app/grandchallenge/core/templates/home.html
@@ -14,7 +14,7 @@
                             <div class="d-sm-flex d-xs-inline justify-content-center align-items-center">
                                 <div class="col-lg-2 col-md-3 col-sm-6 p-0 m-0">
                                     <div class="embed-responsive embed-responsive-1by1">
-                                         <a href="{{ item.get_absolute_url }}"><img class="card embed-responsive-item"
+                                         <a href="{{ item.get_absolute_url }}"><img class="card gc-card embed-responsive-item"
                                              src="{{ item.logo.x20.url }}"
                                              srcset="{{ item.logo.x10.url }} 1x,
                                                      {{ item.logo.x15.url }} 1.5x,

--- a/app/grandchallenge/organizations/templates/organizations/organization_detail.html
+++ b/app/grandchallenge/organizations/templates/organizations/organization_detail.html
@@ -69,7 +69,7 @@
             <div class="row equal-height mx-n2">
                 {% for object in object_list %}
                     <div class="col-12 col-sm-12 col-md-6 col-lg-4 mb-3 px-2">
-                        <div class="card">
+                        <div class="card gc-card">
                             <a class="stretched-link" href="{{ object.get_absolute_url }}"
                                title="View {{ object|meta_attr:'verbose_name'|title }}"></a>
                             <div class="embed-responsive embed-responsive-1by1">

--- a/app/grandchallenge/organizations/templates/organizations/organization_list.html
+++ b/app/grandchallenge/organizations/templates/organizations/organization_list.html
@@ -9,7 +9,7 @@
     <div class="row equal-height mx-n2">
         {% for object in object_list %}
             <div class="col-12 col-sm-6 col-md-4 col-lg-3 mb-3 px-2">
-                <div class="card">
+                <div class="card gc-card">
                     <a class="stretched-link" href="{{ object.get_absolute_url }}"
                        title="View {{ object|meta_attr:'verbose_name'|title }}"></a>
                     <div class="embed-responsive embed-responsive-1by1">

--- a/app/grandchallenge/profiles/templates/profiles/userprofile_detail.html
+++ b/app/grandchallenge/profiles/templates/profiles/userprofile_detail.html
@@ -131,7 +131,7 @@
                 <div class="row equal-height mx-n2">
                     {% for object in object_list %}
                         <div class="col-12 col-sm-12 col-md-6 col-lg-4 mb-3 px-2">
-                            <div class="card">
+                            <div class="card gc-card">
                                 <a class="stretched-link" href="{{ object.get_absolute_url }}"
                                    title="View {{ object|meta_attr:'verbose_name'|title }}"></a>
                                 <div class="embed-responsive embed-responsive-1by1">

--- a/app/grandchallenge/workstations/templates/workstations/workstation_list.html
+++ b/app/grandchallenge/workstations/templates/workstations/workstation_list.html
@@ -19,7 +19,7 @@
     <div class="row equal-height mx-n2">
         {% for object in workstation_list %}
             <div class="col-12 col-sm-6 col-md-4 col-lg-3 mb-3 px-2">
-                <div class="card">
+                <div class="card gc-card">
                     <a class="stretched-link" href="{{ object.get_absolute_url }}"
                        title="View {{ object|meta_attr:'verbose_name'|title }}"></a>
                     <div class="embed-responsive embed-responsive-1by1">


### PR DESCRIPTION
This fixes the missing lock icon for private objects on algorithm, archive and rs cards.  
This adds the gc-card class to organization and workstation cards, to the profile activity overview cards and to the news carousel picture. 
