### PR TITLE
Add AWS_S3_DEFAULT_STORAGE_CLASS option

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -151,9 +151,7 @@ AWS_S3_REGION_NAME = os.environ.get("AWS_S3_REGION_NAME")
 AWS_S3_OBJECT_PARAMETERS = {
     # Note that these do not affect the Uploads bucket, which is configured separately.
     # See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.put_object
-    "StorageClass": os.environ.get(
-        "AWS_S3_DEFAULT_STORAGE_CLASS", "INTELLIGENT_TIERING"
-    ),
+    "StorageClass": os.environ.get("AWS_S3_DEFAULT_STORAGE_CLASS", "STANDARD"),
 }
 AWS_CLOUDWATCH_REGION_NAME = os.environ.get("AWS_CLOUDWATCH_REGION_NAME")
 AWS_CODEBUILD_REGION_NAME = os.environ.get("AWS_CODEBUILD_REGION_NAME")

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -148,6 +148,13 @@ AWS_S3_MAX_MEMORY_SIZE = 1_048_576  # 100 MB
 AWS_S3_ENDPOINT_URL = os.environ.get("AWS_S3_ENDPOINT_URL")
 AWS_DEFAULT_REGION = os.environ.get("AWS_DEFAULT_REGION", "eu-central-1")
 AWS_S3_REGION_NAME = os.environ.get("AWS_S3_REGION_NAME")
+AWS_S3_OBJECT_PARAMETERS = {
+    # Note that these do not affect the Uploads bucket, which is configured separately.
+    # See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.put_object
+    "StorageClass": os.environ.get(
+        "AWS_S3_DEFAULT_STORAGE_CLASS", "INTELLIGENT_TIERING"
+    ),
+}
 AWS_CLOUDWATCH_REGION_NAME = os.environ.get("AWS_CLOUDWATCH_REGION_NAME")
 AWS_CODEBUILD_REGION_NAME = os.environ.get("AWS_CODEBUILD_REGION_NAME")
 AWS_SES_REGION_ENDPOINT = f'email.{os.environ.get("AWS_SES_REGION_NAME", AWS_DEFAULT_REGION)}.amazonaws.com'


### PR DESCRIPTION
AWS made some changes to intelligent tiering (https://aws.amazon.com/blogs/aws/amazon-s3-intelligent-tiering-further-automating-cost-savings-for-short-lived-and-small-objects/) which means that:

-    S3 Intelligent-Tiering now has no minimum storage duration period for all objects.
-    Monitoring and automation charges are no longer collected for objects smaller than 128 KB.

I don't see any good reason not to use this now for all of the long-term storage buckets. The Uploads bucket does not use django storages so does not pick up this configuration, but the objects there are shorted-lived and deleted within 24 hours so is anyway low cost.
