### PR TITLE
Add display set creation task to micro short queue

### DIFF
--- a/app/grandchallenge/reader_studies/tasks.py
+++ b/app/grandchallenge/reader_studies/tasks.py
@@ -84,7 +84,7 @@ def add_image_to_display_set(
         display_set.values.add(civ)
 
 
-@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-2xlarge"])
+@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
 def create_display_sets_for_upload_session(
     *, upload_session_pk, reader_study_pk, interface_pk
 ):


### PR DESCRIPTION
Having it in the 2xl queue might cause a long delay between uploading cases and actually seeing them in the reader study, this might confuse users. I think the task is fast and light enough to justify adding it to the micro short queue.