### PR TITLE
Add PDF download column to job list

### DIFF
--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -25,6 +25,7 @@ from grandchallenge.components.models import (
     ComponentImage,
     ComponentInterface,
     ComponentJob,
+    InterfaceKind,
 )
 from grandchallenge.core.models import RequestBase, UUIDModel
 from grandchallenge.core.storage import (
@@ -578,6 +579,14 @@ class Job(UUIDModel, ComponentJob):
             immutable=True,
         )
         on_commit(run_job.apply_async)
+
+    @cached_property
+    def pdf_outputs(self):
+        pdfs = []
+        for output in self.outputs.all():
+            if output.interface.kind == InterfaceKind.InterfaceKindChoices.PDF:
+                pdfs.append(output)
+        return pdfs
 
 
 @receiver(post_delete, sender=Job)

--- a/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
@@ -71,3 +71,14 @@
         <i class="fa fa-eye"></i> Open Result in Viewer
     </a>
 {% endif %}
+<split></split>
+
+{% if object.pdf_outputs %}
+    {% for pdf in object.pdf_outputs %}
+        <a class="badge badge-primary mr-1"
+           title="Download {{ pdf.interface.title }}"
+           href="{{ pdf.file.url }}">
+            <i class="fa fa-download"></i>
+        </a>
+    {% endfor %}
+{% endif %}

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -547,15 +547,6 @@ class JobsList(PermissionListMixin, PaginatedTableListView):
         "inputs__image__files__file",
         "comment",
     ]
-    columns = [
-        Column(title="Details", sort_field="pk"),
-        Column(title="Created", sort_field="created"),
-        Column(title="Creator", sort_field="creator__username"),
-        Column(title="Result", sort_field="inputs__image__name"),
-        Column(title="Comment", sort_field="comment"),
-        Column(title="Visibility", sort_field="public"),
-        Column(title="Viewer", sort_field="inputs__image__files__file"),
-    ]
     default_sort_column = 1
 
     @cached_property
@@ -581,8 +572,27 @@ class JobsList(PermissionListMixin, PaginatedTableListView):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
-        context.update({"algorithm": self.algorithm})
+        context.update({"algorithm": self.algorithm, "columns": self.columns})
         return context
+
+    @cached_property
+    def columns(self):
+        columns = [
+            Column(title="Details", sort_field="pk"),
+            Column(title="Created", sort_field="created"),
+            Column(title="Creator", sort_field="creator__username"),
+            Column(title="Result", sort_field="inputs__image__name"),
+            Column(title="Comment", sort_field="comment"),
+            Column(title="Visibility", sort_field="public"),
+            Column(title="Viewer", sort_field="inputs__image__files__file"),
+        ]
+
+        if "PDF" in self.algorithm.outputs.values_list("kind", flat=True):
+            columns.append(
+                Column(title="PDF", sort_field="", classes=("nonSortable",)),
+            )
+
+        return columns
 
 
 class JobDetail(ObjectPermissionRequiredMixin, DetailView):

--- a/app/grandchallenge/datatables/static/js/datatables/list.js
+++ b/app/grandchallenge/datatables/static/js/datatables/list.js
@@ -6,6 +6,13 @@ $(document).ready(function () {
         lengthChange: false,
         pageLength: 25,
         serverSide: true,
+        columnDefs: [
+            {
+                targets: 'nonSortable',
+                searchable: false,
+                orderable: false,
+            },
+        ],
         ajax: {
             url: "",
             dataSrc: function ( json ) {


### PR DESCRIPTION
This adds a PDF download column to the algorithm results table. The column contains download buttons for each job's PDF output(s). The PDF interface title is displayed when hovering over the download button so as to tell the possibly multiple PDFs apart. 

Charts and Thumbnails are difficult to include in the list (as modals at best), so left those in the detail view for now. 

Part of pitch: https://github.com/DIAGNijmegen/rse-roadmap/issues/96