### PR TITLE
Demote log line parse error to warning

### DIFF
--- a/app/grandchallenge/components/backends/amazon_sagemaker_batch.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_batch.py
@@ -536,7 +536,7 @@ class AmazonSageMakerBatchExecutor(Executor):
                 )
                 timestamp = ms_timestamp_to_datetime(event["timestamp"])
             except (JSONDecodeError, KeyError, ValueError):
-                logger.error("Could not parse log")
+                logger.warning("Could not parse log")
                 continue
 
             if parsed_log is not None:

--- a/app/grandchallenge/components/backends/docker.py
+++ b/app/grandchallenge/components/backends/docker.py
@@ -179,7 +179,7 @@ class DockerExecutor(DockerConnectionMixin, Executor):
                 timestamp, log = line.replace("\x00", "").split(" ", 1)
                 parsed_log = parse_structured_log(log=log)
             except (JSONDecodeError, KeyError, ValueError):
-                logger.error("Could not parse log")
+                logger.warning("Could not parse log")
                 continue
 
             if parsed_log is not None:


### PR DESCRIPTION
These only occur as CloudWatch has a limit of `2 ** 14` characters per log line, so the structured log is broken. Doesn't really matter that these long lines are dropped.