### PR TITLE
Handle request errors in CSL update task

### DIFF
--- a/app/grandchallenge/publications/tasks.py
+++ b/app/grandchallenge/publications/tasks.py
@@ -1,6 +1,7 @@
 import logging
 
 from celery import shared_task
+from requests.exceptions import RequestException
 
 from grandchallenge.publications.models import Publication
 from grandchallenge.publications.utils import get_identifier_csl
@@ -19,6 +20,9 @@ def update_publication_metadata():
             logger.warning(
                 f"Identifier {publication.identifier} not recognised"
             )
+            continue
+        except RequestException as e:
+            logger.warning(f"Error updating {publication.identifier}: {e}")
             continue
 
         publication.identifier = new_identifier

--- a/app/grandchallenge/publications/tasks.py
+++ b/app/grandchallenge/publications/tasks.py
@@ -1,6 +1,7 @@
 import logging
 
 from celery import shared_task
+from django.conf import settings
 from requests.exceptions import RequestException
 
 from grandchallenge.publications.models import Publication
@@ -9,7 +10,7 @@ from grandchallenge.publications.utils import get_identifier_csl
 logger = logging.getLogger(__name__)
 
 
-@shared_task
+@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-2xlarge"])
 def update_publication_metadata():
     for publication in Publication.objects.all():
         try:


### PR DESCRIPTION
Demotes a few sentry alerts to warnings and continues. Uses the 2xlarge queue as this takes a while. I think this is fine without an atomic block as it is a single update, and doesn't matter if this task runs many times.