### PR TITLE
Email create, update and detail views

### DIFF
--- a/app/config/urls/root.py
+++ b/app/config/urls/root.py
@@ -156,6 +156,7 @@ urlpatterns = [
             namespace="hanging-protocols",
         ),
     ),
+    path("emails/", include("grandchallenge.emails.urls", namespace="emails")),
 ]
 
 if settings.DEBUG and settings.ENABLE_DEBUG_TOOLBAR:

--- a/app/grandchallenge/core/templates/grandchallenge/partials/userlinks.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/userlinks.html
@@ -78,6 +78,12 @@
             <a class="dropdown-item"
                href="{% url 'cases:raw-image-upload-session-list' %}">
                 Your Uploads</a>
+            {% if 'emails.view_email' in perms %}
+                <div class="dropdown-divider"></div>
+                <a class="dropdown-item"
+                   href="{% url 'emails:list' %}">
+                    Emails</a>
+            {% endif %}
             <div class="dropdown-divider"></div>
             <a class="dropdown-item"
                href="{% url 'account_logout' %}?next=/">

--- a/app/grandchallenge/emails/forms.py
+++ b/app/grandchallenge/emails/forms.py
@@ -1,0 +1,15 @@
+from django import forms
+
+from grandchallenge.core.forms import SaveFormInitMixin
+from grandchallenge.core.widgets import MarkdownEditorWidget
+from grandchallenge.emails.models import Email
+
+
+class EmailForm(SaveFormInitMixin, forms.ModelForm):
+    class Meta:
+        model = Email
+        fields = (
+            "subject",
+            "body",
+        )
+        widgets = {"body": MarkdownEditorWidget}

--- a/app/grandchallenge/emails/models.py
+++ b/app/grandchallenge/emails/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.urls import reverse
 
 
 class Email(models.Model):
@@ -18,3 +19,6 @@ class Email(models.Model):
 
     def __str__(self):
         return self.subject
+
+    def get_absolute_url(self):
+        return reverse("emails:detail", kwargs={"pk": self.pk})

--- a/app/grandchallenge/emails/tasks.py
+++ b/app/grandchallenge/emails/tasks.py
@@ -99,6 +99,7 @@ def send_bulk_email(action, email_pk):
                 "vendor/mailgun_transactional_emails/action.html",
                 {
                     "title": subject,
+                    "username": user.username,
                     "content": html_body,
                     "link": link,
                 },

--- a/app/grandchallenge/emails/templates/emails/email_detail.html
+++ b/app/grandchallenge/emails/templates/emails/email_detail.html
@@ -27,19 +27,17 @@
             </div>
         </div>
         <div class="col-4">
-            {% if not object.sent and "change_email" in perms %}
+            {% if not object.sent and "emails.change_email" in perms %}
                 <div class="alert alert-warning ml-3" role="alert">
                         This email has not been sent yet.
                         You can come back and edit it. When it's ready to be sent,
                         please contact support@grand-challenge.org to send it for you.
                 </div>
                 <div class="text-right">
-                    {% if "change_email" in perms and not object.sent %}
-                        <a href="{% url "emails:update" pk=object.pk %}"
-                           class="btn btn-primary">
-                            <i class="fa fa-edit"></i> Edit email
-                        </a>
-                    {% endif %}
+                    <a href="{% url "emails:update" pk=object.pk %}"
+                       class="btn btn-primary">
+                        <i class="fa fa-edit"></i> Edit email
+                    </a>
                 </div>
             {% endif %}
         </div>

--- a/app/grandchallenge/emails/templates/emails/email_detail.html
+++ b/app/grandchallenge/emails/templates/emails/email_detail.html
@@ -22,6 +22,7 @@
     </div>
     <div class="row">
         <div class="col-8">
