### PR TITLE
Add new default internal challenge view

### DIFF
--- a/app/grandchallenge/challenges/templates/challenges/challenge_list.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_list.html
@@ -1,46 +1,26 @@
-{% extends 'base.html' %}
-{% load static %}
+{% extends "base.html" %}
 {% load url %}
-{% load humanize %}
-{% load meta_attr %}
-{% load update_search_params %}
+{% load static %}
 
-{% block title %}Challenges - {{ block.super }}{% endblock %}
+
+{% block title %}
+    Challenges - {{ block.super }}
+{% endblock %}
 
 {% block content %}
-    {% if perms.challenges.change_externalchallenge %}
-        <p>
-            <a class="btn btn-primary"
-               href="{% url 'challenges:external-create' %}"
-               title="Add an External Challenge">
-                <i class="fas fa-plus"></i> Add a new external challenge
-            </a>
-            <a class="btn btn-primary"
-               href="{% url 'challenges:external-list' %}"
-               title="Edit External Challenges">
-                <i class="fas fa-edit"></i> Edit external challenges
-            </a>
-        </p>
-    {% endif %}
+    <p class="text-right">
+        <a class="btn btn-primary"
+           href="{% url 'challenges:combined-list' %}"
+           title="All challenges">
+            <i class="fas fa-list mr-1"></i> View all challenges
+        </a>
+    </p>
 
     {% include "grandchallenge/partials/filters.html" with filter=filter filters_applied=filters_applied %}
 
     {% include "grandchallenge/partials/cards.html" with page_obj=page_obj %}
 
-    <div class="d-flex justify-content-end">
-        <ul class="pagination">
-            <li class="page-item {% if current_page == 1 %}disabled{% endif %}">
-                <a class="page-link" href="?{% update_search_params page=previous_page %}">Previous</a>
-            </li>
-
-            <li class="page-item disabled"><span class="page-link">Page {{ current_page }} of {{ num_pages }}</span>
-            </li>
-
-            <li class="page-item {% if current_page == num_pages %}disabled{% endif %}">
-                <a class="page-link" href="?{% update_search_params page=next_page %}">Next</a>
-            </li>
-        </ul>
-    </div>
+    {% include "grandchallenge/partials/pagination.html" %}
 
     {% include "grandchallenge/partials/cards_info_modal.html" %}
 

--- a/app/grandchallenge/challenges/templates/challenges/combined_challenge_list.html
+++ b/app/grandchallenge/challenges/templates/challenges/combined_challenge_list.html
@@ -1,0 +1,52 @@
+{% extends 'base.html' %}
+{% load static %}
+{% load url %}
+{% load humanize %}
+{% load meta_attr %}
+{% load update_search_params %}
+
+{% block title %}All Challenges - {{ block.super }}{% endblock %}
+
+{% block content %}
+    {% if perms.challenges.change_externalchallenge %}
+        <p>
+            <a class="btn btn-primary"
+               href="{% url 'challenges:external-create' %}"
+               title="Add an External Challenge">
+                <i class="fas fa-plus"></i> Add a new external challenge
+            </a>
+            <a class="btn btn-primary"
+               href="{% url 'challenges:external-list' %}"
+               title="Edit External Challenges">
+                <i class="fas fa-edit"></i> Edit external challenges
+            </a>
+        </p>
+    {% endif %}
+
+    {% include "grandchallenge/partials/filters.html" with filter=filter filters_applied=filters_applied %}
+
+    {% include "grandchallenge/partials/cards.html" with page_obj=page_obj %}
+
+    <div class="d-flex justify-content-end">
+        <ul class="pagination">
+            <li class="page-item {% if current_page == 1 %}disabled{% endif %}">
+                <a class="page-link" href="?{% update_search_params page=previous_page %}">Previous</a>
+            </li>
+
+            <li class="page-item disabled"><span class="page-link">Page {{ current_page }} of {{ num_pages }}</span>
+            </li>
+
+            <li class="page-item {% if current_page == num_pages %}disabled{% endif %}">
+                <a class="page-link" href="?{% update_search_params page=next_page %}">Next</a>
+            </li>
+        </ul>
+    </div>
+
+    {% include "grandchallenge/partials/cards_info_modal.html" %}
+
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    <script src="{% static "js/cards_info_modal.js" %}"></script>
+{% endblock %}

