### PR TITLE
Adds status bagde to challenge cards

### DIFF
--- a/app/grandchallenge/challenges/filters.py
+++ b/app/grandchallenge/challenges/filters.py
@@ -1,4 +1,4 @@
-from django_filters import ModelMultipleChoiceFilter
+from django_filters import ChoiceFilter, ModelMultipleChoiceFilter
 from django_select2.forms import Select2MultipleWidget
 
 from grandchallenge.challenges.models import (
@@ -7,6 +7,12 @@ from grandchallenge.challenges.models import (
 )
 from grandchallenge.core.filters import TitleDescriptionModalityStructureFilter
 from grandchallenge.task_categories.models import TaskType
+
+
+STATUS_CHOICES = (
+    (True, "Accepting submissions"),
+    (False, "Not accepting submissions"),
+)
 
 
 class ChallengeFilter(TitleDescriptionModalityStructureFilter):
@@ -19,6 +25,11 @@ class ChallengeFilter(TitleDescriptionModalityStructureFilter):
         queryset=ChallengeSeries.objects.all(),
         widget=Select2MultipleWidget,
         label="Challenge Series",
+    )
+    status = ChoiceFilter(
+        choices=STATUS_CHOICES,
+        method="filter_by_status",
+        label="Challenge status",
     )
 
     class Meta(TitleDescriptionModalityStructureFilter.Meta):
@@ -34,3 +45,11 @@ class ChallengeFilter(TitleDescriptionModalityStructureFilter):
             "short_name",
             "event_name",
         )
+
+    def filter_by_status(self, queryset, name, value):
+        ids = [
+            challenge.id
+            for challenge in queryset
+            if challenge.accepting_submissions == eval(value)
+        ]
+        return queryset.filter(pk__in=ids)

--- a/app/grandchallenge/challenges/filters.py
+++ b/app/grandchallenge/challenges/filters.py
@@ -26,11 +26,6 @@ class ChallengeFilter(TitleDescriptionModalityStructureFilter):
         widget=Select2MultipleWidget,
         label="Challenge Series",
     )
-    status = ChoiceFilter(
-        choices=STATUS_CHOICES,
-        method="filter_by_status",
-        label="Challenge status",
-    )
 
     class Meta(TitleDescriptionModalityStructureFilter.Meta):
         model = Challenge
@@ -45,6 +40,14 @@ class ChallengeFilter(TitleDescriptionModalityStructureFilter):
             "short_name",
             "event_name",
         )
+
+
+class InternalChallengeFilter(ChallengeFilter):
+    status = ChoiceFilter(
+        choices=STATUS_CHOICES,
+        method="filter_by_status",
+        label="Challenge status",
+    )
 
     def filter_by_status(self, queryset, name, value):
         ids = [

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -556,6 +556,12 @@ class Challenge(ChallengeBase):
         user.groups.remove(self.admins_group)
         unfollow(user=user, obj=self.forum, send_action=False)
 
+    @property
+    def accepting_submissions(self):
+        return True in (
+            phase.open_for_submissions for phase in self.phase_set.all()
+        )
+
     class Meta(ChallengeBase.Meta):
         verbose_name = "challenge"
         verbose_name_plural = "challenges"

--- a/app/grandchallenge/challenges/templates/challenges/challenge_card_body.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_card_body.html
@@ -2,7 +2,12 @@
 {% load url %}
 {% load humanize %}
 
-<div class="mb-2">
+<div>
+    {% if challenge.accepting_submissions %}
+        <span class="badge badge-success mt-2 above-stretched-link" data-toggle="tooltip" data-placement="top"><i class="far fa-clock fa-fw"></i> Accepting submissions</span><br>
+    {% elif challenge.is_self_hosted and not challenge.accepting_submissions %}
+        <span class="badge badge-danger mt-2 above-stretched-link" data-toggle="tooltip" data-placement="top"><i class="far fa-clock fa-fw"></i> Not accepting submissions</span><br>
+    {% endif %}
     {% if challenge.description %}
         <a href="#InfoModal"
            class="badge badge-info above-stretched-link"

--- a/app/grandchallenge/challenges/views.py
+++ b/app/grandchallenge/challenges/views.py
@@ -51,15 +51,9 @@ class ChallengeList(FilterMixin, ListView):
     ordering = "-created"
     filter_class = ChallengeFilter
     paginate_by = 40
-
-    def get_queryset(self):
-        return (
-            super()
-            .get_queryset()
-            .filter(hidden=False)
-            .prefetch_related("phase_set", "publications")
-            .order_by("-created")
-        )
+    queryset = Challenge.objects.filter(hidden=False).prefetch_related(
+        "phase_set", "publications"
+    )
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)

--- a/app/grandchallenge/challenges/views.py
+++ b/app/grandchallenge/challenges/views.py
@@ -14,7 +14,10 @@ from guardian.mixins import (
     PermissionRequiredMixin as ObjectPermissionRequiredMixin,
 )
 
-from grandchallenge.challenges.filters import ChallengeFilter
+from grandchallenge.challenges.filters import (
+    ChallengeFilter,
+    InternalChallengeFilter,
+)
 from grandchallenge.challenges.forms import (
     ChallengeCreateForm,
     ChallengeUpdateForm,
@@ -49,7 +52,7 @@ class ChallengeCreate(LoginRequiredMixin, SuccessMessageMixin, CreateView):
 class ChallengeList(FilterMixin, ListView):
     model = Challenge
     ordering = "-created"
-    filter_class = ChallengeFilter
+    filter_class = InternalChallengeFilter
     paginate_by = 40
     queryset = Challenge.objects.filter(hidden=False).prefetch_related(
         "phase_set", "publications"

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -582,6 +582,10 @@ class Phase(UUIDModel):
             .exists()
         )
 
+    @property
+    def open_for_submissions(self):
+        return self.submission_limit != 0
+
 
 class Method(UUIDModel, ComponentImage):
     """Store the methods for performing an evaluation."""


### PR DESCRIPTION
This adds a status badge to all challenge cards, indicating whether they are currently open to submissions (in any phase) or not. 
This also enables filtering internal challenges on their status and it fixes the count of the challenges. 

I got feedback on the looks of the badge from Bram and the 10% team, rather than superimposing the badge on the card-img (as I proposed in the milestone pitch), we agreed to just add it as the first badge in the card-body. 

RE implementation: I also played around with annotating the queryset instead of adding `accepting_submissions` as a property. Both work fine and are no different in terms of db queries as far as I could tell, but I opted for implementing this as a property to be able to add it to the filter easily (much more complicated to enable filtering on an annotated queryset it seems) and also in light of the possible changes we might make in the future. 

Closes #2111 