### PR TITLE
Add validation before making algorithm public

### DIFF
--- a/app/grandchallenge/algorithms/forms.py
+++ b/app/grandchallenge/algorithms/forms.py
@@ -120,10 +120,12 @@ class RepoNameValidationMixin:
 class AlgorithmPublishValidation:
     def clean_public(self):
         public = self.cleaned_data.get("public")
+        # presence of a contact email is already checked
         if public and (
             not self.instance.summary
             or not self.instance.public_test_case
             or not self.instance.mechanism
+            or not self.instance.display_editors
         ):
             raise ValidationError(
                 "To publish this algorithm you need at least 1 public test case with a successful result from the latest version of the algorithm. You also need a summary and description of the mechanism of your algorithm. The link to update your algorithm description can be found on the algorithm information page."

--- a/app/grandchallenge/algorithms/forms.py
+++ b/app/grandchallenge/algorithms/forms.py
@@ -117,6 +117,20 @@ class RepoNameValidationMixin:
         return repo_name
 
 
+class AlgorithmPublishValidation:
+    def clean_public(self):
+        public = self.cleaned_data.get("public")
+        if public and (
+            not self.instance.summary
+            or not self.instance.public_test_case
+            or not self.instance.mechanism
+        ):
+            raise ValidationError(
+                "To publish this algorithm you need at least 1 public test case with a successful result from the latest version of the algorithm. You also need a summary and description of the mechanism of your algorithm. The link to update your algorithm description can be found on the algorithm information page."
+            )
+        return public
+
+
 class AlgorithmIOValidationMixin:
     def clean(self):
         cleaned_data = super().clean()
@@ -137,6 +151,7 @@ class AlgorithmIOValidationMixin:
 class AlgorithmForm(
     RepoNameValidationMixin,
     AlgorithmIOValidationMixin,
+    AlgorithmPublishValidation,
     WorkstationUserFilterMixin,
     ModelForm,
     ViewContentMixin,
@@ -490,3 +505,9 @@ class AlgorithmRepoForm(RepoNameValidationMixin, SaveFormInitMixin, ModelForm):
     class Meta:
         model = Algorithm
         fields = ("repo_name",)
+
+
+class AlgorithmPublishForm(AlgorithmPublishValidation, ModelForm):
+    class Meta:
+        model = Algorithm
+        fields = ("public",)

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -391,6 +391,15 @@ class Algorithm(UUIDModel, TitleSlugDescriptionModel, ViewContentMixin):
     def remove_user(self, user):
         return user.groups.remove(self.users_group)
 
+    @cached_property
+    def public_test_case(self):
+        try:
+            return self.latest_ready_image.job_set.filter(
+                status=Job.SUCCESS, public=True
+            ).exists()
+        except AttributeError:
+            return False
+
 
 @receiver(post_delete, sender=Algorithm)
 def delete_algorithm_groups_hook(*_, instance: Algorithm, using, **__):

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
@@ -98,7 +98,13 @@
         <div class="alert alert-warning" role="alert">
             Please update your algorithm settings. Grand Challenge now requires a <u>contact email address</u> for all algorithms.<br>
             You will also need to indicate whether you want the algorithm editors to be displayed on the Information page.
-            Please also take note of the new <u>Algorithm description</u> form, accessible through the 'Update description' button.
+        </div>
+    {% endif %}
+
+    {% if 'change_algorithm' in algorithm_perms and object.public and not object.summary or object.public and not object.mechanism or object.public and not object.public_test_case %}
+        <div class="alert alert-danger" role="alert">
+            <i class="fas fa-exclamation-triangle mr-1"></i>{% if not object.summary or not object.mechanism %}Please update your algorithm description and add at least a summary and description of your algorithm's mechanism
+            <a href="{% url 'algorithms:description-update' slug=object.slug %}">here</a>.{% endif %} {% if not object.public_test_case %}Please also upload a public test case <a href="{% url 'algorithms:execution-session-create' slug=object.slug %}">here</a>.{% endif %}
         </div>
     {% endif %}
 
@@ -118,6 +124,14 @@
                            href="{% url 'algorithms:description-update' slug=object.slug %}">
                             <i class="fa fa-edit"></i> Update Description
                         </a>
+                        {% if not object.public %}
+                            <a class="btn btn-primary btn-block"
+                               href="#publishAlgorithmModal"
+                               data-toggle="modal"
+                               data-target="#publishAlgorithmModal">
+                                <i class="fa fa-star"></i> Publish Algorithm
+                            </a>
+                        {% endif %}
                     </span>
                 {% endif %}
             </div>
@@ -402,9 +416,50 @@
             </div>
         {% endif %}
     </div>
+
+    {#  modal  #}
+    <div class="modal" id="publishAlgorithmModal" tabindex="-1" role="dialog">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Make this algorithm public</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p>Making an algorithm public means that it will be publicly listed on the <a href="{% url 'algorithms:list' %}">algorithm overview page</a>. Everyone will be able to see your algorithm description and the public results linked to your algorithm.</p>
+                    <p>However, users will <b>still need to request access to your algorithm</b> to try it out themselves, unless you have your access request handling set to "accept all users".</p>
+                    <p>To publish your algorithm you need:</p>
+                    <ul class="list-unstyled">
+                        <li>{% if object.public_test_case %}<i class="fas fa-check-circle text-success mr-1"></i>{% else %}<i class="fas fa-exclamation-circle text-danger mr-1"></i>{% endif %}at least 1 public test case with a successful result based on the latest version of the algorithm</li>
+                        <li>{% if object.summary %}<i class="fas fa-check-circle text-success mr-1"></i>{% else %}<i class="fas fa-exclamation-circle text-danger mr-1"></i>{% endif %}a summary of your algorithm</li>
+                        <li>{% if object.mechanism %}<i class="fas fa-check-circle text-success mr-1"></i>{% else %}<i class="fas fa-exclamation-circle text-danger mr-1"></i>{% endif %}a description of the mechanism behind your algorithm</li>
+                        <li>{% if object.contact_email %}<i class="fas fa-check-circle text-success mr-1"></i>{% else %}<i class="fas fa-exclamation-circle text-danger mr-1"></i>{% endif %}a contact email address (add in settings)</li>
+                        <li>{% if object.display_editors %}<i class="fas fa-check-circle text-success mr-1"></i>{% else %}<i class="fas fa-exclamation-circle text-danger mr-1"></i>{% endif %}a publicly visible list of the editors of the algorithm (enable in settings)</li>
+                    </ul>
+                </div>
+                <div class="modal-footer">
+                    <div class="col-12 d-flex justify-content-center">
+                        <a type="button" class="btn btn-sm btn-secondary mr-1" href="{% url 'algorithms:update' slug=object.slug %}">Update Settings</a>
+                        <a type="button" class="btn btn-sm btn-secondary mr-1" href="{% url 'algorithms:description-update' slug=object.slug %}">Update Description</a>
+                        <a type="button" class="btn btn-sm btn-secondary" href="{% url 'algorithms:execution-session-create' slug=object.slug %}">Add Test Case</a>
+                    </div>
+                    <div class="col-12 d-flex justify-content-center">
+                        <a type="button" class="btn btn-sm btn-primary {% if not object.mechanism or not object.summary or not object.public_test_case or not object.contact_email or not object.display_editors %}disabled{% endif %}" hx-post="{% url 'algorithms:publish' slug=object.slug %}" hx-vals='{"public": true}'>Publish algorithm</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}
 
 {% block script %}
     {{ block.super }}
     <script src="{% static "js/refresh_sidebar.js" %}"></script>
+    <script>
+        document.body.addEventListener('htmx:configRequest', (event) => {
+            event.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
+            })
+    </script>
 {% endblock %}

--- a/app/grandchallenge/algorithms/templates/algorithms/model_facts_field.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/model_facts_field.html
@@ -5,6 +5,6 @@
   <div>
         <label class="label mt-3 mb-0" for="{{ field.id_for_label }}"><h5>{{ field.label }}</h5></label>
         <span id="hint_{{ field.auto_id }}" class="form-text text-muted mb-2">{{ field.help_text|clean }}</span>
-        {% crispy_field field 'class' 'textarea' %}
+        {% crispy_field field 'class' 'textarea form-control' %}
   </div>
 </div>

--- a/app/grandchallenge/algorithms/urls.py
+++ b/app/grandchallenge/algorithms/urls.py
@@ -15,6 +15,7 @@ from grandchallenge.algorithms.views import (
     AlgorithmPermissionRequestCreate,
     AlgorithmPermissionRequestList,
     AlgorithmPermissionRequestUpdate,
+    AlgorithmPublishView,
     AlgorithmUpdate,
     EditorsUpdate,
     JobDetail,
@@ -32,6 +33,7 @@ urlpatterns = [
     path("create/", AlgorithmCreate.as_view(), name="create"),
     path("<slug>/", AlgorithmDetail.as_view(), name="detail"),
     path("<slug>/update/", AlgorithmUpdate.as_view(), name="update"),
+    path("<slug>/publish/", AlgorithmPublishView.as_view(), name="publish"),
     path(
         "<slug>/description-update/",
         AlgorithmDescriptionUpdate.as_view(),

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 import requests
 from django.conf import settings
+from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.cache import cache
@@ -14,7 +15,7 @@ from django.core.exceptions import (
 )
 from django.db.models import OuterRef, Subquery
 from django.forms.utils import ErrorList
-from django.http import Http404, HttpResponseRedirect
+from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -50,6 +51,7 @@ from grandchallenge.algorithms.forms import (
     AlgorithmImageUpdateForm,
     AlgorithmInputsForm,
     AlgorithmPermissionRequestUpdateForm,
+    AlgorithmPublishForm,
     AlgorithmRepoForm,
     AlgorithmUpdateForm,
     JobForm,
@@ -916,3 +918,25 @@ class AlgorithmAddRepo(
 
         kwargs.update({"repos": repos})
         return kwargs
+
+
+class AlgorithmPublishView(
+    LoginRequiredMixin,
+    ObjectPermissionRequiredMixin,
+    UpdateView,
+):
+    model = Algorithm
+    form_class = AlgorithmPublishForm
+    permission_required = "algorithms.change_algorithm"
+    raise_exception = True
+
+    def form_valid(self, form):
+        super().form_valid(form)
+        response = HttpResponse()
+        response["HX-Refresh"] = "true"
+        messages.add_message(
+            self.request,
+            messages.SUCCESS,
+            "Your algorithm has been published successfully.",
+        )
+        return response

--- a/app/tests/algorithms_tests/test_forms.py
+++ b/app/tests/algorithms_tests/test_forms.py
@@ -1,10 +1,11 @@
 import pytest
 from actstream.actions import is_following
 
-from grandchallenge.algorithms.forms import AlgorithmForm
+from grandchallenge.algorithms.forms import AlgorithmForm, AlgorithmPublishForm
 from grandchallenge.algorithms.models import (
     Algorithm,
     AlgorithmPermissionRequest,
+    Job,
 )
 from grandchallenge.components.models import ComponentInterface
 from grandchallenge.core.utils.access_requests import (
@@ -12,6 +13,8 @@ from grandchallenge.core.utils.access_requests import (
 )
 from tests.algorithms_tests.factories import (
     AlgorithmFactory,
+    AlgorithmImageFactory,
+    AlgorithmJobFactory,
     AlgorithmPermissionRequestFactory,
 )
 from tests.algorithms_tests.utils import get_algorithm_creator
@@ -382,3 +385,28 @@ def test_disjoint_interfaces():
     )
     assert form.is_valid() is False
     assert "The sets of Inputs and Outputs must be unique" in str(form.errors)
+
+
+@pytest.mark.django_db
+def test_publish_algorithm():
+    algorithm = AlgorithmFactory()
+
+    form = AlgorithmPublishForm(instance=algorithm, data={"public": True})
+    assert form.is_valid() is False
+
+    # add a summary and a mechanism
+    algorithm.summary = "Summary"
+    algorithm.mechanism = "Mechanism"
+    algorithm.save()
+
+    form = AlgorithmPublishForm(instance=algorithm, data={"public": True})
+    assert form.is_valid() is False
+
+    # add a public result
+    ai = AlgorithmImageFactory(algorithm=algorithm, ready=True)
+    _ = AlgorithmJobFactory(
+        algorithm_image=ai, status=Job.SUCCESS, public=True
+    )
+    del algorithm.latest_ready_image
+    form = AlgorithmPublishForm(instance=algorithm, data={"public": True})
+    assert form.is_valid()

--- a/app/tests/algorithms_tests/test_forms.py
+++ b/app/tests/algorithms_tests/test_forms.py
@@ -402,11 +402,18 @@ def test_publish_algorithm():
     form = AlgorithmPublishForm(instance=algorithm, data={"public": True})
     assert form.is_valid() is False
 
+    # set display editors to true
+    algorithm.display_editors = True
+    algorithm.save()
+    form = AlgorithmPublishForm(instance=algorithm, data={"public": True})
+    assert form.is_valid() is False
+
     # add a public result
     ai = AlgorithmImageFactory(algorithm=algorithm, ready=True)
     _ = AlgorithmJobFactory(
         algorithm_image=ai, status=Job.SUCCESS, public=True
     )
     del algorithm.latest_ready_image
+    del algorithm.public_test_case
     form = AlgorithmPublishForm(instance=algorithm, data={"public": True})
     assert form.is_valid()

--- a/app/tests/algorithms_tests/test_views.py
+++ b/app/tests/algorithms_tests/test_views.py
@@ -440,6 +440,13 @@ class TestObjectPermissionRequiredViews:
                 ai.algorithm,
                 None,
             ),
+            (
+                "publish",
+                {"slug": ai.algorithm.slug},
+                "change_algorithm",
+                ai.algorithm,
+                None,
+            ),
         ]:
 
             def _get_view():


### PR DESCRIPTION
- This adds validation before making an algorithm public. To publish an algorithm, the algorithm needs at least 1 successful, public results for the latest container image, as well as a summary and mechanism description. It also needs a contact email address and the list of editors needs to be visible on the algorithm page.
- This also adds a button to the algorithm detail page to publish the algorithm that shows which of these requirements are already satisfied and which are not: 
![image](https://user-images.githubusercontent.com/30069334/175494691-245cc334-81b5-4767-997f-1e8330998747.png)
![image](https://user-images.githubusercontent.com/30069334/175494738-cb7c2ca1-5d34-4e3e-8ace-54733f35e2db.png)

Addresses https://github.com/DIAGNijmegen/rse-roadmap/issues/154