### PR TITLE
Check for expired github token

### DIFF
--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -916,6 +916,10 @@ class AlgorithmAddRepo(
             kwargs.update({"repos": []})
             return kwargs
 
+        if user_token.refresh_token_is_expired:
+            kwargs.update({"repos": []})
+            return kwargs
+
         if user_token.access_token_is_expired:
             user_token.refresh_access_token()
             user_token.save()

--- a/app/grandchallenge/github/models.py
+++ b/app/grandchallenge/github/models.py
@@ -42,6 +42,10 @@ class GitHubUserToken(models.Model):
     def access_token_is_expired(self):
         return self.access_token_expires < timezone.now()
 
+    @property
+    def refresh_token_is_expired(self):
+        return self.access_token_expires < timezone.now()
+
     def refresh_access_token(self):
         resp = requests.post(
             "https://github.com/login/oauth/access_token",


### PR DESCRIPTION
Closes https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/16

The idea here is that if the refresh token is expired, the user has to go through the same process as when they do not have a token to begin with.