### PR TITLE
Fix required draggable when parent_id and specialized_view is set

### DIFF
--- a/app/grandchallenge/hanging_protocols/forms.py
+++ b/app/grandchallenge/hanging_protocols/forms.py
@@ -92,9 +92,11 @@ class HangingProtocolForm(SaveFormInitMixin, forms.ModelForm):
                     )
 
     def _validate_parent_id(self, *, viewport, viewport_names):
-        if viewport.get("draggable", False) is False:
+        if viewport.get("draggable", False) is False and not viewport.get(
+            "specialized_view"
+        ) in ["minimap", "3D-sideview"]:
             self.add_error(
-                error=f"Viewport {viewport['viewport_name']} has a parent_id but is not draggable.",
+                error=f"Viewport {viewport['viewport_name']} has a parent_id but is not draggable or is not a specialized view.",
                 field="json",
             )
         if viewport["parent_id"] not in viewport_names:

--- a/app/tests/hanging_protocols_tests/test_forms.py
+++ b/app/tests/hanging_protocols_tests/test_forms.py
@@ -193,7 +193,7 @@ def test_hanging_protocol_parent_id_draggable():
     )
     assert (
         form.errors["json"][0]
-        == "Viewport main has a parent_id but is not draggable."
+        == "Viewport main has a parent_id but is not draggable or is not a specialized view."
     )
 
     form = HangingProtocolForm(
@@ -208,7 +208,7 @@ def test_hanging_protocol_parent_id_draggable():
         in form.errors["json"]
     )
     assert (
-        "Viewport main has a parent_id but is not draggable."
+        "Viewport main has a parent_id but is not draggable or is not a specialized view."
         in form.errors["json"]
     )
 
@@ -219,6 +219,14 @@ def test_hanging_protocol_parent_id_draggable():
         }
     )
     assert form.is_valid()
+
+    form = HangingProtocolForm(
+        {
+            "title": "main",
+            "json": '[{"viewport_name": "main", "parent_id": "secondary", "specialized_view": "minimap"}, {"viewport_name": "secondary"}]',
+        }
+    )
+    assert form.is_valid(), form.errors
 
 
 def test_hanging_protocol_slice_plane_indicator():


### PR DESCRIPTION
It was correctly reported it was not possible to unset the draggable property when creating specialized views. This in-form clean was missed when extending the validation to account for the new views.