### PR TITLE
Automatically remove stale container images

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1125,6 +1125,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "grandchallenge.evaluation.tasks.update_phase_statistics",
         "schedule": timedelta(days=1),
     },
+    "remove_inactive_container_images": {
+        "task": "grandchallenge.components.tasks.remove_inactive_container_images",
+        "schedule": timedelta(days=1),
+    },
     **{
         f"stop_expired_services_{region}": {
             "task": "grandchallenge.components.tasks.stop_expired_services",

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -496,7 +496,7 @@ class Phase(UUIDModel, ViewContentMixin):
                 "the creator_must_be_verified box needs to be checked."
             )
 
-        if self.submission_limit > 0 and not self.latest_executable_method:
+        if self.submission_limit > 0 and not self.latest_executable_image:
             raise ValidationError(
                 "You need to first add a valid method for this phase before you "
                 "can change the submission limit to above 0."
@@ -683,7 +683,7 @@ class Phase(UUIDModel, ViewContentMixin):
         )
 
     @property
-    def latest_executable_method(self):
+    def latest_executable_image(self):
         if self.method_set.all():
             return (
                 self.method_set.executable_images()

--- a/app/grandchallenge/evaluation/tasks.py
+++ b/app/grandchallenge/evaluation/tasks.py
@@ -62,7 +62,7 @@ def create_evaluation(*, submission_pk, max_initial_jobs=1):
         submission.user_upload.delete()
 
     # TODO - move this to the form and make it an input here
-    method = submission.phase.latest_executable_method
+    method = submission.phase.latest_executable_image
     if not method:
         logger.info("No method ready for this submission")
         Notification.send(

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -72,7 +72,7 @@
                         <p><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> The submission limit for this phase is 0, but the start and end dates indicate that this phase should be open to submissions now. The submission limit needs to be above 0 for participants to submit to this phase.</p>
                 </div>
             {% endif %}
-            {% if not phase.latest_executable_method %}
+            {% if not phase.latest_executable_image %}
                 <div class="alert alert-danger pb-1" role="alert">
                     <p><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> There is no valid evaluation method for this phase. Please upload a method container <a href="{% url 'evaluation:method-create' challenge_short_name=challenge.short_name %}">here</a>. </p>
                 </div>

--- a/app/grandchallenge/workstations/urls.py
+++ b/app/grandchallenge/workstations/urls.py
@@ -30,11 +30,6 @@ urlpatterns = [
         name="workstation-session-create",
     ),
     path(
-        "<slug>/<uuid:pk>/sessions/create/",
-        SessionCreate.as_view(),
-        name="workstation-image-session-create",
-    ),
-    path(
         "<slug>/editors/update/",
         WorkstationEditorsUpdate.as_view(),
         name="editors-update",

--- a/app/grandchallenge/workstations/utils.py
+++ b/app/grandchallenge/workstations/utils.py
@@ -1,12 +1,4 @@
-from django.conf import settings
-from django.http import Http404
-from django.shortcuts import get_object_or_404
-
-from grandchallenge.workstations.models import (
-    Session,
-    Workstation,
-    WorkstationImage,
-)
+from grandchallenge.workstations.models import Session, WorkstationImage
 
 
 def get_or_create_active_session(
@@ -52,39 +44,3 @@ def get_or_create_active_session(
         )
 
     return session
-
-
-def get_workstation_image_or_404(
-    *, pk: str = None, slug: str = settings.DEFAULT_WORKSTATION_SLUG
-) -> WorkstationImage:
-    """
-    Gets the workstation image based on the provided pk. If this is absent,
-    gets the workstation from the slug and returns the latest container image
-    for this workstation.
-
-    Parameters
-    ----------
-    pk
-        The primary key of the workstation image
-    slug
-        The slug of the workstation
-
-    Raises
-    ------
-    Http404
-        If either the Workstation or WorkstationImage cannot be found
-
-    Returns
-    -------
-        The `WorkstationImage` that corresponds to this `pk` or `slug`.
-    """
-    if pk is not None:
-        workstation_image = get_object_or_404(WorkstationImage, pk=pk)
-    else:
-        workstation = get_object_or_404(Workstation, slug=slug)
-
-        workstation_image = workstation.latest_executable_image
-        if workstation_image is None:
-            raise Http404("No container images found for this workstation")
-
-    return workstation_image

--- a/app/tests/components_tests/test_models.py
+++ b/app/tests/components_tests/test_models.py
@@ -20,7 +20,9 @@ from grandchallenge.components.models import (
     InterfaceSuperKindChoices,
 )
 from grandchallenge.components.schemas import INTERFACE_VALUE_SCHEMA
-from grandchallenge.components.tasks import remove_image_from_registry
+from grandchallenge.components.tasks import (
+    remove_container_image_from_registry,
+)
 from tests.algorithms_tests.factories import (
     AlgorithmImageFactory,
     AlgorithmJobFactory,
@@ -1061,7 +1063,7 @@ def test_cannot_change_image(algorithm_image):
 
 
 @pytest.mark.django_db
-def test_remove_image_from_registry(algorithm_image, settings):
+def test_remove_container_image_from_registry(algorithm_image, settings):
     # Override the celery settings
     settings.task_eager_propagates = (True,)
     settings.task_always_eager = (True,)
@@ -1079,7 +1081,7 @@ def test_remove_image_from_registry(algorithm_image, settings):
     assert ai.is_in_registry is True
 
     with capture_on_commit_callbacks() as callbacks:
-        remove_image_from_registry(
+        remove_container_image_from_registry(
             pk=ai.pk,
             app_label=ai._meta.app_label,
             model_name=ai._meta.model_name,

--- a/app/tests/workstations_tests/test_permissions.py
+++ b/app/tests/workstations_tests/test_permissions.py
@@ -125,7 +125,6 @@ def test_workstation_user_permissions(
     [
         "workstations:default-session-create",
         "workstations:workstation-session-create",
-        "workstations:workstation-image-session-create",
     ],
 )
 def test_workstation_redirect_permissions(
@@ -155,14 +154,8 @@ def test_workstation_redirect_permissions(
 
     kwargs = {}
 
-    if viewname in [
-        "workstations:workstation-session-create",
-        "workstations:workstation-image-session-create",
-    ]:
+    if viewname == "workstations:workstation-session-create":
         kwargs.update({"slug": two_workstation_sets.ws1.workstation.slug})
-
-    if viewname == "workstations:workstation-image-session-create":
-        kwargs.update({"pk": two_workstation_sets.ws1.image.pk})
 
     for test in tests:
         response = get_view_for_user(

--- a/app/tests/workstations_tests/test_utils.py
+++ b/app/tests/workstations_tests/test_utils.py
@@ -1,17 +1,8 @@
 import pytest
-from django.conf import settings
-from django.http import Http404
 
-from grandchallenge.workstations.models import Session, Workstation
-from grandchallenge.workstations.utils import (
-    get_or_create_active_session,
-    get_workstation_image_or_404,
-)
-from tests.factories import (
-    UserFactory,
-    WorkstationFactory,
-    WorkstationImageFactory,
-)
+from grandchallenge.workstations.models import Session
+from grandchallenge.workstations.utils import get_or_create_active_session
+from tests.factories import UserFactory, WorkstationImageFactory
 
 
 @pytest.mark.django_db
@@ -65,37 +56,3 @@ def test_get_or_create_active_session():
     assert s_4.workstation_image == wsi
     assert s_4.creator == user
     assert Session.objects.all().count() == 4
-
-
-@pytest.mark.django_db
-def test_get_workstation_image_or_404():
-    # No default workstation
-    with pytest.raises(Http404):
-        get_workstation_image_or_404()
-
-    default_workstation = Workstation.objects.get(
-        slug=settings.DEFAULT_WORKSTATION_SLUG
-    )
-    default_wsi = WorkstationImageFactory(
-        workstation=default_workstation,
-        is_manifest_valid=True,
-        is_in_registry=True,
-    )
-    wsi = WorkstationImageFactory(is_manifest_valid=True, is_in_registry=True)
-
-    found_wsi = get_workstation_image_or_404()
-    assert found_wsi == default_wsi
-
-    found_wsi = get_workstation_image_or_404(slug=wsi.workstation.slug)
-    assert found_wsi == wsi
-
-    found_wsi = get_workstation_image_or_404(pk=wsi.pk)
-    assert found_wsi == wsi
-
-    # No images for workstation
-    with pytest.raises(Http404):
-        get_workstation_image_or_404(slug=WorkstationFactory().slug)
-
-    # Incorrect pk
-    with pytest.raises(Http404):
-        get_workstation_image_or_404(pk=WorkstationFactory().pk)


### PR DESCRIPTION
This PR adds a periodic task to remove any stale images from the registry. Also removes the ability to launch a workstation by the container image pk (as discussed with @miriam-groeneveld).