### PR TITLE
Create and use PkToHyperlinkedRelatedField for session field on feedback serializer

### DIFF
--- a/app/grandchallenge/core/serializer_fields.py
+++ b/app/grandchallenge/core/serializer_fields.py
@@ -1,0 +1,11 @@
+from rest_framework import serializers
+
+
+class PkToHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
+    """
+    A HyperlinkedRelatedField that allows you to use the primary key of the
+    model when writing, but returns the URL of the object when reading.
+    """
+
+    def to_internal_value(self, data):
+        return self.get_queryset().get(pk=data)

--- a/app/grandchallenge/core/serializer_fields.py
+++ b/app/grandchallenge/core/serializer_fields.py
@@ -1,3 +1,5 @@
+from django.core.exceptions import ObjectDoesNotExist
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 
@@ -7,5 +9,20 @@ class PkToHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
     model when writing, but returns the URL of the object when reading.
     """
 
+    default_error_messages = {
+        "required": _("This field is required."),
+        "does_not_exist": _(
+            'Invalid pk "{pk_value}" - object does not exist.'
+        ),
+        "incorrect_type": _(
+            "Incorrect type. Expected pk value, received {data_type}."
+        ),
+    }
+
     def to_internal_value(self, data):
-        return self.get_queryset().get(pk=data)
+        try:
+            return self.get_queryset().get(pk=data)
+        except ObjectDoesNotExist:
+            self.fail("does_not_exist", pk_value=data)
+        except (TypeError, ValueError):
+            self.fail("incorrect_type", data_type=type(data).__name__)

--- a/app/grandchallenge/workstations/serializers.py
+++ b/app/grandchallenge/workstations/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework.fields import CharField
-from rest_framework.relations import HyperlinkedRelatedField
 from rest_framework.serializers import ModelSerializer
 
+from grandchallenge.core.serializer_fields import PkToHyperlinkedRelatedField
 from grandchallenge.workstations.models import Feedback, Session
 
 
@@ -14,7 +14,7 @@ class SessionSerializer(ModelSerializer):
 
 
 class FeedbackSerializer(ModelSerializer):
-    session = HyperlinkedRelatedField(
+    session = PkToHyperlinkedRelatedField(
         queryset=Session.objects.all(), view_name="api:session-detail"
     )
 

--- a/app/tests/core_tests/test_serializer_fields.py
+++ b/app/tests/core_tests/test_serializer_fields.py
@@ -1,6 +1,5 @@
 import pytest
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import serializers
 
 from grandchallenge.core.serializer_fields import PkToHyperlinkedRelatedField
@@ -15,8 +14,10 @@ def test_pk_to_hyperlinked_serializer():
         )
 
     serializer = TestSerializer(data={"related_user": -1})
-    with pytest.raises(ObjectDoesNotExist):
-        serializer.is_valid()
+    assert not serializer.is_valid()
+    assert serializer.errors["related_user"] == [
+        'Invalid pk "-1" - object does not exist.'
+    ]
 
     u = get_user_model().objects.create(username="test")
     serializer = TestSerializer(data={"related_user": u.pk})

--- a/app/tests/core_tests/test_serializer_fields.py
+++ b/app/tests/core_tests/test_serializer_fields.py
@@ -1,0 +1,24 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
+from rest_framework import serializers
+
+from grandchallenge.core.serializer_fields import PkToHyperlinkedRelatedField
+
+
+@pytest.mark.django_db
+def test_pk_to_hyperlinked_serializer():
+    class TestSerializer(serializers.Serializer):
+        related_user = PkToHyperlinkedRelatedField(
+            queryset=get_user_model().objects.all(),
+            view_name="api:profiles-user-detail",
+        )
+
+    serializer = TestSerializer(data={"related_user": -1})
+    with pytest.raises(ObjectDoesNotExist):
+        serializer.is_valid()
+
+    u = get_user_model().objects.create(username="test")
+    serializer = TestSerializer(data={"related_user": u.pk})
+    assert serializer.is_valid()
+    assert serializer.validated_data["related_user"] == u

--- a/app/tests/workstations_tests/test_api.py
+++ b/app/tests/workstations_tests/test_api.py
@@ -203,7 +203,7 @@ def test_create_session_feedback(client):
             client=client,
             method=client.post,
             data={
-                "session": session.api_url,
+                "session": session.pk,
                 "user_comment": "Some comment",
                 "screenshot": file,
             },
@@ -228,13 +228,13 @@ def test_only_session_creator_can_create_session_feedback(client):
         viewname="api:workstations-feedback-list",
         client=client,
         method=client.post,
-        data={"session": session.api_url, "user_comment": "Some comment"},
+        data={"session": session.pk, "user_comment": "Some comment"},
         user=user2,
         follow=True,
     )
     assert response.status_code == 400
     assert response.json() == {
-        "session": ["Invalid hyperlink - Object does not exist."]
+        "session": [f'Invalid pk "{session.pk}" - object does not exist.']
     }
     assert Feedback.objects.count() == 0
 
@@ -242,7 +242,7 @@ def test_only_session_creator_can_create_session_feedback(client):
         viewname="api:workstations-feedback-list",
         client=client,
         method=client.post,
-        data={"session": session.api_url, "user_comment": "Some comment"},
+        data={"session": session.pk, "user_comment": "Some comment"},
         user=user1,
         follow=True,
     )


### PR DESCRIPTION
Specialized implementation of the HyperlinkedRelatedField that maintains the hyperlink representation when reading serialized data but allows us to use only the pk when writing to the field. 

This is useful for the feedback endpoint because we only know the session pk when writing to that endpoint and cannot reverse it into the full URL (at least not without hardcoding it). 