### PR TITLE
Add admin action to send a verification reminder to users

### DIFF
--- a/app/grandchallenge/verifications/admin.py
+++ b/app/grandchallenge/verifications/admin.py
@@ -2,6 +2,9 @@ from django.contrib import admin
 from django.utils.timezone import now
 from pyswot import is_academic
 
+from grandchallenge.verifications.emails import (
+    send_verification_reminder_email,
+)
 from grandchallenge.verifications.models import Verification
 
 
@@ -19,6 +22,18 @@ def mark_not_verified(modeladmin, request, queryset):
 
 mark_not_verified.short_description = "Mark selected users as not verified"
 mark_not_verified.allowed_permissions = ("change",)
+
+
+def send_reminder_email(modeladmin, request, queryset):
+    for verification in queryset.filter(
+        email_is_verified=False, is_verified=False
+    ):
+        send_verification_reminder_email(verification=verification)
+
+
+send_reminder_email.short_description = (
+    "Email selected users a verification reminder"
+)
 
 
 class VerificationAdmin(admin.ModelAdmin):
@@ -45,7 +60,7 @@ class VerificationAdmin(admin.ModelAdmin):
         "verified_at",
     )
     search_fields = ("user__username", "email", "user__email")
-    actions = (mark_verified, mark_not_verified)
+    actions = (mark_verified, mark_not_verified, send_reminder_email)
     autocomplete_fields = ("user",)
 
     def email_is_academic(self, instance):

--- a/app/grandchallenge/verifications/emails.py
+++ b/app/grandchallenge/verifications/emails.py
@@ -23,3 +23,24 @@ def send_verification_email(*, verification: Verification):
         recipient_list=[verification.email],
         message=message,
     )
+
+
+def send_verification_reminder_email(*, verification: Verification):
+    site = Site.objects.get_current()
+    send_verification_email(verification=verification)
+    reminder_message = (
+        f"Dear {verification.user.username},\n\n"
+        f"This is a reminder to confirm your access to email address {verification.email}. "
+        "An email has been sent to that address with a verification link.\n\n"
+        "Please disregard this email if you did not make this confirmation "
+        "request.\n\n"
+        "Regards,\n"
+        f"{site.name}\n"
+        f"This is an automated service email from {site.domain}."
+    )
+    send_mail(
+        subject=f"[{site.domain.lower()}] Please confirm your email address",
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        recipient_list=[verification.signup_email],
+        message=reminder_message,
+    )


### PR DESCRIPTION
I've noticed more and more users neglect to verify their alternative verification email. This eases sending reminder emails.