### PR TITLE
Maintain carousel img aspect ratio when sclaing

### DIFF
--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -198,8 +198,27 @@ ul.socialaccount_providers > li {
     text-overflow: ellipsis;
 }
 
-@media only screen and (max-width: 560px) {
+@media only screen and (max-width: 580px) {
   .text-truncate-container {
-    height: 11rem;
+      height: 11rem;
   }
+  .carousel-img-container {
+      height: 15rem;
+  }
+}
+
+@media only screen and (min-width: 580px) and (max-width: 1200px) {
+    .carousel-img-container {
+        height: 10rem;
+    }
+}
+
+@media only screen and (min-width: 1200px) {
+    .carousel-img-container {
+        height: 12rem;
+    }
+}
+
+.carousel-img {
+    object-fit: cover;
 }

--- a/app/grandchallenge/core/templates/home.html
+++ b/app/grandchallenge/core/templates/home.html
@@ -13,15 +13,13 @@
                         {% for item in news_caroussel_items %}
                             <div class="carousel-item {% if forloop.counter == 1 %}active{% endif %}">
                                 <div class="d-sm-flex d-xs-inline justify-content-center align-items-center">
-                                    <div class="col-12 col-lg-2 col-md-3 col-sm-6 p-0 my-3">
-                                        <div class="embed-responsive embed-responsive-1by1 gc-card">
-                                             <a href="{{ item.get_absolute_url }}"><img class="card gc-card embed-responsive-item"
-                                                 src="{{ item.logo.x20.url }}"
-                                                 srcset="{{ item.logo.x10.url }} 1x,
-                                                         {{ item.logo.x15.url }} 1.5x,
-                                                         {{ item.logo.x20.url }} 2x"
-                                                 alt="{{ item.title }}" loading="lazy"></a>
-                                        </div>
+                                    <div class="col-12 col-lg-2 col-md-3 col-sm-6 p-0 my-3 d-inline-block carousel-img-container w-100">
+                                        <a href="{{ item.get_absolute_url }}"><img class="card gc-card carousel-img m-auto h-100 mw-100"
+                                             src="{{ item.logo.x20.url }}"
+                                             srcset="{{ item.logo.x10.url }} 1x,
+                                                     {{ item.logo.x15.url }} 1.5x,
+                                                      {{ item.logo.x20.url }} 2x"
+                                             alt="{{ item.title }}" loading="lazy"></a>
                                     </div>
                                     <div class="col-12 col-lg-8 col-md-7 col-sm-6 text-primary text-truncate-container">
                                         <a class="stretched-link text-decoration-none text-primary"


### PR DESCRIPTION
- This sets the carousel img container to a specific height depending on screen size and ensures that the embedded img always fills the full height and the maximally available width of the containing div while maintaining the image's original aspect ratio.
- Images that are too wide will be cropped when necessary.

Before:
![image](https://user-images.githubusercontent.com/30069334/138112163-77f3dcc7-4cab-4985-8b1f-9ec1606fb6a1.png)


After:
![image](https://user-images.githubusercontent.com/30069334/138112107-ec9110a3-0c7a-4834-ad88-2fa2ac15f306.png)
