### PR TITLE
Adds + sign to user count in jumbotron

### DIFF
--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -198,7 +198,7 @@ ul.socialaccount_providers > li {
     text-overflow: ellipsis;
 }
 
-@media only screen and (max-width: 580px) {
+@media only screen and (max-width: 768px) {
   .text-truncate-container {
       height: 12rem;
   }
@@ -235,4 +235,8 @@ ul.socialaccount_providers > li {
 .thumbnail {
     max-height:90px;
     max-width:90px;
+}
+
+.box-shadow {
+    box-shadow: 0 0 1rem 0 rgba(0, 0, 0, .1);
 }

--- a/app/grandchallenge/core/templates/grandchallenge/partials/jumbotron.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/jumbotron.html
@@ -15,9 +15,9 @@
                 <p class="lead">{{ jumbotron_description }}</p>
                 {% if request.resolver_match.view_name == 'home' %}
                     <div class="text-light text-center row pt-lg-5 pt-md-5 pt-sm-4">
-                        <div class="col-lg-4 col-sm-3 mb-2"><i class="fa fa-users fa-lg mr-2" aria-hidden="true"></i>{{ all_users.count|round_to:1000|intcomma }} &nbsp;users</div>
-                        <div class="col-lg-4 col-sm-3 mb-2"><i class="fa fa-trophy fa-lg mr-2" aria-hidden="true"></i>{{ all_challenges.count|intcomma }} &nbsp;challenges</div>
-                        <div class="col-lg-4 col-sm-3 mb-2"><i class="fa fa-code fa-lg mr-2" aria-hidden="true"></i>{{ all_algorithms.count|intcomma }} &nbsp;algorithms</div>
+                        <div class="col-sm-4 mb-2"><i class="fa fa-users fa-lg mr-2" aria-hidden="true"></i>{{ all_users.count|round_to:1000|intcomma }}+ &nbsp;users</div>
+                        <div class="col-sm-4 mb-2"><i class="fa fa-trophy fa-lg mr-2" aria-hidden="true"></i>{{ all_challenges.count|intcomma }} &nbsp;challenges</div>
+                        <div class="col-sm-4 mb-2"><i class="fa fa-code fa-lg mr-2" aria-hidden="true"></i>{{ all_algorithms.count|intcomma }} &nbsp;algorithms</div>
                     </div>
                 {% endif %}
             </div>

--- a/app/grandchallenge/core/templates/home.html
+++ b/app/grandchallenge/core/templates/home.html
@@ -106,7 +106,7 @@
                                 </div>
                                 <div class="col-md-6 my-3">
                                     <a href="{{ highlight.url }}"><img src="{% static highlight.image %}"
-                                                                       class="img-fluid w-100"
+                                                                       class="img-fluid w-100 box-shadow"
                                                                        loading="lazy"
                                                                        alt="{{ highlight.url_title }} Image"></a>
                                 </div>


### PR DESCRIPTION
 - Adds a '+' to the user count in the jumbotron.
- Fixes a small css inconsistency and adds a box-shadow to the images in the feature overview (taken from Harm's [PR](https://github.com/comic/grand-challenge.org/pull/2118)). 