### PR TITLE
Deactive duplicate users

### DIFF
--- a/app/grandchallenge/verifications/forms.py
+++ b/app/grandchallenge/verifications/forms.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -6,6 +8,7 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from pyswot.pyswot import _domain_parts, _is_stoplisted
 
 from grandchallenge.core.forms import SaveFormInitMixin
+from grandchallenge.profiles.tasks import deactivate_user
 from grandchallenge.verifications.models import Verification
 from grandchallenge.verifications.resources.free_email_domains import (
     FREE_EMAIL_DOMAINS,
@@ -91,9 +94,36 @@ class ConfirmEmailForm(SaveFormInitMixin, forms.Form):
     def clean_token(self):
         token = self.cleaned_data["token"]
 
+        try:
+            self.user.verification
+        except ObjectDoesNotExist:
+            self.deactivate_duplicate_users(token=token)
+            raise ValidationError("Token is invalid")
+
         if not email_verification_token_generator.check_token(
             self.user, token
         ):
             raise ValidationError("Token is invalid")
 
         return token
+
+    def deactivate_duplicate_users(self, *, token):
+        # This user is trying to validate for another,
+        # likely a duplicate account, do not wait for commit here
+        deactivate_user.signature(
+            kwargs={"user_pk": self.user.pk}
+        ).apply_async()
+
+        # Try to invalidate the verification created at this time, match on
+        # the token created time
+        timeband = 2  # +/- seconds to find a verification
+        ts = email_verification_token_generator.get_timestamp(token)
+        v = Verification.objects.get(
+            created__gt=ts - timedelta(seconds=timeband),
+            created__lt=ts + timedelta(seconds=timeband),
+        )
+        v.is_verified = False
+        v.verified_at = None
+        v.save()
+
+        deactivate_user.signature(kwargs={"user_pk": v.user.pk}).apply_async()

--- a/app/grandchallenge/verifications/tokens.py
+++ b/app/grandchallenge/verifications/tokens.py
@@ -1,23 +1,9 @@
-from datetime import datetime, timezone
-
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
-from django.utils.http import base36_to_int
 
 
 class EmailVerificationTokenGenerator(PasswordResetTokenGenerator):
-    # Timestamps are relative to this, see PasswordResetTokenGenerator
-    epoch = datetime(2001, 1, 1, tzinfo=timezone.utc)
-
     def _make_hash_value(self, user, timestamp):
         return f"{user.pk}{timestamp}{user.verification.email_is_verified}"
-
-    def get_timestamp(self, token):
-        ts_b36, _ = token.split("-")
-        ts = base36_to_int(ts_b36)
-        return ts + self.epoch
-
-    def _num_seconds(self, dt):
-        return int((dt - self.epoch).total_seconds())
 
 
 email_verification_token_generator = EmailVerificationTokenGenerator()

--- a/app/grandchallenge/verifications/tokens.py
+++ b/app/grandchallenge/verifications/tokens.py
@@ -1,9 +1,23 @@
+from datetime import datetime, timezone
+
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
+from django.utils.http import base36_to_int
 
 
 class EmailVerificationTokenGenerator(PasswordResetTokenGenerator):
+    # Timestamps are relative to this, see PasswordResetTokenGenerator
+    epoch = datetime(2001, 1, 1, tzinfo=timezone.utc)
+
     def _make_hash_value(self, user, timestamp):
         return f"{user.pk}{timestamp}{user.verification.email_is_verified}"
+
+    def get_timestamp(self, token):
+        ts_b36, _ = token.split("-")
+        ts = base36_to_int(ts_b36)
+        return ts + self.epoch
+
+    def _num_seconds(self, dt):
+        return int((dt - self.epoch).total_seconds())
 
 
 email_verification_token_generator = EmailVerificationTokenGenerator()


### PR DESCRIPTION
If a user tries to use a token that belongs to another account they are automatically disabled. Cannot close both accounts as finding the verification the token belongs to is tricky, but still lets the user keep one of their accounts.