### PR TITLE
Automatically remove access request notifications

### DIFF
--- a/app/grandchallenge/participants/models.py
+++ b/app/grandchallenge/participants/models.py
@@ -18,6 +18,10 @@ class RegistrationRequest(RequestBase):
     )
 
     @property
+    def base_object(self):
+        return self.challenge
+
+    @property
     def object_name(self):
         return self.challenge.short_name
 

--- a/app/tests/core_tests/test_permission_requests.py
+++ b/app/tests/core_tests/test_permission_requests.py
@@ -246,10 +246,12 @@ def test_permission_request_notifications_flow(
     pr.refresh_from_db()
     assert pr.status == request_model.ACCEPTED
 
-    # check that status update results in notification for follower of request object
-    assert Notification.objects.all()[1].user == user
+    # check that status update results in notification for follower of request object,
+    # and removal of the notification for the editor
+    assert Notification.objects.count() == 1
+    assert Notification.objects.all()[0].user == user
     assert f"Your registration request for {base_obj_str} was accepted" in Notification.objects.all()[
-        1
+        0
     ].print_notification(
         user=user
     )
@@ -265,9 +267,10 @@ def test_permission_request_notifications_flow(
 
     pr.refresh_from_db()
     assert pr.status == request_model.REJECTED
-    assert Notification.objects.all()[2].user == user
+    assert Notification.objects.count() == 2
+    assert Notification.objects.all()[1].user == user
     assert f"Your registration request for {base_obj_str} was rejected" in Notification.objects.all()[
-        2
+        1
     ].print_notification(
         user=user
     )

--- a/app/tests/participants_tests/test_participants.py
+++ b/app/tests/participants_tests/test_participants.py
@@ -130,7 +130,6 @@ def test_participation_request_notification_flow(client):
         user=ch.creator
     )
 
-    Notification.objects.all().delete()
     # accept permission request
     _ = get_view_for_user(
         client=client,
@@ -145,7 +144,8 @@ def test_participation_request_notification_flow(client):
     reg2.refresh_from_db()
     assert reg2.status == "ACPT"
     assert Notification.objects.count() == 1
-    # upon request acceptance, the user gets notified
+    # upon request acceptance, the user gets notified and the notification for the admin
+    # is removed automatically
     assert Notification.objects.first().user == user2
     assert "was approved" in Notification.objects.first().print_notification(
         user=user2


### PR DESCRIPTION
I'd like to improve the access request workflow for algorithm editors, reader study editors etc. a little bit. The current workflow is cumbersome as it requires many clicks: (1) view the notification (2) go to the algorithm (3) go to the list of access requests (4) go to the request update form (5) accept or reject the request (6) go back to the notifications list (7) delete the notification or mark it as read.

This PR removes the need for the last two clicks by automatically deleting notifications that editors or challenge admins receive when there is a new access request. These notifications are removed when the access request has been taken care of, i.e., when it no longer has status "pending".

If this is not how notifications should behave, please just close the PR.

I've added this only in one place (`core/signals.py`) while most of the logic for challenge participation requests seems to be separate from the logic for other kinds of access requests. Therefore, I was doubting whether this should be separately added for `RegistrationRequest` objects to `participants/signals.py`. Instead, I've now added a `base_object` property to that class to be able to handle them all in one place.