### PR TITLE
Don't cache is_editable as aggressively

### DIFF
--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1133,17 +1133,7 @@ class DisplaySet(UUIDModel):
 
     @cached_property
     def is_editable(self):
-        cache_key = f"{self._meta.app_label}.{self._meta.model_name}-{self.pk}-editable-{self.modified.timestamp()}"
-        cached = cache.get(cache_key)
-        if cached:
-            return cached
-        for key in cache.keys(
-            f"{self._meta.app_label}.{self._meta.model_name}-editable-{self.pk}-*"
-        ):
-            cache.delete(key)
-        is_editable = not self.answers.exists()
-        cache.set(cache_key, is_editable, timeout=None)
-        return is_editable
+        return not self.answers.exists()
 
     @property
     def api_url(self):

--- a/app/tests/reader_studies_tests/test_signals.py
+++ b/app/tests/reader_studies_tests/test_signals.py
@@ -155,9 +155,7 @@ def test_assert_modification_allowed():
     ds = DisplaySetFactory(reader_study=rs)
     ds.values.add(civ)
 
-    # clear cache (saving updates modification time)
     del ds.is_editable
-    ds.save()
 
     civ2 = ComponentInterfaceValueFactory(interface=ci, value=True)
     ds.values.remove(civ)
@@ -170,7 +168,6 @@ def test_assert_modification_allowed():
     AnswerFactory(question=q, display_set=ds)
 
     del ds.is_editable
-    ds.save()
 
     with pytest.raises(ValidationError):
         with transaction.atomic():


### PR DESCRIPTION
The aggressive caching leads to issues when checking if a display set can be edited, as the display set's modified time does not get updated when an answer is created. Updating the display set when this happens seems counter productive, as that would also invalidate the cache for the value list, slowing down the view.