### PR TITLE
Fix autocomplete for verified email test

### DIFF
--- a/app/tests/groups_tests/test_views.py
+++ b/app/tests/groups_tests/test_views.py
@@ -139,7 +139,9 @@ class TestAutocompleteViews:
         archive.add_editor(admin)
 
         user = UserFactory()
-        VerificationFactory(user=user, is_verified=True)
+        VerificationFactory(
+            user=user, email="verification@email.com", is_verified=True
+        )
 
         response = get_view_for_user(
             client=client,
@@ -148,5 +150,4 @@ class TestAutocompleteViews:
             data={"q": user.verification.email},
         )
         assert response.status_code == 200
-
         assert str(user.pk) in response.json()["results"][0]["id"]


### PR DESCRIPTION
Closes #2473 

There are multiple ways of fixing the issue, but I felt that making the verification email unique was closest to what the test was supposed to test. 