### PR TITLE
Fix non-distinct list of interfaces

### DIFF
--- a/app/grandchallenge/reader_studies/forms.py
+++ b/app/grandchallenge/reader_studies/forms.py
@@ -237,7 +237,7 @@ class ReaderStudyUpdateForm(
         super().__init__(*args, **kwargs)
         self.fields["view_content"].help_text += (
             " The following interfaces are used in your reader study: "
-            f"{', '.join(self.instance.display_sets.values_list('values__interface__slug', flat=True).distinct())}."
+            f"{', '.join(self.instance.display_sets.values_list('values__interface__slug', flat=True).order_by().distinct())}."
         )
 
 


### PR DESCRIPTION
Currently, this shows up in a reader study:
![image](https://user-images.githubusercontent.com/7871310/189129140-6604c467-9688-4bee-8e93-cb21dff76cbd.png)

This fixes it.

Not sure why the `distinct()` doesn't catch correctly without a clear of the ordering.