### PR TITLE
Add compute costs to challenge stats

### DIFF
--- a/app/grandchallenge/pages/templates/pages/challenge_statistics.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_statistics.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load url %}
 {% load naturaldelta %}
+{% load dict_lookup %}
 
 {% block title %}
         Statistics
@@ -22,29 +23,20 @@
 {% block content %}
     <h3 class="mb-3">Challenge statistics</h3>
     {% if average_job_durations %}
-        <div class="table-responsive">
-            <table class="table table-hover table-sm w-50">
-                <tbody>
-                    {% for phase, durations in average_job_durations.items %}
-                        <tr>
-                            <td>
-                                Average algorithm job duration for {{ phase }}:
-                            </td>
-                             <td>
-                                {{ durations.average_duration|naturaldelta }}
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                Total algorithm job duration for {{ phase }}:
-                            </td>
-                             <td>
-                                {{ durations.total_duration|naturaldelta }}
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+        <div class="row equal-height mx-n2">
+            {% for phase, durations in average_job_durations.items %}
+                <div class="card m-1">
+                    <div class="card-header">{{ phase }}</div>
+                    <div class="card-body">
+                        <ul>
+                            <li>Average algorithm job duration: {{ durations.average_duration|naturaldelta }}</li>
+                            <li>Total duration of all jobs for this phase: {{ durations.total_duration|naturaldelta }}</li>
+                            <li>Number of archive items: {% get_dict_values num_archive_items phase as item_count %} {{ item_count }}</li>
+                            <li>Average compute cost per algorithm job: {% get_dict_values compute_costs phase as cost %} {% if cost %}{{ cost }} €{% else %} NA {% endif %}</li>
+                        </ul>
+                    </div>
+                </div>
+            {% endfor %}
         </div>
     {% else %}
         No statistics to show for this challenge.

--- a/app/tests/pages_tests/test_pages.py
+++ b/app/tests/pages_tests/test_pages.py
@@ -4,6 +4,7 @@ from itertools import chain
 import pytest
 from django.db.models import BLANK_CHOICE_DASH
 from django.utils.timezone import now
+from guardian.shortcuts import assign_perm
 
 from grandchallenge.components.models import (
     ComponentInterface,
@@ -324,8 +325,9 @@ def test_create_page_with_same_title(client, two_challenge_sets):
 def test_challenge_statistics_page_permissions(client):
     challenge = ChallengeFactory()
     staff = UserFactory(is_staff=True)
-    admin, user = UserFactory.create_batch(2)
+    admin, reviewer, user = UserFactory.create_batch(3)
     challenge.add_admin(admin)
+    assign_perm("challenges.view_challengerequest", reviewer)
 
     response = get_view_for_user(
         viewname="pages:statistics",
@@ -342,6 +344,14 @@ def test_challenge_statistics_page_permissions(client):
         challenge=challenge,
     )
     response.status_code = 404
+
+    response = get_view_for_user(
+        viewname="pages:statistics",
+        client=client,
+        user=reviewer,
+        challenge=challenge,
+    )
+    response.status_code = 200
 
     response = get_view_for_user(
         viewname="pages:statistics",


### PR DESCRIPTION
This adds the number of archive items and the average compute costs to the challenge stats page and gives the challenge reviewers (aka 10%) access to these pages. 