### PR TITLE
Add display-set filter to answer

### DIFF
--- a/app/grandchallenge/reader_studies/filters.py
+++ b/app/grandchallenge/reader_studies/filters.py
@@ -15,4 +15,8 @@ class AnswerFilter(FilterSet):
 
     class Meta:
         model = Answer
-        fields = ("creator", "question__reader_study")
+        fields = (
+            "creator",
+            "question__reader_study",
+            "display_set",
+        )

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -1134,7 +1134,11 @@ class AnswerViewSet(
     serializer_class = AnswerSerializer
     queryset = (
         Answer.objects.all()
-        .select_related("creator", "question__reader_study")
+        .select_related(
+            "creator",
+            "question__reader_study",
+            "display_set",
+        )
         .prefetch_related("images")
     )
     permission_classes = [DjangoObjectPermissions]

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -1137,7 +1137,6 @@ class AnswerViewSet(
         .select_related(
             "creator",
             "question__reader_study",
-            "display_set",
         )
         .prefetch_related("images")
     )

--- a/scripts/development_fixtures.py
+++ b/scripts/development_fixtures.py
@@ -46,7 +46,12 @@ from grandchallenge.evaluation.models import (
 from grandchallenge.github.models import GitHubUserToken, GitHubWebhookMessage
 from grandchallenge.modalities.models import ImagingModality
 from grandchallenge.pages.models import Page
-from grandchallenge.reader_studies.models import Answer, Question, ReaderStudy
+from grandchallenge.reader_studies.models import (
+    Answer,
+    DisplaySet,
+    Question,
+    ReaderStudy,
+)
 from grandchallenge.task_categories.models import TaskType
 from grandchallenge.verifications.models import Verification
 from grandchallenge.workstations.models import Workstation
@@ -509,6 +514,7 @@ def _create_reader_studies(users):
         workstation=Workstation.objects.last(),
         logo=create_uploaded_image(),
         description="Test reader study",
+        view_content={"main": ["generic-medical-image"]},
     )
     reader_study.editors_group.user_set.add(users["readerstudy"])
     reader_study.readers_group.user_set.add(users["demo"])
@@ -519,10 +525,27 @@ def _create_reader_studies(users):
         answer_type=Question.AnswerType.SINGLE_LINE_TEXT,
     )
 
-    answer = Answer.objects.create(
-        creator=users["readerstudy"], question=question, answer="foo"
+    display_set = DisplaySet.objects.create(reader_study=reader_study)
+    image = Image(
+        name="test_image2.mha",
+        modality=ImagingModality.objects.get(modality="MR"),
+        width=128,
+        height=128,
+        color_space="RGB",
     )
-    answer.images.add(Image.objects.first())
+    image.save()
+    civ = ComponentInterfaceValue.objects.create(
+        interface=ComponentInterface.objects.get(slug="generic-medical-image"),
+        image=image,
+    )
+    display_set.values.set([civ])
+
+    answer = Answer.objects.create(
+        creator=users["readerstudy"],
+        question=question,
+        answer="foo",
+        display_set=display_set,
+    )
     answer.save()
 
 


### PR DESCRIPTION
This PR adds a display-set filter to the (mine) end-point of answers.

This is needed to selectively retrieve answers per-case in CIRRUS. 

In addition, I've added a display_set addition to the development fixture reader-study.
