### PR TITLE
Gather widgets media in htmx list view

### DIFF
--- a/app/grandchallenge/components/form_fields.py
+++ b/app/grandchallenge/components/form_fields.py
@@ -29,6 +29,12 @@ def _join_with_br(a, b):
 
 
 class InterfaceFormField:
+    _possible_widgets = {
+        UserUploadMultipleWidget,
+        UserUploadSingleWidget,
+        JSONEditorWidget,
+    }
+
     def __init__(
         self,
         *,

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_images_list.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_images_list.html
@@ -2,10 +2,6 @@
 {% load static %}
 {% load url %}
 
-{% block extra_css %}
-    <link href="{% static 'vendored/jsoneditor/jsoneditor.min.css' %}" rel="stylesheet">
-{% endblock %}
-
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'reader-studies:list' %}">Reader Studies</a></li>
@@ -15,7 +11,6 @@
 {% endblock %}
 
 {% block content %}
-
     <h1>{{ reader_study.title }} Cases</h1>
     <p>
         <a class="btn btn-primary"
@@ -116,5 +111,5 @@
         });
     </script>
     <script src="{% static "rest_framework/js/csrf.js" %}"></script>
-    <script src="{% static 'vendored/jsoneditor/jsoneditor.min.js' %}"></script>
+    {{ form_media }}
 {% endblock %}

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -12,6 +12,7 @@ from django.core.exceptions import (
 )
 from django.db import transaction
 from django.db.models import Count, Q
+from django.forms import Media
 from django.forms.utils import ErrorList
 from django.http import (
     Http404,
@@ -376,13 +377,14 @@ class ReaderStudyDisplaySetList(
     ]
     text_align = "left"
     default_sort_order = "asc"
+    form_class = DisplaySetForm
 
     @cached_property
     def reader_study(self):
         return get_object_or_404(ReaderStudy, slug=self.kwargs["slug"])
 
     def render_row(self, *, object_, page_context):
-        form = DisplaySetForm(instance=object_)
+        form = self.form_class(instance=object_)
         return render_to_string(
             self.row_template,
             context={**page_context, "object": object_, "form": form},
@@ -393,8 +395,14 @@ class ReaderStudyDisplaySetList(
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+
+        media = Media()
+        for widget in self.form_class._possible_widgets:
+            media = media + widget().media
+
         context.update(
             {
+                "form_media": media,
                 "reader_study": self.reader_study,
                 "reader_study_display_set_view_feature": settings.READER_STUDY_DISPLAY_SET_VIEW_FEATURE,
             }


### PR DESCRIPTION
`htmx` requires that all of the forms media is loaded first.
If we are using a form that is rendered by htmx in a list view,
then we need to know about all of the possible forms and their
media up front. The widgets used in a form are generated dynamically,
so for each form used in a htmx view we declare up front what
widgets are possible, and gather their media.

An error is logged to sentry if a form is rendered with an
unexpected widget.