### PR TITLE
Use proper view_content format in migration method

### DIFF
--- a/app/grandchallenge/reader_studies/management/commands/migrate_to_display_sets.py
+++ b/app/grandchallenge/reader_studies/management/commands/migrate_to_display_sets.py
@@ -29,9 +29,9 @@ class Command(BaseCommand):
                 )
                 continue
 
-            view_content = {"main": "generic-medical-image"}
+            view_content = {"main": ["generic-medical-image"]}
             if "main-overlay" in content_keys:
-                view_content["main-overlay"] = "generic-overlay"
+                view_content["main"].append("generic-overlay")
 
             try:
                 migrate_reader_study_to_display_sets(rs, view_content)

--- a/app/grandchallenge/reader_studies/utils.py
+++ b/app/grandchallenge/reader_studies/utils.py
@@ -14,7 +14,9 @@ def _get_civ(image, slug):
     except ComponentInterfaceValue.DoesNotExist:
         raise ValueError(f"ComponentInterface {slug} does not exist.")
 
-    civ = ComponentInterfaceValue.objects.filter(image=image, interface=ci)
+    civ = ComponentInterfaceValue.objects.filter(
+        image=image, interface=ci
+    ).first()
     if civ is None:
         civ = ComponentInterfaceValue.objects.create(image=image, interface=ci)
     return civ

--- a/app/grandchallenge/reader_studies/utils.py
+++ b/app/grandchallenge/reader_studies/utils.py
@@ -29,6 +29,9 @@ def migrate_reader_study_to_display_sets(rs, view_content):  # noqa: C901
             ds = DisplaySet.objects.create(reader_study=rs)
             images = []
             for key in item:
+                # view_content does not contain *-overlay keys, the second
+                # value in the lit of slugs should be the overlay. This is
+                # handled in the else clause here.
                 if "overlay" in key:
                     continue
                 try:

--- a/app/grandchallenge/reader_studies/utils.py
+++ b/app/grandchallenge/reader_studies/utils.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.db import transaction
 
 from grandchallenge.components.models import (
@@ -8,8 +6,6 @@ from grandchallenge.components.models import (
 )
 from grandchallenge.reader_studies.models import Answer, DisplaySet
 from grandchallenge.workstations.models import Workstation
-
-logger = logging.getLogger(__name__)
 
 
 def _get_civ(image, slug):
@@ -47,9 +43,9 @@ def migrate_reader_study_to_display_sets(rs, view_content):  # noqa: C901
                     )
                 else:
                     if len(slugs) > 2:
-                        logger.warning(
+                        raise ValueError(
                             f"More than two interface slugs provided for {key} "
-                            f"in {rs.slug}. Ignoring all values after the second."
+                            f"in {rs.slug}."
                         )
                     image = rs.images.get(name=item[key])
                     ds.values.add(_get_civ(image, slugs[0]))

--- a/app/grandchallenge/reader_studies/utils.py
+++ b/app/grandchallenge/reader_studies/utils.py
@@ -14,9 +14,9 @@ def _get_civ(image, slug):
     except ComponentInterfaceValue.DoesNotExist:
         raise ValueError(f"ComponentInterface {slug} does not exist.")
 
-    civ, _ = ComponentInterfaceValue.objects.get_or_create(
-        image=image, interface=ci
-    )
+    civ = ComponentInterfaceValue.objects.filter(image=image, interface=ci)
+    if civ is None:
+        civ = ComponentInterfaceValue.objects.create(image=image, interface=ci)
     return civ
 
 

--- a/app/tests/reader_studies_tests/test_api.py
+++ b/app/tests/reader_studies_tests/test_api.py
@@ -1791,10 +1791,7 @@ def test_migrate_to_display_sets(client, settings):
     rs.refresh_from_db()
     assert rs.use_display_sets is False
 
-    rs.view_content = {
-        "main": "generic-medical-image",
-        "main-overlay": "generic-overlay",
-    }
+    rs.view_content = {"main": ["generic-medical-image", "generic-overlay"]}
     images = [ImageFactory() for _ in range(6)]
     rs.images.set(images)
     q = QuestionFactory(reader_study=rs)
@@ -1842,8 +1839,8 @@ def test_migrate_to_display_sets(client, settings):
     rs.add_editor(editor)
     rs.add_reader(reader)
     rs.view_content = {
-        "main": "generic-medical-image",
-        "secondary": "generic-overlay",
+        "main": ["generic-medical-image"],
+        "secondary": ["generic-overlay"],
     }
     images = [ImageFactory() for _ in range(6)]
     rs.images.set(images)


### PR DESCRIPTION
This PR fixes the migration method to handle the view_content field properly. The initial function still used `*-overlay` keys in the view_content field, but those are no longer there. Instead a list of slugs is used for each viewport. Luckily this has no consequences for the migrations that have already been executed, as we did not use the reader study's view_content field there. However, it is was not usable when using the actual field, as the format of the value gets validated there. This PR fixes that.