### PR TITLE
Add validation for CIV value saving

### DIFF
--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -962,8 +962,43 @@ class ComponentInterfaceValue(models.Model):
         else:
             return f"Component Interface Value {self.pk} for {self.interface}"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._value_orig = self.value
+        self._image_orig = self.image
+        self._file_orig = self.file
+
+    def save(self, *args, **kwargs):
+        if (
+            (
+                self._value_orig not in (None, self.interface.default_value)
+                and self.value is not None
+                and self._value_orig != self.value
+            )
+            or (self._image_orig and self._image_orig != self.image)
+            or (
+                self._file_orig.name not in (None, "")
+                and self._file_orig != self.file
+            )
+        ):
+            raise ValidationError(
+                "You cannot change the value, file or image of an existing CIV. "
+                "Please create a new CIV instead."
+            )
+        super().save(*args, **kwargs)
+
     def clean(self):
         super().clean()
+        attributes = [
+            attribute
+            for attribute in [self.value, self.image, self.file.name]
+            if attribute is not None
+            if attribute != ""
+        ]
+        if len(attributes) > 1:
+            raise ValidationError(
+                "Only one of image, value and file can be defined."
+            )
 
         if self.interface.is_image_kind:
             self._validate_image_only()

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -1393,13 +1393,11 @@ class DisplaySetUpdate(
 
             if ci.kind in InterfaceKind.interface_type_json():
                 if current_value:
-                    current_value.value = civ
-                    current_value.save()
-                else:
-                    val = ComponentInterfaceValue.objects.create(
-                        interface=ci, value=civ
-                    )
-                    instance.values.add(val)
+                    assigned_civs.append(current_value)
+                val = ComponentInterfaceValue.objects.create(
+                    interface=ci, value=civ
+                )
+                instance.values.add(val)
             else:
                 if civ is None:
 

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -422,11 +422,11 @@ def test_display_set_update(client):
     assert response.status_code == 302
     assert not ds1.values.filter(pk=civ_img.pk).exists()
     assert ds1.values.filter(pk=civ_img_new.pk).exists()
-    civ_str.refresh_from_db()
-    assert civ_str.value == "new-title"
+    assert not ds1.values.filter(pk=civ_str.pk).exists()
+    assert ds1.values.filter(interface__kind="STR").get().value == "new-title"
 
-    # A new ds should have been created for civ_img
-    assert DisplaySet.objects.count() == 3
+    # Two new ds should have been created, one for civ_img and one for civ_str
+    assert DisplaySet.objects.count() == 4
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This adds checks when saving a CIV to ensure:

- The value of image can only be changed from None to something, never from something to something else
- The value of value can only be changed from None or its default to something, never from something to something else
- The value of file can only be changed from "" or None to something, never from something to something else
- One, and only one, of image, value or file should be set

With these checks in place, the `DisplaySetUpdate` view needed a small change as well. 