### PR TITLE
AnswerType specific answer rendering for PDF report

### DIFF
--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -927,6 +927,14 @@ class AnswerType(models.TextChoices):
     MULTIPLE_ANGLES = "MANG", "Multiple angles"
 
     @staticmethod
+    def get_choice_types():
+        return [
+            AnswerType.CHOICE,
+            AnswerType.MULTIPLE_CHOICE,
+            AnswerType.MULTIPLE_CHOICE_DROPDOWN,
+        ]
+
+    @staticmethod
     def get_annotation_types():
         return [
             AnswerType.BOUNDING_BOX_2D,

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1379,7 +1379,7 @@ class Answer(UUIDModel):
                     "title", flat=True
                 ).all()
             ]
-            return ", ".join(list)
+            return format_html(", ".join(list))
         elif self.question.answer_type == Question.AnswerType.BOOL:
             return (
                 format_html('<span class="success">✔</span>')

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -11,7 +11,6 @@ from django.db.models import Avg, Count, Q, Sum
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.utils.functional import cached_property
-from django.utils.html import format_html
 from django_extensions.db.models import TitleSlugDescriptionModel
 from guardian.shortcuts import assign_perm, get_objects_for_group, remove_perm
 from jsonschema import RefResolutionError
@@ -1363,31 +1362,6 @@ class Answer(UUIDModel):
             raise ValidationError(
                 "Answer for required question cannot be None"
             )
-
-    @property
-    def html_string(self):
-        if self.question.answer_type in (
-            Question.AnswerType.CHOICE,
-            Question.AnswerType.MULTIPLE_CHOICE,
-            Question.AnswerType.MULTIPLE_CHOICE_DROPDOWN,
-        ):
-            list = [
-                format_html("<u>{}</u>", option)
-                if option in self.answer_text
-                else format_html("{}", option)
-                for option in self.question.options.values_list(
-                    "title", flat=True
-                ).all()
-            ]
-            return format_html(", ".join(list))
-        elif self.question.answer_type == Question.AnswerType.BOOL:
-            return (
-                format_html('<span class="success">✔</span>')
-                if self.answer
-                else format_html('<span class="danger">✘</span>')
-            )
-        else:
-            return self.answer_text
 
     @property
     def answer_text(self):

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -11,6 +11,7 @@ from django.db.models import Avg, Count, Q, Sum
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.utils.functional import cached_property
+from django.utils.html import format_html
 from django_extensions.db.models import TitleSlugDescriptionModel
 from guardian.shortcuts import assign_perm, get_objects_for_group, remove_perm
 from jsonschema import RefResolutionError
@@ -1362,6 +1363,31 @@ class Answer(UUIDModel):
             raise ValidationError(
                 "Answer for required question cannot be None"
             )
+
+    @property
+    def html_string(self):
+        if self.question.answer_type in (
+            Question.AnswerType.CHOICE,
+            Question.AnswerType.MULTIPLE_CHOICE,
+            Question.AnswerType.MULTIPLE_CHOICE_DROPDOWN,
+        ):
+            list = [
+                format_html("<u>{}</u>", option)
+                if option in self.answer_text
+                else format_html("{}", option)
+                for option in self.question.options.values_list(
+                    "title", flat=True
+                ).all()
+            ]
+            return ", ".join(list)
+        elif self.question.answer_type == Question.AnswerType.BOOL:
+            return (
+                format_html('<span class="success">✔</span>')
+                if self.answer
+                else format_html('<span class="danger">✘</span>')
+            )
+        else:
+            return self.answer_text
 
     @property
     def answer_text(self):

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_display_set_pdf_report.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_display_set_pdf_report.html
@@ -46,16 +46,16 @@
         <div class="answers">
             <h2 style="margin-top:50px;">Answers</h2>
             <table>
-                {% for question, answer in answers.items %}
+                {% for answer in answers %}
                     <tr>
-                        <td class="left"><b>{{ question }}:</b></td>
-                        {% if answer.question.answer_type == "BOOL" %}
+                        <td class="left"><b>{{ answer.question.question_text }}:</b></td>
+                        {% if answer.question.answer_type == answer.question.AnswerType.BOOL %}
                             {% if answer.answer %}
                                 <td><span class="success">✔</span></td>
                             {% else %}
                                 <td><span class="danger">✘</span></td>
                             {% endif %}
-                        {% elif answer.question.answer_type == "CHOI" or answer.question.answer_type == "MCHO" or answer.question.answer_type == "MCHD"%}
+                        {% elif answer.question.answer_type in answer.question.AnswerType.get_choice_types %}
                             <td>
                                 {% for option in answer.question.options.all %}
                                     {% if option.title in answer.answer_text %}

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_display_set_pdf_report.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_display_set_pdf_report.html
@@ -49,7 +49,26 @@
                 {% for question, answer in answers.items %}
                     <tr>
                         <td class="left"><b>{{ question }}:</b></td>
-                        <td>{{ answer }}</td>
+                        {% if answer.question.answer_type == "BOOL" %}
+                            {% if answer.answer %}
+                                <td><span class="success">✔</span></td>
+                            {% else %}
+                                <td><span class="danger">✘</span></td>
+                            {% endif %}
+                        {% elif answer.question.answer_type == "CHOI" or answer.question.answer_type == "MCHO" or answer.question.answer_type == "MCHD"%}
+                            <td>
+                                {% for option in answer.question.options.all %}
+                                    {% if option.title in answer.answer_text %}
+                                        <u>{{ option.title }}</u>
+                                    {% else %}
+                                        {{ option.title }}
+                                    {% endif %}
+                                    {% if not forloop.last %}, {% endif %}
+                                {% endfor %}
+                            </td>
+                        {% else %}
+                            <td>{{ answer.answer_text }}</td>
+                        {% endif %}
                     </tr>
                 {% endfor %}
             </table>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_display_set_pdf_report.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_display_set_pdf_report.html
@@ -49,7 +49,7 @@
                 {% for question, answer in answers.items %}
                     <tr>
                         <td class="left"><b>{{ question }}:</b></td>
-                        <td>{{ answer|safe }}</td>
+                        <td>{{ answer }}</td>
                     </tr>
                 {% endfor %}
             </table>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_display_set_pdf_report.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_display_set_pdf_report.html
@@ -10,6 +10,8 @@
         td.left {width:30%;}
         h1 {text-align: center;}
         div.answers {padding: 3px;}
+        .success {color:green;}
+        .danger {color:red;}
         @page {
             @frame content_frame {
                 left: 50pt;
@@ -47,7 +49,7 @@
                 {% for question, answer in answers.items %}
                     <tr>
                         <td class="left"><b>{{ question }}:</b></td>
-                        <td>{{ answer }}</td>
+                        <td>{{ answer|safe }}</td>
                     </tr>
                 {% endfor %}
             </table>

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -1488,27 +1488,25 @@ class DisplaySetPDFReport(
         return response
 
     def get_context_data(self):
-        answer_dict = {
-            answer.question.question_text: answer
-            for answer in self.display_set.answers.select_related(
+        answers = (
+            self.display_set.answers.select_related(
                 "creator", "question", "answer_image"
             )
             .filter(
                 creator=self.user,
                 is_ground_truth=False,
                 answer_image__isnull=True,
+                answer__isnull=False,
             )
             .exclude(
                 question__answer_type__in=AnswerType.get_annotation_types(),
             )
-            .all()
-            if answer.answer is not None
-        }
+        )
         context = {
             "reader_study": self.reader_study,
             "display_set": self.display_set,
             "user": self.user,
             "created": now(),
-            "answers": answer_dict,
+            "answers": answers,
         }
         return context

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -1489,7 +1489,7 @@ class DisplaySetPDFReport(
 
     def get_context_data(self):
         answer_dict = {
-            answer.question.question_text: answer.answer_text
+            answer.question.question_text: answer.html_string
             for answer in self.display_set.answers.select_related(
                 "creator", "question", "answer_image"
             )
@@ -1502,6 +1502,7 @@ class DisplaySetPDFReport(
                 question__answer_type__in=AnswerType.get_annotation_types(),
             )
             .all()
+            if answer.answer is not None
         }
         context = {
             "reader_study": self.reader_study,

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -1489,7 +1489,7 @@ class DisplaySetPDFReport(
 
     def get_context_data(self):
         answer_dict = {
-            answer.question.question_text: answer.html_string
+            answer.question.question_text: answer
             for answer in self.display_set.answers.select_related(
                 "creator", "question", "answer_image"
             )

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -560,33 +560,11 @@ def test_pdf_report_content(client):
     assert str(ds1) in str(response.context["display_set"])
     assert str(ds2) not in str(response.context["display_set"])
     assert str(reader) in str(response.context["user"])
-    assert number_answer_reader.question.question_text in str(
-        response.context["answers"]
-    )
-    assert str(number_answer_reader.answer) in str(response.context["answers"])
+    assert number_answer_reader in response.context["answers"]
 
-    assert str(number_answer_editor.answer) not in str(
-        response.context["answers"]
-    )
-    assert str(number_gt_answer.answer) not in str(response.context["answers"])
-    assert str(number_answer_ds2.answer) not in str(
-        response.context["answers"]
-    )
-    assert str(number_empty_answer.answer) not in str(
-        response.context["answers"]
-    )
-    assert str(number_empty_answer.question.question_text) not in str(
-        response.context["answers"]
-    )
-    assert str(annotation_answer.answer) not in str(
-        response.context["answers"]
-    )
-    assert annotation_answer.question.question_text not in str(
-        response.context["answers"]
-    )
-    assert str(image_answer.answer_image) not in str(
-        response.context["answers"]
-    )
-    assert image_answer.question.question_text not in str(
-        response.context["answers"]
-    )
+    assert number_answer_editor not in response.context["answers"]
+    assert number_gt_answer not in response.context["answers"]
+    assert number_answer_ds2 not in response.context["answers"]
+    assert number_empty_answer not in response.context["answers"]
+    assert annotation_answer not in response.context["answers"]
+    assert image_answer not in response.context["answers"]

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -485,6 +485,11 @@ def test_pdf_report_content(client):
         answer_type=Question.AnswerType.MASK,
         question_text="Mask question",
     )
+    q4 = QuestionFactory(
+        reader_study=rs,
+        answer_type=Question.AnswerType.NUMBER,
+        question_text="Number question 2",
+    )
     number_gt_answer = AnswerFactory(
         question=q1,
         creator=reader,
@@ -512,6 +517,13 @@ def test_pdf_report_content(client):
         answer=4,
         is_ground_truth=False,
         display_set=ds2,
+    )
+    number_empty_answer = AnswerFactory(
+        question=q4,
+        creator=editor,
+        answer=None,
+        is_ground_truth=False,
+        display_set=ds1,
     )
     annotation_answer = AnswerFactory(
         question=q2,
@@ -558,6 +570,12 @@ def test_pdf_report_content(client):
     )
     assert str(number_gt_answer.answer) not in str(response.context["answers"])
     assert str(number_answer_ds2.answer) not in str(
+        response.context["answers"]
+    )
+    assert str(number_empty_answer.answer) not in str(
+        response.context["answers"]
+    )
+    assert str(number_empty_answer.question.question_text) not in str(
         response.context["answers"]
     )
     assert str(annotation_answer.answer) not in str(


### PR DESCRIPTION
For the reader study PDF report:
- render all options for choice type answers and underline the selected option(s) (circling selected options is not possible because the `border-radius` css property is not supported by `xhtml2pdf`)
- render either a green checkmark or a red cross for boolean answers

Only render answers with a value, leave out empty answers.

![image](https://user-images.githubusercontent.com/30069334/182577157-7abb83d3-683f-4260-abf6-9540de3b3439.png)


Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/163