### PR TITLE
Ignore Flake8 B905: requiring explicit strict kwarg to zip

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,3 +48,5 @@ ignore =
     W503
     # N818 Exceptions should be named Error (TODO)
     N818
+    # B905 requiring explicit strict keyword argument for build-in zip(): python 3.10 feature
+    B905


### PR DESCRIPTION
This is from [PEP 618](https://peps.python.org/pep-0618/) and was introduced in python 3.10. So can't check for this right now since the web container runs on py3.8.