### PR TITLE
Check for existence of creator before querying for team memership

### DIFF
--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_row.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_row.html
@@ -22,7 +22,7 @@
 <split></split>
 
 {{ object.submission.creator|user_profile_link }}
-{% if object.submission.phase.challenge.use_teams %}
+{% if object.submission.phase.challenge.use_teams and object.submission.creator %}
     {% with user_teams|get_key:object.submission.creator.username as team %}
         {% if team %}
             (<a href="{{ team.1 }}">{{ team.0 }}</a>)


### PR DESCRIPTION
It turns out that the leaderboard rendering issue depended on the Teams setting being enabled. Sorting and searching by submission_creator_username works just fine, it was only the team query that failed when the submission creator was None. 

Closes #2227 