### PR TITLE
Enable adding json file CIV to display set 

### DIFF
--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 from datetime import timedelta
+from json import JSONDecodeError
 from pathlib import Path
 
 from celery import signature
@@ -1191,7 +1192,10 @@ class ComponentInterfaceValue(models.Model):
         if not user_upload.is_completed:
             raise ValidationError("User upload is not completed.")
         if self.interface.is_json_kind:
-            value = json.loads(user_upload.read_object())
+            try:
+                value = json.loads(user_upload.read_object())
+            except JSONDecodeError as e:
+                raise ValidationError(e)
             self.interface.validate_against_schema(value=value)
         self._user_upload_validated = True
 


### PR DESCRIPTION
This enables adding a json file CIV to a display set (next to updating an existing json file civ). This is relevant when default answers are defined after display sets were added, or when you edit one display set and then update the remaining sets. 

Also handle Json errors correctly. 

This addressing the following two sentry errors:

https://sentry.io/organizations/grand-challenge/issues/3885186430/?project=303639&query=is%3Aunresolved&referrer=issue-stream

https://sentry.io/organizations/grand-challenge/issues/3888699684/?project=303639&query=is%3Aunresolved&referrer=issue-stream