### PR TITLE
Handle unset names

### DIFF
--- a/app/grandchallenge/profiles/forms.py
+++ b/app/grandchallenge/profiles/forms.py
@@ -67,8 +67,8 @@ class UserProfileForm(forms.ModelForm):
         return url
 
     def clean(self):
-        first_name = self.cleaned_data["first_name"]
-        last_name = self.cleaned_data["last_name"]
+        first_name = self.cleaned_data.get("first_name", "")
+        last_name = self.cleaned_data.get("last_name", "")
 
         c = slice(-2, None)
         if first_name[c] == first_name[c].upper() == last_name[c]:


### PR DESCRIPTION
For social sign ups the names are overridden by what is provided
by the social provider, so these can be empty.