### PR TITLE
[Session Control] module scoping JS

### DIFF
--- a/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
@@ -368,7 +368,7 @@
 {% block script %}
     {{ block.super }}
     {{ workstation_domains|json_script:"workstation-domains" }}
-    <script src="{% static 'workstations/js/session-control.js' %}"></script>
+    <script type="module" src="{% static 'workstations/js/session-control.mjs' %}"></script>
 
     <script type="text/javascript">
         $('#resultInfoModal').on('show.bs.modal', function (event) {

--- a/app/grandchallenge/algorithms/templates/algorithms/job_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_list.html
@@ -84,6 +84,6 @@
         })
     </script>
 
-    <script src="{% static 'workstations/js/session-control.js' %}"></script>
+    <script type="module" src="{% static 'workstations/js/session-control.mjs' %}"></script>
 
 {% endblock %}

--- a/app/grandchallenge/archives/templates/archives/archive_cases_list.html
+++ b/app/grandchallenge/archives/templates/archives/archive_cases_list.html
@@ -30,6 +30,6 @@
 {% block script %}
     {{ block.super }}
     {{ workstation_domains|json_script:"workstation-domains" }}
-    <script src="{% static 'workstations/js/session-control.js' %}"></script>
+    <script type="module" src="{% static 'workstations/js/session-control.mjs' %}"></script>
 
 {% endblock %}

--- a/app/grandchallenge/archives/templates/archives/archive_items_list.html
+++ b/app/grandchallenge/archives/templates/archives/archive_items_list.html
@@ -30,6 +30,6 @@
 {% block script %}
     {{ block.super }}
     {{ workstation_domains|json_script:"workstation-domains" }}
-    <script src="{% static 'workstations/js/session-control.js' %}"></script>
+    <script type="module" src="{% static 'workstations/js/session-control.mjs' %}"></script>
 
 {% endblock %}

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -434,6 +434,6 @@
     {{ block.super }}
     <script src="{% static "js/refresh_sidebar.js" %}"></script>
     {{ workstation_domains|json_script:"workstation-domains" }}
-    <script src="{% static 'workstations/js/session-control.js' %}"></script>
+    <script type="module" src="{% static 'workstations/js/session-control.mjs' %}"></script>
 
 {% endblock %}

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_images_list.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_images_list.html
@@ -122,7 +122,7 @@
     <script src="{% static "rest_framework/js/csrf.js" %}"></script>
     <script src="{% static 'reader_studies/js/autocomplete_htmx.js' %}" type="text/javascript"></script>
     {{ workstation_domains|json_script:"workstation-domains" }}
-    <script src="{% static 'workstations/js/session-control.js' %}"></script>
+    <script type="module" src="{% static 'workstations/js/session-control.mjs' %}"></script>
     {{ form_media }}
 
     <link rel="stylesheet" href="{% static 'css/select2-bootstrap4-theme/select2-bootstrap4.css' %}">

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_progress.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_progress.html
@@ -123,5 +123,5 @@
     <script src="{% static 'reader_studies/js/remove_answers.js' %}"></script>
     <script src="{% static "rest_framework/js/csrf.js" %}"></script>
     {{ workstation_domains|json_script:"workstation-domains" }}
-    <script src="{% static 'workstations/js/session-control.js' %}"></script>
+    <script type="module" src="{% static 'workstations/js/session-control.mjs' %}"></script>
 {% endblock %}

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_statistics.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_statistics.html
@@ -97,5 +97,5 @@
         });
     </script>
     {{ workstation_domains|json_script:"workstation-domains" }}
-    <script src="{% static 'workstations/js/session-control.js' %}"></script>
+    <script type="module" src="{% static 'workstations/js/session-control.mjs' %}"></script>
 {% endblock %}

--- a/app/grandchallenge/workstations/static/workstations/js/session-control.js
+++ b/app/grandchallenge/workstations/static/workstations/js/session-control.js
@@ -13,6 +13,11 @@ function openWorkstationSession(element) {
             return;
         }
 
+        if (event.altKey) {
+            copyTextToClipboard(query);
+            return;
+        }
+
         const potentialSessionOrigins = JSON.parse(document.getElementById('workstation-domains').textContent);
         const workstationWindow = window.open('', windowIdentifier);
 
@@ -26,7 +31,7 @@ function openWorkstationSession(element) {
             console.warn(err);
         }
 
