### PR TITLE
Fix json file upload for archive items 

### DIFF
--- a/app/grandchallenge/archives/tasks.py
+++ b/app/grandchallenge/archives/tasks.py
@@ -103,7 +103,7 @@ def update_archive_item_update_kwargs(
                 upload_pks[civ.pk] = upload_session.pk
             civ.save()
             civ_pks_to_add.add(civ.pk)
-        elif interface.is_file_kind:
+        elif interface.requires_file:
             civ = ComponentInterfaceValue.objects.create(interface=interface)
             user_upload.copy_object(to_field=civ.file)
             civ.full_clean()

--- a/app/grandchallenge/archives/views.py
+++ b/app/grandchallenge/archives/views.py
@@ -433,8 +433,10 @@ class ArchiveEditArchiveItem(
             update_archive_item_update_kwargs(
                 instance=self.archive_item,
                 interface=ci,
-                value=value if ci.is_json_kind else None,
-                user_upload=value if ci.is_file_kind else None,
+                value=value
+                if ci.is_json_kind and not ci.requires_file
+                else None,
+                user_upload=value if ci.requires_file else None,
                 upload_session=upload_session,
                 civ_pks_to_add=civ_pks_to_add,
                 upload_pks=upload_pks,


### PR DESCRIPTION
This fixes the json file (json kind interfaces not stored in the db) upload for archive items, both through the API and the UI. 