### PR TITLE
Remove stopped containers from runserver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ migrations:
 	docker compose run -u $(USER_ID) --rm web python manage.py makemigrations
 
 runserver: build_web_test build_http development_fixtures
-	docker compose up
+	bash -c "trap 'docker compose down' EXIT; docker compose up"
 
 minio:
 	docker compose run \


### PR DESCRIPTION
With this PR developers will no longer have containers start again when they reboot their machines, if they exit cleanly by using CTRL+C once.