### PR TITLE
Make interface fields optional on DS update form

### DIFF
--- a/app/grandchallenge/cases/widgets.py
+++ b/app/grandchallenge/cases/widgets.py
@@ -8,7 +8,6 @@ from django.forms import (
     MultiWidget,
 )
 from django.forms.widgets import ChoiceWidget
-from django.utils.datastructures import MultiValueDictKeyError
 
 from grandchallenge.cases.models import Image
 from grandchallenge.uploads.widgets import UserUploadMultipleWidget
@@ -76,11 +75,11 @@ class FlexibleImageWidget(MultiWidget):
     def value_from_datadict(self, data, files, name):
         try:
             value = data[name]
-        except (MultiValueDictKeyError, KeyError):
+        except KeyError:
             # this happens if the data comes from the DS create / update form
             try:
                 value = data[f"WidgetChoice-{name}"]
-            except (MultiValueDictKeyError, KeyError):
+            except KeyError:
                 value = None
         if value:
             if value in WidgetChoices.names:

--- a/app/grandchallenge/cases/widgets.py
+++ b/app/grandchallenge/cases/widgets.py
@@ -76,11 +76,11 @@ class FlexibleImageWidget(MultiWidget):
     def value_from_datadict(self, data, files, name):
         try:
             value = data[name]
-        except MultiValueDictKeyError:
+        except (MultiValueDictKeyError, KeyError):
+            # this happens if the data comes from the DS create / update form
             try:
-                # this happens if the data comes from the DS update form
                 value = data[f"WidgetChoice-{name}"]
-            except MultiValueDictKeyError:
+            except (MultiValueDictKeyError, KeyError):
                 value = None
         if value:
             if value in WidgetChoices.names:

--- a/app/grandchallenge/reader_studies/forms.py
+++ b/app/grandchallenge/reader_studies/forms.py
@@ -615,6 +615,7 @@ class DisplaySetUpdateForm(DisplaySetCreateForm):
             widget=FlexibleImageWidget(
                 user=self.user, current_value=current_value
             ),
+            required=False,
         )
 
     def _get_file_field(self, *, interface, values, current_value):

--- a/app/tests/cases_tests/test_widget.py
+++ b/app/tests/cases_tests/test_widget.py
@@ -24,6 +24,13 @@ def test_flexible_image_field_validation():
         image_queryset=get_objects_for_user(user, "cases.view_image"),
         upload_queryset=UserUpload.objects.filter(creator=user).all(),
     )
+    parsed_value_for_empty_data = field.widget.value_from_datadict(
+        data={}, name=ci.slug, files={}
+    )
+    decompressed_value_for_missing_value = field.widget.decompress(value=None)
+    assert not parsed_value_for_empty_data
+    assert decompressed_value_for_missing_value == [None, None]
+
     parsed_value_for_image_with_permission = field.widget.value_from_datadict(
         data={ci.slug: im1.pk}, name=ci.slug, files={}
     )

--- a/app/tests/reader_studies_tests/test_forms.py
+++ b/app/tests/reader_studies_tests/test_forms.py
@@ -1111,6 +1111,33 @@ def test_display_set_update_form(form_class, file_widget):
     ]
 
 
+@pytest.mark.parametrize(
+    "form_class",
+    (
+        DisplaySetCreateForm,
+        DisplaySetUpdateForm,
+    ),
+)
+@pytest.mark.django_db
+def test_display_set_form_interface_fields_not_required(form_class):
+    rs = ReaderStudyFactory()
+    user = UserFactory()
+    rs.add_editor(user)
+    ci_img = ComponentInterfaceFactory(kind="IMG")
+    ci_file = ComponentInterfaceFactory(kind="JSON", store_in_database=False)
+    ci_str = ComponentInterfaceFactory(kind="STR")
+    for ci in [ci_img, ci_file, ci_str]:
+        civ = ComponentInterfaceValueFactory(interface=ci)
+        ds = DisplaySetFactory(reader_study=rs)
+        ds.values.add(civ)
+
+    instance = None if form_class == DisplaySetCreateForm else ds
+    form = form_class(user=user, instance=instance, reader_study=rs)
+    for name, field in form.fields.items():
+        if not name == "order":
+            assert not field.required
+
+
 @pytest.mark.django_db
 def test_display_set_update_form_image_field_queryset_filters():
     rs = ReaderStudyFactory()


### PR DESCRIPTION
- Makes interface fields optional on DS update form
- Fixes FlexibleImageWidget `value_from_datadict` to handle missing keys correctly 

Closes #2767 