### PR TITLE
Add permissive CORS header on 413 errors

### DIFF
--- a/dockerfiles/http/nginx.conf.template
+++ b/dockerfiles/http/nginx.conf.template
@@ -156,6 +156,14 @@ http {
 
     server_name .${SERVER_NAME};
 
+    error_page 413 = @error_413;
+
+    location @error_413 {
+        # Add permissive CORS header to 413 errors
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        return 413;
+    }
+
     location =/ping {
       # Used for determining if a workstation rendering region is active
 

--- a/dockerfiles/http/nginx.conf.template
+++ b/dockerfiles/http/nginx.conf.template
@@ -158,8 +158,9 @@ http {
 
     error_page 413 = @error_413;
 
-    location @error_413 {
+    location =@error_413 {
         # Add permissive CORS header to 413 errors
+        internal;
         add_header 'Access-Control-Allow-Origin' '*' always;
         return 413;
     }


### PR DESCRIPTION
When making a request that triggers a 413 error in CIRRUS, the actual 413 error cannot be seen because a CORS error overrules it.  This PR adds a permissive CORS header to the 413 response to fix it.