-        if (workstationWindow === null || isBlankContext ) {
+        if (workstationWindow === null || isBlankContext) {
             window.open(creationURI, windowIdentifier);
         } else {
             workstationWindow.focus();
@@ -46,9 +51,9 @@ function openWorkstationSession(element) {
 }
 
 function genSessionControllersHook() {
-     const data = document.currentScript.dataset;
-     const querySelector = (typeof data.sessionControlQuerySelector === 'undefined') ? '[data-session-control]' : data.sessionControlQuerySelector;
-     return () => {
+    const data = document.currentScript.dataset;
+    const querySelector = (typeof data.sessionControlQuerySelector === 'undefined') ? '[data-session-control]' : data.sessionControlQuerySelector;
+    return () => {
         const sessionControllerElements = document.querySelectorAll(querySelector);
         for (let element of sessionControllerElements) {
             element.onclick = openWorkstationSession(element);
@@ -59,13 +64,13 @@ function genSessionControllersHook() {
 function sendSessionControlMessage(targetWindow, origin, action, ackCallback) {
     const messageId = UUIDv4();
     const msg = {
-                sessionControl: {
-                    meta: {
-                        id: messageId
-                    },
-                    ...action,
-                }
-            };
+        sessionControl: {
+            meta: {
+                id: messageId
+            },
+            ...action,
+        }
+    };
     targetWindow.postMessage(msg, origin);
 
     function checkAckMessage(event) {
@@ -77,18 +82,27 @@ function sendSessionControlMessage(targetWindow, origin, action, ackCallback) {
         if (!ack) {
             return
         }
-        if ( ack.id === messageId ) {
+        if (ack.id === messageId) {
             ackCallback();
             window.removeEventListener('message', checkAckMessage);
         }
     }
+
     window.addEventListener('message', checkAckMessage);
 }
 
 function UUIDv4() {
-  return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
-    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-  );
+    return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
+        (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+    );
+}
+
+function copyTextToClipboard(text) {
+    const blob = new Blob([text], {type: "text/plain"});
+    const data = [new ClipboardItem({ "text/plain": blob })];
+    navigator.clipboard.write(data).then(function () {
+        console.log("Copied to clipboard successfully!");
+    });
 }
 
 let sessionControllersHook;
@@ -104,10 +118,12 @@ $(document).ready(() => {
     //  add listeners:
 
     // ajax-based tables
-    $('#ajaxDataTable').on('draw.dt', () => {sessionControllersHook()});
+    $('#ajaxDataTable').on('draw.dt', () => {
+        sessionControllersHook()
+    });
 
     // htmx-based tables
-    htmx.onLoad(function() {
+    htmx.onLoad(function () {
         sessionControllersHook()
     });
 });

--- a/app/grandchallenge/workstations/static/workstations/js/session-control.mjs
+++ b/app/grandchallenge/workstations/static/workstations/js/session-control.mjs
@@ -50,14 +50,10 @@ function openWorkstationSession(element) {
     }
 }
 
-function genSessionControllersHook() {
-    const data = document.currentScript.dataset;
-    const querySelector = (typeof data.sessionControlQuerySelector === 'undefined') ? '[data-session-control]' : data.sessionControlQuerySelector;
-    return () => {
-        const sessionControllerElements = document.querySelectorAll(querySelector);
-        for (let element of sessionControllerElements) {
-            element.onclick = openWorkstationSession(element);
-        }
+function hookSessionControllers() {
+    const sessionControllerElements = document.querySelectorAll('[data-session-control]');
+    for (const element of sessionControllerElements) {
+        element.onclick = openWorkstationSession(element);
     }
 }
 
@@ -105,25 +101,20 @@ function copyTextToClipboard(text) {
     });
 }
 
-let sessionControllersHook;
-if (typeof sessionControllersHook === 'undefined') { // singleton
-    sessionControllersHook = genSessionControllersHook();
-}
-
 $(document).ready(() => {
     // Run default once
-    sessionControllersHook();
+    hookSessionControllers();
 
     // Sometimes content insertion is deferred and might result in adding session-control elements later:
     //  add listeners:
 
     // ajax-based tables
     $('#ajaxDataTable').on('draw.dt', () => {
-        sessionControllersHook()
+        hookSessionControllers()
     });
 
     // htmx-based tables
     htmx.onLoad(function () {
-        sessionControllersHook()
+        hookSessionControllers()
     });
 });

--- a/app/tests/templates/session_control.html
+++ b/app/tests/templates/session_control.html
@@ -31,5 +31,5 @@
 {% block script %}
     {{ block.super }}
     {{ workstation_domains|json_script:"workstation-domains" }}
-    <script src="{% static 'workstations/js/session-control.js' %}"></script>
+    <script type="module" src="{% static 'workstations/js/session-control.mjs' %}"></script>
 {% endblock %}


### PR DESCRIPTION
This PR adds:
* Alt-click behavior to copy the query string (supports CIRRUS devs debugs)
* Module scopes session-control.js

The other session JS code is only being loaded on a single duty page, however, the session-control code will be included on a lot of different pages. Making it a module prevents it from conflicting with other (potential) JS. This does entail that overwriting the session-control data attribute querySelector is no longer possible. Tbh, this will likely never be used and another path can be followed to re-implement this if needed.