### PR TITLE
Fix partially unanswered Display Set filtering

### DIFF
--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -1220,11 +1220,14 @@ class DisplaySetViewSet(
             queryset = (
                 queryset.annotate(
                     answer_count=Count(
-                        "answers", filter=Q(answers__is_ground_truth=False)
+                        "answers",
+                        filter=Q(
+                            answers__is_ground_truth=False,
+                            answers__creator=user,
+                        ),
                     )
                 )
                 .exclude(
-                    answers__creator=user,
                     answer_count__gte=answerable_question_count,
                 )
                 .order_by("order", "created")


### PR DESCRIPTION
Relates to: https://github.com/DIAGNijmegen/rse-cirrus-core/issues/2183

An error in reader-study sequencing: partially answered display sets were excluded when unanswered display sets were requested.

This only occurred in the corner case where:
- not all answers for a display set were saved (error in saving or newly created questions)
- **and** there are other user' answers for that specific display set that total more than the number of answerable questions

Pretty hard to think of when writing tests, but happens easily in production.