### PR TITLE
 Fix for showing limited number of github repos

### DIFF
--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -959,9 +959,10 @@ class AlgorithmAddRepo(
             response = requests.get(
                 url, headers=headers, timeout=5, params=params
             ).json()
-            total = response["total_count"]
+            total = response.get("total_count", 0)
             result = []
-            result += [obj[value_key] for obj in response[object_key]]
+            if object_key in response:
+                result += [obj[value_key] for obj in response[object_key]]
             if total > page_items and page < math.ceil(total / page_items):
                 result += recursive_get(url, object_key, value_key, page + 1)
 

--- a/app/tests/github_tests/test_views.py
+++ b/app/tests/github_tests/test_views.py
@@ -59,7 +59,8 @@ def test_github_webhook(client, settings):
 @pytest.mark.django_db
 @patch("grandchallenge.github.views.requests.post")
 @patch("grandchallenge.github.views.requests.get")
-def test_redirect_view(get, post, client):
+@patch("grandchallenge.algorithms.views.requests.get")
+def test_redirect_view(alg_get, get, post, client):
     resp = Response()
     resp.status_code = 200
     resp.headers["Content-Type"] = "application/json"
@@ -97,6 +98,13 @@ def test_redirect_view(get, post, client):
     assert response.status_code == 403
 
     VerificationFactory(user=user, is_verified=True)
+
+    repo_response = Response()
+    repo_response.status_code = 200
+    repo_response.headers["Content-Type"] = "application/json"
+    repo_response._content = b'{"total_count": 1, "installations": [{"id": 1}], "repositories":[{"full_name" :"repo"}]}'
+    alg_get.return_value = repo_response
+
     response = get_view_for_user(
         client=client,
         viewname="github:install-complete",


### PR DESCRIPTION
Fix issue where only the first 30 github app installations and repos were retrieved.
Default parameter per_page is increased from 30 (default) to 100(max).
Request is repeated until all items are retrieved.

Closes #2299
