### PR TITLE
Prevent error in values_for_interfaces

### DIFF
--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1023,7 +1023,9 @@ class ReaderStudy(UUIDModel, TitleSlugDescriptionModel, ViewContentMixin):
                 "selected": "",
                 "selected_image": "",
             }
-            for interface in sorted(interfaces.keys())
+            for interface in sorted(
+                x for x in interfaces.keys() if x is not None
+            )
         }
 
         cache.set(cache_key, values_for_interfaces, timeout=None)


### PR DESCRIPTION
Somehow the `interfaces` dict sometimes has `None` keys, which breaks sorting (see https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/12). I haven't been able to reproduce this behavior, but this PR will at least prevent the display set list view from erroring out if it happens.