### PR TITLE
Fix markdowneditor widget for admin

### DIFF
--- a/app/grandchallenge/core/static/css/markdown.css
+++ b/app/grandchallenge/core/static/css/markdown.css
@@ -1,0 +1,31 @@
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: black
+    }
+
+    .module {
+        background-color: black
+    }
+
+    h2 {
+        color:white
+    }
+
+    i {
+        color: white
+    }
+
+    .nav-tabs {
+        border-bottom-color: black
+    }
+
+    .markdownx-preview {
+        overflow: hidden !important;
+        background-color: white;
+        padding: 1.5rem 1.5rem;
+    }
+
+    .help {
+        margin: 0 !important;
+    }
+}

--- a/app/grandchallenge/core/static/css/markdown.css
+++ b/app/grandchallenge/core/static/css/markdown.css
@@ -1,3 +1,6 @@
+/* Bootstrap css conflicts with the markdown editor css in the Django admin in dark mode,
+this adds additional styles to fix that */
+
 @media (prefers-color-scheme: dark) {
     body {
         background-color: black

--- a/app/grandchallenge/core/templates/markdownx/widget-admin.html
+++ b/app/grandchallenge/core/templates/markdownx/widget-admin.html
@@ -1,3 +1,3 @@
-<style> body {background-color:black} .module {background-color:black} i {color:white} .nav-tabs {border-bottom-color: black} .markdownx-preview {overflow:hidden!important;} .markdownx-preview > * {color:white!important;} .help {margin:0!important;} </style>
+<style> @media (prefers-color-scheme: dark) { body {background-color:black} .module {background-color:black} i {color:white} .nav-tabs {border-bottom-color: black} .markdownx-preview {overflow:hidden!important;} .markdownx-preview > * {color:white!important;} .help {margin:0!important;} } </style>
 
 {% include 'markdownx/widget.html' %}

--- a/app/grandchallenge/core/templates/markdownx/widget-admin.html
+++ b/app/grandchallenge/core/templates/markdownx/widget-admin.html
@@ -1,3 +1,0 @@
-<style> @media (prefers-color-scheme: dark) { body {background-color:black} .module {background-color:black} i {color:white} .nav-tabs {border-bottom-color: black} .markdownx-preview {overflow:hidden!important;} .markdownx-preview > * {color:white!important;} .help {margin:0!important;} } </style>
-
-{% include 'markdownx/widget.html' %}

--- a/app/grandchallenge/core/templates/markdownx/widget-admin.html
+++ b/app/grandchallenge/core/templates/markdownx/widget-admin.html
@@ -1,0 +1,3 @@
+<style> body {background-color:black} .module {background-color:black} i {color:white} .nav-tabs {border-bottom-color: black} .markdownx-preview {overflow:hidden!important;} .markdownx-preview > * {color:white!important;} .help {margin:0!important;} </style>
+
+{% include 'markdownx/widget.html' %}

--- a/app/grandchallenge/core/widgets.py
+++ b/app/grandchallenge/core/widgets.py
@@ -37,6 +37,8 @@ class MarkdownEditorWidget(MarkdownxWidget):
 
 
 class MarkdownEditorAdminWidget(AdminMarkdownxWidget):
+    template_name = "markdownx/widget-admin.html"
+
     @property
     def media(self):
         return forms.Media(

--- a/app/grandchallenge/core/widgets.py
+++ b/app/grandchallenge/core/widgets.py
@@ -37,8 +37,6 @@ class MarkdownEditorWidget(MarkdownxWidget):
 
 
 class MarkdownEditorAdminWidget(AdminMarkdownxWidget):
-    template_name = "markdownx/widget-admin.html"
-
     @property
     def media(self):
         return forms.Media(
@@ -47,6 +45,7 @@ class MarkdownEditorAdminWidget(AdminMarkdownxWidget):
                     *AdminMarkdownxWidget.Media.css["all"],
                     "vendor/css/base.min.css",
                     "vendor/fa/css/all.css",
+                    "css/markdown.css",
                 ]
             },
             js=[


### PR DESCRIPTION
The `MarkdownEditorAdminWidget` didn't display nicely in dark mode. The toolbar was almost invisible and in the preview some of the text would show in black rather than white and hence be invisible as well. Also, the main div had a white rather than a black background. 

![image](https://user-images.githubusercontent.com/30069334/163551533-50fbb27c-90b3-4757-8a4d-0e3abdbc97d3.png)

This PR fixes that: 

![image](https://user-images.githubusercontent.com/30069334/163551642-4a845377-8100-45dc-8ae8-778241c8f2ce.png)


![image](https://user-images.githubusercontent.com/30069334/163569596-85a333f1-4932-4729-8df8-8607f01586f3.png)