### PR TITLE
Handle type errors in json extraction

### DIFF
--- a/app/grandchallenge/evaluation/templatetags/evaluation_extras.py
+++ b/app/grandchallenge/evaluation/templatetags/evaluation_extras.py
@@ -25,7 +25,7 @@ def get_jsonpath(obj: dict, jsonpath):
 
         return val
 
-    except KeyError:
+    except (KeyError, TypeError):
         return ""
 
 
@@ -33,7 +33,7 @@ def get_jsonpath(obj: dict, jsonpath):
 def get_key(obj: dict, key):
     try:
         return obj[key]
-    except KeyError:
+    except (KeyError, TypeError):
         return ""
 
 


### PR DESCRIPTION
Occurs when users misconfigure their phase settings and try to look up things in float values. See Sentry.