### PR TITLE
Fix json file validation

### DIFF
--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -1075,7 +1075,7 @@ class ComponentInterfaceValue(models.Model):
         if not user_upload.is_completed:
             raise ValidationError("User upload is not completed.")
         if self.interface.is_json_kind:
-            value = user_upload.read_object()
+            value = json.loads(user_upload.read_object())
             self.interface.validate_against_schema(value=value)
         self._user_upload_validated = True
 

--- a/app/grandchallenge/reader_studies/forms.py
+++ b/app/grandchallenge/reader_studies/forms.py
@@ -623,7 +623,10 @@ class FileForm(Form):
         self.display_set = display_set
 
     def save(self):
-        civ = self.display_set.values.get(interface=self.interface)
+        try:
+            civ = self.display_set.values.get(interface=self.interface)
+        except ObjectDoesNotExist:
+            civ = None
         user_upload = self.cleaned_data["user_upload"]
         on_commit(
             lambda: add_file_to_display_set.apply_async(
@@ -631,7 +634,7 @@ class FileForm(Form):
                     "user_upload_pk": str(user_upload.pk),
                     "interface_pk": str(self.interface.pk),
                     "display_set_pk": str(self.display_set.pk),
-                    "civ_pk": str(civ.pk),
+                    "civ_pk": str(civ.pk) if civ else None,
                 }
             )
         )


### PR DESCRIPTION
The schema validation in `validate_user_upload` didn't work because the file contents weren't parsed correctly. This function is only called in two places (ds file updating and adding a file to a civ). The tests for both scenarios were incomplete and didn't catch the issue. I updated the tests accordingly. 