### PR TITLE
Fix not being able to post empty answers for non-required questions.

### DIFF
--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1671,6 +1671,8 @@ class Answer(UUIDModel):
                     "Provided options are not valid for this question"
                 )
 
+        # Image types can have empty answers while an image is being uploaded,
+        # as such we never consider it empty.
         answer_is_empty = (
             answer == question.empty_answer_value
             and not question.is_image_type

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1476,6 +1476,9 @@ class Question(UUIDModel, OverlaySegmentsMixin):
 
     def is_answer_valid(self, *, answer):
         """Validates ``answer`` against ``ANSWER_TYPE_SCHEMA``."""
+        if self.answer_type == Question.AnswerType.HEADING:  # Never valid
+            return False
+
         allowed_types = [{"$ref": f"#/definitions/{self.answer_type}"}]
 
         if self.empty_answer_value is None:

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1456,6 +1456,13 @@ class Question(UUIDModel, OverlaySegmentsMixin):
         ]
 
     @property
+    def allow_empty_list_types(self):
+        return [
+            self.AnswerType.MULTIPLE_CHOICE,
+            self.AnswerType.MULTIPLE_CHOICE_DROPDOWN,
+        ]
+
+    @property
     def empty_answer_values(self):
         """Returns a list of answer values which are considered to be empty"""
         result = []
@@ -1463,6 +1470,8 @@ class Question(UUIDModel, OverlaySegmentsMixin):
             result.append(None)
         if self.answer_type in self.allow_blank_types:
             result.append("")
+        if self.answer_type in self.allow_empty_list_types:
+            result.append([])
         return result
 
     def is_answer_valid(self, *, answer):

--- a/app/tests/reader_studies_tests/test_api.py
+++ b/app/tests/reader_studies_tests/test_api.py
@@ -275,32 +275,24 @@ def test_answer_creator_is_reader(client):
     "answer_type,answer,expected",
     (
         (Question.AnswerType.BOOL, True, 201),
-        (Question.AnswerType.BOOL, None, 400),
         (Question.AnswerType.BOOL, "True", 400),
         (Question.AnswerType.BOOL, 12, 400),
         (Question.AnswerType.NUMBER, 12, 201),
-        (Question.AnswerType.NUMBER, None, 201),
         (Question.AnswerType.NUMBER, "12", 400),
         (Question.AnswerType.NUMBER, True, 400),
         (Question.AnswerType.SINGLE_LINE_TEXT, "dgfsgfds", 201),
-        (Question.AnswerType.SINGLE_LINE_TEXT, "", 201),
         (Question.AnswerType.SINGLE_LINE_TEXT, None, 400),
         (Question.AnswerType.SINGLE_LINE_TEXT, True, 400),
         (Question.AnswerType.SINGLE_LINE_TEXT, 12, 400),
         (Question.AnswerType.MULTI_LINE_TEXT, "dgfsgfds", 201),
-        (Question.AnswerType.MULTI_LINE_TEXT, "", 201),
         (Question.AnswerType.MULTI_LINE_TEXT, None, 400),
         (Question.AnswerType.MULTI_LINE_TEXT, True, 400),
         (Question.AnswerType.MULTI_LINE_TEXT, 12, 400),
-        (Question.AnswerType.CHOICE, None, 201),
-        (Question.AnswerType.MULTIPLE_CHOICE, [], 201),
         (Question.AnswerType.MULTIPLE_CHOICE, None, 400),
-        (Question.AnswerType.MULTIPLE_CHOICE_DROPDOWN, [], 201),
         (Question.AnswerType.MULTIPLE_CHOICE_DROPDOWN, None, 400),
         # Headings are always incorrect when answering
         (Question.AnswerType.HEADING, True, 400),
         (Question.AnswerType.HEADING, "null", 400),
-        (Question.AnswerType.HEADING, None, 400),
         # Annotations
         (Question.AnswerType.BOUNDING_BOX_2D, "", 400),
         (Question.AnswerType.BOUNDING_BOX_2D, True, 400),
@@ -795,16 +787,6 @@ def test_answer_creator_is_reader(client):
             },
             400,
         ),
