### PR TITLE
Add js and html for info modal for algorithm and challenge cards

### DIFF
--- a/app/grandchallenge/core/templates/home.html
+++ b/app/grandchallenge/core/templates/home.html
@@ -116,5 +116,12 @@
                 </div>
             </div>
         </div>
+
+        {% include "grandchallenge/partials/cards_info_modal.html" %}
     {% endblock %}
 {% endcache %}
+
+{% block script %}
+    {{ block.super }}
+    <script src="{% static "js/cards_info_modal.js" %}"></script>
+{% endblock %}


### PR DESCRIPTION
The info button on highlighted challenge and algorithm cards on the home page was not working. This fixes that.