### PR TITLE
Fix leaderboard sorting by date

### DIFF
--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -447,7 +447,9 @@ class LeaderboardDetail(
                 )
             )
 
-        columns.append(Column(title="Created", sort_field="created"))
+        columns.append(
+            Column(title="Created", sort_field="submission__created")
+        )
 
         if self.phase.scoring_method_choice == self.phase.MEAN:
             columns.append(Column(title="Mean Position", sort_field="rank"))


### PR DESCRIPTION
Sorting by creation date used to rely on the evaluation's creation date, not the displayed submission's creation date.