### PR TITLE
Optimise leaderboard detail view

### DIFF
--- a/app/grandchallenge/core/templatetags/to_range.py
+++ b/app/grandchallenge/core/templatetags/to_range.py
@@ -1,0 +1,8 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def to_range(stop: int, step: int = 1):
+    return range(0, stop, step)

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -9,6 +9,7 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.db.transaction import on_commit
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.text import get_valid_filename
 from django.utils.timezone import localtime
 from django_extensions.db.fields import AutoSlugField
@@ -923,6 +924,12 @@ class Evaluation(UUIDModel, ComponentJob):
     @property
     def output_interfaces(self):
         return self.submission.phase.outputs
+
+    @cached_property
+    def metrics_json_file(self):
+        for output in self.outputs.all():
+            if output.interface.slug == "metrics-json-file":
+                return output.value
 
     def clean(self):
         if self.submission.phase != self.method.phase:

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load url %}
 {% load static %}
+{% load to_range %}
 
 {% block title %}Leaderboard - {{ block.super }}{% endblock %}
 
@@ -65,7 +66,7 @@
 
     {% if "change_challenge" in challenge_perms %}
         <h3>Export</h3>
-        {% for offset in offsets %}
+        {% for offset in object_list.count|to_range:limit %}
             <p>
                 <a class="btn btn-primary"
                    href="{% url 'api:evaluation-list' %}?format=csv&submission__phase={{ phase.pk }}&offset={{ offset }}&limit={{ limit }}"

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_row.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_row.html
@@ -36,7 +36,7 @@
     <split></split>
 {% endif %}
 
-{% with object.metrics.0|get_jsonpath:object.submission.phase.score_jsonpath as metric %}
+{% with object.metrics_json_file|get_jsonpath:object.submission.phase.score_jsonpath as metric %}
     <a href="{{ object.get_absolute_url }}">
         {% if object.submission.phase.scoring_method_choice == object.submission.phase.ABSOLUTE %}
             <b>{% endif %}
@@ -44,7 +44,7 @@
             {{ metric|floatformat:object.submission.phase.score_decimal_places }}
             {% if object.submission.phase.score_error_jsonpath %}
                 &nbsp;±&nbsp;
-                {{ object.metrics.0|get_jsonpath:object.submission.phase.score_error_jsonpath|floatformat:object.submission.phase.score_decimal_places }}
+                {{ object.metrics_json_file|get_jsonpath:object.submission.phase.score_error_jsonpath|floatformat:object.submission.phase.score_decimal_places }}
             {% endif %}
             {% if object.submission.phase.scoring_method_choice != object.submission.phase.ABSOLUTE %}
                 &nbsp;(
@@ -59,13 +59,13 @@
 {% endwith %}
 
 {% for col in object.submission.phase.extra_results_columns %}
-    {% with object.metrics.0|get_jsonpath:col.path as metric %}
+    {% with object.metrics_json_file|get_jsonpath:col.path as metric %}
         <a href="{{ object.get_absolute_url }}">
             {% filter remove_whitespace %}
                 {{ metric|floatformat:object.submission.phase.score_decimal_places }}
                 {% if col.error_path %}
                     &nbsp;±&nbsp;
-                    {{ object.metrics.0|get_jsonpath:col.error_path|floatformat:object.submission.phase.score_decimal_places }}
+                    {{ object.metrics_json_file|get_jsonpath:col.error_path|floatformat:object.submission.phase.score_decimal_places }}
                 {% endif %}
                 {% if object.submission.phase.scoring_method_choice != object.submission.phase.ABSOLUTE %}
                     &nbsp;(


### PR DESCRIPTION
The view was slow as it was counting the objects 4 times on each request. I also think the array aggregation was slow, this moves to prefetching the interfaces and values instead. Will profile this in production.