### PR TITLE
Use widget value instead of label in QuestionSerializer

### DIFF
--- a/app/grandchallenge/reader_studies/serializers.py
+++ b/app/grandchallenge/reader_studies/serializers.py
@@ -55,7 +55,6 @@ class QuestionSerializer(HyperlinkedModelSerializer):
     options = CategoricalOptionSerializer(many=True, read_only=True)
     interface = ComponentInterfaceSerializer(read_only=True)
     look_up_table = LookUpTableSerializer(read_only=True)
-    widget = CharField(source="get_widget_display", read_only=True)
 
     class Meta:
         model = Question

--- a/app/tests/reader_studies_tests/test_serializers.py
+++ b/app/tests/reader_studies_tests/test_serializers.py
@@ -15,5 +15,5 @@ def test_widget_on_question_serializer(rf):
     serializer2 = QuestionSerializer(qu, context={"request": rf.get("/foo")})
     assert (
         serializer2.data["widget"]
-        == QuestionWidgetKindChoices.ACCEPT_REJECT.label
+        == QuestionWidgetKindChoices.ACCEPT_REJECT.value
     )


### PR DESCRIPTION
Using the value in the serializer allows us to change the label without breaking functionality in CIRRUS. (As we _should_ have done with answer_type, direction and image_port).

https://github.com/comic/grand-challenge.org/blob/f654c41fbc6850eac0172baa90b0a009746cee34/app/grandchallenge/reader_studies/models.py#L913