-        (Question.AnswerType.BOUNDING_BOX_2D, None, 201),
-        (Question.AnswerType.MULTIPLE_2D_BOUNDING_BOXES, None, 201),
-        (Question.AnswerType.DISTANCE_MEASUREMENT, None, 201),
-        (Question.AnswerType.MULTIPLE_DISTANCE_MEASUREMENTS, None, 201),
-        (Question.AnswerType.POINT, None, 201),
-        (Question.AnswerType.MULTIPLE_POINTS, None, 201),
-        (Question.AnswerType.POLYGON, None, 201),
-        (Question.AnswerType.MULTIPLE_POLYGONS, None, 201),
-        (Question.AnswerType.ANGLE, None, 201),
-        (Question.AnswerType.MULTIPLE_ANGLES, None, 201),
         (Question.AnswerType.ELLIPSE, "wwoljg", 400),
         (Question.AnswerType.ELLIPSE, True, 400),
         (Question.AnswerType.ELLIPSE, 42, 400),
@@ -921,11 +903,7 @@ def test_answer_is_correct_type(client, answer_type, answer, expected):
     reader = UserFactory()
     rs.add_reader(reader)
 
-    q = QuestionFactory(
-        reader_study=rs,
-        answer_type=answer_type,
-        required=False,
-    )
+    q = QuestionFactory(reader_study=rs, answer_type=answer_type)
 
     response = get_view_for_user(
         viewname="api:reader-studies-answer-list",

--- a/app/tests/reader_studies_tests/test_api.py
+++ b/app/tests/reader_studies_tests/test_api.py
@@ -950,7 +950,6 @@ def test_answer_is_correct_type(client, answer_type, answer, expected):
         (Question.AnswerType.SINGLE_LINE_TEXT, ""),
         (Question.AnswerType.MULTI_LINE_TEXT, ""),
         (Question.AnswerType.TEXT, ""),
-        (Question.AnswerType.TEXT, ""),
         # Null answers
         (Question.AnswerType.NUMBER, None),
         (Question.AnswerType.CHOICE, None),

--- a/app/tests/reader_studies_tests/test_api.py
+++ b/app/tests/reader_studies_tests/test_api.py
@@ -782,10 +782,15 @@ def test_answer_creator_is_reader(client):
             },
             400,
         ),
+        (Question.AnswerType.TEXT, None, 400),
         (Question.AnswerType.SINGLE_LINE_TEXT, None, 400),
         (Question.AnswerType.MULTI_LINE_TEXT, None, 400),
+        (Question.AnswerType.TEXT, "", 201),
+        (Question.AnswerType.SINGLE_LINE_TEXT, "", 201),
+        (Question.AnswerType.MULTI_LINE_TEXT, "", 201),
         (Question.AnswerType.BOOL, None, 400),
-        (Question.AnswerType.NUMBER, None, 400),
+        (Question.AnswerType.NUMBER, None, 201),
+        (Question.AnswerType.NUMBER, "", 400),
         (Question.AnswerType.HEADING, None, 400),
         (Question.AnswerType.BOUNDING_BOX_2D, None, 201),
         (Question.AnswerType.MULTIPLE_2D_BOUNDING_BOXES, None, 201),
@@ -797,9 +802,11 @@ def test_answer_creator_is_reader(client):
         (Question.AnswerType.MULTIPLE_POLYGONS, None, 201),
         (Question.AnswerType.ANGLE, None, 201),
         (Question.AnswerType.MULTIPLE_ANGLES, None, 201),
-        (Question.AnswerType.CHOICE, None, 400),
+        (Question.AnswerType.CHOICE, None, 201),
         (Question.AnswerType.MULTIPLE_CHOICE, None, 400),
         (Question.AnswerType.MULTIPLE_CHOICE_DROPDOWN, None, 400),
+        (Question.AnswerType.MULTIPLE_CHOICE, [], 201),
+        (Question.AnswerType.MULTIPLE_CHOICE_DROPDOWN, [], 201),
         (Question.AnswerType.ELLIPSE, "wwoljg", 400),
         (Question.AnswerType.ELLIPSE, True, 400),
         (Question.AnswerType.ELLIPSE, 42, 400),
@@ -916,7 +923,11 @@ def test_answer_is_correct_type(client, answer_type, answer, expected):
     reader = UserFactory()
     rs.add_reader(reader)
 
