### PR TITLE
Correct DateTimeInput format

### DIFF
--- a/app/grandchallenge/core/models.py
+++ b/app/grandchallenge/core/models.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.conf import settings
 from django.db import models
-from django.utils.timezone import get_current_timezone
+from django.utils.timezone import localtime
 from django.utils.translation import gettext_lazy as _
 from django_extensions.db.models import (
     TitleSlugDescriptionModel as BaseTitleSlugDescriptionModel,
@@ -76,9 +76,7 @@ class RequestBase(models.Model):
 
     @staticmethod
     def format_date(date):
-        return date.astimezone(get_current_timezone()).strftime(
-            "%b %d, %Y at %H:%M"
-        )
+        return localtime(date).strftime("%b %d, %Y at %H:%M")
 
     def user_affiliation(self):
         profile = self.user.user_profile

--- a/app/grandchallenge/core/models.py
+++ b/app/grandchallenge/core/models.py
@@ -2,6 +2,7 @@ import uuid
 
 from django.conf import settings
 from django.db import models
+from django.utils.timezone import get_current_timezone
 from django.utils.translation import gettext_lazy as _
 from django_extensions.db.models import (
     TitleSlugDescriptionModel as BaseTitleSlugDescriptionModel,
@@ -75,7 +76,9 @@ class RequestBase(models.Model):
 
     @staticmethod
     def format_date(date):
-        return date.strftime("%b %d, %Y at %H:%M")
+        return date.astimezone(get_current_timezone()).strftime(
+            "%b %d, %Y at %H:%M"
+        )
 
     def user_affiliation(self):
         profile = self.user.user_profile

--- a/app/grandchallenge/evaluation/forms.py
+++ b/app/grandchallenge/evaluation/forms.py
@@ -99,10 +99,10 @@ class PhaseCreateForm(
         fields = ("title", "submissions_open_at", "submissions_close_at")
         widgets = {
             "submissions_open_at": forms.DateTimeInput(
-                format=("%Y-%m-%d %H:%M"), attrs={"type": "datetime-local"}
+                format=("%Y-%m-%dT%H:%M"), attrs={"type": "datetime-local"}
             ),
             "submissions_close_at": forms.DateTimeInput(
-                format=("%Y-%m-%d %H:%M"), attrs={"type": "datetime-local"}
+                format=("%Y-%m-%dT%H:%M"), attrs={"type": "datetime-local"}
             ),
         }
 
@@ -137,10 +137,10 @@ class PhaseUpdateForm(PhaseTitleMixin, forms.ModelForm):
                 schema=EXTRA_RESULT_COLUMNS_SCHEMA
             ),
             "submissions_open_at": forms.DateTimeInput(
-                format=("%Y-%m-%d %H:%M"), attrs={"type": "datetime-local"}
+                format=("%Y-%m-%dT%H:%M"), attrs={"type": "datetime-local"}
             ),
             "submissions_close_at": forms.DateTimeInput(
-                format=("%Y-%m-%d %H:%M"), attrs={"type": "datetime-local"}
+                format=("%Y-%m-%dT%H:%M"), attrs={"type": "datetime-local"}
             ),
         }
 

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -15,6 +15,7 @@ from django.db import models
 from django.db.transaction import on_commit
 from django.utils import timezone
 from django.utils.text import get_valid_filename
+from django.utils.timezone import get_current_timezone
 from django_extensions.db.fields import AutoSlugField
 from guardian.shortcuts import assign_perm, remove_perm
 
@@ -656,13 +657,19 @@ class Phase(UUIDModel):
     @property
     def submission_status_string(self):
         if self.status == StatusChoices.OPEN and self.submissions_close_at:
-            return f'Accepting submissions for {self.title} until {self.submissions_close_at.strftime("%b %d %Y at %H:%M")}'
+            return (
+                f"Accepting submissions for {self.title} until "
+                f'{self.submissions_close_at.astimezone(get_current_timezone()).strftime("%b %d %Y at %H:%M")}'
+            )
         elif (
             self.status == StatusChoices.OPEN and not self.submissions_close_at
         ):
             return f"Accepting submissions for {self.title}"
         elif self.status == StatusChoices.OPENING_SOON:
-            return f'Opening submissions for {self.title} on {self.submissions_open_at.strftime("%b %d %Y at %H:%M")}'
+            return (
+                f"Opening submissions for {self.title} on "
+                f'{self.submissions_open_at.astimezone(get_current_timezone()).strftime("%b %d %Y at %H:%M")}'
+            )
         elif self.status == StatusChoices.COMPLETED:
             return f"{self.title} completed"
         elif self.status == StatusChoices.CLOSED:

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -15,7 +15,7 @@ from django.db import models
 from django.db.transaction import on_commit
 from django.utils import timezone
 from django.utils.text import get_valid_filename
-from django.utils.timezone import get_current_timezone
+from django.utils.timezone import localtime
 from django_extensions.db.fields import AutoSlugField
 from guardian.shortcuts import assign_perm, remove_perm
 
@@ -659,7 +659,7 @@ class Phase(UUIDModel):
         if self.status == StatusChoices.OPEN and self.submissions_close_at:
             return (
                 f"Accepting submissions for {self.title} until "
-                f'{self.submissions_close_at.astimezone(get_current_timezone()).strftime("%b %d %Y at %H:%M")}'
+                f'{localtime(self.submissions_close_at).strftime("%b %d %Y at %H:%M")}'
             )
         elif (
             self.status == StatusChoices.OPEN and not self.submissions_close_at
@@ -668,7 +668,7 @@ class Phase(UUIDModel):
         elif self.status == StatusChoices.OPENING_SOON:
             return (
                 f"Opening submissions for {self.title} on "
-                f'{self.submissions_open_at.astimezone(get_current_timezone()).strftime("%b %d %Y at %H:%M")}'
+                f'{localtime(self.submissions_open_at).strftime("%b %d %Y at %H:%M")}'
             )
         elif self.status == StatusChoices.COMPLETED:
             return f"{self.title} completed"


### PR DESCRIPTION
To use an input element of type `datetime-local`, the validation format needs to be changed to `YYYY-MM-DDThh:mm`. 