### PR TITLE
Create dependency-update.yml

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -1,0 +1,60 @@
+name: Dependency Update
+
+on:
+  schedule:
+    - cron: '27 6 * * 2'
+  workflow_dispatch:
+
+env:
+  PYTHON_VERSION: '3.8'
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-update:
+    name: Dependency Update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install poetry
+        run: |
+          python -m pip install poetry
+      - name: Update Depencencies
+        id: dependency-update
+        timeout-minutes: 5
+        run: |
+          POETRY_LOG=$(poetry update --lock --dry-run --no-interaction --no-ansi)
+          POETRY_LOG="${POETRY_LOG//'%'/'%25'}"
+          POETRY_LOG="${POETRY_LOG//$'\n'/'%0A'}"
+          POETRY_LOG="${POETRY_LOG//$'\r'/'%0D'}"
+          echo "::set-output name=poetry-log::$POETRY_LOG"
+      - name: Set the environment
+        run: |
+          echo "GIT_COMMIT_ID=$(git describe --always --dirty)" >> $GITHUB_ENV
+          echo "GIT_BRANCH_NAME=$(echo ${{ github.ref }} | cut -d/ -f3- | sed "s/[^[:alnum:]]//g")" >> $GITHUB_ENV
+          echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> $GITHUB_ENV
+      - name: Build the test container and make the docs
+        run: |
+          make build_web_test
+          make docs
+      - name: Run the django tests
+        run: |
+          docker pull crccheck/hello-world
+          docker-compose run --rm web pytest --cov-report --cov=. --durations 10
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: "Automated dependency update"
+          branch-suffix: "short-commit-hash"
+          delete-branch: true
+          title: "Automated dependency update"
+          body: "Output:\n\n```\n${{ steps.dependency-update.outputs.poetry-log }}\n```"


### PR DESCRIPTION
This PR adds a workflow that runs every Tuesday morning to update the poetry dependencies, respecting the specifications in `pyproject.toml`. It will create a new PR after running the tests and building the docs. The reason we do this in this action is that a PR created by a bot user will not launch more actions to prevent infinite loops.