-    q = QuestionFactory(reader_study=rs, answer_type=answer_type)
+    q = QuestionFactory(
+        reader_study=rs,
+        answer_type=answer_type,
+        required=False,
+    )
 
     response = get_view_for_user(
         viewname="api:reader-studies-answer-list",

--- a/app/tests/reader_studies_tests/test_api.py
+++ b/app/tests/reader_studies_tests/test_api.py
@@ -931,11 +931,20 @@ def test_answer_is_correct_type(client, answer_type, answer, expected):
         # Null answers
         (Question.AnswerType.NUMBER, None),
         (Question.AnswerType.CHOICE, None),
-        *(
-            (answer_type, None)
-            for answer_type in Question.AnswerType.get_annotation_types()
-            if answer_type not in Question.AnswerType.get_image_types()
-        ),
+        (Question.AnswerType.BOUNDING_BOX_2D, None),
+        (Question.AnswerType.MULTIPLE_2D_BOUNDING_BOXES, None),
+        (Question.AnswerType.DISTANCE_MEASUREMENT, None),
+        (Question.AnswerType.MULTIPLE_DISTANCE_MEASUREMENTS, None),
+        (Question.AnswerType.POINT, None),
+        (Question.AnswerType.MULTIPLE_POINTS, None),
+        (Question.AnswerType.POLYGON, None),
+        (Question.AnswerType.MULTIPLE_POLYGONS, None),
+        (Question.AnswerType.LINE, None),
+        (Question.AnswerType.MULTIPLE_LINES, None),
+        (Question.AnswerType.ANGLE, None),
+        (Question.AnswerType.MULTIPLE_ANGLES, None),
+        (Question.AnswerType.ELLIPSE, None),
+        (Question.AnswerType.MULTIPLE_ELLIPSES, None),
         # Empty-collection answers
         (Question.AnswerType.MULTIPLE_CHOICE, []),
         (Question.AnswerType.MULTIPLE_CHOICE_DROPDOWN, []),

--- a/app/tests/reader_studies_tests/test_models.py
+++ b/app/tests/reader_studies_tests/test_models.py
@@ -431,6 +431,22 @@ def test_validate_answer():
 NUMBER_ANSWER_VALIDATION_INPUT = (
     (
         AnswerType.NUMBER,
+        None,
+        {
+            "required": False,
+        },
+        nullcontext(),
+    ),
+    (
+        AnswerType.NUMBER,
+        None,
+        {
+            "required": True,
+        },
+        pytest.raises(ValidationError),
+    ),
+    (
+        AnswerType.NUMBER,
         2,
         {
             "answer_min_value": 0,
@@ -512,8 +528,18 @@ TEXT_ANSWER_VALIDATION_INPUT = (
     (
         AnswerType.TEXT,
         "",
-        {},
+        {
+            "required": False,
+        },
         nullcontext(),
+    ),
+    (
+        AnswerType.TEXT,
+        "",
+        {
+            "required": True,
+        },
+        pytest.raises(ValidationError),
     ),
     (
         AnswerType.TEXT,
@@ -566,11 +592,20 @@ TEXT_ANSWER_VALIDATION_INPUT = (
     ),
     (
         AnswerType.TEXT,
-        "",
+        "not hello world",
         {
             "answer_match_pattern": r"^hello world$",
         },
         pytest.raises(ValidationError),
+    ),
+    (
+        AnswerType.TEXT,
+        "",
+        {
+            "answer_min_size": 1,
+            "required": False,
+        },
+        nullcontext(),
     ),
 )
 

--- a/app/tests/reader_studies_tests/validation_tests.py
+++ b/app/tests/reader_studies_tests/validation_tests.py
@@ -232,7 +232,7 @@ def test_new_answer_type_listed():
     [
         ["STXT", False],
         ["MTXT", False],
-        ["BOOL", False],
+        ["BOOL", True],
         ["NUMB", True],
         ["2DBB", True],
         ["M2DB", True],


### PR DESCRIPTION
Closes #2916

This changeset prevents running validators on non-required questions with an explicit empty answer. Special allowance had to be made for blank-type answer types and image types.

This required some work to understand the broken tests and their initial meaning. I've added a few cases to those tests to further the scope and some corner cases.