### PR TITLE
Add a list of incomplete jobs to evaluation detail

### DIFF
--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -528,7 +528,12 @@ class AlgorithmImage(UUIDModel, ComponentImage):
         ordering = ("created", "creator")
 
     def __str__(self):
-        return f"Algorithm image {self.pk} for {self.algorithm} ({truncatewords(self.comment, 4)})"
+        out = f"Algorithm image {self.pk} for {self.algorithm}"
+
+        if self.comment:
+            out += f" ({truncatewords(self.comment, 4)})"
+
+        return out
 
     def get_absolute_url(self):
         return reverse(

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -202,6 +202,45 @@
     {% if "change_challenge" in challenge_perms %}
         <div class="card card-danger border-danger">
             <div class="card-header bg-danger text-white">Evaluation Admin</div>
+
+            {% if incomplete_jobs %}
+                <div class="card-body">
+                    <h3 class="card-title">Incomplete Jobs</h3>
+
+                    <p>
+                        The following algorithm jobs need to complete before the evaluation method
+                        can be executed on the predictions.
+                    </p>
+
+                    <table class="table table-borderless table-hover table-sm">
+                        <thead class="thead-light">
+                        <tr>
+                            <th>ID</th>
+                            <th>Created</th>
+                            <th>Status</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for job in incomplete_jobs %}
+                            <tr>
+                                <td><a href="{{ job.get_absolute_url }}">{{ job.pk }}</a></td>
+                                <td>{{ job.created }}</td>
+                                <td>
+                                    <span class="badge badge-{{ job.status_context }}">
+                                    {% if job.animate %}
+                                        <span class="spinner-border spinner-border-sm" role="status"
+                                            aria-hidden="true"></span>
+                                    {% endif %}
+                                    {{ job.get_status_display }}
+                                    </span>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% endif %}
+
             <div class="card-body">
                 <h3 class="card-title">Visibility</h3>
 


### PR DESCRIPTION
![Screenshot 2023-06-27 at 16-17-30 algorithm-evaluation-3 - Gc](https://github.com/comic/grand-challenge.org/assets/12661555/e76c70f4-316e-43cb-9b6a-708fd5ae39c9)

The list is filtered by the permission, algorithm image and archive as input.

Closes #2897