### PR TITLE
Challenge stats page

### DIFF
--- a/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
@@ -90,6 +90,15 @@
                             </a>
                         </div>
                     {% endif %}
+                    {% if request.user.is_staff %}
+                        <div class="nav-item">
+                            <a class="nav-link {% if request.resolver_match.view_name == 'pages:statistics'  %}active{% endif %}"
+                               href="{% url 'pages:statistics' challenge_short_name=challenge.short_name %}">
+                                <i class="fas fa-chart-bar fa-fw"></i>
+                                    Statistics
+                            </a>
+                        </div>
+                    {% endif %}
                 </ul>
             </div>
         </div>

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -19,7 +19,7 @@ from django.core.validators import (
     RegexValidator,
 )
 from django.db import models
-from django.db.models import Avg, F, QuerySet
+from django.db.models import Avg, F, QuerySet, Sum
 from django.db.transaction import on_commit
 from django.forms import ModelChoiceField, ModelMultipleChoiceField
 from django.utils.functional import cached_property
@@ -888,6 +888,13 @@ class DurationQuerySet(models.QuerySet):
             self.with_duration()
             .exclude(duration=None)
             .aggregate(Avg("duration"))["duration__avg"]
+        )
+
+    def total_duration(self):
+        return (
+            self.with_duration()
+            .exclude(duration=None)
+            .aggregate(Sum("duration"))["duration__sum"]
         )
 
 

--- a/app/grandchallenge/core/mixins.py
+++ b/app/grandchallenge/core/mixins.py
@@ -1,0 +1,6 @@
+from django.contrib.auth.mixins import UserPassesTestMixin
+
+
+class UserIsStaffMixin(UserPassesTestMixin):
+    def test_func(self):
+        return self.request.user.is_staff

--- a/app/grandchallenge/pages/templates/pages/challenge_statistics.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_statistics.html
@@ -25,23 +25,21 @@
         <div class="table-responsive">
             <table class="table table-hover table-sm w-50">
                 <tbody>
-                    {% for phase, duration in average_job_durations.items %}
+                    {% for phase, durations in average_job_durations.items %}
                         <tr>
                             <td>
                                 Average algorithm job duration for {{ phase }}:
                             </td>
                              <td>
-                                {{ duration|naturaldelta }}
+                                {{ durations.average_duration|naturaldelta }}
                             </td>
                         </tr>
-                    {% endfor %}
-                    {% for phase, size in average_file_sizes.items %}
                         <tr>
                             <td>
-                                Average image file size for {{ phase }}:
+                                Total algorithm job duration for {{ phase }}:
                             </td>
                              <td>
-                                {{ size }} MB
+                                {{ durations.total_duration|naturaldelta }}
                             </td>
                         </tr>
                     {% endfor %}

--- a/app/grandchallenge/pages/templates/pages/challenge_statistics.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_statistics.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+{% load url %}
+{% load naturaldelta %}
+
+{% block title %}
+        Statistics
+    - {{ block.super }}
+{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% url 'challenges:list' %}">Challenges</a></li>
+        <li class="breadcrumb-item"><a
+                href="{{ challenge.get_absolute_url }}">{% firstof challenge.title challenge.short_name %}</a></li>
+        <li class="breadcrumb-item active"
+            aria-current="page">
+            Challenge Statistics
+        </li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <h3 class="mb-3">Challenge statistics</h3>
+    {% if average_job_durations %}
+        <div class="table-responsive">
+            <table class="table table-hover table-sm w-50">
+                <tbody>
+                    {% for phase, duration in average_job_durations.items %}
+                        <tr>
+                            <td>
+                                Average algorithm job duration for {{ phase }}:
+                            </td>
+                             <td>
+                                {{ duration|naturaldelta }}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    {% for phase, size in average_file_sizes.items %}
+                        <tr>
+                            <td>
+                                Average image file size for {{ phase }}:
+                            </td>
+                             <td>
+                                {{ size }} MB
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% else %}
+        No statistics to show for this challenge.
+    {% endif %}
+{% endblock %}

