### PR TITLE
Make the Archive API more consistent

### DIFF
--- a/app/grandchallenge/archives/serializers.py
+++ b/app/grandchallenge/archives/serializers.py
@@ -11,7 +11,7 @@ from grandchallenge.archives.tasks import (
 )
 from grandchallenge.components.serializers import (
     ComponentInterfaceValuePostSerializer,
-    ComponentInterfaceValueSerializer,
+    HyperlinkedComponentInterfaceValueSerializer,
 )
 from grandchallenge.hanging_protocols.serializers import (
     HangingProtocolSerializer,
@@ -22,11 +22,11 @@ class ArchiveItemSerializer(serializers.ModelSerializer):
     archive = HyperlinkedRelatedField(
         read_only=True, view_name="api:archive-detail"
     )
-    values = ComponentInterfaceValueSerializer(many=True)
+    values = HyperlinkedComponentInterfaceValueSerializer(many=True)
 
     class Meta:
         model = ArchiveItem
-        fields = ("id", "archive", "values")
+        fields = ("pk", "archive", "values")
 
 
 class ArchiveSerializer(serializers.ModelSerializer):
@@ -42,7 +42,7 @@ class ArchiveSerializer(serializers.ModelSerializer):
     class Meta:
         model = Archive
         fields = (
-            "id",
+            "pk",
             "name",
             "title",
             "algorithms",

--- a/app/tests/archives_tests/test_serializers.py
+++ b/app/tests/archives_tests/test_serializers.py
@@ -18,7 +18,7 @@ from tests.serializer_helpers import (
                 "factory": ArchiveWithHangingProtocol,
                 "serializer": ArchiveSerializer,
                 "fields": (
-                    "id",
+                    "pk",
                     "name",
                     "title",
                     "api_url",

--- a/app/tests/archives_tests/test_views.py
+++ b/app/tests/archives_tests/test_views.py
@@ -450,7 +450,7 @@ def test_api_archive_item_add_and_update_non_image_file(client, settings):
             HTTP_X_FORWARDED_PROTO="https",
         )
     assert response.status_code == 200
-    assert response.json()["id"] == str(item.pk)
+    assert response.json()["pk"] == str(item.pk)
     item.refresh_from_db()
     assert item.values.count() == 1
     new_civ = item.values.get()

--- a/app/tests/archives_tests/test_views.py
+++ b/app/tests/archives_tests/test_views.py
@@ -243,8 +243,8 @@ def test_api_archive_item_list_is_filtered(client):
     assert response.status_code == 200
     assert response.json()["count"] == 2
     assert i3.id not in (
-        response.json()["results"][0]["id"],
-        response.json()["results"][1]["id"],
+        response.json()["results"][0]["pk"],
+        response.json()["results"][1]["pk"],
     )
 
 
@@ -263,7 +263,7 @@ def test_api_archive_item_retrieve_permissions(client):
         client=client,
     )
     assert response.status_code == 200
-    assert response.json()["id"] == str(i1.pk)
+    assert response.json()["pk"] == str(i1.pk)
 
     # user cannot retrieve archive item
     response = get_view_for_user(
@@ -283,7 +283,7 @@ def test_api_archive_item_retrieve_permissions(client):
         client=client,
     )
     assert response.status_code == 200
-    assert response.json()["id"] == str(i1.pk)
+    assert response.json()["pk"] == str(i1.pk)
 
 
 @pytest.mark.django_db
@@ -328,7 +328,7 @@ def test_api_archive_item_interface_type_update(client, settings):
             HTTP_X_FORWARDED_PROTO="https",
         )
     assert response.status_code == 200
-    assert response.json()["id"] == str(item.pk)
+    assert response.json()["pk"] == str(item.pk)
     item.refresh_from_db()
     # check that the old item was removed and a new one was added with the same
     # image but the new interface type
@@ -365,7 +365,7 @@ def test_api_archive_item_add_and_update_value(client, settings):
             HTTP_X_FORWARDED_PROTO="https",
         )
     assert response.status_code == 200
-    assert response.json()["id"] == str(item.pk)
+    assert response.json()["pk"] == str(item.pk)
     item.refresh_from_db()
     assert item.values.count() == 1
     civ = item.values.get()
@@ -384,7 +384,7 @@ def test_api_archive_item_add_and_update_value(client, settings):
             HTTP_X_FORWARDED_PROTO="https",
         )
     assert response.status_code == 200
-    assert response.json()["id"] == str(item.pk)
+    assert response.json()["pk"] == str(item.pk)
     item.refresh_from_db()
     assert item.values.count() == 1
     new_civ = item.values.get()
@@ -424,7 +424,7 @@ def test_api_archive_item_add_and_update_non_image_file(client, settings):
             HTTP_X_FORWARDED_PROTO="https",
         )
     assert response.status_code == 200
-    assert response.json()["id"] == str(item.pk)
+    assert response.json()["pk"] == str(item.pk)
     item.refresh_from_db()
     assert item.values.count() == 1
     civ = item.values.get()


### PR DESCRIPTION
Uses hyperlinks for CIVs and pk rather than id.

Closes #2339 