### PR TITLE
Deprecate _IMAGE answer types

### DIFF
--- a/app/grandchallenge/algorithms/tasks.py
+++ b/app/grandchallenge/algorithms/tasks.py
@@ -84,7 +84,7 @@ def on_job_creation_error(self, task_id, *args, **kwargs):
         error_message += str(res)
 
     job.update_status(
-        status=job.FAILURE, error_message=error_message,
+        status=job.CANCELLED, error_message=error_message,
     )
 
     on_commit(linked_task.apply_async)
@@ -104,7 +104,7 @@ def execute_algorithm_job_for_inputs(*, job_pk):
     missing_inputs = list(civ for civ in job.inputs.all() if not civ.has_value)
     if missing_inputs:
         job.update_status(
-            status=job.FAILURE,
+            status=job.CANCELLED,
             error_message=(
                 f"Job can't be started, input is missing for "
                 f"{oxford_comma([c.interface.title for c in missing_inputs])}"

--- a/app/grandchallenge/reader_studies/forms.py
+++ b/app/grandchallenge/reader_studies/forms.py
@@ -38,8 +38,10 @@ from grandchallenge.core.widgets import JSONEditorWidget, MarkdownEditorWidget
 from grandchallenge.groups.forms import UserGroupForm
 from grandchallenge.reader_studies.models import (
     Answer,
+    AnswerType,
     CASE_TEXT_SCHEMA,
     CategoricalOption,
+    DEPRECATED_ANSWER_TYPES,
     HANGING_LIST_SCHEMA,
     Question,
     ReaderStudy,
@@ -235,6 +237,13 @@ class ReaderStudyCopyForm(Form):
 class QuestionForm(SaveFormInitMixin, ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        self.fields["answer_type"].choices = [
+            a
+            for a in AnswerType.choices
+            if a[0] not in DEPRECATED_ANSWER_TYPES
+        ]
+
         self.helper = FormHelper()
         self.helper.form_tag = True
         self.helper.layout = Layout(

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -161,8 +161,14 @@
             {% endif %}
 
             {% if "read_readerstudy" in readerstudy_perms and object.is_valid %}
+                {% if object.has_deprecated_questions %}
+                    <div class="alert alert-danger" role="alert">
+                        This reader study can no longer be run, please remove the deprecated questions.
+                    </div>
+                {% endif %}
+
                 <p>
-                    <a class="btn btn-primary"
+                    <a class="btn btn-primary {% if object.has_deprecated_questions %}disabled{% endif %}"
                        href="{% url 'workstations:workstation-session-create' slug=object.workstation.slug %}?{% workstation_query reader_study=object %}">
                         <i class="fas fa-eye"></i> Launch this Reader Study
                     </a>
@@ -265,7 +271,12 @@
                         <li class="list-group-item">
                             <div class="row">
                                 <div class="col justify-content-start">
-                                    <div>{{ question }}</div>
+                                    <div>
+                                        {% if question.is_deprecated %}
+                                            <i class="fa fa-exclamation-triangle text-danger" title="Deprecated Question Type"></i>
+                                        {% endif %}
+                                        {{ question }}
+                                    </div>
                                 </div>
                                 <div class="col-md-auto justify-content-end">
                                     <a class="btn btn-primary btn-sm"

--- a/app/tests/algorithms_tests/test_tasks.py
+++ b/app/tests/algorithms_tests/test_tasks.py
@@ -522,7 +522,7 @@ def test_execute_algorithm_job_for_inputs(
     execute_algorithm_job_for_inputs(job_pk=job.pk)
 
     job.refresh_from_db()
-    assert job.status == Job.FAILURE
+    assert job.status == Job.CANCELLED
     assert "Job can't be started, input is missing for " in job.error_message
 
 


### PR DESCRIPTION
Disables the link for launching reader studies with deprecated answer types, showing a warning telling the user to remove them. Disallows adding new questions with deprecated answer types.

Closes #2266