### PR TITLE
Always show edit button display-set detail but disable when needed

### DIFF
--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_display_set_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_display_set_detail.html
@@ -28,11 +28,18 @@
     </tr>
   </table>
   <div class="d-flex justify-content-between px-1 py-2">
-    {% if object.is_editable %}
-      <button class="btn btn-primary" hx-get="{% url 'reader-studies:display-set-update' pk=object.pk %}" hx-target="#ds-content-{{ object.id }}" hx-swap="outerHTML">Edit</button>
-    {% else %}
-      <div></div>
-    {% endif %}
+      <button
+          class="btn btn-primary"
+          hx-get="{% url 'reader-studies:display-set-update' pk=object.pk %}"
+          hx-target="#ds-content-{{ object.id }}"
+          hx-swap="outerHTML"
+          {% if not object.is_editable %}
+              title="Cannot edit: answers for display set exist"
+              disabled
+          {% endif %}
+      >
+          Edit
+      </button>
     <a href="{% url 'workstations:workstation-session-create' slug=object.reader_study.workstation.slug %}?{% workstation_query display_set=object config=reader_study.workstation_config %}" class="btn btn-primary">
       <i class="fa fa-eye"></i> View Display Set
     </a>


### PR DESCRIPTION
This confused at least one user, I suspect there are 10 more that we don't know about.

![disabled edit](https://user-images.githubusercontent.com/7871310/174272922-42b81ccc-be15-4816-ae5a-981396bd7677.png)
