### PR TITLE
Fix OpenAPI Schema for client generation

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -872,6 +872,7 @@ SPECTACULAR_SETTINGS = {
     "ENUM_NAME_OVERRIDES": {
         "ColorInterpolationEnum": "grandchallenge.workstation_configs.models.LookUpTable.COLOR_INTERPOLATION_CHOICES",
     },
+    "COMPONENT_SPLIT_REQUEST": True,
 }
 
 REST_KNOX = {"AUTH_HEADER_PREFIX": "Bearer"}

--- a/app/grandchallenge/algorithms/serializers.py
+++ b/app/grandchallenge/algorithms/serializers.py
@@ -92,7 +92,9 @@ class JobSerializer(serializers.ModelSerializer):
         source="algorithm_image.algorithm.title", read_only=True
     )
     hanging_protocol = HangingProtocolSerializer(
-        source="algorithm_image.algorithm.hanging_protocol", read_only=True
+        source="algorithm_image.algorithm.hanging_protocol",
+        read_only=True,
+        allow_null=True,
     )
     view_content = JSONField(
         source="algorithm_image.algorithm.view_content", read_only=True

--- a/app/grandchallenge/archives/serializers.py
+++ b/app/grandchallenge/archives/serializers.py
@@ -25,7 +25,7 @@ class ArchiveItemSerializer(serializers.ModelSerializer):
     )
     values = HyperlinkedComponentInterfaceValueSerializer(many=True)
     hanging_protocol = HangingProtocolSerializer(
-        source="archive.hanging_protocol", read_only=True
+        source="archive.hanging_protocol", read_only=True, allow_null=True
     )
     view_content = JSONField(source="archive.view_content", read_only=True)
 

--- a/app/grandchallenge/cases/serializers.py
+++ b/app/grandchallenge/cases/serializers.py
@@ -75,21 +75,31 @@ class RawImageUploadSessionSerializer(serializers.ModelSerializer):
     )
     status = CharField(source="get_status_display", read_only=True)
     archive = SlugRelatedField(
-        slug_field="slug", queryset=Archive.objects.none(), required=False
+        slug_field="slug",
+        queryset=Archive.objects.none(),
+        required=False,
+        write_only=True,
     )
     answer = PrimaryKeyRelatedField(
-        queryset=Answer.objects.none(), required=False
+        queryset=Answer.objects.none(),
+        required=False,
+        write_only=True,
     )
     interface = SlugRelatedField(
         slug_field="slug",
         queryset=ComponentInterface.objects.all(),
         required=False,
+        write_only=True,
     )
     archive_item = PrimaryKeyRelatedField(
-        queryset=ArchiveItem.objects.none(), required=False
+        queryset=ArchiveItem.objects.none(),
+        required=False,
+        write_only=True,
     )
     display_set = PrimaryKeyRelatedField(
-        queryset=DisplaySet.objects.none(), required=False
+        queryset=DisplaySet.objects.none(),
+        required=False,
+        write_only=True,
     )
 
     class Meta:

--- a/app/grandchallenge/components/serializers.py
+++ b/app/grandchallenge/components/serializers.py
@@ -17,7 +17,7 @@ from grandchallenge.workstation_configs.serializers import (
 class ComponentInterfaceSerializer(serializers.ModelSerializer):
     kind = serializers.CharField(source="get_kind_display", read_only=True)
     super_kind = SerializerMethodField()
-    look_up_table = LookUpTableSerializer(read_only=True)
+    look_up_table = LookUpTableSerializer(read_only=True, allow_null=True)
 
     class Meta:
         model = ComponentInterface
@@ -163,5 +163,8 @@ class HyperlinkedComponentInterfaceValueSerializer(
 ):
     # Serializes images with hyperlinks for external usage
     image = serializers.HyperlinkedRelatedField(
-        queryset=Image.objects.all(), view_name="api:image-detail"
+        queryset=Image.objects.all(),
+        view_name="api:image-detail",
+        read_only=True,
+        allow_null=True,
     )

--- a/app/grandchallenge/components/serializers.py
+++ b/app/grandchallenge/components/serializers.py
@@ -163,7 +163,6 @@ class HyperlinkedComponentInterfaceValueSerializer(
 ):
     # Serializes images with hyperlinks for external usage
     image = serializers.HyperlinkedRelatedField(
-        queryset=Image.objects.all(),
         view_name="api:image-detail",
         read_only=True,
         allow_null=True,

--- a/app/grandchallenge/reader_studies/serializers.py
+++ b/app/grandchallenge/reader_studies/serializers.py
@@ -53,8 +53,8 @@ class QuestionSerializer(HyperlinkedModelSerializer):
     form_direction = CharField(source="get_direction_display", read_only=True)
     image_port = CharField(source="get_image_port_display", read_only=True)
     options = CategoricalOptionSerializer(many=True, read_only=True)
-    interface = ComponentInterfaceSerializer(read_only=True)
-    look_up_table = LookUpTableSerializer(read_only=True)
+    interface = ComponentInterfaceSerializer(read_only=True, allow_null=True)
+    look_up_table = LookUpTableSerializer(read_only=True, allow_null=True)
     widget = CharField(source="get_widget_display", read_only=True)
 
     class Meta:
@@ -83,7 +83,7 @@ class DisplaySetSerializer(HyperlinkedModelSerializer):
     )
     values = HyperlinkedComponentInterfaceValueSerializer(many=True)
     hanging_protocol = HangingProtocolSerializer(
-        source="reader_study.hanging_protocol", read_only=True
+        source="reader_study.hanging_protocol", read_only=True, allow_null=True
     )
     view_content = JSONField(
         source="reader_study.view_content", read_only=True


### PR DESCRIPTION
Our OpenAPI Schema had a few errors in it related to read or write only fields, this PR fixes them. It also splits the request and response models in the schema to allow for easier generation of clients, see https://drf-spectacular.readthedocs.io/en/latest/client_generation.html for motivation.