### PR TITLE
Reduce the number of options for the archive item update form

### DIFF
--- a/app/grandchallenge/archives/forms.py
+++ b/app/grandchallenge/archives/forms.py
@@ -189,12 +189,7 @@ class AddCasesForm(UploadRawImagesForm):
 
 class ArchiveItemForm(SaveFormInitMixin, Form):
     def __init__(
-        self,
-        *args,
-        user=None,
-        archive_item=None,
-        interface=None,
-        **kwargs,
+        self, *args, user=None, archive_item=None, interface=None, **kwargs,
     ):
         super().__init__(*args, **kwargs)
 

--- a/app/grandchallenge/archives/forms.py
+++ b/app/grandchallenge/archives/forms.py
@@ -189,7 +189,12 @@ class AddCasesForm(UploadRawImagesForm):
 
 class ArchiveItemForm(SaveFormInitMixin, Form):
     def __init__(
-        self, *args, archive=None, user=None, archive_item=None, **kwargs
+        self,
+        *args,
+        user=None,
+        archive_item=None,
+        interface=None,
+        **kwargs,
     ):
         super().__init__(*args, **kwargs)
 
@@ -200,15 +205,18 @@ class ArchiveItemForm(SaveFormInitMixin, Form):
         else:
             values = ComponentInterfaceValue.objects.none()
 
-        for inp in ComponentInterface.objects.all():
-            initial = values.filter(interface=inp).first()
-            if initial:
-                initial = initial.value
-            self.fields[inp.slug] = InterfaceFormField(
-                kind=inp.kind,
-                schema=inp.schema,
-                initial=initial or inp.default_value,
-                required=False,
-                user=user,
-                help_text=clean(inp.description) if inp.description else "",
-            ).field
+        initial = values.filter(interface=interface).first()
+
+        if initial:
+            initial = initial.value
+
+        self.fields[interface.slug] = InterfaceFormField(
+            kind=interface.kind,
+            schema=interface.schema,
+            initial=initial or interface.default_value,
+            required=False,
+            user=user,
+            help_text=clean(interface.description)
+            if interface.description
+            else "",
+        ).field

--- a/app/grandchallenge/archives/templates/archives/archive_items_row.html
+++ b/app/grandchallenge/archives/templates/archives/archive_items_row.html
@@ -17,9 +17,11 @@
 </ul>
 <split></split>
 
-<a href="{% url 'archives:item-edit' archive_slug=object.archive.slug pk=object.pk interface_slug='TODO' %}">
-    <span class="badge badge-primary">
-        <i class="fa fa-plus"></i> Add Value to Item
-    </span>
-</a>
+<select class="form-control" onchange="location = this.value;">
+    {% for interface in interfaces %}
+        {% if interface not in object_interfaces %}
+            <option value="{% url 'archives:item-edit' archive_slug=object.archive.slug pk=object.pk interface_slug=interface.slug %}">Add {{ interface.title }}</option>
+        {% endif %}
+    {% endfor %}
+</select>
 <split></split>

--- a/app/grandchallenge/archives/templates/archives/archive_items_row.html
+++ b/app/grandchallenge/archives/templates/archives/archive_items_row.html
@@ -5,14 +5,21 @@
 
 <ul class="list-unstyled mb-0">
     {% for civ in object.values.all %}
-        <li>{{ civ.interface.title }}: {{ civ.title }}</li>
+        <li>
+            {{ civ.interface.title }}: {{ civ.title }}
+            <a href="{% url 'archives:item-edit' archive_slug=object.archive.slug pk=object.pk interface_slug=civ.interface.slug %}">
+                <span class="badge badge-primary">
+                    <i class="fa fa-edit"></i> Edit
+                </span>
+            </a>
+        </li>
     {% endfor %}
 </ul>
 <split></split>
 
-<a href="{% url 'archives:item-edit' slug=object.archive.slug id=object.pk %}">
+<a href="{% url 'archives:item-edit' archive_slug=object.archive.slug pk=object.pk interface_slug='TODO' %}">
     <span class="badge badge-primary">
-        <i class="fa fa-edit"></i> Edit
+        <i class="fa fa-plus"></i> Add Value to Item
     </span>
 </a>
 <split></split>

--- a/app/grandchallenge/archives/urls.py
+++ b/app/grandchallenge/archives/urls.py
@@ -63,7 +63,7 @@ urlpatterns = [
         name="cases-create",
     ),
     path(
-        "<slug>/items/<id>/edit",
+        "<slug:archive_slug>/items/<uuid:pk>/edit/<slug:interface_slug>/",
         ArchiveEditArchiveItem.as_view(),
         name="item-edit",
     ),

