### PR TITLE
Add spinner while waiting for session control hooks to run 

### DIFF
--- a/app/grandchallenge/workstations/static/workstations/js/session-control.mjs
+++ b/app/grandchallenge/workstations/static/workstations/js/session-control.mjs
@@ -43,8 +43,10 @@ function openWorkstationSession(element) {
 
             potentialSessionOrigins.forEach((origin) => {
                 sendSessionControlMessage(workstationWindow, origin, {loadQuery: query}, () => {
-                    clearTimeout(fallback)
-                }, element);
+                    clearTimeout(fallback);
+                    workstationWindow.focus(); // absolutely necessary in Firefox, in Chrome/Edge window.open() already focuses the window
+                    removeSpinner(element);
+                });
             });
         }
     }
@@ -57,7 +59,7 @@ function hookSessionControllers() {
     }
 }
 
-function sendSessionControlMessage(targetWindow, origin, action, ackCallback, triggeringElement) {
+function sendSessionControlMessage(targetWindow, origin, action, ackCallback) {
     const messageId = UUIDv4();
     const msg = {
         sessionControl: {
@@ -80,8 +82,6 @@ function sendSessionControlMessage(targetWindow, origin, action, ackCallback, tr
         }
         if (ack.id === messageId) {
             ackCallback();
-            targetWindow.focus(); // absolutely necessary in Firefox, in Chrome/Edge window.open() already focusses the window
-            removeSpinner(triggeringElement);
             window.removeEventListener('message', checkAckMessage);
         }
     }

--- a/app/grandchallenge/workstations/static/workstations/js/session-control.mjs
+++ b/app/grandchallenge/workstations/static/workstations/js/session-control.mjs
@@ -111,7 +111,7 @@ function setSpinner(element) {
 }
 
 function removeSpinner(element) {
-    const spinner = element.querySelector("span");
+    const spinner = element.querySelector(".spinner-border");
     element.removeChild(spinner);
     element.querySelector("i").style.display = "inline-block";
 }


### PR DESCRIPTION
This replaces the eye icon on the launch button with a spinner until the ack message has been received or the timeout has been reached and a new window is opened and focussed. 

I also decreased the timeout to 1s as per Chris' earlier request. 


https://user-images.githubusercontent.com/30069334/216616855-3d3477f8-1df5-428f-958e-bd4852f26e33.mp4

