### PR TITLE
Fix updating Questions not working when partially set to read-only

### DIFF
--- a/app/grandchallenge/reader_studies/forms.py
+++ b/app/grandchallenge/reader_studies/forms.py
@@ -271,6 +271,10 @@ class QuestionForm(SaveFormInitMixin, DynamicFormMixin, ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        for field_name in self.instance.read_only_fields:
+            self.fields[field_name].required = False
+            self.fields[field_name].disabled = True
+
         self.helper = FormHelper()
         self.helper.form_tag = True
         self.helper.layout = Layout(
@@ -328,19 +332,6 @@ class QuestionForm(SaveFormInitMixin, DynamicFormMixin, ModelForm):
                 field=None,
             )
         return super().clean()
-
-    def full_clean(self):
-        """Override of the form's full_clean method.
-
-        Some fields are made readonly once the question has been answered.
-        Because disabled fields do not get included in the post data, this
-        causes issues with required fields. Therefore we populate them here.
-        """
-        data = self.data.copy()
-        for field in self.instance.read_only_fields:
-            data[field] = getattr(self.instance, field)
-        self.data = data
-        return super().full_clean()
 
     class Meta:
         model = Question

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -494,7 +494,7 @@ class QuestionOptionMixin:
     def validate_options(self, form, _super):
         context = self.get_context_data()
         options = context["options"]
-        if form.data["answer_type"] not in [
+        if form.cleaned_data["answer_type"] not in [
             Question.AnswerType.CHOICE,
             Question.AnswerType.MULTIPLE_CHOICE,
             Question.AnswerType.MULTIPLE_CHOICE_DROPDOWN,
@@ -547,10 +547,6 @@ class QuestionUpdate(
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        form_fields = context["form"].fields
-        for field_name in self.object.read_only_fields:
-            form_fields[field_name].required = False
-            form_fields[field_name].disabled = True
         if self.request.POST:
             context["options"] = CategoricalOptionFormSet(
                 self.request.POST, instance=self.object


### PR DESCRIPTION
Closes #2608

The full_clean hack is not longer required if the read-only fields are set to be disabled in the form itself instead of the view.