### PR TITLE
Adjust carousel image layout

### DIFF
--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -232,10 +232,6 @@ ul.socialaccount_providers > li {
     }
 }
 
-.carousel-img {
-    object-fit: cover;
-}
-
 .thumbnail {
     max-height:90px;
     max-width:90px;

--- a/app/grandchallenge/core/templates/home.html
+++ b/app/grandchallenge/core/templates/home.html
@@ -8,13 +8,13 @@
     {% block content %}
         {% if news_caroussel_items %}
             <div class="container mb-5 p-0">
-                <div class="carousel slide" id="carouselIndicators" data-ride="carousel" data-interval="5000">
+                <div class="carousel slide" id="carouselIndicators" data-ride="carousel" data-interval="10000">
                     <div class="carousel-inner m-0 px-0">
                         {% for item in news_caroussel_items %}
                             <div class="carousel-item {% if forloop.counter == 1 %}active{% endif %}">
-                                <div class="d-md-flex d-xs-inline justify-content-center align-items-center">
-                                    <div class="col-12 col-md-3 p-0 my-3 d-inline-block carousel-img-container w-100">
-                                        <a href="{{ item.get_absolute_url }}"><img class="card gc-card carousel-img m-auto h-100 mw-100 border-0"
+                                <div class="d-md-flex d-sm-inline-flex justify-content-center align-items-center">
+                                    <div class="col-12 col-md-3 p-0 my-3 d-md-flex d-sm-inline-flex carousel-img-container w-100 justify-content-center align-items-center">
+                                        <a href="{{ item.get_absolute_url }}"><img class="rounded m-auto mh-100 mw-100 border-0"
                                              src="{{ item.logo.x20.url }}"
                                              srcset="{{ item.logo.x10.url }} 1x,
                                                      {{ item.logo.x15.url }} 1.5x,


### PR DESCRIPTION
Show the images entirely rather than cropping them while maintaining the same height for the entire reel. 
![image](https://user-images.githubusercontent.com/30069334/203569558-267865c6-adc0-49fa-86aa-38588fc2d00f.png)


Only issue at this point is that the image is not centered vertically on the mobile view for some reason:

![image](https://user-images.githubusercontent.com/30069334/203569483-8fbb9329-61a4-40c7-ab15-3316e8ae7588.png)
