### PR TITLE
Separate interface lists for reader studies and archives

### DIFF
--- a/app/grandchallenge/algorithms/templates/components/componentinterface_list.html
+++ b/app/grandchallenge/algorithms/templates/components/componentinterface_list.html
@@ -26,7 +26,7 @@
         You can select multiple options for your algorithms {{ list_type|lower }}.
         However, the same option cannot be used for both input to and output from your algorithm.
         If an option does not exist for your use case please contact support with the title, description, and kind
-        for your new interface option.
+        for your new interface.
     </p>
 
     <div class="table-responsive">

--- a/app/grandchallenge/archives/forms.py
+++ b/app/grandchallenge/archives/forms.py
@@ -193,9 +193,9 @@ class AddCasesForm(UploadRawImagesForm):
             (
                 'See the <a href="{}">list of interfaces</a> for more '
                 "information about each interface. "
-                "Please contact support if your desired output is missing."
+                "Please contact support if your desired interface is missing."
             ),
-            reverse_lazy("algorithms:component-interface-list"),
+            reverse_lazy("archives:component-interface-list"),
         ),
     )
 

--- a/app/grandchallenge/archives/templates/archives/componentinterface_list.html
+++ b/app/grandchallenge/archives/templates/archives/componentinterface_list.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+{% load url %}
+
+{% block title %}
+    Interface Options - {{ block.super }}
+{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% url 'archives:list' %}">Archives</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Interface Options</li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <h2>Archive Interface Options</h2>
+
+    <p>
+        Here is a list of the existing options that you can use for archive items.
+        You can select multiple interfaces for your archive item but each interface can only be used once per archive item.
+        If an option does not exist for your use case please contact support with the title, description, and kind
+        for your new interface.
+    </p>
+
+    <div class="table-responsive">
+        <table class="table table-hover table-borderless table-sm" id="interfacesTable">
+            <thead class="thead-light">
+            <tr>
+                <th>Title</th>
+                <th>Description</th>
+                <th>Kind</th>
+                <th>Slug</th>
+            </tr>
+            </thead>
+            <tbody>
+
+            {% for interface in object_list %}
+                <tr>
+                    <td>{{ interface.title }}</td>
+                    <td>{{ interface.description }}</td>
+                    <td>{{ interface.get_kind_display }}</td>
+                    <td><code>{{ interface.slug }}</code></td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    <script type="text/javascript">
+        $(document).ready(function () {
+            $('#interfacesTable').DataTable({
+                "pageLength": 100,
+            });
+        });
+    </script>
+{% endblock %}

--- a/app/grandchallenge/archives/urls.py
+++ b/app/grandchallenge/archives/urls.py
@@ -16,6 +16,7 @@ from grandchallenge.archives.views import (
     ArchiveUploadersUpdate,
     ArchiveUploadSessionCreate,
     ArchiveUsersUpdate,
+    ComponentInterfaceList,
 )
 
 app_name = "archives"
