### PR TITLE
Fix admin task to requeue jobs

### DIFF
--- a/app/tests/resources/gc_demo_algorithm/copy_io.py
+++ b/app/tests/resources/gc_demo_algorithm/copy_io.py
@@ -7,8 +7,6 @@ if __name__ == "__main__":
     res = {"score": 1}  # dummy metric for ranking on leaderboard
     files = {x for x in Path("/input").rglob("*") if x.is_file()}
 
-    raise ValueError
-
     for file in files:
         try:
             with open(file) as f:

--- a/app/tests/resources/gc_demo_algorithm/copy_io.py
+++ b/app/tests/resources/gc_demo_algorithm/copy_io.py
@@ -7,6 +7,8 @@ if __name__ == "__main__":
     res = {"score": 1}  # dummy metric for ranking on leaderboard
     files = {x for x in Path("/input").rglob("*") if x.is_file()}
 
+    raise ValueError
+
     for file in files:
         try:
             with open(file) as f:


### PR DESCRIPTION
For some reason doing queryset.update then iterating through
the queryset to execute the jobs didn't work. This instead
does a bulk update and requeing of the job one by one and
appears to fix the issue. We no longer need to issue the command
twice to requeue a job.