### PR TITLE
Add reader study modified time to ds cache key

### DIFF
--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1104,7 +1104,11 @@ class DisplaySet(UUIDModel):
 
     @cached_property
     def value_list(self):
-        cache_key = f"{self._meta.app_label}.{self._meta.model_name}-{self.pk}-{self.modified.timestamp()}"
+        cache_key = (
+            f"{self._meta.app_label}.{self._meta.model_name}-{self.pk}-"
+            f"{self.reader_study.modified.timestamp()}-"
+            f"{self.modified.timestamp()}"
+        )
         cached = cache.get(cache_key)
         if cached:
             return cached


### PR DESCRIPTION
This ensures the ds cache gets invalidated whenever a display set in the reader study is changed or added. With the current caching, newly added interfaces would not be displayed in existing display sets.