### PR TITLE
Fix input and output count annotation for UserAlgorithmsForPhaseMixin

### DIFF
--- a/app/grandchallenge/algorithms/forms.py
+++ b/app/grandchallenge/algorithms/forms.py
@@ -370,7 +370,8 @@ class UserAlgorithmsForPhaseMixin:
         return (
             get_objects_for_user(self._user, "algorithms.change_algorithm")
             .annotate(
-                input_count=Count("inputs"), output_count=Count("outputs")
+                input_count=Count("inputs", distinct=True),
+                output_count=Count("outputs", distinct=True),
             )
             .filter(
                 inputs__in=inputs,
@@ -391,8 +392,8 @@ class UserAlgorithmsForPhaseMixin:
             )
             .select_related("algorithm")
             .annotate(
-                input_count=Count("algorithm__inputs"),
-                output_count=Count("algorithm__outputs"),
+                input_count=Count("algorithm__inputs", distinct=True),
+                output_count=Count("algorithm__outputs", distinct=True),
             )
             .filter(
                 algorithm__inputs__in=inputs,


### PR DESCRIPTION
Annotating the algorithm or algorithm image queryset by both input and output count resulted in wrong counts without the `distinct` argument added. See here: https://docs.djangoproject.com/en/4.2/topics/db/aggregation/#combining-multiple-aggregations