### PR TITLE
Remove reader study feature flags

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1148,14 +1148,6 @@ WORKSTATIONS_RENDERING_SUBDOMAINS = {
 }
 # Number of minutes grace period before the container is stopped
 WORKSTATIONS_GRACE_MINUTES = 5
-# Feature Flag for reader study admin view
-READER_STUDY_VIEW_AS_USER_FEATURE = strtobool(
-    os.environ.get("READER_STUDY_VIEW_AS_USER_FEATURE", "False")
-)
-# Feature flag for reader study display set view
-READER_STUDY_DISPLAY_SET_VIEW_FEATURE = strtobool(
-    os.environ.get("READER_STUDY_DISPLAY_SET_VIEW_FEATURE", "False")
-)
 
 CELERY_BEAT_SCHEDULE = {
     "ping_google": {

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_progress.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_progress.html
@@ -34,7 +34,7 @@
                             {{ user.obj|user_profile_link }}
                         </div>
                     </div>
-                    <div class="col-4 {% if reader_study_view_as_user_feature %} col-md-2 {% else %}col-md-4 {% endif %}p-1">
+                    <div class="col-4 col-md-2 p-1">
                         <div class="progress h-100">
                             <div class="progress-bar" role="progressbar"
                                  style="width: {{ user.progress.questions }}%"
@@ -43,14 +43,13 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-2 {% if reader_study_view_as_user_feature %} col-md-1 {% else %}col-md-2 {% endif %} p-1">
+                    <div class="col-2 col-md-1 p-1">
                         <div class="h-100 d-flex align-items-center">
                             <div>
                                 &nbsp;{{ user.progress.questions|floatformat }}%
                             </div>
                         </div>
                     </div>
-                    {% if reader_study_view_as_user_feature %}
                     <div class="col-6 col-md-3 p-1">
                         <div class="d-flex justify-content-md-end justify-content-start align-items-center">
                             <a class="btn btn-primary"
@@ -59,8 +58,7 @@
                             </a>
                         </div>
                     </div>
-                    {% endif %}
-                    <div class="{% if reader_study_view_as_user_feature %}col-6 col-md-3 {% else %}col-12 col-md-3 {% endif %}p-1">
+                    <div class="col-6 col-md-3 p-1">
                         <div class="d-flex justify-content-md-center justify-content-start align-items-center">
                             <!-- Answer removal is handled by Modal, see below -->
                             <button type="button"

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_statistics.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_statistics.html
@@ -27,9 +27,7 @@
                     {% for question in object.statistics.questions %}
                         <th>{{ question }} (GT)</th>
                     {% endfor %}
-                    {% if reader_study_display_set_view_feature %}
-                        <th>View case</th>
-                    {% endif %}
+                    <th>View case</th>
                 </tr>
             </thead>
             <tbody>
@@ -42,7 +40,6 @@
                             {% get_ground_truth object entry.id question as ground_truth %}
                             <td data-order="{{ ground_truth }}">{{ ground_truth }}</td>
                         {% endfor %}
-                    {% if reader_study_display_set_view_feature %}
                         <td data-order="{{ entry.id }}">
                             <a href="{% url 'workstations:workstation-session-create' slug=object.workstation.slug %}?{% workstation_query display_set=entry %}">
                                 <span class="badge badge-primary">
@@ -50,7 +47,6 @@
                                 </span>
                             </a>
                         </td>
-                    {% endif %}
                     </tr>
                 {% endfor %}
             </tbody>

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -412,7 +412,6 @@ class ReaderStudyDisplaySetList(
             {
                 "form_media": media,
                 "reader_study": self.reader_study,
-                "reader_study_display_set_view_feature": settings.READER_STUDY_DISPLAY_SET_VIEW_FEATURE,
             }
         )
         return context


### PR DESCRIPTION
This removes the two feature flags `READER_STUDY_DISPLAY_SET_VIEW_FEATURE` and `READER_STUDY_VIEW_AS_USER_FEATURE`. They are no longer necessary since Cirrus now supports them.