### PR TITLE
Add base cost to challenge cost estimate

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -137,6 +137,9 @@ CHALLENGES_ECR_STORAGE_COST_CENTS_PER_TB_PER_YEAR = int(
 CHALLENGES_COMPUTE_COST_CENTS_PER_HOUR = int(
     os.environ.get("CHALLENGES_COMPUTE_COST_CENTS_PER_HOUR", 100)
 )
+CHALLENGE_BASE_COST_IN_EURO = int(
+    os.environ.get("CHALLENGE_BASE_COST_IN_EURO", 5000)
+)
 
 ##############################################################################
 #

--- a/app/grandchallenge/challenges/forms.py
+++ b/app/grandchallenge/challenges/forms.py
@@ -11,6 +11,7 @@ from crispy_forms.layout import (
 from django import forms
 from django.core.exceptions import ValidationError
 from django.urls import reverse
+from django.utils.html import format_html
 from django.utils.text import format_lazy
 from django_select2.forms import Select2MultipleWidget
 from django_summernote.widgets import SummernoteInplaceWidget
@@ -261,9 +262,10 @@ class ChallengeRequestForm(
             "inference_time_limit_in_minutes": "Average algorithm job run time in minutes",
             "structured_challenge_submission_doi": "DOI",
             "structured_challenge_submission_form": "PDF",
-            "challenge_fee_agreement": "I confirm that I have read and understood the "
-            "<a href='https://grand-challenge.org/challenge-policy-and-pricing/'>pricing "
-            "policy</a> for running a challenge.",
+            "challenge_fee_agreement": format_html(
+                "I confirm that I have read and understood the <a href='{}'>pricing policy</a> for running a challenge.",
+                "https://grand-challenge.org/challenge-policy-and-pricing/",
+            ),
         }
         help_texts = {
             "title": "The name of the planned challenge.",

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -921,6 +921,7 @@ class ChallengeRequest(UUIDModel, ChallengeBase):
                 settings.CHALLENGES_ECR_STORAGE_COST_CENTS_PER_TB_PER_YEAR
             )
             budget = {
+                "Base cost": settings.CHALLENGE_BASE_COST_IN_EURO,
                 "Data storage cost for phase 1": None,
                 "Compute costs for phase 1": None,
                 "Total phase 1": None,
@@ -1023,6 +1024,7 @@ class ChallengeRequest(UUIDModel, ChallengeBase):
                         budget["Total phase 1"],
                         budget["Total phase 2"],
                         budget["Docker storage cost"],
+                        budget["Base cost"],
                     ],
                 )
             )

--- a/app/grandchallenge/challenges/templates/challenges/challenge_cost.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_cost.html
@@ -5,11 +5,11 @@
             <div class="table-responsive pt-2 w-50">
                 <table class="table table-hover table-sm">
                     {% for field, value in budget.items %}
-                        <tr {% if "Total" in field %}class="table-light"{% endif %}><td class="col-5 font-weight-bold">{{ field }}</td> <td class="col-7">{{ value }} €</td></tr>
+                        <tr class="{% if field == "Total" %} table-dark {% elif "Total" in field or "Base" in field %}table-light{% endif %}"><td class="col-5 font-weight-bold">{{ field }}</td> <td class="col-7 text-right {% if field == "Total" %}font-weight-bold{% endif %}">{{ value }} €</td></tr>
                     {% endfor %}
                     <tr>
                         <td class="col-5 font-weight-bold">Total number of submissions to challenge</td>
-                        <td class="col-7">{{ total_submissions }}
+                        <td class="col-7 text-right">{{ total_submissions }}
                             {% if total_submissions > 500 %}
                                 <br><small class="text-danger">This is an unusually high number of submissions. You may want to reconsider the number of submissions for each phase. </small>
                             {% endif %}
@@ -25,6 +25,7 @@
                 {% if image_size_warning %}
                     <div class="bg-danger rounded p-2 mb-3 text-white"><i class="fa fa-exclamation-circle mx-2" aria-hidden="true"></i> {{ image_size_warning }}</div>
                 {% endif %}
+                <div class="text-center"><i class="fa fa-exclamation-circle mx-2" aria-hidden="true"></i>The estimated costs are excluding VAT.</div>
             </div>
         </div>
     </div>

--- a/app/tests/challenges_tests/test_tasks.py
+++ b/app/tests/challenges_tests/test_tasks.py
@@ -146,6 +146,7 @@ def test_challenge_request_budget_calculation(challenge_request):
         == challenge_request.budget["Total phase 1"]
         + challenge_request.budget["Total phase 2"]
         + challenge_request.budget["Docker storage cost"]
+        + challenge_request.budget["Base cost"]
     )
 
 


### PR DESCRIPTION
This adds the base cost to the challenge cost estimate calculation: 
![image](https://github.com/comic/grand-challenge.org/assets/30069334/a8b379bf-b084-4a95-9bd5-d2848bd83bd5)

And also fixes the label for the "agree to pricing policy" checkbox where the link wouldn't show correctly. 