### PR TITLE
Correctly mock get_doi_csl

### DIFF
--- a/app/tests/publications_tests/test_views.py
+++ b/app/tests/publications_tests/test_views.py
@@ -22,7 +22,7 @@ def test_publication_creation(client, mocker):
     assert Publication.objects.count() == 0
 
     mocker.patch(
-        "grandchallenge.publications.utils.get_doi_csl", return_value=TEST_CSL
+        "grandchallenge.publications.fields.get_doi_csl", return_value=TEST_CSL
     )
 
     # only registered users can create a publication
@@ -59,7 +59,7 @@ def test_publication_object_visibilty(client, mocker):
     assert not user2.has_perm("view_algorithm", alg)
 
     mocker.patch(
-        "grandchallenge.publications.utils.get_doi_csl", return_value=TEST_CSL
+        "grandchallenge.publications.fields.get_doi_csl", return_value=TEST_CSL
     )
 
     # create publication


### PR DESCRIPTION
The publication tests already tried to mock the `get_doi_csl` method, but did so incorrectly in these two tests. We need to mock where the function is used, not where it is defined. I also checked the other publication tests, there was only one where mocking was necessary and there the path to the function was already correct. 

Closes #2491 