--- a/app/grandchallenge/pages/urls.py
+++ b/app/grandchallenge/pages/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from grandchallenge.pages.views import (
     ChallengeHome,
+    ChallengeStatistics,
     PageCreate,
     PageDelete,
     PageDetail,
@@ -14,6 +15,7 @@ app_name = "pages"
 urlpatterns = [
     path("pages/", PageList.as_view(), name="list"),
     path("pages/create/", PageCreate.as_view(), name="create"),
+    path("statistics/", ChallengeStatistics.as_view(), name="statistics"),
     path("", ChallengeHome.as_view(), name="home"),
     path("<slug>/", PageDetail.as_view(), name="detail"),
     path("<slug>/update/", PageUpdate.as_view(), name="update"),

--- a/app/grandchallenge/pages/views.py
+++ b/app/grandchallenge/pages/views.py
@@ -1,3 +1,5 @@
+from statistics import mean
+
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.db.models import Q
@@ -7,6 +9,7 @@ from django.views.generic import (
     DeleteView,
     DetailView,
     ListView,
+    TemplateView,
     UpdateView,
 )
 from guardian.mixins import LoginRequiredMixin
@@ -14,6 +17,11 @@ from guardian.mixins import (
     PermissionRequiredMixin as ObjectPermissionRequiredMixin,
 )
 
+from grandchallenge.algorithms.models import Job
+from grandchallenge.components.models import ComponentInterfaceValue
+from grandchallenge.core.mixins import UserIsStaffMixin
+from grandchallenge.evaluation.models import Submission
+from grandchallenge.evaluation.utils import SubmissionKindChoices
 from grandchallenge.pages.forms import PageCreateForm, PageUpdateForm
 from grandchallenge.pages.models import Page
 from grandchallenge.subdomains.utils import reverse, reverse_lazy
@@ -144,3 +152,63 @@ class PageDelete(
     def delete(self, request, *args, **kwargs):
         messages.success(self.request, self.success_message)
         return super().delete(request, *args, **kwargs)
+
+
+class ChallengeStatistics(LoginRequiredMixin, UserIsStaffMixin, TemplateView):
+    template_name = "pages/challenge_statisticss.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data()
+        phases = (
+            self.request.challenge.phase_set.filter(
+                submission_kind=SubmissionKindChoices.ALGORITHM
+            )
+            .select_related("archive")
+            .prefetch_related("archive__items__values")
+            .all()
+        )
+        duration_dict = {}
+        file_size_dict = {}
+        for phase in phases:
+            duration_dict[phase.title] = self.get_average_job_duration(
+                phase=phase
+            )
+            file_size_dict[phase.title] = self.get_average_image_file_size(
+                phase=phase
+            )
+
+        context.update(
+            {
+                "average_job_durations": duration_dict,
+                "average_file_sizes": file_size_dict,
+            }
+        )
+
+        return context
+
+    def get_average_job_duration(self, phase):
+        algorithm_images = Submission.objects.filter(
+            phase__slug=phase.slug
+        ).values_list("algorithm_image__pk")
+        average_job_duration = Job.objects.filter(
+            algorithm_image__pk__in=algorithm_images, status=Job.SUCCESS
+        ).average_duration()
+        return average_job_duration
+
+    def get_average_image_file_size(self, phase):
+        file_sizes = []
+        image_civs = phase.archive.items.filter(
+            values__image__isnull=False
+        ).values_list("values__pk")
+        images = [
+            civ.image
+            for civ in ComponentInterfaceValue.objects.filter(
+                pk__in=image_civs
+            )
+            .prefetch_related("image__files")
+            .all()
+        ]
+        for image in images:
+            for file in image.files.all():
+                file_sizes.append(file.file.size / 1000000)
+        return mean(file_sizes)


### PR DESCRIPTION
This adds a very simple statistics page to each challenge that is only accessible by staff users. The statistics page is empty for Type 1 challenges, and shows the average job duration per phase and the average image file size per phase. 