### PR TITLE
Add `is_ground_truth` to answer serializer and filter

### DIFF
--- a/app/grandchallenge/reader_studies/filters.py
+++ b/app/grandchallenge/reader_studies/filters.py
@@ -19,4 +19,5 @@ class AnswerFilter(FilterSet):
             "creator",
             "question__reader_study",
             "display_set",
+            "is_ground_truth",
         )

--- a/app/grandchallenge/reader_studies/serializers.py
+++ b/app/grandchallenge/reader_studies/serializers.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ValidationError
 from django.db.transaction import on_commit
 from guardian.shortcuts import get_objects_for_user
 from rest_framework.fields import (
+    BooleanField,
     CharField,
     DurationField,
     JSONField,
@@ -179,6 +180,8 @@ class AnswerSerializer(HyperlinkedModelSerializer):
         read_only=True, view_name="api:image-detail"
     )
     total_edit_duration = DurationField(read_only=True)
+    # At the moment only non-ground-truth answers are created over REST
+    is_ground_truth = BooleanField(read_only=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -252,6 +255,7 @@ class AnswerSerializer(HyperlinkedModelSerializer):
             "answer_image",
             "last_edit_duration",
             "total_edit_duration",
+            "is_ground_truth",
         )
         swagger_schema_fields = {
             "properties": {"answer": {"title": "Answer", **ANSWER_TYPE_SCHEMA}}

--- a/app/tests/reader_studies_tests/test_filters.py
+++ b/app/tests/reader_studies_tests/test_filters.py
@@ -1,0 +1,22 @@
+import pytest
+
+from grandchallenge.reader_studies.filters import AnswerFilter
+from grandchallenge.reader_studies.models import Answer
+from tests.reader_studies_tests.factories import AnswerFactory
+
+
+@pytest.mark.django_db
+def test_answers_filterable_by_ground_truth():
+    a, gt = AnswerFactory(is_ground_truth=False), AnswerFactory(
+        is_ground_truth=True
+    )
+    qs = Answer.objects.all()
+
+    f = AnswerFilter(data={}, queryset=qs)
+    assert {*f.qs} == {a, gt}
+
+    f = AnswerFilter(data={"is_ground_truth": "true"}, queryset=qs)
+    assert {*f.qs} == {gt}
+
+    f = AnswerFilter(data={"is_ground_truth": "false"}, queryset=qs)
+    assert {*f.qs} == {a}


### PR DESCRIPTION
All answers: /api/v1/reader-studies/answers/
Only ground truth: /api/v1/reader-studies/answers/?is_ground_truth=true
Only non-ground truth: /api/v1/reader-studies/answers/?is_ground_truth=false

https://github.com/DIAGNijmegen/rse-roadmap/issues/91