### PR TITLE
Fix evaluation query for algorithm submission checks

### DIFF
--- a/app/grandchallenge/evaluation/forms.py
+++ b/app/grandchallenge/evaluation/forms.py
@@ -307,14 +307,14 @@ class SubmissionForm(SaveFormInitMixin, forms.ModelForm):
                     Evaluation.FAILURE,
                     Evaluation.CANCELLED,
                 ],
-                submission__phase=self._phase,
             )
+            .exclude(submission__phase=self._phase)
             .exists()
         ):
             # This causes problems in `set_evaluation_inputs` if two
             # evaluations are running for the same image at the same time
             raise ValidationError(
-                "A evaluation for this algorithm is already in progress for "
+                "An evaluation for this algorithm is already in progress for "
                 "another phase. Please wait for the other evaluation to "
                 "complete."
             )


### PR DESCRIPTION
A combined exclude translates to an AND SQL query rather than an OR query. For the latter, there need to be two seperate exclude statements: https://docs.djangoproject.com/en/4.0/ref/models/querysets/#exclude 

