### PR TITLE
Add no_proxy environment variable

### DIFF
--- a/app/grandchallenge/components/backends/amazon_sagemaker_batch.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_batch.py
@@ -468,7 +468,8 @@ class AmazonSageMakerBatchExecutor(Executor):
                     "InstanceCount": 1,
                 },
                 Environment={  # Up to 16 pairs
-                    "LOGLEVEL": "INFO",
+                    "LOG_LEVEL": "INFO",
+                    "no_proxy": f"s3.{settings.AWS_DEFAULT_REGION}.amazonaws.com",
                 },
                 ModelClientConfig={
                     "InvocationsTimeoutInSeconds": self._time_limit,

--- a/app/tests/components_tests/test_amazon_sagemaker_batch_backend.py
+++ b/app/tests/components_tests/test_amazon_sagemaker_batch_backend.py
@@ -140,7 +140,10 @@ def test_execute(settings):
             service_response={"TransformJobArn": "string"},
             expected_params={
                 "TransformJobName": executor._transform_job_name,
-                "Environment": {"LOGLEVEL": "INFO"},
+                "Environment": {
+                    "LOG_LEVEL": "INFO",
+                    "no_proxy": "s3.eu-central-1.amazonaws.com",
+                },
                 "ModelClientConfig": {
                     "InvocationsMaxRetries": 0,
                     "InvocationsTimeoutInSeconds": 60,


### PR DESCRIPTION
Participants container images will sometimes set `HTTP_PROXY` or `HTTPS_PROXY`, and the boto client used to download and upload the input/output data picks up these settings. This is not a risk as the instances are firewalled and run in a VPC without internet access, and can only communicate with the S3 endpoint. This forces any set proxy to be bypassed for S3.

https://github.com/DIAGNijmegen/rse-roadmap/issues/158