### PR TITLE
Raise Http404 on challenge not found

### DIFF
--- a/app/tests/core_tests/integration_tests.py
+++ b/app/tests/core_tests/integration_tests.py
@@ -565,9 +565,8 @@ class ViewsTest(GrandChallengeFrameworkTestCase):
             % (page_url, response.status_code),
         )
 
-    def test_non_exitant_project_gives_404_or_302(self):
+    def test_non_exitant_project_gives_404(self):
         """Reproduces https://github.com/comic/grand-challenge.org/issues/219."""
-        # main domain robots.txt
         non_existant_url = reverse(
             "pages:home",
             kwargs={"challenge_short_name": "nonexistingproject"},
@@ -577,9 +576,9 @@ class ViewsTest(GrandChallengeFrameworkTestCase):
         # We redirect to the main challenge if it is not found
         self.assertEqual(
             response.status_code,
-            302,
+            404,
             "Expected non existing url"
-            "'%s' to give 302, instead found %s"
+            "'%s' to give 404, instead found %s"
             % (non_existant_url, response.status_code),
         )
 

--- a/app/tests/subdomain_tests/test_middleware.py
+++ b/app/tests/subdomain_tests/test_middleware.py
@@ -1,7 +1,6 @@
 import pytest
 from django.contrib.sites.middleware import CurrentSiteMiddleware
 from django.core.handlers.wsgi import WSGIRequest
-from django.http import HttpResponseRedirect
 
 from grandchallenge.subdomains.middleware import (
     challenge_subdomain_middleware,
@@ -52,13 +51,7 @@ def test_invalid_domain(settings, rf, host, subdomain):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "subdomain",
-    [
-        None,
-        "challengesubdomaintest",
-        "ChallengeSubdomainTest",
-        "notachallenge",
-    ],
+    "subdomain", [None, "challengesubdomaintest", "ChallengeSubdomainTest"],
 )
 def test_challenge_attribute(settings, rf, subdomain):
     settings.ALLOWED_HOSTS = [f".{SITE_DOMAIN}"]
@@ -77,8 +70,6 @@ def test_challenge_attribute(settings, rf, subdomain):
         assert request.challenge is None
     elif subdomain.lower() == c.short_name.lower():
         assert request.challenge == c
-    else:
-        assert request.url == f"http://{SITE_DOMAIN}/"
 
 
 @pytest.mark.django_db
@@ -88,7 +79,6 @@ def test_challenge_attribute(settings, rf, subdomain):
         (None, WSGIRequest, False),
         ("us-east-1", WSGIRequest, False),
         ("c", WSGIRequest, True),
-        ("notaregion", HttpResponseRedirect, False),
     ],
 )
 def test_rendering_challenge_settings(


### PR DESCRIPTION
It was kind of weird that we were redirecting to the main domain, so raise a 404 instead.