### PR TITLE
Reduce db calls for notification list

### DIFF
--- a/app/grandchallenge/notifications/models.py
+++ b/app/grandchallenge/notifications/models.py
@@ -209,7 +209,7 @@ class Notification(UUIDModel):
                 format_html(
                     '<a href="{}">{}</a>',
                     self.action_object.get_absolute_url(),
-                    self.action_object,
+                    self.action_object.subject,
                 ),
                 format_html(
                     '<a href="{}">{}</a>',
@@ -221,14 +221,23 @@ class Notification(UUIDModel):
         elif (
             self.type
             == NotificationType.NotificationTypeChoices.FORUM_POST_REPLY
-            or self.type
+        ):
+            return format_html(
+                "{} {} {} {}.",
+                user_profile_link(self.actor),
+                self.message,
+                format_html(
+                    '<a href="{}">{}</a>',
+                    self.target.get_absolute_url(),
+                    self.target.subject,
+                ),
+                naturaltime(self.created),
+            )
+        elif (
+            self.type
             == NotificationType.NotificationTypeChoices.ACCESS_REQUEST
         ):
-            if (
-                self.type
-                == NotificationType.NotificationTypeChoices.ACCESS_REQUEST
-                and self.target_content_type.model == "challenge"
-            ):
+            if self.target_content_type.model == "challenge":
                 notification_addition = format_html(
                     '<span class="text-truncate font-italic text-muted align-middle '
                     'mx-2">| Accept or decline <a href="{}"> here </a>.</span>',

--- a/app/grandchallenge/notifications/templates/actstream/follow_list.html
+++ b/app/grandchallenge/notifications/templates/actstream/follow_list.html
@@ -40,7 +40,7 @@
                         <div class="mt-1 pt-2 p-0">
                         <input class="checkbox mr-2" name="checkbox" type="checkbox" id="{{ follow.pk }}"
                                    value="{{ follow.pk }}" data-flag={% if follow.flag == 'job-active' %}"job-follow"{% else %}"standard-follow"{% endif %} data-url="{% url 'api:follow-detail' pk=follow.pk %}">
-                            <a href="{{ follow.follow_object.get_absolute_url }}">{{ follow.follow_object }}</a>
+                            <a href="{{ follow.follow_object.get_absolute_url }}">{% if follow.content_type.name == 'Topic' %} {{ follow.follow_object.subject }}{% else %}{{ follow.follow_object }}{% endif %}</a>
                             <span class="text-truncate font-italic text-muted align-middle mx-2 ">{{ follow.content_type.name|title }}
                                 {% if follow.flag != 'job-active' and follow.content_type.model == 'algorithm' %} Access Requests {% elif follow.flag == 'job-active' %} Job Notifications {% endif %}| subscribed to since {{ follow.started|date:'F j, Y' }} {% if forum.follow_object.last_post_on %}| last activity on {{ forum.follow_object.last_post_on|date:'F j, Y, P' }}{% endif %}</span>
                         </div>


### PR DESCRIPTION
The notification list view was slow for some participants. It turned out that the custom prefetching did not always work fully: that's because an empty call to `select_related()` only follows and prefetches non-null foreign keys. For our `Submission` model, however, `Phase` is a nullable FK, and so the phase (and subsequently the challenge for the phase) was not prefetched, which resulted in a lot of N+1 queries for notifications of types `Evaluation_Status` and `Missing_Method`. The same is true for the `Verification` of the `User` model. 

This PR now explicitly prefetches those nullable FKs. The test has also been adjusted to catch those cases. 