### PR TITLE
Enable html emails in admin

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -717,6 +717,7 @@ MARKDOWNX_MARKDOWN_EXTENSIONS = [
     "markdown.extensions.tables",
     "markdown.extensions.sane_lists",
     "markdown.extensions.codehilite",
+    "markdown.extensions.attr_list",
     BS4Extension(),
 ]
 MARKDOWNX_MARKDOWNIFY_FUNCTION = (

--- a/app/grandchallenge/emails/admin.py
+++ b/app/grandchallenge/emails/admin.py
@@ -1,7 +1,9 @@
 from django.contrib import admin, messages
 from django.db.transaction import on_commit
+from django.forms import ModelForm
 from markdownx.admin import MarkdownxModelAdmin
 
+from grandchallenge.core.widgets import MarkdownEditorAdminWidget
 from grandchallenge.emails.models import Email
 from grandchallenge.emails.tasks import send_bulk_email
 from grandchallenge.emails.utils import SendActionChoices
@@ -23,9 +25,17 @@ def schedule_emails(modeladmin, queryset, request, action):
         )
 
 
+class EmailAdminForm(ModelForm):
+    class Meta:
+        model = Email
+        widgets = {"body": MarkdownEditorAdminWidget}
+        exclude = ()
+
+
 class EmailAdmin(MarkdownxModelAdmin):
     list_display = ("subject", "sent", "sent_at")
     actions = [*SendActionChoices]
+    form = EmailAdminForm
 
     @admin.action(description="Send to mailing list", permissions=["change"])
     def send_to_mailing_list(self, request, queryset):

--- a/app/grandchallenge/emails/tasks.py
+++ b/app/grandchallenge/emails/tasks.py
@@ -5,7 +5,6 @@ from django.contrib.sites.models import Site
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.mail import EmailMultiAlternatives, get_connection
 from django.core.paginator import Paginator
-from django.template.defaultfilters import safe
 from django.template.loader import render_to_string
 from django.utils.html import strip_tags
 from django.utils.timezone import now
@@ -100,7 +99,7 @@ def send_bulk_email(action, email_pk):
                 "vendor/mailgun_transactional_emails/action.html",
                 {
                     "title": subject,
-                    "content": safe(html_body),
+                    "content": html_body,
                     "link": link,
                 },
             )

--- a/app/grandchallenge/emails/tasks.py
+++ b/app/grandchallenge/emails/tasks.py
@@ -3,10 +3,14 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.mail import send_mass_mail
+from django.core.mail import EmailMultiAlternatives, get_connection
 from django.core.paginator import Paginator
+from django.template.defaultfilters import safe
+from django.template.loader import render_to_string
+from django.utils.html import strip_tags
 from django.utils.timezone import now
 
+from grandchallenge.core.templatetags.bleach import md2html
 from grandchallenge.emails.models import Email
 from grandchallenge.emails.utils import SendActionChoices
 from grandchallenge.subdomains.utils import reverse
@@ -57,6 +61,18 @@ def get_receivers(action):
     return receivers
 
 
+def send_mass_html_email(datatuple):
+    connection = get_connection()
+    messages = []
+    for subject, message, sender, recipient, html in datatuple:
+        email = EmailMultiAlternatives(
+            subject, message, sender, recipient, connection=connection
+        )
+        email.attach_alternative(html, "text/html")
+        messages.append(email)
+    return connection.send_messages(messages)
+
+
 @shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
 def send_bulk_email(action, email_pk):
     try:
@@ -65,6 +81,7 @@ def send_bulk_email(action, email_pk):
         return
     subject = email.subject
     body = email.body
+    html_body = md2html(body)
     receivers = get_receivers(action=action)
     paginator = Paginator(receivers, 100)
     site = Site.objects.get_current()
@@ -76,20 +93,29 @@ def send_bulk_email(action, email_pk):
         messages = []
         for recipient in paginator.page(page_nr).object_list:
             user = get_user_model().objects.get(pk=recipient.pk)
+            link = reverse(
+                "profile-update", kwargs={"username": user.username}
+            )
+            html_content = render_to_string(
+                "vendor/mailgun_transactional_emails/action.html",
+                {
+                    "title": subject,
+                    "content": safe(html_body),
+                    "link": link,
+                },
+            )
+            html_content_without_linebreaks = html_content.replace("\n", "")
+            text_content = strip_tags(html_content_without_linebreaks)
             messages.append(
                 (
                     f"[{site.domain.lower()}] {subject}",
-                    f"Dear {user.username},"
-                    f"\n\n{body}\n\n"
-                    f"Kind regards, \nGrand Challenge team \n\n"
-                    f"To unsubscribe from this mailing list, "
-                    f"uncheck 'Receive newsletter' in your profile settings:"
-                    f" {reverse('profile-update', kwargs={'username': user.username})}",
+                    text_content,
                     settings.DEFAULT_FROM_EMAIL,
                     [user.email],
+                    html_content_without_linebreaks,
                 )
             )
-        send_mass_mail(messages)
+        send_mass_html_email(messages)
         email.status_report = {"last_processed_batch": page_nr}
         email.save()
 