@@ -23,6 +24,11 @@ app_name = "archives"
 urlpatterns = [
     path("", ArchiveList.as_view(), name="list"),
     path("create/", ArchiveCreate.as_view(), name="create"),
+    path(
+        "interfaces/",
+        ComponentInterfaceList.as_view(),
+        name="component-interface-list",
+    ),
     path("<slug>/", ArchiveDetail.as_view(), name="detail"),
     path("<slug>/update/", ArchiveUpdate.as_view(), name="update"),
     path(

--- a/app/grandchallenge/archives/views.py
+++ b/app/grandchallenge/archives/views.py
@@ -718,3 +718,8 @@ class ArchiveItemViewSet(UpdateModelMixin, ReadOnlyModelViewSet):
             return ArchiveItemPostSerializer
         else:
             return ArchiveItemSerializer
+
+
+class ComponentInterfaceList(LoginRequiredMixin, ListView):
+    model = ComponentInterface
+    template_name = "archives/componentinterface_list.html"

--- a/app/grandchallenge/reader_studies/forms.py
+++ b/app/grandchallenge/reader_studies/forms.py
@@ -27,6 +27,8 @@ from django.forms.models import inlineformset_factory
 from django.utils.text import format_lazy
 from django_select2.forms import Select2MultipleWidget
 
+from grandchallenge.cases.forms import UploadRawImagesForm
+from grandchallenge.components.models import ComponentInterface, InterfaceKind
 from grandchallenge.core.forms import (
     PermissionRequestUpdateForm,
     SaveFormInitMixin,
@@ -434,3 +436,25 @@ class GroundTruthForm(SaveFormInitMixin, Form):
         values = [x for x in rdr]
 
         return values
+
+
+class AddCasesForm(UploadRawImagesForm):
+    interface = ModelChoiceField(
+        queryset=ComponentInterface.objects.filter(
+            kind__in=InterfaceKind.interface_type_image()
+        ),
+        help_text=format_lazy(
+            (
+                'See the <a href="{}">list of interfaces</a> for more '
+                "information about each interface. "
+                "Please contact support if your desired interface is missing."
+            ),
+            reverse_lazy("reader-studies:component-interface-list"),
+        ),
+    )
+
+    def save(self, *args, **kwargs):
+        self._linked_task.kwargs.update(
+            {"interface_pk": self.cleaned_data["interface"].pk}
+        )
+        return super().save(*args, **kwargs)

--- a/app/grandchallenge/reader_studies/templates/reader_studies/componentinterface_list.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/componentinterface_list.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+{% load url %}
+
+{% block title %}
+    Interface Options - {{ block.super }}
+{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% url 'reader-studies:list' %}">Reader Studies</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Interface Options</li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <h2>Reader Study Interface Options</h2>
+
+    <p>
+        Here is a list of the existing options that you can use for display items.
+        You can select multiple interfaces for your display set but each interface can only be used once per display set.
+        If an option does not exist for your use case please contact support with the title, description, and kind
+        for your new interface.
+    </p>
+
+    <div class="table-responsive">
+        <table class="table table-hover table-borderless table-sm" id="interfacesTable">
+            <thead class="thead-light">
+            <tr>
+                <th>Title</th>
+                <th>Description</th>
+                <th>Kind</th>
+                <th>Slug</th>
+            </tr>
+            </thead>
+            <tbody>
+
+            {% for interface in object_list %}
+                <tr>
+                    <td>{{ interface.title }}</td>
+                    <td>{{ interface.description }}</td>
+                    <td>{{ interface.get_kind_display }}</td>
+                    <td><code>{{ interface.slug }}</code></td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    <script type="text/javascript">
+        $(document).ready(function () {
+            $('#interfacesTable').DataTable({
+                "pageLength": 100,
+            });
+        });
+    </script>
+{% endblock %}

--- a/app/grandchallenge/reader_studies/urls.py
+++ b/app/grandchallenge/reader_studies/urls.py
@@ -6,6 +6,7 @@ from grandchallenge.reader_studies.views import (
     AddImagesToReaderStudy,
     AddQuestionToReaderStudy,
     AnswersRemove,
+    ComponentInterfaceList,
     EditorsUpdate,
     QuestionDelete,
     QuestionUpdate,
@@ -32,6 +33,11 @@ app_name = "reader-studies"
 urlpatterns = [
     path("", ReaderStudyList.as_view(), name="list"),
     path("create/", ReaderStudyCreate.as_view(), name="create"),
+    path(
+        "interfaces/",
+        ComponentInterfaceList.as_view(),
+        name="component-interface-list",
+    ),
     path("<slug>/", ReaderStudyDetail.as_view(), name="detail"),
     path("<slug>/update/", ReaderStudyUpdate.as_view(), name="update"),
     path("<slug>/delete/", ReaderStudyDelete.as_view(), name="delete"),

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -49,10 +49,12 @@ from rest_framework.settings import api_settings
 from rest_framework.viewsets import GenericViewSet, ReadOnlyModelViewSet
 from rest_framework_guardian.filters import ObjectPermissionsFilter
 
-from grandchallenge.archives.forms import AddCasesForm
 from grandchallenge.cases.forms import UploadRawImagesForm
 from grandchallenge.cases.models import Image, RawImageUploadSession
-from grandchallenge.components.models import ComponentInterfaceValue
+from grandchallenge.components.models import (
+    ComponentInterface,
+    ComponentInterfaceValue,
+)
 from grandchallenge.components.serializers import (
     ComponentInterfaceValuePostSerializer,
 )
@@ -71,6 +73,7 @@ from grandchallenge.reader_studies.filters import (
     ReaderStudyFilter,
 )
 from grandchallenge.reader_studies.forms import (
+    AddCasesForm,
     AnswersRemoveForm,
     CategoricalOptionFormSet,
     GroundTruthForm,
@@ -1205,3 +1208,8 @@ class QuestionDelete(
         return HttpResponseForbidden(
             reason="This question already has answers associated with it"
         )
+
+
+class ComponentInterfaceList(LoginRequiredMixin, ListView):
+    model = ComponentInterface
+    template_name = "reader_studies/componentinterface_list.html"


### PR DESCRIPTION
Well, I thought that would be a quick and simple fix, but was a bit more complicated than I thought. I opted for creating new pages for the different contexts, that required a copy of the AddCasesForm for reader studies to be able to reference the correct url. Alternative was to cram everything into the single componentsinterface_list.html, which became quite messy. 