### PR TITLE
Add ALGORITHMS_JOB_BATCH_LIMIT

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1095,6 +1095,8 @@ if strtobool(os.environ.get("PUSH_CLOUDWATCH_METRICS", "False")):
 
 # The name of the group whose members will be able to create algorithms
 ALGORITHMS_CREATORS_GROUP_NAME = "algorithm_creators"
+# Number of jobs that can be scheduled in one task
+ALGORITHMS_JOB_BATCH_LIMIT = 256
 
 # Disallow some challenge names due to subdomain or media folder clashes
 DISALLOWED_CHALLENGE_NAMES = {

--- a/app/grandchallenge/algorithms/exceptions.py
+++ b/app/grandchallenge/algorithms/exceptions.py
@@ -1,2 +1,6 @@
 class ImageImportError(Exception):
     pass
+
+
+class TooManyJobsScheduled(Exception):
+    pass

--- a/scripts/algorithm_evaluation_fixtures.py
+++ b/scripts/algorithm_evaluation_fixtures.py
@@ -110,6 +110,7 @@ def _create_challenge(
     p.submission_kind = p.SubmissionKind.ALGORITHM
     p.archive = archive
     p.score_jsonpath = "score"
+    p.submission_limit = 10
     p.save()
 
     m = Method(creator=creator, phase=p)


### PR DESCRIPTION
Sets limits on how many algorithm jobs can be scheduled at once.

Not super happy with this implementation but I think that it is the best we can do without refactoring everything. We know that Celery chords are not reliable so we cannot wait for jobs to be done in batches, so this still schedules everything in advance.

Closes #2231