### PR TITLE
Make ds values field read only in admin

### DIFF
--- a/app/grandchallenge/reader_studies/admin.py
+++ b/app/grandchallenge/reader_studies/admin.py
@@ -67,7 +67,7 @@ class ReaderStudyPermissionRequestAdmin(GuardedModelAdmin):
 
 class DisplaySetAdmin(GuardedModelAdmin):
     list_filter = ("reader_study__slug",)
-    readonly_fields = ("reader_study",)
+    readonly_fields = ("reader_study", "values")
     list_display = (
         "reader_study",
         "order",


### PR DESCRIPTION
Now, all ComponentINterfaceValues get loaded each time a ds is opened in the admin. This causes GC to crash in production.