### PR TITLE
Add link_images to serializer of workstation configs

### DIFF
--- a/app/grandchallenge/workstation_configs/serializers.py
+++ b/app/grandchallenge/workstation_configs/serializers.py
@@ -105,6 +105,7 @@ class WorkstationConfigSerializer(ModelSerializer):
             "show_annotation_counter_tool",
             "enabled_preprocessors",
             "auto_jump_center_of_gravity",
+            "link_images",
         ]
 
     def get_enabled_preprocessors(self, obj):


### PR DESCRIPTION
An oversight from me when implementing this. Or rather, I am pretty sure I modified the serializer it at one point but the change got lost in my epic battle with git via WSL2.