### PR TITLE
Adds full text search to documentation

### DIFF
--- a/app/grandchallenge/core/templates/markdownx/widget.html
+++ b/app/grandchallenge/core/templates/markdownx/widget.html
@@ -28,7 +28,9 @@
         <p class="text-muted m-0 small">
             You can use
             <a href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet" target="_blank">markdown syntax</a>
-            here. Drag and drop images to upload them to the server.
+            here. Drag and drop images to upload them to the server. For code blocks with python syntax highlighting
+            use ```python ```. See <a href="https://pygments.org/languages/">here</a> for a list of other
+            supported languages.
         </p>
     </div>
     <div class="tab-pane fade" id="preview-{{ widget.attrs.id }}" role="tabpanel" aria-labelledby="preview-tab-{{ widget.attrs.id }}">

--- a/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
+++ b/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
@@ -90,26 +90,42 @@
 {% block content %}
     {% if 'documentation.change_docpage' in perms %}
         <div class="row mt-3">
-            <div class="col-8 col-sm-7 d-inline-block text-left">
+            <div class="col-12 col-sm-6 col-md-7 d-inline-block text-left">
                 <a class="btn btn-md btn-outline-dark d-inline-flex mb-1" href="{% url 'documentation:list' %}">Page overview</a>
-                <a class="btn btn-md btn-outline-dark d-inline-flex mb-1" href="{% url 'documentation:create' %}">Add page</a>
+                <a class="btn btn-md btn-outline-dark d-inline-flex mb-1" href="{% url 'documentation:create' %}">Add</a>
+                <a class="btn btn-md btn-outline-dark mb-1" href="{% url 'documentation:update' slug=currentdocpage.slug %}">Edit</a>
             </div>
-            <div class="col-4 col-sm-5 d-inline-block text-right">
-                <a class="btn btn-md btn-outline-dark mb-1" href="{% url 'documentation:update' slug=currentdocpage.slug %}">Edit current page</a>
+            <div class="col-12 col-sm-6 col-md-5 justify-content-start justify-content-sm-end form-inline">
+                <form>
+                    <input class="form-control mb-1" type="text" name="query" placeholder="Search...">
+                </form>
             </div>
         </div>
     {% endif %}
-    <div class="mt-4" id=pageContainer>{{ currentdocpage.content|md2html }}</div>
-    <div class="row">
-        <div class="d-inline-block col-6 text-left">
-            {% if currentdocpage.previous %}
-                <a class="btn btn-md btn-outline-dark" href="{% url 'documentation:detail' slug=currentdocpage.previous.slug %}">Previous section</a>
+    {% if search_results != None %}
+        <div class="mt-4" id=pageContainer>
+            {% if search_results %}
+                {% for result in search_results %}
+                    <a href="{% url 'documentation:detail' slug=result.slug %}"><h5>{{ result.title }}</h5></a>
+                    <div class="mb-3">{{ result.headline|safe }}</div>
+                {% endfor %}
+            {% else %}
+                <div>There are no matches for <b>{{ query }}</b>.</div>
             {% endif %}
         </div>
-        <div class="d-inline col-6 text-right">
-            {% if currentdocpage.next %}
-                <a class="btn btn-md btn-outline-dark" href="{% url 'documentation:detail' slug=currentdocpage.next.slug %}">Next section</a>
-            {% endif %}
+    {% else %}
+        <div class="mt-4" id=pageContainer>{{ currentdocpage.content|md2html }}</div>
+        <div class="row">
+            <div class="d-inline-block col-6 text-left">
+                {% if currentdocpage.previous %}
+                    <a class="btn btn-md btn-outline-dark" href="{% url 'documentation:detail' slug=currentdocpage.previous.slug %}">Previous section</a>
+                {% endif %}
+            </div>
+            <div class="d-inline col-6 text-right">
+                {% if currentdocpage.next %}
+                    <a class="btn btn-md btn-outline-dark" href="{% url 'documentation:detail' slug=currentdocpage.next.slug %}">Next section</a>
+                {% endif %}
+            </div>
         </div>
-    </div>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
- This adds a full-text search bar to the documentation. The searching is done on stemmed keywords (meaning that searching for 'algorithm' looks for both plural and singular of the word, for example), but it does not do partial matching, so searching for 'p' won't return matches of words containing p. This also means that we're not correcting for typos, so searching for "algoritm" won't return algorithm matches.... If we want this to work, we would need to use [Trigram similarity](https://docs.djangoproject.com/en/3.2/ref/contrib/postgres/search/#trigram-similarity) instead.

https://user-images.githubusercontent.com/30069334/137448423-32111ec8-60d1-4451-940a-32278b6da753.mp4


- It also adds help text about syntax highlighting to the markdown widget. 