### PR TITLE
Show main image name on ds list view

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1285,7 +1285,7 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = int(
 RETINA_GRADERS_GROUP_NAME = "retina_graders"
 RETINA_ADMINS_GROUP_NAME = "retina_admins"
 
-ENABLE_DEBUG_TOOLBAR = True
+ENABLE_DEBUG_TOOLBAR = False
 
 if DEBUG:
     # Allow localhost in development

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1122,7 +1122,7 @@ READER_STUDY_VIEW_AS_USER_FEATURE = strtobool(
 )
 # Feature flag for reader study display set view
 READER_STUDY_DISPLAY_SET_VIEW_FEATURE = strtobool(
-    os.environ.get("READER_STUDY_DISPLAY_SET_VIEW_FEATURE", "True")
+    os.environ.get("READER_STUDY_DISPLAY_SET_VIEW_FEATURE", "False")
 )
 
 CELERY_BEAT_SCHEDULE = {
@@ -1285,7 +1285,7 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = int(
 RETINA_GRADERS_GROUP_NAME = "retina_graders"
 RETINA_ADMINS_GROUP_NAME = "retina_admins"
 
-ENABLE_DEBUG_TOOLBAR = False
+ENABLE_DEBUG_TOOLBAR = True
 
 if DEBUG:
     # Allow localhost in development

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -889,6 +889,16 @@ class DisplaySet(UUIDModel):
             ]
         )
 
+    @cached_property
+    def main_image_title(self):
+        try:
+            interface_slug = self.reader_study.view_content["main"][0]
+            return self.values.filter(
+                interface__slug=interface_slug
+            ).values_list("image__name", flat=True)[0]
+        except KeyError:
+            return self.values.values_list("image__name", flat=True)[0]
+
 
 class AnswerType(models.TextChoices):
     # WARNING: Do not change the display text, these are used in the front end

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_display_sets_row.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_display_sets_row.html
@@ -11,7 +11,7 @@
       <h5 class="mb-0">
         <button class="btn btn-link w-100" data-toggle="collapse" data-target="#collapse-{{ object.id }}" aria-expanded="true" aria-controls="collapse{{ object.id }}">
           <div class="d-flex justify-content-between">
-            <div>{{ object.id }}</div>
+            <div>[{{ object.id }}] {{ object.main_image_title }}</div>
             <div><i class="fa fa-plus-circle"></i></div>
           </div>
         </button>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_statistics.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_statistics.html
@@ -21,7 +21,7 @@
         <table class="table table-hover table-striped table-sm mb-3">
             <thead>
                 <tr>
-                    <th>[DisplaySet ID] Main image name</th>
+                    <th>DisplaySet ID</th>
                     <th>Total score / max score</th>
                     <th>Average score</th>
                     {% for question in object.statistics.questions %}
@@ -35,7 +35,7 @@
             <tbody>
                 {% for entry in object.statistics.scores_by_case %}
                     <tr>
-                        <td data-order="{{ entry.id }}">[{{ entry.id }}] {{ entry.main_image_title }}</td>
+                        <td data-order="{{ entry.id }}">{{ entry.id }}</td>
                         <td data-order="{{ entry.sum|stringformat:'020f' }}">{{ entry.sum }} / {{ object.statistics.max_score_cases }}</td>
                         <td data-order="{{ entry.avg|stringformat:'020f' }}">{{ entry.avg|floatformat:4 }}</td>
                         {% for question in object.statistics.questions %}

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_statistics.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_statistics.html
@@ -21,7 +21,7 @@
         <table class="table table-hover table-striped table-sm mb-3">
             <thead>
                 <tr>
-                    <th>Image name</th>
+                    <th>[DisplaySet ID] Main image name</th>
                     <th>Total score / max score</th>
                     <th>Average score</th>
                     {% for question in object.statistics.questions %}
@@ -35,7 +35,7 @@
             <tbody>
                 {% for entry in object.statistics.scores_by_case %}
                     <tr>
-                        <td data-order="{{ entry.id }}">{{ entry.id }}</td>
+                        <td data-order="{{ entry.id }}">[{{ entry.id }}] {{ entry.main_image_title }}</td>
                         <td data-order="{{ entry.sum|stringformat:'020f' }}">{{ entry.sum }} / {{ object.statistics.max_score_cases }}</td>
                         <td data-order="{{ entry.avg|stringformat:'020f' }}">{{ entry.avg|floatformat:4 }}</td>
                         {% for question in object.statistics.questions %}

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -374,7 +374,7 @@ class ReaderStudyDisplaySetList(
     row_template = "reader_studies/readerstudy_display_sets_row.html"
     search_fields = ["pk", "values__image__name", "values__file"]
     columns = [
-        Column(title="Name", sort_field="order"),
+        Column(title="[DisplaySet ID] Main image name", sort_field="order"),
     ]
     text_align = "left"
     default_sort_order = "asc"


### PR DESCRIPTION
This adds the image name of the first image to the display set list view. 
![image](https://user-images.githubusercontent.com/30069334/171153614-f1f150f2-0ff2-4033-8f47-23a679d8b5df.png)

On the list view this does not add any queries, on the statistics view, however, this adds one query per display set and I couldn't find a way to reduce the queries, so leaving it at the display set id for the statistics page.

Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/148