### PR TITLE
Add archive item to UploadSession serializer

### DIFF
--- a/app/grandchallenge/archives/tasks.py
+++ b/app/grandchallenge/archives/tasks.py
@@ -4,7 +4,7 @@ from django.db import transaction
 from django.db.transaction import on_commit
 
 from grandchallenge.archives.models import Archive, ArchiveItem
-from grandchallenge.cases.models import Image
+from grandchallenge.cases.models import Image, RawImageUploadSession
 from grandchallenge.components.models import (
     ComponentInterface,
     ComponentInterfaceValue,
@@ -48,6 +48,12 @@ def add_images_to_archive_item(
 ):
     archive_item = ArchiveItem.objects.get(pk=archive_item_pk)
     interface = ComponentInterface.objects.get(pk=interface_pk)
+    session = RawImageUploadSession.objects.get(pk=upload_session_pk)
+
+    if archive_item.values.filter(
+        interface=interface, image__in=session.image_set.all()
+    ).exists():
+        return
 
     with transaction.atomic():
         archive_item.values.remove(

--- a/app/grandchallenge/archives/tasks.py
+++ b/app/grandchallenge/archives/tasks.py
@@ -49,19 +49,12 @@ def add_images_to_archive_item(
     archive_item = ArchiveItem.objects.get(pk=archive_item_pk)
     interface = ComponentInterface.objects.get(pk=interface_pk)
 
-    civ_pks_to_remove = set()
-    civ_pks_to_add = set()
-
-    civ = archive_item.values.filter(interface=interface).first()
-    if civ:
-        civ_pks_to_remove.add(civ.pk)
-
     with transaction.atomic():
+        archive_item.values.remove(
+            *archive_item.values.filter(interface=interface)
+        )
         new_civ = ComponentInterfaceValue.objects.create(interface=interface)
-        civ_pks_to_add.add(new_civ)
-
-        archive_item.values.remove(*civ_pks_to_remove)
-        archive_item.values.add(*civ_pks_to_add)
+        archive_item.values.add(new_civ)
 
         on_commit(
             add_images_to_component_interface_value.signature(

--- a/app/grandchallenge/archives/tasks.py
+++ b/app/grandchallenge/archives/tasks.py
@@ -36,6 +36,31 @@ def add_images_to_archive(*, upload_session_pk, archive_pk, interface_pk=None):
 
 
 @shared_task
+def add_image_to_archive_item(
+    *, upload_session_pk, archive_item_pk, interface_pk=None
+):
+    image = Image.objects.filter(origin_id=upload_session_pk).get()
+    archive_item = ArchiveItem.objects.get(pk=archive_item_pk)
+
+    if interface_pk is not None:
+        interface = ComponentInterface.objects.get(pk=interface_pk)
+    else:
+        interface = ComponentInterface.objects.get(
+            slug="generic-medical-image"
+        )
+
+    if ComponentInterfaceValue.objects.filter(
+        interface=interface, image=image
+    ).exists():
+        return
+
+    civ = ComponentInterfaceValue.objects.create(
+        interface=interface, image=image
+    )
+    archive_item.values.add(civ)
+
+
+@shared_task
 def update_archive_item_values(
     *, archive_item_pk, civ_pks_to_remove, civ_pks_to_add,
 ):

--- a/app/grandchallenge/archives/tasks.py
+++ b/app/grandchallenge/archives/tasks.py
@@ -61,8 +61,8 @@ def add_images_to_archive_item(
     )
     update_archive_item_values(
         archive_item_pk=archive_item_pk,
-        civ_pks_to_remove=civ_pks_to_remove,
-        civ_pks_to_add=civ_pks_to_add,
+        civ_pks_to_remove=list(civ_pks_to_remove),
+        civ_pks_to_add=list(civ_pks_to_add),
     )
 
 

--- a/app/grandchallenge/archives/tasks.py
+++ b/app/grandchallenge/archives/tasks.py
@@ -1,46 +1,50 @@
 from celery import shared_task
+from django.conf import settings
+from django.db import transaction
+from django.db.transaction import on_commit
 
-from grandchallenge.algorithms.tasks import (
-    add_images_to_component_interface_value,
-)
 from grandchallenge.archives.models import Archive, ArchiveItem
 from grandchallenge.cases.models import Image
 from grandchallenge.components.models import (
     ComponentInterface,
     ComponentInterfaceValue,
 )
+from grandchallenge.components.tasks import (
+    add_images_to_component_interface_value,
+)
 
 
-@shared_task
+@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
 def add_images_to_archive(*, upload_session_pk, archive_pk, interface_pk=None):
-    images = Image.objects.filter(origin_id=upload_session_pk)
-    archive = Archive.objects.get(pk=archive_pk)
-    if interface_pk is not None:
-        interface = ComponentInterface.objects.get(pk=interface_pk)
-    else:
-        interface = ComponentInterface.objects.get(
-            slug="generic-medical-image"
-        )
-
-    for image in images:
-        civ = ComponentInterfaceValue.objects.filter(
-            interface=interface, image=image
-        ).first()
-        if civ is None:
-            civ = ComponentInterfaceValue.objects.create(
-                interface=interface, image=image
+    with transaction.atomic():
+        images = Image.objects.filter(origin_id=upload_session_pk)
+        archive = Archive.objects.get(pk=archive_pk)
+        if interface_pk is not None:
+            interface = ComponentInterface.objects.get(pk=interface_pk)
+        else:
+            interface = ComponentInterface.objects.get(
+                slug="generic-medical-image"
             )
-        if ArchiveItem.objects.filter(
-            archive=archive, values__in=[civ.pk]
-        ).exists():
-            continue
-        item = ArchiveItem.objects.create(archive=archive)
-        item.values.set([civ])
+
+        for image in images:
+            civ = ComponentInterfaceValue.objects.filter(
+                interface=interface, image=image
+            ).first()
+            if civ is None:
+                civ = ComponentInterfaceValue.objects.create(
+                    interface=interface, image=image
+                )
+            if ArchiveItem.objects.filter(
+                archive=archive, values__in=[civ.pk]
+            ).exists():
+                continue
+            item = ArchiveItem.objects.create(archive=archive)
+            item.values.set([civ])
 
 
-@shared_task
+@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
 def add_images_to_archive_item(
-    *, upload_session_pk, archive_item_pk, interface_pk=None
+    *, upload_session_pk, archive_item_pk, interface_pk
 ):
     archive_item = ArchiveItem.objects.get(pk=archive_item_pk)
     interface = ComponentInterface.objects.get(pk=interface_pk)
@@ -52,24 +56,29 @@ def add_images_to_archive_item(
     if civ:
         civ_pks_to_remove.add(civ.pk)
 
-    civ = ComponentInterfaceValue.objects.create(interface=interface)
-    civ_pks_to_add.add(civ)
+    with transaction.atomic():
+        new_civ = ComponentInterfaceValue.objects.create(interface=interface)
+        civ_pks_to_add.add(new_civ)
 
-    add_images_to_component_interface_value(
-        component_interface_value_pk=civ.pk,
-        upload_session_pk=upload_session_pk,
-    )
-    update_archive_item_values(
-        archive_item_pk=archive_item_pk,
-        civ_pks_to_remove=list(civ_pks_to_remove),
-        civ_pks_to_add=list(civ_pks_to_add),
-    )
+        archive_item.values.remove(*civ_pks_to_remove)
+        archive_item.values.add(*civ_pks_to_add)
+
+        on_commit(
+            add_images_to_component_interface_value.signature(
+                kwargs={
+                    "component_interface_value_pk": new_civ.pk,
+                    "upload_session_pk": upload_session_pk,
+                },
+                immutable=True,
+            ).apply_async
+        )
 
 
-@shared_task
+@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
 def update_archive_item_values(
     *, archive_item_pk, civ_pks_to_remove, civ_pks_to_add,
 ):
-    archive_item = ArchiveItem.objects.get(pk=archive_item_pk)
-    archive_item.values.remove(*civ_pks_to_remove)
-    archive_item.values.add(*civ_pks_to_add)
+    with transaction.atomic():
+        archive_item = ArchiveItem.objects.get(pk=archive_item_pk)
+        archive_item.values.remove(*civ_pks_to_remove)
+        archive_item.values.add(*civ_pks_to_add)

--- a/app/grandchallenge/archives/views.py
+++ b/app/grandchallenge/archives/views.py
@@ -34,9 +34,6 @@ from rest_framework.settings import api_settings
 from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework_guardian.filters import ObjectPermissionsFilter
 
-from grandchallenge.algorithms.tasks import (
-    add_images_to_component_interface_value,
-)
 from grandchallenge.archives.filters import ArchiveFilter
 from grandchallenge.archives.forms import (
     AddCasesForm,
@@ -69,6 +66,9 @@ from grandchallenge.components.models import (
     ComponentInterface,
     ComponentInterfaceValue,
     InterfaceKind,
+)
+from grandchallenge.components.tasks import (
+    add_images_to_component_interface_value,
 )
 from grandchallenge.core.filters import FilterMixin
 from grandchallenge.core.forms import UserFormKwargsMixin

--- a/app/grandchallenge/cases/serializers.py
+++ b/app/grandchallenge/cases/serializers.py
@@ -201,18 +201,10 @@ class RawImageUploadSessionSerializer(serializers.ModelSerializer):
             )
 
         if "archive_item" in attrs:
-            archive_item_interfaces = attrs["archive_item"].values.values_list(
-                "interface__slug", flat=True
-            )
-            interface_slug = (
-                attrs["interface"].slug
-                if "interface" in attrs
-                else "generic-medical-image"
-            )
-            if interface_slug in archive_item_interfaces:
+            if "interface" not in attrs:
                 raise ValidationError(
-                    f"This archive item already has a component interface of "
-                    f"{interface_slug} associated with it."
+                    "An interface needs to be defined to upload to an "
+                    "archive item."
                 )
             if len(uploads) > 1:
                 raise ValidationError(

--- a/app/grandchallenge/cases/serializers.py
+++ b/app/grandchallenge/cases/serializers.py
@@ -10,8 +10,8 @@ from rest_framework.relations import (
 
 from grandchallenge.archives.models import Archive, ArchiveItem
 from grandchallenge.archives.tasks import (
-    add_image_to_archive_item,
     add_images_to_archive,
+    add_images_to_archive_item,
 )
 from grandchallenge.cases.models import (
     Image,
@@ -206,11 +206,6 @@ class RawImageUploadSessionSerializer(serializers.ModelSerializer):
                     "An interface needs to be defined to upload to an "
                     "archive item."
                 )
-            if len(uploads) > 1:
-                raise ValidationError(
-                    "Only one image can be uploaded to an archive item "
-                    "at a time."
-                )
 
         return attrs
 
@@ -251,7 +246,7 @@ def _get_linked_task(*, targets, interface):
         }
         if interface:
             kwargs["interface_pk"] = interface.pk
-        return add_image_to_archive_item.signature(
+        return add_images_to_archive_item.signature(
             kwargs=kwargs, immutable=True,
         )
     elif "reader_study" in targets:

--- a/app/grandchallenge/cases/serializers.py
+++ b/app/grandchallenge/cases/serializers.py
@@ -200,12 +200,11 @@ class RawImageUploadSessionSerializer(serializers.ModelSerializer):
                 "or archive item uploads."
             )
 
-        if "archive_item" in attrs:
-            if "interface" not in attrs:
-                raise ValidationError(
-                    "An interface needs to be defined to upload to an "
-                    "archive item."
-                )
+        if "archive_item" in attrs and "interface" not in attrs:
+            raise ValidationError(
+                "An interface needs to be defined to upload to an "
+                "archive item."
+            )
 
         return attrs
 
@@ -241,13 +240,12 @@ def _get_linked_task(*, targets, interface):
             kwargs["interface_pk"] = interface.pk
         return add_images_to_archive.signature(kwargs=kwargs, immutable=True,)
     elif "archive_item" in targets:
-        kwargs = {
-            "archive_item_pk": targets["archive_item"].pk,
-        }
-        if interface:
-            kwargs["interface_pk"] = interface.pk
         return add_images_to_archive_item.signature(
-            kwargs=kwargs, immutable=True,
+            kwargs={
+                "archive_item_pk": targets["archive_item"].pk,
+                "interface_pk": interface.pk,
+            },
+            immutable=True,
         )
     elif "reader_study" in targets:
         return add_images_to_reader_study.signature(

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -19,6 +19,8 @@ from django.db.transaction import on_commit
 from django.utils.module_loading import import_string
 from django.utils.timezone import now
 
+from grandchallenge.algorithms.exceptions import ImageImportError
+from grandchallenge.cases.models import RawImageUploadSession
 from grandchallenge.components.backends.exceptions import (
     ComponentException,
     EventError,
@@ -534,3 +536,29 @@ def stop_expired_services(*, app_label: str, model_name: str, region: str):
         service.stop()
 
     return [str(s) for s in services_to_stop]
+
+
+@shared_task
+def add_images_to_component_interface_value(
+    *, component_interface_value_pk, upload_session_pk
+):
+    session = RawImageUploadSession.objects.get(pk=upload_session_pk)
+
+    if session.image_set.count() != 1:
+        error_message = "Image imports should result in a single image"
+        session.status = RawImageUploadSession.FAILURE
+        session.error_message = error_message
+        session.save()
+        raise ImageImportError(error_message)
+
+    civ = get_model_instance(
+        pk=component_interface_value_pk,
+        app_label="components",
+        model_name="componentinterfacevalue",
+    )
+
+    civ.image = session.image_set.get()
+    civ.full_clean()
+    civ.save()
+
+    civ.image.update_viewer_groups_permissions()

--- a/app/tests/algorithms_tests/test_tasks.py
+++ b/app/tests/algorithms_tests/test_tasks.py
@@ -11,7 +11,6 @@ from django_capture_on_commit_callbacks import capture_on_commit_callbacks
 from grandchallenge.algorithms.exceptions import ImageImportError
 from grandchallenge.algorithms.models import DEFAULT_INPUT_INTERFACE_SLUG, Job
 from grandchallenge.algorithms.tasks import (
-    add_images_to_component_interface_value,
     create_algorithm_jobs,
     execute_algorithm_job_for_inputs,
     filter_civs_for_algorithm,
@@ -23,6 +22,9 @@ from grandchallenge.components.models import (
     ComponentInterfaceValue,
     InterfaceKind,
     InterfaceKindChoices,
+)
+from grandchallenge.components.tasks import (
+    add_images_to_component_interface_value,
 )
 from grandchallenge.notifications.models import Notification
 from tests.algorithms_tests.factories import (

--- a/app/tests/cases_tests/test_api.py
+++ b/app/tests/cases_tests/test_api.py
@@ -493,33 +493,3 @@ def test_session_with_user_upload_to_archive_item(client, settings):
         "An interface needs to be defined to upload to an archive item."
         in response.json()["non_field_errors"]
     )
-
-    # try to upload multiple files to the same archive item
-    upload4 = create_upload_from_file(
-        file_path=Path(__file__).parent / "resources" / "image10x10x10.mha",
-        creator=user,
-    )
-    upload5 = create_upload_from_file(
-        file_path=Path(__file__).parent / "resources" / "image10x11x12x13.mha",
-        creator=user,
-    )
-    ci2 = ComponentInterfaceFactory()
-    with capture_on_commit_callbacks(execute=True):
-        response = get_view_for_user(
-            viewname="api:upload-session-list",
-            user=user,
-            client=client,
-            method=client.post,
-            content_type="application/json",
-            data={
-                "uploads": [upload4.api_url, upload5.api_url],
-                "archive_item": item.pk,
-                "interface": ci2.slug,
-            },
-            HTTP_X_FORWARDED_PROTO="https",
-        )
-    assert response.status_code == 400
-    assert (
-        "Only one image can be uploaded to an archive item at a time."
-        in response.json()["non_field_errors"]
-    )

--- a/app/tests/cases_tests/test_api.py
+++ b/app/tests/cases_tests/test_api.py
@@ -398,7 +398,7 @@ def test_session_with_user_duplicate_upload(client):
 
 
 @pytest.mark.django_db
-def test_session_with_user_upload_to_archive_item(client, settings):
+def test_user_upload_to_archive_item_with_new_interface(client, settings):
     # Override the celery settings
     settings.task_eager_propagates = (True,)
     settings.task_always_eager = (True,)
@@ -418,7 +418,7 @@ def test_session_with_user_upload_to_archive_item(client, settings):
         file_path=Path(__file__).parent / "resources" / "image10x10x10.mha",
         creator=user,
     )
-    # with interface
+
     with capture_on_commit_callbacks(execute=True):
         response = get_view_for_user(
             viewname="api:upload-session-list",
@@ -442,12 +442,25 @@ def test_session_with_user_upload_to_archive_item(client, settings):
     assert "generic-overlay" in [
         item.interface.slug for item in item.values.all()
     ]
-    generic_overlay_civ_1 = item.values.filter(
-        interface__slug="generic-overlay"
-    ).get()
+
+
+@pytest.mark.django_db
+def test_user_upload_to_archive_item_with_existing_interface(client, settings):
+    # Override the celery settings
+    settings.task_eager_propagates = (True,)
+    settings.task_always_eager = (True,)
+
+    user = UserFactory()
+    archive = ArchiveFactory()
+    archive.add_editor(user=user)
+    ci = ComponentInterface.objects.filter(slug="generic-overlay").get()
+    civ = ComponentInterfaceValueFactory(interface=ci)
+    item = ArchiveItemFactory(archive=archive)
+    item.values.add(civ)
+    assert item.values.count() == 1
 
     # upload another generic-overlay to the same item
-    upload2 = create_upload_from_file(
+    upload = create_upload_from_file(
         file_path=Path(__file__).parent / "resources" / "image10x10x10.mha",
         creator=user,
     )
@@ -459,7 +472,7 @@ def test_session_with_user_upload_to_archive_item(client, settings):
             method=client.post,
             content_type="application/json",
             data={
-                "uploads": [upload2.api_url],
+                "uploads": [upload.api_url],
                 "archive_item": item.pk,
                 "interface": "generic-overlay",
             },
@@ -469,11 +482,26 @@ def test_session_with_user_upload_to_archive_item(client, settings):
     item.refresh_from_db()
     # check that there is only one civ with the generic-overlay interface
     assert item.values.filter(interface__slug="generic-overlay").count() == 1
-    # and that the previously added one is not longer associated with the item
-    assert generic_overlay_civ_1 not in item.values.all()
+    # and that the previously added one is no longer associated with the item
+    assert civ not in item.values.all()
 
-    # try upload without interface
-    upload3 = create_upload_from_file(
+
+@pytest.mark.django_db
+def test_user_upload_to_archive_item_without_interface(client, settings):
+    # Override the celery settings
+    settings.task_eager_propagates = (True,)
+    settings.task_always_eager = (True,)
+
+    user = UserFactory()
+    archive = ArchiveFactory()
+    archive.add_editor(user=user)
+    ci = ComponentInterface.objects.filter(slug="generic-overlay").get()
+    civ = ComponentInterfaceValueFactory(interface=ci)
+    item = ArchiveItemFactory(archive=archive)
+    item.values.add(civ)
+    assert item.values.count() == 1
+
+    upload = create_upload_from_file(
         file_path=Path(__file__).parent / "resources" / "image10x10x10.mha",
         creator=user,
     )
@@ -484,7 +512,7 @@ def test_session_with_user_upload_to_archive_item(client, settings):
             client=client,
             method=client.post,
             content_type="application/json",
-            data={"uploads": [upload3.api_url], "archive_item": item.pk},
+            data={"uploads": [upload.api_url], "archive_item": item.pk},
             HTTP_X_FORWARDED_PROTO="https",
         )
 

--- a/scripts/development_fixtures.py
+++ b/scripts/development_fixtures.py
@@ -23,7 +23,7 @@ from machina.apps.forum.models import Forum
 
 from grandchallenge.algorithms.models import Algorithm, AlgorithmImage, Job
 from grandchallenge.anatomy.models import BodyRegion, BodyStructure
-from grandchallenge.archives.models import Archive
+from grandchallenge.archives.models import Archive, ArchiveItem
 from grandchallenge.cases.models import Image
 from grandchallenge.challenges.models import (
     Challenge,
@@ -535,6 +535,21 @@ def _create_archive(users):
     )
     archive.editors_group.user_set.add(users["archive"])
     archive.uploaders_group.user_set.add(users["demo"])
+
+    image = Image(
+        name="test_image2.mha",
+        modality=ImagingModality.objects.get(modality="MR"),
+        width=128,
+        height=128,
+        color_space="RGB",
+    )
+    image.save()
+    item = ArchiveItem.objects.create(archive=archive)
+    civ = ComponentInterfaceValue.objects.create(
+        interface=ComponentInterface.objects.get(slug="generic-medical-image"),
+        image=image,
+    )
+    item.values.add(civ)
 
 
 def _create_user_tokens(users):


### PR DESCRIPTION
- This adds the option to target an archive item (next to an archive or a reader study) while uploading cases through the api.
- Doing this requires that an interface is specified.