--- a/app/grandchallenge/archives/views.py
+++ b/app/grandchallenge/archives/views.py
@@ -506,8 +506,14 @@ class ArchiveItemsList(
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update({"archive": self.archive})
+        context.update({"archive": self.archive, "interfaces": ComponentInterface.objects.all().order_by("title")})
         return context
+
+    def render_row(self, *, object_, page_context):
+        page_context["object_interfaces"] = [
+            v.interface for v in object_.values.all()
+        ]
+        return super().render_row(object_=object_, page_context=page_context)
 
     def get_queryset(self):
         qs = super().get_queryset()

--- a/app/grandchallenge/archives/views.py
+++ b/app/grandchallenge/archives/views.py
@@ -377,16 +377,20 @@ class ArchiveEditArchiveItem(
 
     @cached_property
     def archive(self):
-        return get_object_or_404(Archive, slug=self.kwargs["slug"])
+        return get_object_or_404(Archive, slug=self.kwargs["archive_slug"])
 
     @cached_property
     def archive_item(self):
-        return get_object_or_404(ArchiveItem, pk=self.kwargs["id"])
+        return get_object_or_404(ArchiveItem, pk=self.kwargs["pk"])
+
+    @cached_property
+    def interface(self):
+        return get_object_or_404(ComponentInterface, slug=self.kwargs["interface_slug"])
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs.update(
-            {"archive": self.archive, "archive_item": self.archive_item}
+            {"archive_item": self.archive_item, "interface": self.interface}
         )
         return kwargs
 
@@ -466,7 +470,7 @@ class ArchiveEditArchiveItem(
 
         return HttpResponseRedirect(
             reverse(
-                "archives:items-list", kwargs={"slug": self.kwargs["slug"]},
+                "archives:items-list", kwargs={"slug": self.archive.slug},
             )
         )
 
@@ -490,7 +494,7 @@ class ArchiveItemsList(
     ]
     columns = [
         Column(title="Values", sort_field="created"),
-        Column(title="Edit", sort_field="pk"),
+        Column(title="Add", sort_field="pk"),
     ]
 
     @cached_property

--- a/app/grandchallenge/archives/views.py
+++ b/app/grandchallenge/archives/views.py
@@ -385,7 +385,9 @@ class ArchiveEditArchiveItem(
 
     @cached_property
     def interface(self):
-        return get_object_or_404(ComponentInterface, slug=self.kwargs["interface_slug"])
+        return get_object_or_404(
+            ComponentInterface, slug=self.kwargs["interface_slug"]
+        )
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -469,9 +471,7 @@ class ArchiveEditArchiveItem(
         on_commit(tasks.apply_async)
 
         return HttpResponseRedirect(
-            reverse(
-                "archives:items-list", kwargs={"slug": self.archive.slug},
-            )
+            reverse("archives:items-list", kwargs={"slug": self.archive.slug},)
         )
 
 
@@ -506,7 +506,14 @@ class ArchiveItemsList(
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context.update({"archive": self.archive, "interfaces": ComponentInterface.objects.all().order_by("title")})
+        context.update(
+            {
+                "archive": self.archive,
+                "interfaces": ComponentInterface.objects.all().order_by(
+                    "title"
+                ),
+            }
+        )
         return context
 
     def render_row(self, *, object_, page_context):

--- a/app/tests/archives_tests/test_forms.py
+++ b/app/tests/archives_tests/test_forms.py
@@ -221,14 +221,17 @@ def test_archive_item_form(client, settings):
         viewname="archives:item-edit",
         client=client,
         method=client.get,
-        reverse_kwargs={"slug": archive.slug, "id": ai.pk},
+        reverse_kwargs={
+            "archive_slug": archive.slug,
+            "pk": ai.pk,
+            "interface_slug": ci.slug,
+        },
         follow=True,
         user=editor,
     )
     assert response.status_code == 200
 
-    for _ci in ComponentInterface.objects.all():
-        assert _ci.slug in response.rendered_content
+    assert ci.slug in response.rendered_content
 
     assert f'id="id_{ci.slug}" checked' in response.rendered_content
 
@@ -250,7 +253,11 @@ def test_archive_item_form(client, settings):
                 viewname="archives:item-edit",
                 client=client,
                 method=client.post,
-                reverse_kwargs={"slug": archive.slug, "id": ai.pk},
+                reverse_kwargs={
+                    "archive_slug": archive.slug,
+                    "pk": ai.pk,
+                    "interface_slug": ci.slug,
+                },
                 data={ci.slug: False},
                 follow=True,
                 user=editor,
@@ -270,7 +277,11 @@ def test_archive_item_form(client, settings):
                 viewname="archives:item-edit",
                 client=client,
                 method=client.post,
-                reverse_kwargs={"slug": archive.slug, "id": ai.pk},
+                reverse_kwargs={
+                    "archive_slug": archive.slug,
+                    "pk": ai.pk,
+                    "interface_slug": ci.slug,
+                },
                 data={ci.slug: True},
                 follow=True,
                 user=editor,

--- a/app/tests/archives_tests/test_forms.py
+++ b/app/tests/archives_tests/test_forms.py
@@ -9,7 +9,6 @@ from grandchallenge.archives.models import (
     ArchivePermissionRequest,
 )
 from grandchallenge.components.models import (
-    ComponentInterface,
     ComponentInterfaceValue,
     InterfaceKind,
 )


### PR DESCRIPTION
This PR reworks the archive item add/edit forms such that only one CIV is set at a time. The dropdown automatically redirects to the new form on click.

![image](https://user-images.githubusercontent.com/12661555/144245785-7072ccdc-27c3-4f06-a2d2-c8716b97ad39.png)

Closes #2047 