### PR TITLE
Fix overlay_segments issues

### DIFF
--- a/app/grandchallenge/components/migrations/0012_auto_20220707_1847.py
+++ b/app/grandchallenge/components/migrations/0012_auto_20220707_1847.py
@@ -33,9 +33,8 @@ class Migration(migrations.Migration):
             name="overlay_segments",
             field=models.JSONField(
                 blank=True,
-                default=None,
+                default=list,
                 help_text="The schema that defines how categories of values in the overlay images are differentiated.",
-                null=True,
                 validators=[
                     grandchallenge.core.validators.JSONValidator(
                         schema={

--- a/app/grandchallenge/reader_studies/forms.py
+++ b/app/grandchallenge/reader_studies/forms.py
@@ -1,5 +1,6 @@
 import csv
 import io
+import json
 import logging
 
 from crispy_forms.helper import FormHelper
@@ -287,7 +288,8 @@ class QuestionForm(SaveFormInitMixin, DynamicFormMixin, ModelForm):
         if interface and overlay_segments != interface.overlay_segments:
             self.add_error(
                 error=ValidationError(
-                    f"Overlay segments do not match those of {interface.title}."
+                    f"Overlay segments do not match those of {interface.title}. "
+                    f"Please use {json.dumps(interface.overlay_segments)}."
                 ),
                 field=None,
             )

--- a/app/grandchallenge/reader_studies/migrations/0033_auto_20220707_1847.py
+++ b/app/grandchallenge/reader_studies/migrations/0033_auto_20220707_1847.py
@@ -33,9 +33,8 @@ class Migration(migrations.Migration):
             name="overlay_segments",
             field=models.JSONField(
                 blank=True,
-                default=None,
+                default=list,
                 help_text="The schema that defines how categories of values in the overlay images are differentiated.",
-                null=True,
                 validators=[
                     grandchallenge.core.validators.JSONValidator(
                         schema={


### PR DESCRIPTION
- Disallow null and default to list to prevent two representations of empty data,
  consistent with the existing definition in workstation_configs
- Ensure overlay_segments are set for segmentation interfaces
- Disallow changing the segments if a Question exists
- Dump the segments json for easier editing