### PR TITLE
Truncate text earlier on small screens to accomodate for longer titles

### DIFF
--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -200,16 +200,25 @@ ul.socialaccount_providers > li {
 
 @media only screen and (max-width: 580px) {
   .text-truncate-container {
-      height: 11rem;
+      height: 12rem;
+  }
+  .text-truncate-container p{
+      -webkit-line-clamp: 3;
   }
   .carousel-img-container {
       height: 15rem;
   }
 }
 
-@media only screen and (min-width: 580px) and (max-width: 1200px) {
+@media only screen and (min-width: 768px) and (max-width: 1200px) {
     .carousel-img-container {
         height: 10rem;
+    }
+    .text-truncate-container {
+      height: 10rem;
+    }
+    .text-truncate-container p {
+        -webkit-line-clamp: 3;
     }
 }
 

--- a/app/grandchallenge/core/templates/home.html
+++ b/app/grandchallenge/core/templates/home.html
@@ -12,16 +12,16 @@
                     <div class="carousel-inner m-0 px-0">
                         {% for item in news_caroussel_items %}
                             <div class="carousel-item {% if forloop.counter == 1 %}active{% endif %}">
-                                <div class="d-sm-flex d-xs-inline justify-content-center align-items-center">
-                                    <div class="col-12 col-lg-2 col-md-3 col-sm-6 p-0 my-3 d-inline-block carousel-img-container w-100">
-                                        <a href="{{ item.get_absolute_url }}"><img class="card gc-card carousel-img m-auto h-100 mw-100"
+                                <div class="d-md-flex d-xs-inline justify-content-center align-items-center">
+                                    <div class="col-12 col-md-3 p-0 my-3 d-inline-block carousel-img-container w-100">
+                                        <a href="{{ item.get_absolute_url }}"><img class="card gc-card carousel-img m-auto h-100 mw-100 border-0"
                                              src="{{ item.logo.x20.url }}"
                                              srcset="{{ item.logo.x10.url }} 1x,
                                                      {{ item.logo.x15.url }} 1.5x,
                                                       {{ item.logo.x20.url }} 2x"
                                              alt="{{ item.title }}" loading="lazy"></a>
                                     </div>
-                                    <div class="col-12 col-lg-8 col-md-7 col-sm-6 text-primary text-truncate-container">
+                                    <div class="col-12 col-md-7 text-primary text-truncate-container">
                                         <a class="stretched-link text-decoration-none text-primary"
                                            href="{{ item.get_absolute_url }}">
                                             <h4 class="p-3">{{ item.title }}</h4>


### PR DESCRIPTION
On small screens the description text of blog posts with long titles is not truncated early enough:

![image](https://user-images.githubusercontent.com/30069334/138423975-596fef54-a976-47f5-b6f6-f025f2cd6cd9.png)

This PR fixes that. IT also removes the border of the carousel image and makes the image bigger in wdth on large screens. 