--- a/app/grandchallenge/challenges/urls.py
+++ b/app/grandchallenge/challenges/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from grandchallenge.challenges.views import (
     ChallengeCreate,
     ChallengeList,
+    CombinedChallengeList,
     ExternalChallengeCreate,
     ExternalChallengeList,
     ExternalChallengeUpdate,
@@ -13,6 +14,9 @@ app_name = "challenges"
 
 urlpatterns = [
     path("", ChallengeList.as_view(), name="list"),
+    path(
+        "all-challenges", CombinedChallengeList.as_view(), name="combined-list"
+    ),
     path("my-challenges/", UsersChallengeList.as_view(), name="users-list"),
     path("create/", ChallengeCreate.as_view(), name="create"),
     path("external/", ExternalChallengeList.as_view(), name="external-list"),

--- a/app/grandchallenge/challenges/urls.py
+++ b/app/grandchallenge/challenges/urls.py
@@ -15,7 +15,9 @@ app_name = "challenges"
 urlpatterns = [
     path("", ChallengeList.as_view(), name="list"),
     path(
-        "all-challenges", CombinedChallengeList.as_view(), name="combined-list"
+        "all-challenges/",
+        CombinedChallengeList.as_view(),
+        name="combined-list",
     ),
     path("my-challenges/", UsersChallengeList.as_view(), name="users-list"),
     path("create/", ChallengeCreate.as_view(), name="create"),

--- a/app/grandchallenge/challenges/views.py
+++ b/app/grandchallenge/challenges/views.py
@@ -11,7 +11,6 @@ from django.views.generic import (
 )
 from guardian.mixins import (
     LoginRequiredMixin,
-    PermissionListMixin,
     PermissionRequiredMixin as ObjectPermissionRequiredMixin,
 )
 
@@ -47,11 +46,8 @@ class ChallengeCreate(LoginRequiredMixin, SuccessMessageMixin, CreateView):
         return form_kwargs
 
 
-class ChallengeList(FilterMixin, PermissionListMixin, ListView):
+class ChallengeList(FilterMixin, ListView):
     model = Challenge
-    permission_required = (
-        f"{model._meta.app_label}.view_{model._meta.model_name}"
-    )
     ordering = "-created"
     filter_class = ChallengeFilter
     paginate_by = 40
@@ -60,6 +56,7 @@ class ChallengeList(FilterMixin, PermissionListMixin, ListView):
         return (
             super()
             .get_queryset()
+            .filter(hidden=False)
             .prefetch_related("phase_set", "publications")
             .order_by("-created")
         )

--- a/app/grandchallenge/challenges/views.py
+++ b/app/grandchallenge/challenges/views.py
@@ -11,6 +11,7 @@ from django.views.generic import (
 )
 from guardian.mixins import (
     LoginRequiredMixin,
+    PermissionListMixin,
     PermissionRequiredMixin as ObjectPermissionRequiredMixin,
 )
 
@@ -24,6 +25,7 @@ from grandchallenge.challenges.models import (
     Challenge,
     ExternalChallenge,
 )
+from grandchallenge.core.filters import FilterMixin
 from grandchallenge.core.templatetags.random_encode import random_encode
 from grandchallenge.datatables.views import Column, PaginatedTableListView
 from grandchallenge.subdomains.mixins import ChallengeSubdomainObjectMixin
@@ -45,9 +47,46 @@ class ChallengeCreate(LoginRequiredMixin, SuccessMessageMixin, CreateView):
         return form_kwargs
 
 
-class ChallengeList(TemplateView):
+class ChallengeList(FilterMixin, PermissionListMixin, ListView):
+    model = Challenge
+    permission_required = (
+        f"{model._meta.app_label}.view_{model._meta.model_name}"
+    )
+    ordering = "-created"
+    filter_class = ChallengeFilter
     paginate_by = 40
-    template_name = "challenges/challenge_list.html"
+
+    def get_queryset(self):
+        return (
+            super()
+            .get_queryset()
+            .prefetch_related("phase_set", "publications")
+            .order_by("-created")
+        )
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+
+        context.update(
+            {
+                "jumbotron_title": "Challenges",
+                "jumbotron_description": format_html(
+                    (
+                        "Here is an overview over the medical image analysis"
+                        " challenges that have been hosted on Grand Challenge."
+                        "<br>Please <a href='{}'>contact us</a> if you would like "
+                        "to host your own challenge."
+                    ),
+                    random_encode("mailto:support@grand-challenge.org"),
+                ),
+            }
+        )
+        return context
+
+
+class CombinedChallengeList(TemplateView):
+    paginate_by = 40
+    template_name = "challenges/combined_challenge_list.html"
 
     @property
     def _current_page(self):

--- a/app/tests/challenges_tests/test_views.py
+++ b/app/tests/challenges_tests/test_views.py
@@ -11,7 +11,9 @@ def test_external_challenge_buttons(client):
     create_url = reverse("challenges:external-create")
     list_url = reverse("challenges:external-list")
 
-    response = get_view_for_user(client=client, viewname="challenges:list")
+    response = get_view_for_user(
+        client=client, viewname="challenges:combined-list"
+    )
 
     assert create_url not in response.rendered_content
     assert list_url not in response.rendered_content
@@ -19,7 +21,7 @@ def test_external_challenge_buttons(client):
     user = UserFactory()
 
     response = get_view_for_user(
-        client=client, viewname="challenges:list", user=user
+        client=client, viewname="challenges:combined-list", user=user
     )
 
     assert create_url not in response.rendered_content
@@ -28,7 +30,7 @@ def test_external_challenge_buttons(client):
     assign_perm("challenges.change_externalchallenge", user)
 
     response = get_view_for_user(
-        client=client, viewname="challenges:list", user=user
+        client=client, viewname="challenges:combined-list", user=user
     )
 
     assert create_url in response.rendered_content


### PR DESCRIPTION
This replaces the `/challenges` page with a listview of internal challenges only. The page links to the old challenge list that includes both internal and external challenges. 

I'm not restricting the view with permission because I assume we want everyone to be able to see this pages (also not-registered users). 

Closes #2112 