+            {# The html email body is set to max-width:600px #}
             <div style="max-width:600px;">
                 <p>Dear user, </p>
                 {{ object.body|md2html }}

--- a/app/grandchallenge/emails/templates/emails/email_detail.html
+++ b/app/grandchallenge/emails/templates/emails/email_detail.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% load url %}
+{% load profiles %}
+{% load bleach %}
+{% load guardian_tags %}
+
+{% block title %}{{ object.subject }} - Emails - {{ block.super }}{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item active">Emails</li>
+        <li class="breadcrumb-item active">{{ object.subject }}</li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <div class="row mb-3">
+        <h2 class="ml-3">{{ object.subject }}</h2>
+        {% if object.sent %}
+            <p>Sent on {{ object.sent_at|date:"j N Y" }}</p>
+        {% endif %}
+    </div>
+    <div class="row">
+        <div class="col-8">
+            <div style="max-width:600px;">
+                <p>Dear user, </p>
+                {{ object.body|md2html }}
+                <p>&mdash; Your Grand Challenge Team</p>
+            </div>
+        </div>
+        <div class="col-4">
+            {% if not object.sent and "change_email" in perms %}
+                <div class="alert alert-warning ml-3" role="alert">
+                        This email has not been sent yet.
+                        Please bookmark this URL in case you want to come back to edit it.
+                </div>
+                <div class="text-right">
+                    {% if "change_email" in perms and not object.sent %}
+                        <a href="{% url "emails:update" pk=object.pk %}"
+                           class="btn btn-primary">
+                            <i class="fa fa-edit"></i> Edit email
+                        </a>
+                    {% endif %}
+                </div>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}

--- a/app/grandchallenge/emails/templates/emails/email_detail.html
+++ b/app/grandchallenge/emails/templates/emails/email_detail.html
@@ -1,14 +1,12 @@
 {% extends "base.html" %}
 {% load url %}
-{% load profiles %}
 {% load bleach %}
