### PR TITLE
Add chart of algorithm usage

### DIFF
--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -415,7 +415,7 @@ class Algorithm(UUIDModel, TitleSlugDescriptionModel, ViewContentMixin):
     @property
     def usage_chart_status_choices(self):
         """A map of int to string for Job.choice"""
-        return {k: v for k, v in Job.status.field.choices}
+        return dict(Job.status.field.choices)
 
     @cached_property
     def usage_statistics(self):

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -441,7 +441,7 @@ class Algorithm(UUIDModel, TitleSlugDescriptionModel, ViewContentMixin):
                 "x": {
                     "timeUnit": "yearmonth",
                     "field": "Timestamp",
-                    "type": "ordinal",
+                    "type": "quantitative",
                     "axis": {"title": "Date"},
                 },
                 "y": {
@@ -452,7 +452,7 @@ class Algorithm(UUIDModel, TitleSlugDescriptionModel, ViewContentMixin):
                 "tooltip": [
                     {
                         "field": "Timestamp",
-                        "type": "ordinal",
+                        "type": "quantitative",
                         "timeUnit": "yearmonth",
                     },
                     {"field": "Status", "type": "nominal"},

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -432,6 +432,7 @@ class Algorithm(UUIDModel, TitleSlugDescriptionModel, ViewContentMixin):
 
     @property
     def usage_totals(self):
+        """The number of jobs for this algorithm faceted by status"""
         totals = {status: 0 for status in self.usage_chart_statuses}
 
         for datum in self.usage_statistics:
@@ -474,6 +475,7 @@ class Algorithm(UUIDModel, TitleSlugDescriptionModel, ViewContentMixin):
                     "field": "Jobs",
                     "type": "quantitative",
                     "title": "Jobs Count",
+                    "stack": True,
                 },
                 "tooltip": [
                     {

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -407,6 +407,15 @@ class Algorithm(UUIDModel, TitleSlugDescriptionModel, ViewContentMixin):
                 credits_left = user_credit.credits
             return max(credits_left, 0) // max(self.credits_per_job, 1)
 
+    @property
+    def usage_statistics(self):
+        return (
+            Job.objects.filter(algorithm_image__algorithm=self)
+            .values("status", "created__year", "created__month")
+            .annotate(job_count=Count("status"))
+            .order_by("created__year", "created__month", "status")
+        )
+
     @cached_property
     def public_test_case(self):
         try:

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
@@ -141,6 +141,9 @@
                 <img class="w-50" loading="lazy" src="{{ object.logo.url }}" alt="Logo for {{ object.title }}">
             {% endif %}
             <h3 class="my-3">About</h3>
+
+            {{ object.usage_statistics }}
+
             {% if object.display_editors %}
                 <div class="row mb-2">
                     <div class="col-3 font-weight-bold">Creator{{ object.editors_group.user_set.all|pluralize }}:</div>

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
@@ -141,9 +141,6 @@
                 <img class="w-50" loading="lazy" src="{{ object.logo.url }}" alt="Logo for {{ object.title }}">
             {% endif %}
             <h3 class="my-3">About</h3>
-
-            {{ object.usage_statistics }}
-
             {% if object.display_editors %}
                 <div class="row mb-2">
                     <div class="col-3 font-weight-bold">Creator{{ object.editors_group.user_set.all|pluralize }}:</div>
@@ -277,6 +274,10 @@
                 {% if object.editor_notes %}
                     <h4>Notes</h4>
                     {{ object.editor_notes|md2html }}
+                {% endif %}
+                {% if object.usage_statistics %}
+                    <h4>Algorithm Usage</h4>
+                    <div class="w-100" id="runtimeMetricsChart"></div>
                 {% endif %}
                 <p>
                     <a class="btn btn-primary"
@@ -476,4 +477,13 @@
             event.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
             })
     </script>
+
+    {% if object.usage_statistics and "change_algorithm" in algorithm_perms %}
+        <script src="{% static 'vendored/vega/vega.min.js' %}"></script>
+        <script src="{% static 'vendored/vega-lite/vega-lite.min.js' %}"></script>
+        <script src="{% static 'vendored/vega-embed/vega-embed.min.js' %}"></script>
+
+        {{ object.usage_chart|json_script:"runtimeMetricsData" }}
+        <script type="module" src="{% static "algorithms/js/render_runtime_metrics_chart.js" %}"></script>
+    {% endif %}
 {% endblock %}

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
@@ -278,6 +278,13 @@
                 {% if object.usage_statistics %}
                     <h4>Algorithm Usage</h4>
                     <div class="w-100" id="runtimeMetricsChart"></div>
+                    <h5>Totals</h5>
+                    <dl class="inline">
+                        {% for job_status, job_count in object.usage_totals.items %}
+                            <dt>{{ job_status }}</dt>
+                            <dd>{{ job_count }}</dd>
+                        {% endfor %}
+                    </dl>
                 {% endif %}
                 <p>
                     <a class="btn btn-primary"

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
@@ -3,7 +3,6 @@
 {% load crispy_forms_tags %}
 {% load url %}
 {% load profiles %}
-{% load guardian_tags %}
 {% load bleach %}
 {% load humanize %}
 {% load remove_whitespace %}
@@ -25,8 +24,6 @@
 {% endblock %}
 
 {% block sidebar %}
-    {% get_obj_perms request.user for object as "algorithm_perms" %}
-
     <div class="col-12 col-md-4 col-lg-3 mb-3">
         <ul class="nav nav-pills flex-column" id="v-pills-tab" role="tablist"
             aria-orientation="vertical">
@@ -85,8 +82,6 @@
 {% endblock %}
 
 {% block content %}
-    {% get_obj_perms request.user for object as "algorithm_perms" %}
-
     {% if 'change_algorithm' in algorithm_perms %}
         {% if object.display_editors == None or not object.contact_email %}
             <div class="alert alert-warning" role="alert">

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -186,18 +186,20 @@ class AlgorithmDetail(ObjectPermissionRequiredMixin, DetailView):
         editor_remove_form = EditorsForm()
         editor_remove_form.fields["action"].initial = EditorsForm.REMOVE
 
-        context.update(
-            {"form": form, "editor_remove_form": editor_remove_form}
-        )
-
         pending_permission_requests = (
             AlgorithmPermissionRequest.objects.filter(
                 algorithm=context["object"],
                 status=AlgorithmPermissionRequest.PENDING,
             ).count()
         )
+
         context.update(
-            {"pending_permission_requests": pending_permission_requests}
+            {
+                "form": form,
+                "editor_remove_form": editor_remove_form,
+                "pending_permission_requests": pending_permission_requests,
+                "algorithm_perms": get_perms(self.request.user, self.object),
+            }
         )
 
         return context

--- a/app/tests/algorithms_tests/test_models.py
+++ b/app/tests/algorithms_tests/test_models.py
@@ -374,6 +374,7 @@ def test_usage_statistics():
                 "field": "Jobs",
                 "type": "quantitative",
                 "title": "Jobs Count",
+                "stack": True,
             },
             "tooltip": [
                 {


### PR DESCRIPTION
Show algorithm editors how often their algorithm has been used. I have re-used the rendering of the runtime metrics chart. Bit of a hack, but as part of the statistics pitch I can standardise the rendering of vega charts.

![image](https://user-images.githubusercontent.com/12661555/221147364-b124f694-87f9-47ff-9d6f-54036da12c98.png)

See https://github.com/DIAGNijmegen/rse-roadmap/issues/207