### PR TITLE
Check if variables are not None to allow values of zero

### DIFF
--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -914,12 +914,12 @@ class ChallengeRequest(UUIDModel, CommonChallengeFieldsMixin):
     @cached_property
     def budget(self):
         if (
-            self.inference_time_limit_in_minutes
-            and self.phase_1_number_of_test_images
-            and self.phase_1_number_of_submissions_per_team
-            and self.average_size_of_test_image_in_mb
-            and self.phase_2_number_of_test_images
-            and self.phase_2_number_of_submissions_per_team
+            self.inference_time_limit_in_minutes is not None
+            and self.phase_1_number_of_test_images is not None
+            and self.phase_1_number_of_submissions_per_team is not None
+            and self.average_size_of_test_image_in_mb is not None
+            and self.phase_2_number_of_test_images is not None
+            and self.phase_2_number_of_submissions_per_team is not None
         ):
             compute_costs = settings.CHALLENGES_COMPUTE_COST_CENTS_PER_HOUR
             s3_storage_costs = (

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -620,9 +620,9 @@ def challenge_request():
         inference_time_limit_in_minutes=10,
         average_size_of_test_image_in_mb=10,
         phase_1_number_of_submissions_per_team=10,
-        phase_2_number_of_submissions_per_team=1,
+        phase_2_number_of_submissions_per_team=0,
         phase_1_number_of_test_images=100,
-        phase_2_number_of_test_images=500,
+        phase_2_number_of_test_images=0,
         number_of_tasks=1,
         structured_challenge_submission_doi="10.5281/zenodo.6362337",
     )


### PR DESCRIPTION
Fixes https://sentry.io/organizations/grand-challenge/issues/3814067033/?project=303639&query=is%3Aunresolved&referrer=issue-stream 

There should always be a budget now for requests. For this particular case, the budget ended up being `None` because they had filled in 0s for the phase 2 specs, and so the conditional `if self.phase_2_... ` evaluated to False, when it really should not (setting 0 should be allowed, definitely for Type 2 specs but also for the other fields - the budget stuff usually needs to be adjusted and updated again after discussion with the organizers anyway). 