### PR TITLE
Limit the number of scheduled jobs and parallel scheduling

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1149,7 +1149,9 @@ if strtobool(os.environ.get("PUSH_CLOUDWATCH_METRICS", "False")):
 # The name of the group whose members will be able to create algorithms
 ALGORITHMS_CREATORS_GROUP_NAME = "algorithm_creators"
 # Number of jobs that can be scheduled in one task
-ALGORITHMS_JOB_BATCH_LIMIT = 256
+ALGORITHMS_JOB_BATCH_LIMIT = int(
+    os.environ.get("ALGORITHMS_JOB_BATCH_LIMIT", "64")
+)
 # Maximum and minimum values the user can set for algorithm requirements
 ALGORITHMS_MIN_MEMORY_GB = 4
 ALGORITHMS_MAX_MEMORY_GB = 30

--- a/app/grandchallenge/evaluation/tasks.py
+++ b/app/grandchallenge/evaluation/tasks.py
@@ -12,6 +12,7 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import Count, Q
 from django.db.transaction import on_commit
+from redis.exceptions import LockError
 
 from grandchallenge.algorithms.exceptions import TooManyJobsScheduled
 from grandchallenge.algorithms.models import Job
@@ -128,9 +129,16 @@ def create_evaluation(*, submission_pk, max_initial_jobs=1):
         raise RuntimeError("No algorithm or predictions file found")
 
 
+def _cache_key_from_method(method):
+    return f"lock.{method.__module__}.{method.__name__}"
+
+
 @shared_task(
     **settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-2xlarge"],
-    throws=(TooManyJobsScheduled,),
+    throws=(
+        TooManyJobsScheduled,
+        LockError,
+    ),
 )
 def create_algorithm_jobs_for_evaluation(
     *, evaluation_pk, max_jobs=1, retries=0
@@ -164,6 +172,7 @@ def create_algorithm_jobs_for_evaluation(
         )
 
     if Job.objects.active().count() >= settings.ALGORITHMS_JOB_BATCH_LIMIT:
+        logger.info("Retrying task as too many jobs scheduled")
         retry_with_delay()
         raise TooManyJobsScheduled
 
@@ -200,31 +209,39 @@ def create_algorithm_jobs_for_evaluation(
     evaluation.update_status(status=Evaluation.EXECUTING_PREREQUISITES)
 
     try:
-        jobs = create_algorithm_jobs(
-            algorithm_image=evaluation.submission.algorithm_image,
-            civ_sets=[
-                {*ai.values.all()}
-                for ai in evaluation.submission.phase.archive.items.prefetch_related(
-                    "values__interface"
-                )
-            ],
-            creator=None,
-            extra_viewer_groups=challenge_admins,
-            extra_logs_viewer_groups=challenge_admins,
-            task_on_success=task_on_success,
-            task_on_failure=task_on_failure,
-            max_jobs=max_jobs,
-            time_limit=evaluation.submission.phase.algorithm_time_limit,
-        )
+        # Method is expensive so only allow one process at a time
+        with cache.lock(
+            _cache_key_from_method(create_algorithm_jobs),
+            timeout=settings.CELERY_TASK_TIME_LIMIT,
+            blocking_timeout=10,
+        ):
+            jobs = create_algorithm_jobs(
+                algorithm_image=evaluation.submission.algorithm_image,
+                civ_sets=[
+                    {*ai.values.all()}
+                    for ai in evaluation.submission.phase.archive.items.prefetch_related(
+                        "values__interface"
+                    )
+                ],
+                creator=None,
+                extra_viewer_groups=challenge_admins,
+                extra_logs_viewer_groups=challenge_admins,
+                task_on_success=task_on_success,
+                task_on_failure=task_on_failure,
+                max_jobs=max_jobs,
+                time_limit=evaluation.submission.phase.algorithm_time_limit,
+            )
 
-        if not jobs:
-            # No more jobs created from this task, so everything must be ready
-            # for evaluation
-            set_evaluation_inputs.signature(
-                kwargs={"evaluation_pk": str(evaluation.pk)}, immutable=True
-            ).apply_async()
+            if not jobs:
+                # No more jobs created from this task, so everything must be ready
+                # for evaluation
+                set_evaluation_inputs.signature(
+                    kwargs={"evaluation_pk": str(evaluation.pk)},
+                    immutable=True,
+                ).apply_async()
 
-    except TooManyJobsScheduled:
+    except (TooManyJobsScheduled, LockError) as error:
+        logger.info(f"Retrying task due to: {error}")
         retry_with_delay()
         raise
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       DEBUG: 'true'
       PYTHONDONTWRITEBYTECODE: 1
     restart: always
-    command: watchfiles "celery -A config worker -l info -c 1 -Q acks-late-2xlarge,acks-late-micro-short" /app
+    command: watchfiles "celery -A config worker -l info -c 1 -Q acks-late-2xlarge,acks-late-2xlarge-delay,acks-late-micro-short,acks-late-micro-short-delay" /app
     scale: 1
     hostname: "celery-worker-evaluation"
     depends_on:


### PR DESCRIPTION
This PR attempts to solve the problem we saw yesterday with too many scheduled algorithm jobs. Two approaches:

1. The total number of active jobs is limited to 2x the scheduling batch size, we can tune this given performance. This prevents large backlogs of queues and hammering of the SageMaker API to schedule jobs when there are no resources available.
2. Only allow one process to schedule tasks, this prevents parallel workers overloading the database.

If this works well we can apply the same guards to `create_algorithm_jobs_for_archive`

https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/78

Deployment
- [x] It requires the addition of one new queue (`acks-late-2xlarge-delay`)