### PR TITLE
Add timezone information to submission page

### DIFF
--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -3,7 +3,6 @@
 {% load url %}
 {% load guardian_tags %}
 {% load bleach %}
-{% load tz %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
@@ -33,8 +32,6 @@
     {{ phase.submission_page_html|clean }}
 
     <h3>Create a new submission</h3>
-
-    {% get_current_timezone as TIME_ZONE %}
 
     {% if "change_challenge" in challenge_perms %}
 

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -3,6 +3,7 @@
 {% load url %}
 {% load guardian_tags %}
 {% load bleach %}
+{% load tz %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
@@ -33,6 +34,8 @@
 
     <h3>Create a new submission</h3>
 
+    {% get_current_timezone as TIME_ZONE %}
+
     {% if "change_challenge" in challenge_perms %}
 
         {% if request.resolver_match.view_name != "evaluation:submission-create-legacy" %}
@@ -47,9 +50,9 @@
                     {% else %}
                         in total
                     {% endif %}
-                    {% if phase.submissions_open_at and phase.submissions_close_at %}between {{ phase.submissions_open_at }} and {{ phase.submissions_close_at }}
-                    {% elif phase.submissions_open_at and not phase.submissions_close_at %} from {{ phase.submissions_open_at }} onwards
-                    {% elif not phase.submissions_open_at and  phase.submissions_close_at %} until {{ phase.submissions_close_at }}
+                    {% if phase.submissions_open_at and phase.submissions_close_at %}between {{ phase.submissions_open_at }} ({{ TIME_ZONE }}) and {{ phase.submissions_close_at }} ({{ TIME_ZONE }})
+                    {% elif phase.submissions_open_at and not phase.submissions_close_at %} from {{ phase.submissions_open_at }} ({{ TIME_ZONE }}) onwards
+                    {% elif not phase.submissions_open_at and  phase.submissions_close_at %} until {{ phase.submissions_close_at }} ({{ TIME_ZONE }})
                     {% endif %}
                     to this phase.</p>
                     <p>You can change the submission limit and period and the submission start and end dates in
@@ -125,6 +128,12 @@
                 {% endif %}
                 to this phase.
             </div>
+
+            {% if phase.submissions_close_at %}
+                <div class="alert alert-warning">
+                    Submissions to this phase will automatically close at {{ phase.submissions_close_at }} ({{ TIME_ZONE }}).
+                </div>
+            {% endif %}
 
             {% crispy form %}
 


### PR DESCRIPTION
Challenge participants will now see a warning about when the submission will automatically close, along with the timezone information - hopefully no more excuses and pushing back on deadlines due to timezone interpretations.

![image](https://user-images.githubusercontent.com/12661555/173591862-521bf3d8-b5b2-403a-afaf-403f85c3b8ed.png)


