### PR TITLE
Add form and view to create a display set from a job

### DIFF
--- a/app/grandchallenge/algorithms/forms.py
+++ b/app/grandchallenge/algorithms/forms.py
@@ -593,6 +593,7 @@ class DisplaySetFromJobForm(SaveFormInitMixin, Form):
         queryset=Job.objects.none(),
         disabled=True,
         required=True,
+        widget=HiddenInput(),
     )
 
     def __init__(self, *args, user, job, **kwargs):
@@ -609,7 +610,7 @@ class DisplaySetFromJobForm(SaveFormInitMixin, Form):
             "algorithms.view_job",
             accept_global_perms=False,
         ).filter(pk=job.pk)
-        self.fields["job"].initial = self.fields["job"].queryset
+        self.fields["job"].initial = job
 
 
 class AlgorithmPermissionRequestUpdateForm(PermissionRequestUpdateForm):

--- a/app/grandchallenge/algorithms/forms.py
+++ b/app/grandchallenge/algorithms/forms.py
@@ -589,14 +589,8 @@ class DisplaySetFromJobForm(SaveFormInitMixin, Form):
     reader_study = ModelChoiceField(
         queryset=ReaderStudy.objects.none(), required=True
     )
-    job = ModelChoiceField(
-        queryset=Job.objects.none(),
-        disabled=True,
-        required=True,
-        widget=HiddenInput(),
-    )
 