-{% load guardian_tags %}
 
 {% block title %}{{ object.subject }} - Emails - {{ block.super }}{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li class="breadcrumb-item active">Emails</li>
+        <li class="breadcrumb-item text-light">Emails</li>
         <li class="breadcrumb-item active">{{ object.subject }}</li>
     </ol>
 {% endblock %}

--- a/app/grandchallenge/emails/templates/emails/email_detail.html
+++ b/app/grandchallenge/emails/templates/emails/email_detail.html
@@ -6,22 +6,21 @@
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li class="breadcrumb-item text-light">Emails</li>
+        <li class="breadcrumb-item"><a href="{% url 'emails:list' %}">Emails</a></li>
         <li class="breadcrumb-item active">{{ object.subject }}</li>
     </ol>
 {% endblock %}
 
 {% block content %}
-    <div class="row mb-3">
-        <h2 class="ml-3">{{ object.subject }}</h2>
-        {% if object.sent %}
-            <p>Sent on {{ object.sent_at|date:"j N Y" }}</p>
-        {% endif %}
-    </div>
-    <div class="row">
-        <div class="col-8">
-            {# The html email body is set to max-width:600px #}
-            <div style="max-width:600px;">
+    <h2>{{ object.subject }}</h2>
+    {% if object.sent %}
+        <p>Sent on {{ object.sent_at|date:"j N Y" }}</p>
+    {% endif %}
+    <hr>
+    <div class="row ml-1">
+        <div class="d-flex col-8 bg-light rounded p-4 justify-content-center">
+            {# The html email body is set to width:600px #}
+            <div class="bg-white rounded p-2" style="width:600px;">
                 <p>Dear user, </p>
                 {{ object.body|md2html }}
                 <p>&mdash; Your Grand Challenge Team</p>
@@ -31,7 +30,8 @@
             {% if not object.sent and "change_email" in perms %}
                 <div class="alert alert-warning ml-3" role="alert">
                         This email has not been sent yet.
-                        Please bookmark this URL in case you want to come back to edit it.
+                        You can come back and edit it. When it's ready to be sent,
+                        please contact support@grand-challenge.org to send it for you.
                 </div>
                 <div class="text-right">
                     {% if "change_email" in perms and not object.sent %}

--- a/app/grandchallenge/emails/templates/emails/email_form.html
+++ b/app/grandchallenge/emails/templates/emails/email_form.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags %}
+{% load url %}
+
+{% block title %}{% if object %}Update{% else %}Create{% endif %} Email - {{ block.super }}{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item">Emails</li>
+        {% if object %}
+            <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{{ object }}</a></li>
+        {% endif %}
+        <li class="breadcrumb-item active">{% if object %}Update{% else %}Create{% endif %}</li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <h2>{% if object %}Update{% else %}Create{% endif %} Email</h2>
+    {% crispy form %}
+{% endblock %}

--- a/app/grandchallenge/emails/templates/emails/email_form.html
+++ b/app/grandchallenge/emails/templates/emails/email_form.html
@@ -1,12 +1,11 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags %}
-{% load url %}
 
 {% block title %}{% if object %}Update{% else %}Create{% endif %} Email - {{ block.super }}{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li class="breadcrumb-item">Emails</li>
+        <li class="breadcrumb-item text-light">Emails</li>
         {% if object %}
             <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{{ object }}</a></li>
         {% endif %}

--- a/app/grandchallenge/emails/templates/emails/email_form.html
+++ b/app/grandchallenge/emails/templates/emails/email_form.html
@@ -5,7 +5,7 @@
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li class="breadcrumb-item text-light">Emails</li>
+        <li class="breadcrumb-item"><a href="{% url 'emails:list' %}">Emails</a></li>
         {% if object %}
             <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{{ object }}</a></li>
         {% endif %}

--- a/app/grandchallenge/emails/templates/emails/email_list.html
+++ b/app/grandchallenge/emails/templates/emails/email_list.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% load url %}
+
+{% block title %}Emails - {{ block.super }}{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item active">Emails</li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <div class="row mb-3">
+        <h2 class="col-10">Emails</h2>
+        <div class="col-2 text-right"><a class="btn btn-primary" href="{% url 'emails:create' %}"><i class="fas fa-plus"></i> &nbsp; Write new email</a></div>
+    </div>
+    <div class="table-responsive">
+        <table class="table table-hover table-borderless table-sm">
+            <thead class="thead-light">
+            <tr>
+                <th></th>
+                <th class="text-center">Subject</th>
+                <th class="text-center">Status</th>
+            </tr>
+            </thead>
+            <tbody>
+                {% for object in object_list %}
+                    <tr>
+                        <td class="text-center">
+                            <a class="btn btn-dark btn-sm" href="{% url 'emails:detail' pk=object.pk %}"><i class="fa fa-search"></i> View</a>
+                        </td>
+                        <td class="text-center align-middle">{{ object.subject }}</td>
+                        <td class="text-center align-middle">
+                            {% if object.sent %}
+                                <span class="badge badge-success p-2">Sent on {{ object.sent_at|date:"j N Y" }}</span>
+                            {% else %}
+                                <a class="btn btn-primary btn-sm" href="{% url 'emails:update' pk=object.pk %}">Edit</a>
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endblock %}

--- a/app/grandchallenge/emails/templates/vendor/mailgun_transactional_emails/action.html
+++ b/app/grandchallenge/emails/templates/vendor/mailgun_transactional_emails/action.html
@@ -19,6 +19,7 @@
                     <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                         <td class="content-wrap" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 20px;" valign="top">
                             <table width="100%" cellpadding="0" cellspacing="0" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+                                <p>Dear {{ username }}, </p>
                                 {{ content }}
                                 <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                                     <td class="content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">

--- a/app/grandchallenge/emails/urls.py
+++ b/app/grandchallenge/emails/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from grandchallenge.emails.views import EmailCreate, EmailDetail, EmailUpdate
+
+app_name = "emails"
+
+urlpatterns = [
+    path("create/", EmailCreate.as_view(), name="create"),
+    path("<int:pk>/", EmailDetail.as_view(), name="detail"),
+    path("<int:pk>/update/", EmailUpdate.as_view(), name="update"),
+]

--- a/app/grandchallenge/emails/urls.py
+++ b/app/grandchallenge/emails/urls.py
@@ -1,10 +1,16 @@
 from django.urls import path
 
-from grandchallenge.emails.views import EmailCreate, EmailDetail, EmailUpdate
+from grandchallenge.emails.views import (
+    EmailCreate,
+    EmailDetail,
+    EmailList,
+    EmailUpdate,
+)
 
 app_name = "emails"
 
 urlpatterns = [
+    path("", EmailList.as_view(), name="list"),
     path("create/", EmailCreate.as_view(), name="create"),
     path("<int:pk>/", EmailDetail.as_view(), name="detail"),
     path("<int:pk>/update/", EmailUpdate.as_view(), name="update"),

--- a/app/grandchallenge/emails/views.py
+++ b/app/grandchallenge/emails/views.py
@@ -1,5 +1,6 @@
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.views.generic import CreateView, DetailView, UpdateView
-from guardian.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from guardian.mixins import LoginRequiredMixin
 
 from grandchallenge.emails.forms import EmailForm
 from grandchallenge.emails.models import Email

--- a/app/grandchallenge/emails/views.py
+++ b/app/grandchallenge/emails/views.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.mixins import PermissionRequiredMixin
-from django.views.generic import CreateView, DetailView, UpdateView
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
 from guardian.mixins import LoginRequiredMixin
 
 from grandchallenge.emails.forms import EmailForm
@@ -32,3 +32,10 @@ class EmailDetail(LoginRequiredMixin, PermissionRequiredMixin, DetailView):
     model = Email
     permission_required = "emails.view_email"
     raise_exception = True
+
+
+class EmailList(LoginRequiredMixin, PermissionRequiredMixin, ListView):
+    model = Email
+    permission_required = "emails.view_email"
+    raise_exception = True
+    paginate_by = 50

--- a/app/grandchallenge/emails/views.py
+++ b/app/grandchallenge/emails/views.py
@@ -28,5 +28,7 @@ class EmailUpdate(
     raise_exception = True
 
 
-class EmailDetail(DetailView):
+class EmailDetail(LoginRequiredMixin, PermissionRequiredMixin, DetailView):
     model = Email
+    permission_required = "emails.view_email"
+    raise_exception = True

--- a/app/grandchallenge/emails/views.py
+++ b/app/grandchallenge/emails/views.py
@@ -1,0 +1,31 @@
+from django.views.generic import CreateView, DetailView, UpdateView
+from guardian.mixins import LoginRequiredMixin, PermissionRequiredMixin
+
+from grandchallenge.emails.forms import EmailForm
+from grandchallenge.emails.models import Email
+
+
+class EmailCreate(
+    LoginRequiredMixin,
+    PermissionRequiredMixin,
+    CreateView,
+):
+    model = Email
+    form_class = EmailForm
+    permission_required = "emails.add_email"
+    raise_exception = True
+
+
+class EmailUpdate(
+    LoginRequiredMixin,
+    PermissionRequiredMixin,
+    UpdateView,
+):
+    model = Email
+    form_class = EmailForm
+    permission_required = "emails.change_email"
+    raise_exception = True
+
+
+class EmailDetail(DetailView):
+    model = Email

--- a/app/grandchallenge/emails/views.py
+++ b/app/grandchallenge/emails/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.core.exceptions import PermissionDenied
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
 from guardian.mixins import LoginRequiredMixin
 
@@ -26,6 +27,12 @@ class EmailUpdate(
     form_class = EmailForm
     permission_required = "emails.change_email"
     raise_exception = True
+
+    def has_permission(self):
+        if self.get_object().sent:
+            raise PermissionDenied
+        else:
+            return super().has_permission()
 
 
 class EmailDetail(LoginRequiredMixin, PermissionRequiredMixin, DetailView):

--- a/app/tests/emails_tests/test_views.py
+++ b/app/tests/emails_tests/test_views.py
@@ -63,3 +63,26 @@ def test_email_update(client):
     email.refresh_from_db()
     assert email.subject == "Updated subject"
     assert email.body == "Updated content"
+
+
+@pytest.mark.django_db
+def test_email_detail_permission(client):
+    user = UserFactory()
+    email = EmailFactory(subject="Test email", body="Test content")
+    response = get_view_for_user(
+        viewname="emails:detail",
+        client=client,
+        reverse_kwargs={"pk": email.pk},
+        user=user,
+    )
+    assert response.status_code == 403
+
+    # only users with permission can create emails
+    assign_perm("emails.view_email", user)
+    response = get_view_for_user(
+        viewname="emails:detail",
+        client=client,
+        reverse_kwargs={"pk": email.pk},
+        user=user,
+    )
+    assert response.status_code == 200

--- a/app/tests/emails_tests/test_views.py
+++ b/app/tests/emails_tests/test_views.py
@@ -64,6 +64,22 @@ def test_email_update(client):
     assert email.subject == "Updated subject"
     assert email.body == "Updated content"
 
+    # but not when the email has been sent
+    email.sent = True
+    email.save()
+    response = get_view_for_user(
+        viewname="emails:update",
+        client=client,
+        method=client.post,
+        data={"subject": "Updated again", "body": "New content"},
+        reverse_kwargs={"pk": email.pk},
+        user=user,
+    )
+    assert response.status_code == 403
+    email.refresh_from_db()
+    assert email.subject != "Updated again"
+    assert email.body != "New content"
+
 
 @pytest.mark.django_db
 def test_email_detail_permission(client):

--- a/app/tests/emails_tests/test_views.py
+++ b/app/tests/emails_tests/test_views.py
@@ -1,0 +1,65 @@
+import pytest
+from guardian.shortcuts import assign_perm
+
+from grandchallenge.emails.models import Email
+from tests.emails_tests.factories import EmailFactory
+from tests.factories import UserFactory
+from tests.utils import get_view_for_user
+
+
+@pytest.mark.django_db
+def test_email_create(client):
+    user = UserFactory()
+    response = get_view_for_user(
+        viewname="emails:create",
+        client=client,
+        method=client.post,
+        data={"subject": "Test email", "body": "Some dummy content"},
+        user=user,
+    )
+    assert response.status_code == 403
+    assert Email.objects.count() == 0
+
+    # only users with permission can create emails
+    assign_perm("emails.add_email", user)
+    response = get_view_for_user(
+        viewname="emails:create",
+        client=client,
+        method=client.post,
+        data={"subject": "Test email", "body": "Some dummy content"},
+        user=user,
+    )
+    assert response.status_code == 302
+    assert Email.objects.count() == 1
+    assert Email.objects.get().subject == "Test email"
+    assert Email.objects.get().body == "Some dummy content"
+
+
+@pytest.mark.django_db
+def test_email_update(client):
+    user = UserFactory()
+    email = EmailFactory(subject="Test email", body="Test content")
+    response = get_view_for_user(
+        viewname="emails:update",
+        client=client,
+        method=client.post,
+        data={"subject": "Updated subject", "body": "Updated content"},
+        reverse_kwargs={"pk": email.pk},
+        user=user,
+    )
+    assert response.status_code == 403
+
+    # only users with permission can create emails
+    assign_perm("emails.change_email", user)
+    response = get_view_for_user(
+        viewname="emails:update",
+        client=client,
+        method=client.post,
+        data={"subject": "Updated subject", "body": "Updated content"},
+        reverse_kwargs={"pk": email.pk},
+        user=user,
+    )
+    assert response.status_code == 302
+    email.refresh_from_db()
+    assert email.subject == "Updated subject"
+    assert email.body == "Updated content"

--- a/app/tests/emails_tests/test_views.py
+++ b/app/tests/emails_tests/test_views.py
@@ -86,3 +86,26 @@ def test_email_detail_permission(client):
         user=user,
     )
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_email_list_permission(client):
+    user = UserFactory()
+    email1, email2 = EmailFactory.create_batch(2)
+    response = get_view_for_user(
+        viewname="emails:list",
+        client=client,
+        user=user,
+    )
+    assert response.status_code == 403
+
+    # only users with permission can create emails
+    assign_perm("emails.view_email", user)
+    response = get_view_for_user(
+        viewname="emails:list",
+        client=client,
+        user=user,
+    )
+    assert response.status_code == 200
+    assert email1.subject in response.rendered_content
+    assert email2.subject in response.rendered_content


### PR DESCRIPTION
This adds create, update and detail views for emails (restricted through global permissions). 

I also noticed that I had gotten rid of the "Dear user" preprending to the email body, so added that back to template. 

Addresses: https://github.com/DIAGNijmegen/rse-roadmap/issues/130