### PR TITLE
Add environment variable for session control timeout

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -388,6 +388,7 @@ TEMPLATES = [
                 "grandchallenge.core.context_processors.newsletter_signup",
                 "grandchallenge.core.context_processors.viewport_names",
                 "grandchallenge.core.context_processors.workstation_domains",
+                "grandchallenge.core.context_processors.workstation_session_control_timeout",
                 "machina.core.context_processors.metadata",
             ],
             "loaders": [
@@ -1115,6 +1116,9 @@ WORKSTATIONS_RENDERING_SUBDOMAINS = {
 WORKSTATIONS_GRACE_MINUTES = 5
 
 WORKSTATIONS_EXTRA_BROADCAST_DOMAINS = []
+WORKSTATIONS_SESSION_CONTROL_TIMEOUT = int(
+    os.environ.get("WORKSTATIONS_SESSION_CONTROL_TIMEOUT", "3000")
+)
 
 CELERY_BEAT_SCHEDULE = {
     "delete_users_who_dont_login": {

--- a/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
@@ -119,6 +119,7 @@
                         data-create-session-url='{% url 'workstations:workstation-session-create' slug=object.algorithm_image.algorithm.workstation.slug %}'
                         data-workstation-query='{% workstation_query algorithm_job=object config=object.algorithm_image.algorithm.workstation_config %}'
                         data-workstation-window-identifier='workstation-{{ object|meta_attr:'app_label' }}'
+                        data-timeout="{{ workstation_session_control_timeout }}"
                 >
                     <i class="fa fa-eye"></i> Open Result in Viewer
                 </button>

--- a/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
@@ -72,7 +72,8 @@
             data-session-control
             data-create-session-url='{% url 'workstations:workstation-session-create' slug=algorithm.workstation.slug %}'
             data-workstation-query='{% workstation_query algorithm_job=object config=algorithm.workstation_config %}'
-            data-workstation-window-identifier='workstation-{{ object|meta_attr:'app_label' }}'>
+            data-workstation-window-identifier='workstation-{{ object|meta_attr:'app_label' }}'
+            data-timeout="{{ workstation_session_control_timeout }}">
         <i class="fa fa-eye"></i> Open Result in Viewer
     </button>
 {% endif %}

--- a/app/grandchallenge/archives/templates/archives/archive_cases_row.html
+++ b/app/grandchallenge/archives/templates/archives/archive_cases_row.html
@@ -47,7 +47,8 @@
         data-session-control
         data-create-session-url='{% url 'workstations:workstation-session-create' slug=archive.workstation.slug %}'
         data-workstation-query='{% workstation_query image=object config=archive.workstation_config %}'
-        data-workstation-window-identifier='workstation-{{ archive|meta_attr:'app_label' }}'>
+        data-workstation-window-identifier='workstation-{{ archive|meta_attr:'app_label' }}'
+        data-timeout="{{ workstation_session_control_timeout }}">
     <i class="fa fa-eye"></i> View Image
 </button>
 <split></split>

--- a/app/grandchallenge/archives/templates/archives/archive_items_row.html
+++ b/app/grandchallenge/archives/templates/archives/archive_items_row.html
@@ -31,7 +31,8 @@
    data-session-control
    data-create-session-url='{% url 'workstations:workstation-session-create' slug=archive.workstation.slug %}'
    data-workstation-query='{% workstation_query archive_item=object config=archive.workstation_config %}'
-   data-workstation-window-identifier='workstation-{{ archive|meta_attr:'app_label' }}'>
+   data-workstation-window-identifier='workstation-{{ archive|meta_attr:'app_label' }}'
+   data-timeout="{{ workstation_session_control_timeout }}">
     <i class="fa fa-eye"></i> Open Item in Viewer
 </button>
 <split></split>

--- a/app/grandchallenge/core/context_processors.py
+++ b/app/grandchallenge/core/context_processors.py
@@ -94,3 +94,9 @@ def workstation_domains(*_, **__):
             *settings.WORKSTATIONS_EXTRA_BROADCAST_DOMAINS,
         ]
     }
+
+
+def workstation_session_control_timeout(*_, **__):
+    return {
+        "workstation_session_control_timeout": settings.WORKSTATIONS_SESSION_CONTROL_TIMEOUT
+    }

--- a/app/grandchallenge/reader_studies/templates/reader_studies/display_set_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/display_set_detail.html
@@ -50,6 +50,7 @@
               data-create-session-url='{% url 'workstations:workstation-session-create' slug=object.reader_study.workstation.slug %}'
               data-workstation-query='{% workstation_query display_set=object config=reader_study.workstation_config %}'
               data-workstation-window-identifier='workstation-{{ object|meta_attr:'app_label' }}'
+              data-timeout="{{ workstation_session_control_timeout }}"
       >
           <i class="fa fa-eye"></i> View Display Set
       </button>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -122,7 +122,9 @@
                             data-session-control
                             data-create-session-url='{% url 'workstations:workstation-session-create' slug=object.workstation.slug %}'
                             data-workstation-query='{% workstation_query reader_study=object %}'
-                            data-workstation-window-identifier='workstation-{{ object|meta_attr:'app_label' }}'>
+                            data-workstation-window-identifier='workstation-{{ object|meta_attr:'app_label' }}'
+                            data-timeout="{{ workstation_session_control_timeout }}"
+                    >
                         <i class="fas fa-eye"></i> Launch this Reader Study
                     </button>
                 </p>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_images_row.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_images_row.html
@@ -17,6 +17,7 @@
    data-create-session-url='{% url 'workstations:workstation-session-create' slug=reader_study.workstation.slug %}'
    data-workstation-query='{% workstation_query image=object config=reader_study.workstation_config %}'
    data-workstation-window-identifier='workstation-{{ reader_study|meta_attr:'app_label' }}'
+   data-timeout="{{ workstation_session_control_timeout }}"
 >
     <i class="fa fa-eye"></i> View Case
 </button>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_progress.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_progress.html
@@ -57,7 +57,8 @@
                                     data-session-control
                                     data-create-session-url='{% url 'workstations:workstation-session-create' slug=reader_study.workstation.slug %}'
                                     data-workstation-query='{% workstation_query reader_study=reader_study user=user.obj %}'
-                                    data-workstation-window-identifier='workstation-{{ reader_study|meta_attr:'app_label' }}'>
+                                    data-workstation-window-identifier='workstation-{{ reader_study|meta_attr:'app_label' }}'
+                                    data-timeout="{{ workstation_session_control_timeout }}">
                                 <i class="fa fa-eye"></i> View User's Answers
                             </button>
                         </div>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_statistics.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_statistics.html
@@ -48,6 +48,7 @@
                                     data-create-session-url='{% url 'workstations:workstation-session-create' slug=object.workstation.slug %}'
                                     data-workstation-query='{% workstation_query display_set=entry %}'
                                     data-workstation-window-identifier='workstation-{{ object|meta_attr:'app_label' }}'
+                                    data-timeout="{{ workstation_session_control_timeout }}"
                             >
                                 <i class="fa fa-eye"></i>
                             </button>

--- a/app/grandchallenge/workstations/static/workstations/js/session-control.js
+++ b/app/grandchallenge/workstations/static/workstations/js/session-control.js
@@ -6,7 +6,7 @@ function openWorkstationSession(element) {
         const url = element.dataset.createSessionUrl;
         const query = element.dataset.workstationQuery;
         const creationURI = `${url}?${query}`;
-        const timeout = element.dataset.timeout || 3000;
+        const timeout = element.dataset.timeout;
 
         if (event.ctrlKey) {
             window.open(creationURI);

--- a/app/tests/templates/session_control.html
+++ b/app/tests/templates/session_control.html
@@ -12,6 +12,7 @@
             data-create-session-url='{% url 'new-session-test' %}'
             data-workstation-query='queryParam=12345'
             data-workstation-window-identifier='workstation-context'
+            data-timeout="{{ workstation_session_control_timeout }}"
     >
         <i class="fas fa-eye"></i> Launch new Session
     </button>


### PR DESCRIPTION
This adds a `WORKSTATIONS_SESSION_CONTROL_TIMEOUT` environment variable to easily change the timout in production. 