-    def __init__(self, *args, user, job, **kwargs):
+    def __init__(self, *args, user, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.fields["reader_study"].queryset = get_objects_for_user(
@@ -604,13 +598,6 @@ class DisplaySetFromJobForm(SaveFormInitMixin, Form):
             "reader_studies.change_readerstudy",
             accept_global_perms=False,
         ).order_by("title")
-
-        self.fields["job"].queryset = get_objects_for_user(
-            user,
-            "algorithms.view_job",
-            accept_global_perms=False,
-        ).filter(pk=job.pk)
-        self.fields["job"].initial = job
 
 
 class AlgorithmPermissionRequestUpdateForm(PermissionRequestUpdateForm):

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
-from django.db.models import Min, Q, Sum
+from django.db.models import Count, Min, Q, Sum
 from django.db.models.signals import post_delete
 from django.db.transaction import on_commit
 from django.dispatch import receiver
@@ -42,6 +42,7 @@ from grandchallenge.hanging_protocols.models import ViewContentMixin
 from grandchallenge.modalities.models import ImagingModality
 from grandchallenge.organizations.models import Organization
 from grandchallenge.publications.models import Publication
+from grandchallenge.reader_studies.models import DisplaySet
 from grandchallenge.subdomains.utils import reverse
 from grandchallenge.workstations.models import Workstation
 
@@ -654,6 +655,28 @@ class Job(UUIDModel, ComponentJob):
             outputs[output.interface.slug] = output
 
         return outputs
+
+    def get_or_create_display_set(self, *, reader_study):
+        """Get or create a display set from this job for a reader study"""
+        values = {*self.inputs.all(), *self.outputs.all()}
+
+        try:
+            display_set = (
+                reader_study.display_sets.filter(values__in=values)
+                .annotate(
+                    values_match_count=Count(
+                        "values",
+                        filter=Q(values__in=values),
+                    )
+                )
+                .filter(values_match_count=len(values))
+                .get()
+            )
+        except ObjectDoesNotExist:
+            display_set = DisplaySet.objects.create(reader_study=reader_study)
+            display_set.values.set(values)
+
+        return display_set
 
 
 @receiver(post_delete, sender=Job)

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -658,6 +658,11 @@ class Job(UUIDModel, ComponentJob):
 
     def get_or_create_display_set(self, *, reader_study):
         """Get or create a display set from this job for a reader study"""
+        if self.status != self.SUCCESS:
+            raise RuntimeError(
+                "Display sets can only be created from successful jobs"
+            )
+
         values = {*self.inputs.all(), *self.outputs.all()}
 
         try:

--- a/app/grandchallenge/algorithms/templates/algorithms/display_set_from_job_form.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/display_set_from_job_form.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags %}
+{% load url %}
+
+{% block title %}
+    Create Display Set - {{ block.super }}
+{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a
+                href="{% url 'algorithms:list' %}">Algorithms</a>
+        </li>
+        <li class="breadcrumb-item"><a
+                href="{{ object.algorithm_image.algorithm.get_absolute_url }}">{{ object.algorithm_image.algorithm.title }}
+        </a></li>
+        <li class="breadcrumb-item"><a
+                href="{% url 'algorithms:job-list' slug=object.algorithm_image.algorithm.slug %}">Results</a></li>
+        <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{{ object.pk }}</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Create a Display Set</li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <h2>Create a Display Set from this Result</h2>
+
+    <p>
+        Use this form to create a new display set in a reader study from this result.
+        <b>
+            Users with read access to the selected reader study will be able to see this algorithm's inputs and outputs,
+            please select the reader study carefully.
+        </b>
+    </p>
+
+    {% crispy form %}
+{% endblock %}

--- a/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
@@ -49,7 +49,7 @@
                 </a>
             {% endif %}
 
-            {% if perms.reader_studies.add_readerstudy %}
+            {% if object.status == object.SUCCESS and perms.reader_studies.add_readerstudy %}
                 <a class="nav-link"
                    href="{% url "algorithms:display-set-from-job-create" slug=object.algorithm_image.algorithm.slug pk=object.pk %}">
                     <i class="fas fa-edit fa-fw"></i>&nbsp;Edit in Reader Study

--- a/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
@@ -5,6 +5,7 @@
 {% load pathlib %}
 {% load workstations %}
 {% load static %}
+{% load url %}
 
 {% block title %}
     Algorithm Result - {{ block.super }}
@@ -45,6 +46,13 @@
                 <a class="nav-link" id="v-pills-logs-tab" data-toggle="pill"
                    href="#v-pills-logs" role="tab" aria-controls="v-pills-logs"
                    aria-selected="false"><i class="fas fa-terminal fa-fw"></i>&nbsp;Logs
+                </a>
+            {% endif %}
+
+            {% if perms.reader_studies.add_readerstudy %}
+                <a class="nav-link"
+                   href="{% url "algorithms:display-set-from-job-create" slug=object.algorithm_image.algorithm.slug pk=object.pk %}">
+                    <i class="fas fa-edit fa-fw"></i>&nbsp;Edit in Reader Study
                 </a>
             {% endif %}
         </div>

--- a/app/grandchallenge/algorithms/urls.py
+++ b/app/grandchallenge/algorithms/urls.py
@@ -17,6 +17,7 @@ from grandchallenge.algorithms.views import (
     AlgorithmPermissionRequestUpdate,
     AlgorithmPublishView,
     AlgorithmUpdate,
+    DisplaySetFromJobCreate,
     EditorsUpdate,
     JobDetail,
     JobExperimentDetail,
@@ -74,6 +75,11 @@ urlpatterns = [
     path("<slug>/jobs/<uuid:pk>/", JobDetail.as_view(), name="job-detail"),
     path(
         "<slug>/jobs/<uuid:pk>/update/", JobUpdate.as_view(), name="job-update"
+    ),
+    path(
+        "<slug>/jobs/<uuid:pk>/display-set/create/",
+        DisplaySetFromJobCreate.as_view(),
+        name="display-set-from-job-create",
     ),
     path(
         "<slug>/jobs/<uuid:pk>/experiment/",

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -90,6 +90,9 @@ from grandchallenge.groups.views import UserGroupUpdateMixin
 from grandchallenge.reader_studies.models import DisplaySet
 from grandchallenge.subdomains.utils import reverse
 from grandchallenge.verifications.views import VerificationRequiredMixin
+from grandchallenge.workstations.templatetags.workstations import (
+    workstation_query,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -752,7 +755,6 @@ class JobUpdate(LoginRequiredMixin, ObjectPermissionRequiredMixin, UpdateView):
 class DisplaySetFromJobCreate(
     LoginRequiredMixin,
     ObjectPermissionRequiredMixin,
-    SuccessMessageMixin,
     FormView,
 ):
     form_class = DisplaySetFromJobForm
@@ -789,8 +791,13 @@ class DisplaySetFromJobCreate(
         ds = DisplaySet.objects.create(reader_study=reader_study)
         ds.values.set({*job.inputs.all(), *job.outputs.all()})
 
-        self.success_url = reader_study.get_absolute_url()
-        self.success_message = f"Added display set {ds.pk} from job {job.pk}"
+        url = reverse(
+            "workstations:workstation-session-create",
+            kwargs={"slug": reader_study.workstation.slug},
+        )
+        query = workstation_query(display_set=ds)
+
+        self.success_url = f"{url}?{query}"
 
         return super().form_valid(form)
 

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -777,13 +777,11 @@ class DisplaySetFromJobCreate(
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        kwargs.update({"user": self.request.user, "job": self.job})
+        kwargs.update({"user": self.request.user})
         return kwargs
 
     def form_valid(self, form):
-        job = form.cleaned_data["job"]
-
-        display_set = job.get_or_create_display_set(
+        display_set = self.job.get_or_create_display_set(
             reader_study=form.cleaned_data["reader_study"]
         )
         self.success_url = display_set.workstation_url

--- a/app/grandchallenge/archives/templates/archives/archive_cases_to_reader_study_form.html
+++ b/app/grandchallenge/archives/templates/archives/archive_cases_to_reader_study_form.html
@@ -23,7 +23,6 @@
 
     <p>
         Use this form to append items from this archive to a reader study.
-        If the items already belong to the selected reader study then those items will not be added again.
         All items in this archive have been pre-selected for you.
         <b>Be sure to select the correct reader study first!</b>
     </p>

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -144,6 +144,10 @@ based on these scores: the average and total scores for each question as well
 as for each case are displayed in the ``statistics`` view.
 """
 
+from grandchallenge.workstations.templatetags.workstations import (
+    workstation_query,
+)
+
 CASE_TEXT_SCHEMA = {
     "type": "object",
     "properties": {},
@@ -852,6 +856,16 @@ class DisplaySet(UUIDModel):
         return reverse(
             "api:reader-studies-display-set-detail", kwargs={"pk": self.pk}
         )
+
+    @cached_property
+    def workstation_url(self):
+        """The URL to answer this display set in a workstation"""
+        url = reverse(
+            "workstations:workstation-session-create",
+            kwargs={"slug": self.reader_study.workstation.slug},
+        )
+        query = workstation_query(display_set=self)
+        return f"{url}?{query}"
 
     @property
     def description(self):

--- a/app/tests/algorithms_tests/test_views.py
+++ b/app/tests/algorithms_tests/test_views.py
@@ -413,6 +413,13 @@ class TestObjectPermissionRequiredViews:
                 None,
             ),
             (
+                "display-set-from-job-create",
+                {"slug": ai.algorithm.slug, "pk": j.pk},
+                "view_job",
+                j,
+                None,
+            ),
+            (
                 "job-viewers-update",
                 {"slug": ai.algorithm.slug, "pk": j.pk},
                 "change_job",

--- a/app/tests/algorithms_tests/test_views.py
+++ b/app/tests/algorithms_tests/test_views.py
@@ -325,7 +325,7 @@ class TestObjectPermissionRequiredViews:
         ai = AlgorithmImageFactory(is_manifest_valid=True, is_in_registry=True)
         s = RawImageUploadSessionFactory()
         u = UserFactory()
-        j = AlgorithmJobFactory(algorithm_image=ai)
+        j = AlgorithmJobFactory(algorithm_image=ai, status=Job.SUCCESS)
         p = AlgorithmPermissionRequestFactory(algorithm=ai.algorithm)
 
         VerificationFactory(user=u, is_verified=True)

--- a/app/tests/reader_studies_tests/test_models.py
+++ b/app/tests/reader_studies_tests/test_models.py
@@ -17,7 +17,7 @@ from tests.components_tests.factories import (
     ComponentInterfaceFactory,
     ComponentInterfaceValueFactory,
 )
-from tests.factories import ImageFactory, UserFactory
+from tests.factories import ImageFactory, UserFactory, WorkstationFactory
 from tests.reader_studies_tests.factories import (
     AnswerFactory,
     DisplaySetFactory,
@@ -502,3 +502,15 @@ def test_main_image_from_ds():
     ds.refresh_from_db()
     del ds.main_image_title
     assert im1.name == ds.main_image_title
+
+
+@pytest.mark.django_db
+def test_workstation_url():
+    workstation = WorkstationFactory()
+    reader_study = ReaderStudyFactory(workstation=workstation)
+    display_set = DisplaySetFactory(reader_study=reader_study)
+
+    assert (
+        display_set.workstation_url
+        == f"https://testserver/viewers/{workstation.slug}/sessions/create/?displaySet={display_set.pk}"
+    )


### PR DESCRIPTION
This PR adds a new button for users with the global `add_readerstudy` permission to create a display set from a successful job. The view is idempotent and will redirect the user to a workstation session with the display set. The user requires the `change_readerstudy` and `view_job` object permissions.

![image](https://user-images.githubusercontent.com/12661555/180811903-5502a8ec-0c03-4468-b691-88bb3bdc8e84.png)

![image](https://user-images.githubusercontent.com/12661555/180812012-2d265072-2450-4380-b021-a02d3303ec38.png)

https://github.com/DIAGNijmegen/rse-roadmap/issues/162