### PR TITLE
Remove users who do not login

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1156,6 +1156,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "grandchallenge.components.tasks.update_filesystem",
         "schedule": timedelta(hours=COMPONENTS_AMAZON_EFS_TARGET_HOURS),
     },
+    "delete_users_who_dont_signin": {
+        "task": "grandchallenge.profiles.tasks.delete_users_who_dont_signin",
+        "schedule": timedelta(days=1),
+    },
     **{
         f"stop_expired_services_{region}": {
             "task": "grandchallenge.components.tasks.stop_expired_services",

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -83,6 +83,7 @@ DEFAULT_FROM_EMAIL = os.environ.get(
 SERVER_EMAIL = os.environ.get("SERVER_EMAIL", "root@localhost")
 
 ANONYMOUS_USER_NAME = "AnonymousUser"
+USER_LOGIN_TIMEOUT_DAYS = 14
 REGISTERED_USERS_GROUP_NAME = "__registered_users_group__"
 REGISTERED_AND_ANON_USERS_GROUP_NAME = "__registered_and_anonymous_users__"
 
@@ -1156,8 +1157,8 @@ CELERY_BEAT_SCHEDULE = {
         "task": "grandchallenge.components.tasks.update_filesystem",
         "schedule": timedelta(hours=COMPONENTS_AMAZON_EFS_TARGET_HOURS),
     },
-    "delete_users_who_dont_signin": {
-        "task": "grandchallenge.profiles.tasks.delete_users_who_dont_signin",
+    "delete_users_who_dont_login": {
+        "task": "grandchallenge.profiles.tasks.delete_users_who_dont_login",
         "schedule": timedelta(days=1),
     },
     **{

--- a/app/grandchallenge/profiles/admin.py
+++ b/app/grandchallenge/profiles/admin.py
@@ -33,7 +33,12 @@ class UserProfileAdmin(UserAdmin):
         "last_name",
         "is_staff",
     )
-    list_filter = ("is_staff", "is_superuser", "is_active")
+    list_filter = (
+        "is_staff",
+        "is_superuser",
+        "is_active",
+        "user_profile__country",
+    )
     actions = (deactivate_users,)
 
 

--- a/app/grandchallenge/profiles/tasks.py
+++ b/app/grandchallenge/profiles/tasks.py
@@ -1,8 +1,11 @@
+from datetime import timedelta
+
 from celery import shared_task
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sessions.models import Session
 from django.core.paginator import Paginator
+from django.utils.timezone import now
 
 
 @shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
@@ -22,3 +25,11 @@ def deactivate_user(*, user_pk):
         for s in page.object_list:
             if str(s.get_decoded().get("_auth_user_id")) == str(user.id):
                 s.delete()
+
+
+@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
+def delete_users_who_dont_signin():
+    """Remove users who do not sign in after 2 weeks"""
+    get_user_model().objects.filter(
+        last_login__isnull=True, date_joined__lt=now() - timedelta(weeks=2)
+    ).delete()

--- a/app/grandchallenge/profiles/tasks.py
+++ b/app/grandchallenge/profiles/tasks.py
@@ -28,8 +28,13 @@ def deactivate_user(*, user_pk):
 
 
 @shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
-def delete_users_who_dont_signin():
-    """Remove users who do not sign in after 2 weeks"""
-    get_user_model().objects.filter(
-        last_login__isnull=True, date_joined__lt=now() - timedelta(weeks=2)
+def delete_users_who_dont_login():
+    """Remove users who do not sign in after USER_LOGIN_TIMEOUT_DAYS"""
+    get_user_model().objects.exclude(
+        username=settings.ANONYMOUS_USER_NAME
+    ).filter(
+        last_login__isnull=True,
+        date_joined__lt=(
+            now() - timedelta(days=settings.USER_LOGIN_TIMEOUT_DAYS)
+        ),
     ).delete()

--- a/app/tests/profiles_tests/test_tasks.py
+++ b/app/tests/profiles_tests/test_tasks.py
@@ -1,0 +1,26 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
+from guardian.utils import get_anonymous_user
+
+from grandchallenge.profiles.tasks import delete_users_who_dont_login
+from tests.factories import UserFactory
+
+
+@pytest.mark.django_db
+def test_delete_users_who_dont_login(settings, client):
+    settings.USER_LOGIN_TIMEOUT_DAYS = 0
+    anon = get_anonymous_user()
+    u1, u2 = UserFactory.create_batch(2)
+    # u1 logs in and should not be deleted
+    client.force_login(user=u1)
+
+    assert {*get_user_model().objects.all()} == {anon, u1, u2}
+
+    delete_users_who_dont_login()
+
+    assert {*get_user_model().objects.all()} == {anon, u1}
+
+    with pytest.raises(ObjectDoesNotExist):
+        # u2 did not log in so was deleted
+        u2.refresh_from_db()


### PR DESCRIPTION
Sometimes users are created and they do not confirm their accounts. These need to be remove from the database. This has been done manually so far. Now we can switch this to an automated task that removes the users if they do not login with 14 days of creating their account.