### PR TITLE
Update linked repo workflow

### DIFF
--- a/app/grandchallenge/algorithms/forms.py
+++ b/app/grandchallenge/algorithms/forms.py
@@ -114,7 +114,6 @@ class AlgorithmForm(WorkstationUserFilterMixin, SaveFormInitMixin, ModelForm):
             "social_image",
             "public",
             "use_flexible_inputs",
-            "repo_name",
             "inputs",
             "outputs",
             "workstation",
@@ -198,6 +197,11 @@ class AlgorithmForm(WorkstationUserFilterMixin, SaveFormInitMixin, ModelForm):
                 )
 
         return cleaned_data
+
+
+class AlgorithmUpdateForm(AlgorithmForm):
+    class Meta(AlgorithmForm.Meta):
+        fields = AlgorithmForm.Meta.fields + ("repo_name",)
 
 
 class AlgorithmImageForm(ContainerImageForm):

--- a/app/grandchallenge/algorithms/forms.py
+++ b/app/grandchallenge/algorithms/forms.py
@@ -69,7 +69,34 @@ NON_ALGORITHM_INTERFACES = [
 ]
 
 
-class AlgorithmForm(WorkstationUserFilterMixin, SaveFormInitMixin, ModelForm):
+class RepoNameValidationMixin:
+    def clean_repo_name(self):
+        repo_name = self.cleaned_data.get("repo_name")
+        if (
+            Algorithm.objects.exclude(pk=self.instance.pk)
+            .filter(repo_name=repo_name)
+            .exists()
+        ):
+            raise ValidationError(
+                "This repository is already linked to another algorithm."
+            )
+        pattern = re.compile("^([^/]+/[^/]+)$")
+        if "github.com" in repo_name:
+            raise ValidationError(
+                "Please only provide the repository name, not the full url. E.g. 'comic/grand-challenge.org'"
+            )
+        if not pattern.match(repo_name):
+            raise ValidationError(
+                "Please make sure you provide the repository name in the format '<owner>/<repo>', e.g. 'comic/grand-challenge.org'"
+            )
+
+
+class AlgorithmForm(
+    RepoNameValidationMixin,
+    WorkstationUserFilterMixin,
+    SaveFormInitMixin,
+    ModelForm,
+):
     inputs = ModelMultipleChoiceField(
         queryset=ComponentInterface.objects.exclude(
             slug__in=[*NON_ALGORITHM_INTERFACES, "results-json-file"]
@@ -185,17 +212,6 @@ class AlgorithmForm(WorkstationUserFilterMixin, SaveFormInitMixin, ModelForm):
                 "set of inputs you have selected."
             )
 
-        if cleaned_data["repo_name"]:
-            pattern = re.compile("^([^/]+/[^/]+)$")
-            if "github.com" in cleaned_data["repo_name"]:
-                raise ValidationError(
-                    "Please only provide the repository name, not the full url. E.g. 'comic/grand-challenge.org'"
-                )
-            if not pattern.match(cleaned_data["repo_name"]):
-                raise ValidationError(
-                    "Please make sure you provide the repository name in the format '<owner>/<repo>', e.g. 'comic/grand-challenge.org'"
-                )
-
         return cleaned_data
 
 
@@ -293,7 +309,7 @@ class AlgorithmPermissionRequestUpdateForm(PermissionRequestUpdateForm):
         model = AlgorithmPermissionRequest
 
 
-class AlgorithmRepoForm(SaveFormInitMixin, ModelForm):
+class AlgorithmRepoForm(RepoNameValidationMixin, SaveFormInitMixin, ModelForm):
     repo_name = ChoiceField()
 
     def __init__(self, *args, **kwargs):

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_add_repo.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_add_repo.html
@@ -22,4 +22,8 @@
 
     {{ block.super }}
 
+    <div class="mt-3">
+        In case your repository is not listed, you can <a href="{{ github_app_install_url }}">link a new GitHub repo here</a>.
+    </div>
+
 {% endblock %}

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
@@ -255,7 +255,7 @@
                         </a>
                     {% else %}
                         <a class="btn btn-success"
-                           href="{{ github_app_install_url }}">
+                           href={% url "algorithms:add-repo" slug=object.slug %}>
                             <i class="fa fa-code-branch"></i> Link GitHub Repo
                         </a>
                     {% endif %}

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -198,7 +198,6 @@ class AlgorithmDetail(ObjectPermissionRequiredMixin, DetailView):
         context.update(
             {
                 "pending_permission_requests": pending_permission_requests,
-                "github_app_install_url": f"{settings.GITHUB_APP_INSTALL_URL}?state={self.object.slug}",
                 "builds": Build.objects.filter(
                     algorithm_image__algorithm=self.object
                 ),
@@ -807,6 +806,15 @@ class AlgorithmAddRepo(
     permission_required = "algorithms.change_algorithm"
     raise_exception = True
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "github_app_install_url": f"{settings.GITHUB_APP_INSTALL_URL}?state={self.object.slug}"
+            }
+        )
+        return context
+
     def get_form_kwargs(self):
         """Return the keyword arguments for instantiating the form."""
         kwargs = super().get_form_kwargs()
@@ -827,7 +835,6 @@ class AlgorithmAddRepo(
             headers=headers,
             timeout=5,
         ).json()
-
         repos = []
         for installation in installations.get("installations", []):
             response = requests.get(

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -49,6 +49,7 @@ from grandchallenge.algorithms.forms import (
     AlgorithmInputsForm,
     AlgorithmPermissionRequestUpdateForm,
     AlgorithmRepoForm,
+    AlgorithmUpdateForm,
     JobForm,
     UsersForm,
     ViewersForm,
@@ -215,7 +216,7 @@ class AlgorithmUpdate(
     UpdateView,
 ):
     model = Algorithm
-    form_class = AlgorithmForm
+    form_class = AlgorithmUpdateForm
     permission_required = "algorithms.change_algorithm"
     raise_exception = True
 

--- a/app/tests/algorithms_tests/test_forms.py
+++ b/app/tests/algorithms_tests/test_forms.py
@@ -154,6 +154,39 @@ def test_algorithm_create(client, uploaded_image):
 
 
 @pytest.mark.django_db
+def test_algorithm_update_contains_repo_name(client, uploaded_image):
+    # The algorithm creator should automatically get added to the editors group
+    creator = get_algorithm_creator()
+    VerificationFactory(user=creator, is_verified=True)
+
+    response = get_view_for_user(
+        viewname="algorithms:create",
+        client=client,
+        method=client.get,
+        follow=True,
+        user=creator,
+    )
+
+    assert response.status_code == 200
+    assert "repo_name" not in response.rendered_content
+
+    alg = AlgorithmFactory()
+    alg.add_editor(user=creator)
+
+    response = get_view_for_user(
+        viewname="algorithms:update",
+        client=client,
+        method=client.get,
+        reverse_kwargs={"slug": alg.slug},
+        follow=True,
+        user=creator,
+    )
+
+    assert response.status_code == 200
+    assert "repo_name" in response.rendered_content
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "slug, content_parts",
     (


### PR DESCRIPTION
This Pr changes a couple of things in the workflow to link a github repo to an algorithm:

- It removes the repo_name field from the algorithm creation form, as this caused some confusion among users.
- It adds the add_repo views as an intermediary step when linking a repo. This is added because in some cases the app might already be installed, in which case the redirect back to gc does not work anymore.
- It adds validation for repo_name uniqueness and moves the rep_name validation to the field rather than the form.