### PR TITLE
Adds chart output to results list view

### DIFF
--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -581,12 +581,20 @@ class Job(UUIDModel, ComponentJob):
         on_commit(run_job.apply_async)
 
     @cached_property
-    def pdf_outputs(self):
-        pdfs = []
+    def special_outputs(self):
+        outputs = {
+            "CHART": [],
+            "PDF": [],
+        }
         for output in self.outputs.all():
+            if (
+                output.interface.kind
+                == InterfaceKind.InterfaceKindChoices.CHART
+            ):
+                outputs["CHART"].append(output)
             if output.interface.kind == InterfaceKind.InterfaceKindChoices.PDF:
-                pdfs.append(output)
-        return pdfs
+                outputs["PDF"].append(output)
+        return outputs
 
 
 @receiver(post_delete, sender=Job)

--- a/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
@@ -73,12 +73,26 @@
 {% endif %}
 <split></split>
 
-{% if object.pdf_outputs %}
-    {% for pdf in object.pdf_outputs %}
+{% if 'PDF' in output_interface_kinds %}
+    {% for pdf in object.special_outputs.PDF %}
         <a class="badge badge-primary mr-1"
            title="Download {{ pdf.interface.title }}"
            href="{{ pdf.file.url }}">
             <i class="fa fa-download"></i>
         </a>
     {% endfor %}
+    <split></split>
+{% endif %}
+
+
+{% if 'CHART' in output_interface_kinds %}
+    {% for chart in object.special_outputs.CHART %}
+        <a class="badge badge-primary mr-1"
+           title="Inspect {{ chart.interface.title }}"
+           target="_blank"
+           href="{% url 'algorithms:job-detail' slug=algorithm.slug pk=object.pk %}">
+            <i class="fas fa-chart-bar"></i>
+        </a>
+    {% endfor %}
+    <split></split>
 {% endif %}

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -572,7 +572,13 @@ class JobsList(PermissionListMixin, PaginatedTableListView):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
-        context.update({"algorithm": self.algorithm, "columns": self.columns})
+        context.update(
+            {
+                "algorithm": self.algorithm,
+                "columns": self.columns,
+                "output_interface_kinds": self.output_interface_kinds,
+            }
+        )
         return context
 
     @cached_property
@@ -587,12 +593,21 @@ class JobsList(PermissionListMixin, PaginatedTableListView):
             Column(title="Viewer", sort_field="inputs__image__files__file"),
         ]
 
-        if "PDF" in self.algorithm.outputs.values_list("kind", flat=True):
+        if "PDF" in self.output_interface_kinds:
             columns.append(
                 Column(title="PDF", sort_field="", classes=("nonSortable",)),
             )
 
+        if "CHART" in self.output_interface_kinds:
+            columns.append(
+                Column(title="Chart", sort_field="", classes=("nonSortable",)),
+            )
+
         return columns
+
+    @cached_property
+    def output_interface_kinds(self):
+        return self.algorithm.outputs.values_list("kind", flat=True)
 
 
 class JobDetail(ObjectPermissionRequiredMixin, DetailView):


### PR DESCRIPTION
- This adds a chart column to the results list view if the algorithm has a chart output interface. 
- All chart outputs are then represented by chart icons within this one column. 
- Hovering over them shows the interface title and clicking on them opens a new window with the job's detail view. This means that all icons for a given job lead to the same page. _We could add hashes to the url to direct to the specific section of the detail page where the respective chart is located if we want more specificity._ 

![image](https://user-images.githubusercontent.com/30069334/139673326-1f946a75-1904-4627-bb94-5f57f7c95a9e.png)


No N+1 queries :-)