### PR TITLE
Add an implicit background segment

### DIFF
--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -553,7 +553,13 @@ class OverlaySegmentsMixin(models.Model):
 
     @property
     def voxel_values(self):
-        return {x["voxel_value"] for x in self.overlay_segments}
+        allowed_values = {x["voxel_value"] for x in self.overlay_segments}
+
+        # An implicit background value of 0 is always allowed, this saves the
+        # user having to declare it and the annotator mark it
+        allowed_values.add(0)
+
+        return allowed_values
 
     def _validate_voxel_values(self, image):
         if not self.overlay_segments:

--- a/app/tests/components_tests/test_models.py
+++ b/app/tests/components_tests/test_models.py
@@ -870,18 +870,18 @@ def test_validate_voxel_values():
         ci._validate_voxel_values(im)
     assert e.value.message == error_msg
 
-    im = ImageFactory(segments=[0, 1])
+    im = ImageFactory(segments=[0, 1, 2])
     with pytest.raises(ValidationError) as e:
         ci._validate_voxel_values(im)
     assert e.value.message == (
-        "The valid voxel values for this segmentation are: {1}. "
-        "This segmentation is invalid as it contains the voxel values: {0}."
+        "The valid voxel values for this segmentation are: {0, 1}. "
+        "This segmentation is invalid as it contains the voxel values: {2}."
     )
 
     ci.overlay_segments = [
-        {"name": "s1", "visible": True, "voxel_value": 0},
-        {"name": "s2", "visible": True, "voxel_value": 1},
+        {"name": "s1", "visible": True, "voxel_value": 1},
+        {"name": "s2", "visible": True, "voxel_value": 2},
     ]
     ci.save()
-    im = ImageFactory(segments=[0, 1])
+    im = ImageFactory(segments=[0, 1, 2])
     assert ci._validate_voxel_values(im) is None


### PR DESCRIPTION
A background value of 0 is always allowed without the user having to declare it.