### PR TITLE
Fix deadlock issue

### DIFF
--- a/app/grandchallenge/github/tasks.py
+++ b/app/grandchallenge/github/tasks.py
@@ -84,8 +84,13 @@ def check_license(tmpdirname):
         ["licensee", "detect", tmpdirname, "--json", "--no-remote"],
         stdout=subprocess.PIPE,
     )
-    process.wait()
-    return json.loads(process.stdout.read().decode("utf-8"))
+    try:
+        outs, errs = process.communicate(timeout=15)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        raise
+
+    return json.loads(outs.decode("utf-8"))
 
 
 def save_zipfile(ghwm, tmpdirname):

--- a/app/tests/github_tests/test_tasks.py
+++ b/app/tests/github_tests/test_tasks.py
@@ -40,7 +40,7 @@ def test_get_zipfile(get_repo_url):
     assert ghwm2.license_keys == set()
 
     ghwm2.refresh_from_db()
-    assert ghwm2.clone_status == CloneStatusChoices.FAILURE
+    assert ghwm2.clone_status == CloneStatusChoices.SUCCESS
     assert "diagnijmegen-rse-panimg-v0-4-2" in ghwm2.zipfile.name
     assert ghwm2.license_keys == {"apache-2.0"}
     assert ghwm2.has_open_source_license is True

--- a/app/tests/github_tests/test_tasks.py
+++ b/app/tests/github_tests/test_tasks.py
@@ -40,7 +40,7 @@ def test_get_zipfile(get_repo_url):
     assert ghwm2.license_keys == set()
 
     ghwm2.refresh_from_db()
-    assert ghwm2.clone_status == CloneStatusChoices.SUCCESS
+    assert ghwm2.clone_status == CloneStatusChoices.FAILURE
     assert "diagnijmegen-rse-panimg-v0-4-2" in ghwm2.zipfile.name
     assert ghwm2.license_keys == {"apache-2.0"}
     assert ghwm2.has_open_source_license is True


### PR DESCRIPTION
The license check for github repositories with GPL-3.0 license would deadlock due to the combination of subprocess.Popen en wait (see https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait). As there was no timeout provided, the task would take a very long time to fail.