### PR TITLE
Add check for protected items before reader study deletion

### DIFF
--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_confirm_delete.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_confirm_delete.html
@@ -1,21 +1,47 @@
 {% extends "base.html" %}
 
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% url 'reader-studies:list' %}">Reader
+            Studies</a></li>
+        <li class="breadcrumb-item"><a
+                href="{{ object.get_absolute_url }}">{{ object }}</a></li>
+        <li class="breadcrumb-item active"
+            aria-current="page">Delete
+        </li>
+    </ol>
+{% endblock %}
+
 {% block content %}
 
-    <h2>Confirm Deletion</h2>
+    {% if nested_objects.protected %}
+        <h2>Cannot Delete Reader Study</h2>
 
-    <form action="" method="post">
-        {% csrf_token %}
-        <p>Are you sure that you want to delete the reader study "{{ object }}"? <br>
-            <b class="text-danger">WARNING:
-                You are not able to undo this action, once the reader study is deleted
-                it is deleted forever.</b></p>
-        <a href="{{ object.get_absolute_url }}"
-           type="button"
-           class="btn btn-secondary">Cancel</a>
-        <input type="submit"
-               value="I understand, delete the reader study called '{{ object }}'"
-               class="btn btn-danger"/>
-    </form>
+        <p>This reader study cannot be deleted. Please delete the following items first:</p>
+
+        <ul>
+            {% for item in nested_objects.protected %}
+                <li>{{ item }}</li>
+            {% endfor %}
+        </ul>
+
+    {% else %}
+
+        <h2>Confirm Deletion</h2>
+        <form action="" method="post">
+            {% csrf_token %}
+            <p>Are you sure that you want to delete the reader study "{{ object }}"? <br>
+                <b class="text-danger">WARNING:
+                    You are not able to undo this action, once the reader study is deleted
+                    it is deleted forever.</b></p>
+            <a href="{{ object.get_absolute_url }}"
+               type="button"
+               class="btn btn-secondary">Cancel</a>
+            <input type="submit"
+                   value="I understand, delete the reader study called '{{ object }}'"
+                   class="btn btn-danger"/>
+        </form>
+
+    {% endif %}
 
 {% endblock %}

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -1,6 +1,7 @@
 import csv
 
 from django.contrib import messages
+from django.contrib.admin.utils import NestedObjects
 from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
@@ -306,6 +307,15 @@ class ReaderStudyDelete(
     def delete(self, request, *args, **kwargs):
         messages.success(self.request, self.success_message)
         return super().delete(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        nested_objects = NestedObjects(using="default")
+        nested_objects.collect([self.object])
+        context.update({"nested_objects": nested_objects})
+
+        return context
 
 
 class ReaderStudyLeaderBoard(


### PR DESCRIPTION
Removes a 5xx error when a user tries to delete an object with protected dependents.