### PR TITLE
Show all model facts headers

### DIFF
--- a/app/grandchallenge/algorithms/forms.py
+++ b/app/grandchallenge/algorithms/forms.py
@@ -229,7 +229,6 @@ class AlgorithmForm(
             "workstation_config",
             "hanging_protocol",
             "view_content",
-            "detail_page_markdown",
             "job_create_page_markdown",
             "additional_terms_markdown",
             "result_template",
@@ -242,7 +241,6 @@ class AlgorithmForm(
         )
         widgets = {
             "description": TextInput,
-            "detail_page_markdown": MarkdownEditorWidget,
             "job_create_page_markdown": MarkdownEditorWidget,
             "additional_terms_markdown": MarkdownEditorWidget,
             "result_template": MarkdownEditorWidget,
@@ -289,7 +287,6 @@ class AlgorithmForm(
                 reverse_lazy("publications:create"),
             ),
             "description": "Short description of this algorithm, max 1024 characters. This will appear in the info modal on the algorithm overview list.",
-            "detail_page_markdown": "<span class='text-danger'><i class='fa fa-exclamation-triangle'></i> This field will be deprecated. Please use the separate 'Algorithm description' form on the Information page to describe your algorithm instead.</span>",
             "hanging_protocol": format_lazy(
                 (
                     "The hanging protocol to use for this algorithm. "
@@ -332,7 +329,6 @@ class AlgorithmForm(
                 "outputs",
                 "image_requires_gpu",
                 "image_requires_memory_gb",
-                ModelFactsTextField("detail_page_markdown"),
                 "additional_terms_markdown",
                 "job_create_page_markdown",
                 "result_template",
@@ -936,7 +932,7 @@ class AlgorithmImportForm(SaveFormInitMixin, Form):
             )
 
         original_url = self.algorithm_serializer.initial_data["url"]
-        self.algorithm.detail_page_markdown += (
+        self.algorithm.summary += (
             f"\n\n#### Origin\n\nImported from "
             f"[{urlparse(original_url).netloc}]({original_url})."
         )

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
@@ -202,32 +202,59 @@
                 </div>
             </div>
 
-            {{ object.detail_page_markdown|md2html }}
+            <h3>Model Facts</h3>
 
+            <h4 class="mt-5 mb-3">Summary</h4>
             {% if object.summary %}
-                <h3 class="mt-5 mb-3">Summary</h3>
                 {{ object.summary|md2html }}
+            {% elif object.detail_page_markdown %}
+                {{ object.detail_page_markdown|md2html }}
+            {% else %}
+                <div class="alert alert-warning" role="alert">Left empty by the Algorithm Editors</div>
             {% endif %}
+
+            <h4 class="mt-5 mb-3">Mechanism</h4>
             {% if object.mechanism %}
-                <h3 class="mt-5 mb-3">Mechanism</h3>
                 {{ object.mechanism|md2html }}
+            {% else %}
+                <div class="alert alert-warning" role="alert">Left empty by the Algorithm Editors</div>
             {% endif %}
+
+            <h4 class="mt-5 mb-3">Validation and Performance</h4>
             {% if object.validation_and_performance %}
-                <h3 class="mt-5 mb-3">Validation and Performance</h3>
                 {{ object.validation_and_performance|md2html }}
+            {% else %}
+                <div class="alert alert-warning" role="alert">Left empty by the Algorithm Editors</div>
             {% endif %}
+
+            <h4 class="mt-5 mb-3">Uses and Directions</h4>
             {% if object.uses_and_directions %}
-                <h3 class="mt-5 mb-3">Uses and Directions</h3>
                 {{ object.uses_and_directions|md2html }}
+            {% else %}
+                <div class="alert alert-warning" role="alert">Left empty by the Algorithm Editors</div>
             {% endif %}
+
+            <h4 class="mt-5 mb-3">Warnings</h4>
             {% if object.warnings %}
-                <h3 class="mt-5 mb-3">Warnings</h3>
                 {{ object.warnings|md2html }}
+            {% else %}
+                <div class="alert alert-warning" role="alert">Left empty by the Algorithm Editors</div>
             {% endif %}
+
+            <h4 class="mt-5 mb-3">Common Error Messages</h4>
             {% if object.common_error_messages %}
-                <h3 class="mt-5 mb-3">Common Error Messages</h3>
                 {{ object.common_error_messages|md2html }}
+            {% else %}
+                <div class="alert alert-warning" role="alert">Left empty by the Algorithm Editors</div>
             {% endif %}
+
+            <p>
+                Information on this algorithm has been provided by the Algorithm Editors,
+                following the Model Facts labels guidelines from
+                Sendak, M.P., Gao, M., Brajer, N. et al.
+                Presenting machine learning model information to clinical end users with model facts labels.
+                npj Digit. Med. 3, 41 (2020). <a href="https://doi.org/10.1038/s41746-020-0253-3">10.1038/s41746-020-0253-3</a>
+            </p>
 
             {% if "change_algorithm" in algorithm_perms %}
                 <hr>

--- a/app/tests/algorithms_tests/test_views.py
+++ b/app/tests/algorithms_tests/test_views.py
@@ -788,9 +788,7 @@ def test_import_view(client, authenticated_staff_user, mocker):
     assert algorithm.logo.name.startswith(
         "logos/algorithm/0d11fc7b-c63f-4fd7-b80b-51d2e21492c0/square_logo"
     )
-    assert (
-        "Imported from [grand-challenge.org]" in algorithm.detail_page_markdown
-    )
+    assert "Imported from [grand-challenge.org]" in algorithm.summary
     assert {i.slug for i in algorithm.inputs.all()} == {
         "clinical-information-prostate-mri",
         "coronal-t2-prostate-mri",


### PR DESCRIPTION
This PR removes `detail_page_markdown` from the algorithm settings forms and renders the model facts headers by default. Warnings are added if the algorithm editors have not filled out the section. If a summary is not provided, then the detail_page_markdown will be displayed instead for algorithms that still have not migrated. A citation is added for the model facts paper.

![Screenshot 2023-03-02 at 12-34-32 Test Algorithm - Gc](https://user-images.githubusercontent.com/12661555/222417521-bbc40e60-1803-4265-a43d-7fd27aa27d72.png)

Closes #2462