### PR TITLE
Fix challenge cache, move staticstics tab and enable vega actions

### DIFF
--- a/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
@@ -81,6 +81,13 @@
                             </li>
                         {% endif %}
                     {% endif %}
+                    <div class="nav-item">
+                        <a class="nav-link {% if request.resolver_match.view_name == 'pages:statistics'  %}active{% endif %}"
+                           href="{% url 'pages:statistics' challenge_short_name=challenge.short_name %}">
+                            <i class="fas fa-chart-bar fa-fw"></i>
+                                Statistics
+                        </a>
+                    </div>
                     {% if "change_challenge" in challenge_perms %}
                         <div class="nav-item">
                             <a class="nav-link {% if request.resolver_match.view_name == 'pages:update' or request.resolver_match.view_name == 'pages:delete' or request.resolver_match.view_name == 'pages:create' or request.resolver_match.view_name == 'update' or request.resolver_match.view_name == 'pages:list' or request.resolver_match.app_name == 'admins' or request.resolver_match.view_name == 'participants:list' or request.resolver_match.view_name == 'participants:registration-list' or request.resolver_match.view_name == 'evaluation:phase-update' or request.resolver_match.view_name == 'evaluation:create' or request.resolver_match.view_name == 'evaluation:method-list' or request.resolver_match.view_name == 'evaluation:method-create' %}active{% endif %}"
@@ -90,13 +97,6 @@
                             </a>
                         </div>
                     {% endif %}
-                    <div class="nav-item">
-                        <a class="nav-link {% if request.resolver_match.view_name == 'pages:statistics'  %}active{% endif %}"
-                           href="{% url 'pages:statistics' challenge_short_name=challenge.short_name %}">
-                            <i class="fas fa-chart-bar fa-fw"></i>
-                                Statistics
-                        </a>
-                    </div>
                 </ul>
             </div>
         </div>

--- a/app/grandchallenge/charts/static/js/charts/render_charts.mjs
+++ b/app/grandchallenge/charts/static/js/charts/render_charts.mjs
@@ -1,6 +1,6 @@
 function renderVegaLiteChart(element) {
     const spec = JSON.parse(element.children[0].textContent);
-    vegaEmbed(element, spec, {"actions": false});
+    vegaEmbed(element, spec);
 }
 
 document.addEventListener("DOMContentLoaded", function(event) {

--- a/app/grandchallenge/statistics/tasks.py
+++ b/app/grandchallenge/statistics/tasks.py
@@ -111,6 +111,7 @@ def update_site_statistics_cache():
                 num_submissions=Count("phase__submission")
             )
             .order_by("-num_submissions")
+            .only("pk")
             .first()
         ),
     }


### PR DESCRIPTION
The caching of a challenge was broken if any of the images were unset, this could be solved by #2412. The stats tab was moved as I think that the admin pages should be last. Vega actions are enabled so that people can extract the data or re-mix the charts.