### PR TITLE
Override admin login page

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -560,7 +560,7 @@ LOCAL_APPS = [
 
 INSTALLED_APPS = DJANGO_APPS + LOCAL_APPS + THIRD_PARTY_APPS
 
-ADMIN_URL = f'{os.environ.get("DJANGO_ADMIN_URL", "django-admin")}/'
+ADMIN_URL = os.environ.get("DJANGO_ADMIN_URL", "django-admin")
 
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",

--- a/app/config/urls/root.py
+++ b/app/config/urls/root.py
@@ -5,7 +5,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.sitemaps.views import sitemap
 from django.template.response import TemplateResponse
 from django.urls import path, re_path
-from django.views.generic import TemplateView
+from django.views.generic import RedirectView, TemplateView
 from machina import urls as machina_urls
 
 from grandchallenge.algorithms.sitemaps import AlgorithmsSitemap
@@ -58,7 +58,15 @@ urlpatterns = [
         {"sitemaps": sitemaps},
         name="django.contrib.sitemaps.views.sitemap",
     ),
-    path(settings.ADMIN_URL, admin.site.urls),
+    path(
+        f"{settings.ADMIN_URL}/login/",
+        RedirectView.as_view(url=settings.LOGIN_URL),
+    ),
+    path(
+        f"{settings.ADMIN_URL}/logout/",
+        RedirectView.as_view(url=settings.LOGOUT_URL),
+    ),
+    path(f"{settings.ADMIN_URL}/", admin.site.urls),
     re_path(
         r"accounts/two_factor/setup/?$",
         TwoFactorSetup.as_view(),

--- a/app/tests/core_tests/test_admin.py
+++ b/app/tests/core_tests/test_admin.py
@@ -1,0 +1,15 @@
+import pytest
+
+from grandchallenge.subdomains.utils import reverse
+
+
+@pytest.mark.django_db
+def test_admin_login_is_site_login(client):
+    # Site login is required for 2FA and social auth flow
+    login_url = reverse("admin:login")
+
+    response = client.get(path=login_url)
+
+    assert login_url == "https://testserver/django-admin/login/"
+    assert response.status_code == 302
+    assert response.url == "/accounts/login/"


### PR DESCRIPTION
We have a login page that supports social login and 2FA, this forces the admin site to use it.