### PR TITLE
Return 404 for leaderboard redirect if challenge has no phase

### DIFF
--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -373,15 +373,16 @@ class LeaderboardRedirect(RedirectView):
     def get_redirect_url(self, *args, **kwargs):
         # Redirect old leaderboard urls to the first leaderboard for this
         # challenge
-        try:
+        first_phase = self.request.challenge.phase_set.first()
+        if first_phase:
             return reverse(
                 "evaluation:leaderboard",
                 kwargs={
-                    "challenge_short_name": self.request.challenge.short_name,
-                    "slug": self.request.challenge.phase_set.first().slug,
+                    "challenge_short_name": first_phase.short_name,
+                    "slug": first_phase.slug,
                 },
             )
-        except AttributeError:
+        else:
             raise Http404("Leaderboard not found")
 
 

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -373,13 +373,16 @@ class LeaderboardRedirect(RedirectView):
     def get_redirect_url(self, *args, **kwargs):
         # Redirect old leaderboard urls to the first leaderboard for this
         # challenge
-        return reverse(
-            "evaluation:leaderboard",
-            kwargs={
-                "challenge_short_name": self.request.challenge.short_name,
-                "slug": self.request.challenge.phase_set.first().slug,
-            },
-        )
+        try:
+            return reverse(
+                "evaluation:leaderboard",
+                kwargs={
+                    "challenge_short_name": self.request.challenge.short_name,
+                    "slug": self.request.challenge.phase_set.first().slug,
+                },
+            )
+        except AttributeError:
+            raise Http404("Leaderboard not found")
 
 
 class LeaderboardDetail(


### PR DESCRIPTION
Addresses the following sentry error: https://sentry.io/organizations/grand-challenge/issues/2874226578/?project=303639&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&sort=inbox 