### PR TITLE
Remove usage of ImageImportError

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -15,7 +15,6 @@ from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import ignore_logger
 
 from config.denylist import USERNAME_DENYLIST
-from grandchallenge.algorithms.exceptions import ImageImportError
 from grandchallenge.components.exceptions import PriorStepFailed
 from grandchallenge.core.utils import strtobool
 from grandchallenge.core.utils.markdown import BS4Extension
@@ -829,7 +828,7 @@ if SENTRY_DSN:
         traces_sample_rate=float(
             os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.0")
         ),
-        ignore_errors=[PriorStepFailed, ImageImportError],
+        ignore_errors=[PriorStepFailed],
     )
     ignore_logger("django.security.DisallowedHost")
     ignore_logger("aws_xray_sdk")

--- a/app/grandchallenge/algorithms/exceptions.py
+++ b/app/grandchallenge/algorithms/exceptions.py
@@ -1,6 +1,2 @@
-class ImageImportError(Exception):
-    pass
-
-
 class TooManyJobsScheduled(Exception):
     pass

--- a/app/grandchallenge/archives/tasks.py
+++ b/app/grandchallenge/archives/tasks.py
@@ -11,7 +11,7 @@ from grandchallenge.components.models import (
     ComponentInterfaceValue,
 )
 from grandchallenge.components.tasks import (
-    add_images_to_component_interface_value,
+    add_image_to_component_interface_value,
 )
 
 
@@ -64,7 +64,7 @@ def add_images_to_archive_item(
         archive_item.values.add(new_civ)
 
         on_commit(
-            add_images_to_component_interface_value.signature(
+            add_image_to_component_interface_value.signature(
                 kwargs={
                     "component_interface_value_pk": new_civ.pk,
                     "upload_session_pk": upload_session_pk,
@@ -166,7 +166,7 @@ def start_archive_item_update_tasks(
                     build_images.signature(
                         kwargs={"upload_session_pk": upload_pk}
                     ),
-                    add_images_to_component_interface_value.signature(
+                    add_image_to_component_interface_value.signature(
                         kwargs={
                             "component_interface_value_pk": civ_pk,
                             "upload_session_pk": upload_pk,

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -1181,7 +1181,10 @@ class ComponentInterfaceValue(models.Model):
         if self.interface.saved_in_object_store:
             self._validate_file_only()
             with self.file.open("r") as f:
-                value = json.loads(f.read().decode("utf-8"))
+                try:
+                    value = json.loads(f.read().decode("utf-8"))
+                except JSONDecodeError as e:
+                    raise ValidationError(e)
         else:
             self._validate_value_only()
             value = self.value

--- a/app/tests/reader_studies_tests/test_tasks.py
+++ b/app/tests/reader_studies_tests/test_tasks.py
@@ -1,6 +1,5 @@
 import pytest
 
-from grandchallenge.algorithms.exceptions import ImageImportError
 from grandchallenge.cases.models import RawImageUploadSession
 from grandchallenge.components.models import (
     ComponentInterface,
@@ -57,12 +56,12 @@ def test_add_image_to_display_set(settings):
 
     error_message = "Image imports should result in a single image"
 
-    with pytest.raises(ImageImportError):
-        add_image_to_display_set(
-            upload_session_pk=us.pk,
-            display_set_pk=ds.pk,
-            interface_pk=ci.pk,
-        )
+    add_image_to_display_set(
+        upload_session_pk=us.pk,
+        display_set_pk=ds.pk,
+        interface_pk=ci.pk,
+    )
+
     assert ComponentInterfaceValue.objects.filter(interface=ci).count() == 0
     us.refresh_from_db()
     assert us.status == RawImageUploadSession.FAILURE
@@ -70,12 +69,11 @@ def test_add_image_to_display_set(settings):
 
     im1, im2 = ImageFactory.create_batch(2, origin=us)
 
-    with pytest.raises(ImageImportError):
-        add_image_to_display_set(
-            upload_session_pk=us.pk,
-            display_set_pk=ds.pk,
-            interface_pk=ci.pk,
-        )
+    add_image_to_display_set(
+        upload_session_pk=us.pk,
+        display_set_pk=ds.pk,
+        interface_pk=ci.pk,
+    )
     assert ComponentInterfaceValue.objects.filter(interface=ci).count() == 0
     us.refresh_from_db()
     assert us.status == RawImageUploadSession.FAILURE


### PR DESCRIPTION
Using exceptions in celery tasks to communicate validation problems didn't work well, so this refactors the usage. It allows us to make more tasks idempotent by covering the entire task with an atomic block.

See https://github.com/DIAGNijmegen/rse-roadmap/issues/207