### PR TITLE
Allow fullscreen for videos from own origin

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -286,7 +286,7 @@ PERMISSIONS_POLICY = {
     "display-capture": [],
     "document-domain": [],
     "encrypted-media": [],
-    "fullscreen": [],
+    "fullscreen": ["self"],
     "geolocation": [],
     "gyroscope": [],
     "interest-cohort": [],


### PR DESCRIPTION
Fullscreen was disabled for Chrome and Edge. This occured because we use a very strict configuration for django permissions policy. Fullscreen is not allowed in there and this permission setting is currently only supported by chrome and edge: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy/fullscreen

This PR allows fullscreen for same origin sources.

Fixes #2132 