### PR TITLE
Includes gravatar url in mugshot field in profile serializer

### DIFF
--- a/app/grandchallenge/profiles/serializers.py
+++ b/app/grandchallenge/profiles/serializers.py
@@ -9,7 +9,7 @@ from grandchallenge.profiles.models import UserProfile
 class UserProfileSerializer(serializers.ModelSerializer):
     user = UserSerializer()
     location = CountryField(source="country")
-    mugshot = URLField(source="mugshot.x20.url", read_only=True, default="")
+    mugshot = URLField(source="get_mugshot_url", read_only=True, default="")
 
     class Meta:
         model = UserProfile


### PR DESCRIPTION
Uses the `get_mugshot_url` model method to get the mugshot URL in the profile serializer. It returns the gravatar avatar if no mugshot is available.