### PR TITLE
Show first public phase to not logged in users

### DIFF
--- a/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
@@ -76,6 +76,12 @@
                         {% elif not challenge.hidden and challenge.visible_phases.first %}
                             <li class="nav-item">
                                 <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' or request.resolver_match.view_name == 'evaluation:list' or request.resolver_match.view_name == 'evaluation:detail' or request.resolver_match.view_name == 'evaluation:update' %}active{% endif %}"
+                                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.visible_phases.first.slug %}">
+                                    <i class="fas fa-trophy fa-fw"></i>&nbsp;&nbsp;Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
+                            </li>
+                        {% elif not challenge.hidden and not challenge.visible_phases.first %}
+                            <li class="nav-item">
+                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' or request.resolver_match.view_name == 'evaluation:list' or request.resolver_match.view_name == 'evaluation:detail' or request.resolver_match.view_name == 'evaluation:update' %}active{% endif %}"
                                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
                                     <i class="fas fa-trophy fa-fw"></i>&nbsp;&nbsp;Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
                             </li>

--- a/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
@@ -79,12 +79,6 @@
                                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.visible_phases.first.slug %}">
                                     <i class="fas fa-trophy fa-fw"></i>&nbsp;&nbsp;Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
                             </li>
-                        {% elif not challenge.hidden and not challenge.visible_phases.first %}
-                            <li class="nav-item">
-                                <a class="nav-link {% if request.resolver_match.view_name == 'evaluation:leaderboard' or request.resolver_match.view_name == 'evaluation:list' or request.resolver_match.view_name == 'evaluation:detail' or request.resolver_match.view_name == 'evaluation:update' %}active{% endif %}"
-                                   href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
-                                    <i class="fas fa-trophy fa-fw"></i>&nbsp;&nbsp;Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
-                            </li>
                         {% endif %}
                     {% endif %}
                     {% if "change_challenge" in challenge_perms %}


### PR DESCRIPTION
There was a bug that would show the first of all phases to not logged in users instead of the first public phase (when there are public phases). When there are no public phases, the leaderboard (and submit) tab is not shown at all. 