--- a/app/grandchallenge/emails/templates/vendor/mailgun_transactional_emails/LICENSE
+++ b/app/grandchallenge/emails/templates/vendor/mailgun_transactional_emails/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Mailgun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/grandchallenge/emails/templates/vendor/mailgun_transactional_emails/action.html
+++ b/app/grandchallenge/emails/templates/vendor/mailgun_transactional_emails/action.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<head>
+    <meta name="viewport" content="width=device-width"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <title>{{ title }}</title>
+    <style type="text/css">
+        .ReadMsgBody {width: 100%;}  .ExternalClass {width: 100%;}  .eoa_ny1{} img {max-width: 100%;}  body {-webkit-font-smoothing: antialiased;-webkit-text-size-adjust: none;width: 100% !important;height: 100%;line-height: 1.6em;}  body {background-color: #f6f6f6;}  @media only screen and (max-width: 640px) {  body {padding: 0 !important;}  h1 {font-weight: 800 !important;margin: 20px 0 5px !important;}  h2 {font-weight: 800 !important;margin: 20px 0 5px !important;}  h3 {font-weight: 800 !important;margin: 20px 0 5px !important;}  h4 {font-weight: 800 !important;margin: 20px 0 5px !important;}  h1 {font-size: 22px !important;}  h2 {font-size: 18px !important;}  h3 {font-size: 16px !important;}  .container {padding: 0 !important;width: 100% !important;}  .content {padding: 0 !important;}  .content-wrap {padding: 10px !important;}  } span.yshortcuts { color:#000; background-color:none; border:none;}  span.yshortcuts:hover, span.yshortcuts:active, span.yshortcuts:focus {color:#000; background-color:none; border:none;}
+    </style>
+</head>
+
+<body itemscope itemtype="http://schema.org/EmailMessage" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; width: 100% !important; height: 100%; mso-line-height-rule:exactly; line-height: 1.6em; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6">
+<table class="body-wrap" width="100%" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6">
+    <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+        <td style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0;" valign="top"></td>
+        <td class="container" width="600" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; display: block !important; max-width: 600px !important; clear: both !important; margin: 0 auto;" valign="top">
+            <div class="content" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; max-width: 600px; display: block; margin: 0 auto; padding: 20px;">
+                <table class="main" width="100%" cellpadding="0" cellspacing="10" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; border-radius: 3px; background-color: #fff; margin: 0; border: 1px solid #e9e9e9;" bgcolor="#fff">
+                    <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+                        <td class="content-wrap" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 20px;" valign="top">
+                            <table width="100%" cellpadding="0" cellspacing="0" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+                                {{ content }}
+                                <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+                                    <td class="content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                                        &mdash; Your Grand Challenge Team
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+                <div class="footer" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; clear: both; color: #999; margin: 0; padding: 20px;">
+                    <table width="100%" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+                        <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+                            <td class="aligncenter content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; vertical-align: top; color: #999; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top">
+                                To unsubscribe from this newsletter, uncheck <em>Receive Newsletter</em> in
+                                <a href="{{ link }}" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; color: #999; text-decoration: underline; margin: 0;">your profile settings</a>.
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+        </td>
+        <td style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0;" valign="top"></td>
+    </tr>
+</table>
+</body>
+</html>

--- a/app/tests/emails_tests/test_tasks.py
+++ b/app/tests/emails_tests/test_tasks.py
@@ -76,15 +76,13 @@ def test_email_content(settings):
         )
         assert "Test content" in m.body
         if m.to == [u1.email]:
-            assert (
-                reverse("profile-update", kwargs={"username": u1.username})
-                in m.body
-            )
+            assert reverse(
+                "profile-update", kwargs={"username": u1.username}
+            ) in str(m.alternatives)
         else:
-            assert (
-                reverse("profile-update", kwargs={"username": u2.username})
-                in m.body
-            )
+            assert reverse(
+                "profile-update", kwargs={"username": u2.username}
+            ) in str(m.alternatives)
 
     # check that email sending task is idempotent
     mail.outbox.clear()


### PR DESCRIPTION
This adds the action email template from [mailgun ](https://github.com/mailgun/transactional-email-templates)to our email templates and enables mass sending of html emails through the Django admin. 

The email template is relatively simple, just a box of max-width 600px that contains whatever content we want and ends with "Your Grand Challenge Team" as well as the unsubscribe link underneath the box. 

![SimpleTest](https://user-images.githubusercontent.com/30069334/163398487-4dcfa5a4-00e2-492b-8116-7988d2a39ddb.png)

This is what the most recent newsletter would look like: 

![NewsletterTest](https://user-images.githubusercontent.com/30069334/163398560-7990c299-7ff9-4e1e-81a4-2052b01e33d7.png)

I tested how the email displays in different clients with [email on acid](https://www.emailonacid.com/). After some small adjustments to the template, it now looks fine on all tested clients (although image display depends on how you add them in the markdown editor!). 

![image](https://user-images.githubusercontent.com/30069334/163398891-8baa8102-51fe-4f77-a835-28ddb9804bf1.png)

![image](https://user-images.githubusercontent.com/30069334/163398972-dc990b48-472d-4cbc-8239-058f30cbbd09.png)

![image](https://user-images.githubusercontent.com/30069334/163399031-bd44e884-926a-4a23-b14f-16987c9ce636.png)


We could consider adding a banner similar to the one we have on the homepage to the top of the email to make it more recognizable. 


Addresses https://github.com/DIAGNijmegen/rse-roadmap/issues/130
