### PR TITLE
Only prefetch GFKs for the current page

### DIFF
--- a/app/grandchallenge/notifications/views.py
+++ b/app/grandchallenge/notifications/views.py
@@ -88,7 +88,7 @@ class NotificationList(
     paginate_by = 50
 
     def get_queryset(self):
-        return prefetch_generic_foreign_key_objects(
+        return (
             super()
             .get_queryset()
             .select_related(
@@ -99,6 +99,17 @@ class NotificationList(
             )
             .order_by("-created")
         )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        # Prefetch the object list here as at this point it has been paginated
+        # which saves prefetching the related objects for all notifications
+        context["object_list"] = prefetch_generic_foreign_key_objects(
+            context["object_list"]
+        )
+
+        return context
 
 
 class FollowList(


### PR DESCRIPTION
`prefetch_generic_foreign_key_objects` fetches all related objects for all items in the queryset, so only do this post-pagination.