### PR TITLE
Combined Leaderboards creation and visual tweaks

### DIFF
--- a/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
@@ -51,7 +51,7 @@
                                     <i class="fas fa-upload fa-fw"></i>&nbsp;&nbsp;Submit</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link {% if request.resolver_match.view_name in 'evaluation:leaderboard,evaluation:detail,evaluation:update,evaluation:combined-leaderboard-detail,evaluation:combined-leaderboard-update,evaluation:combined-leaderboard-create' %}active{% endif %}"
+                                <a class="nav-link {% if request.resolver_match.view_name in 'evaluation:leaderboard,evaluation:detail,evaluation:update,evaluation:combined-leaderboard-detail' %}active{% endif %}"
                                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">
                                     <i class="fas fa-trophy fa-fw"></i>&nbsp;&nbsp;Leaderboard{{ challenge.phase_set.all|pluralize }}</a>
                             </li>
@@ -90,7 +90,7 @@
                     </div>
                     {% if "change_challenge" in challenge_perms %}
                         <div class="nav-item">
-                            <a class="nav-link {% if request.resolver_match.view_name == 'pages:update' or request.resolver_match.view_name == 'pages:delete' or request.resolver_match.view_name == 'pages:create' or request.resolver_match.view_name == 'update' or request.resolver_match.view_name == 'pages:list' or request.resolver_match.app_name == 'admins' or request.resolver_match.view_name == 'participants:list' or request.resolver_match.view_name == 'participants:registration-list' or request.resolver_match.view_name == 'evaluation:phase-update' or request.resolver_match.view_name == 'evaluation:create' or request.resolver_match.view_name == 'evaluation:method-list' or request.resolver_match.view_name == 'evaluation:method-create' or request.resolver_match.view_name == 'evaluation:evaluation-admin-list' or request.resolver_match.view_name == 'evaluation:method-detail' %}active{% endif %}"
+                            <a class="nav-link {% if request.resolver_match.view_name in 'pages:update,pages:delete,pages:create,update,pages:list,admins,participants:list,participants:registration-list,evaluation:phase-update,evaluation:create,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:combined-leaderboard-update,evaluation:combined-leaderboard-create' %}active{% endif %}"
                                href="{% url 'update' challenge_short_name=challenge.short_name %}">
                                 <i class="fas fa-cog fa-fw"></i>
                                     Admin

--- a/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
@@ -90,7 +90,7 @@
                     </div>
                     {% if "change_challenge" in challenge_perms %}
                         <div class="nav-item">
-                            <a class="nav-link {% if request.resolver_match.view_name in 'pages:update,pages:delete,pages:create,update,pages:list,admins,participants:list,participants:registration-list,evaluation:phase-update,evaluation:create,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:combined-leaderboard-update,evaluation:combined-leaderboard-create' %}active{% endif %}"
+                            <a class="nav-link {% if request.resolver_match.view_name in 'pages:update,pages:delete,pages:create,update,pages:list,participants:list,participants:registration-list,evaluation:phase-update,evaluation:create,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:combined-leaderboard-update,evaluation:combined-leaderboard-create' or request.resolver_match.app_name == 'admins' %}active{% endif %}"
                                href="{% url 'update' challenge_short_name=challenge.short_name %}">
                                 <i class="fas fa-cog fa-fw"></i>
                                     Admin

--- a/app/grandchallenge/evaluation/forms.py
+++ b/app/grandchallenge/evaluation/forms.py
@@ -471,3 +471,4 @@ class CombinedLeaderboardForm(SaveFormInitMixin, forms.ModelForm):
     class Meta:
         model = CombinedLeaderboard
         fields = ("title", "description", "phases", "combination_method")
+        widgets = {"phases": forms.CheckboxSelectMultiple}

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1166,7 +1166,7 @@ class CombinedLeaderboard(TitleSlugDescriptionModel, UUIDModel):
                     }
                 )
 
-        combined_ranks.sort(key=lambda x: x["combined_rank"])
+        self._rank_combined_rank_scores(combined_ranks)
 
         cache_object = {
             "phases": {phase.pk for phase in self.public_phases},
@@ -1175,6 +1175,21 @@ class CombinedLeaderboard(TitleSlugDescriptionModel, UUIDModel):
         }
 
         cache.set(self.combined_ranks_cache_key, cache_object, timeout=None)
+
+    @staticmethod
+    def _rank_combined_rank_scores(combined_ranks):
+        """In-place addition of a rank based on the combined rank"""
+        combined_ranks.sort(key=lambda x: x["combined_rank"])
+        current_score = current_rank = None
+
+        for idx, score in enumerate(
+            cr["combined_rank"] for cr in combined_ranks
+        ):
+            if score != current_score:
+                current_score = score
+                current_rank = idx + 1
+
+            combined_ranks[idx]["rank"] = current_rank
 
     def schedule_combined_ranks_update(self):
         on_commit(

--- a/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_detail.html
@@ -2,6 +2,7 @@
 {% load url %}
 {% load dict_lookup %}
 {% load static %}
+{% load humanize %}
 
 {% block title %}{{ object.title|title}} Leaderboard - {{ block.super }}{% endblock %}
 
@@ -44,9 +45,10 @@
         <table class="table table-hover table-borderless table-sm" id="combinedRanksTable">
             <thead class="thead-light">
             <tr>
-                <th>Combined Rank ({{ object.get_combination_method_display }})</th>
+                <th>#</th>
                 <th>User</th>
                 <th>Created</th>
+                <th>Combined Rank ({{ object.get_combination_method_display }})</th>
                 {% for phase in object.public_phases %}
                     <th>{{ phase.title|title }} Rank</th>
                 {% endfor %}
@@ -55,9 +57,10 @@
             <tbody>
             {% for combined_rank in object.combined_ranks %}
                 <tr>
-                    <td>{{ combined_rank.combined_rank }}</td>
+                    <td>{{ forloop.counter|ordinal }}</td>
                     <td><a href="{% url 'profile-detail' username=combined_rank.user %}">{{ combined_rank.user }}</a></td>
-                    <td data-order="{{ combined_rank.created|date:"U" }}">{{ combined_rank.created }}</td>
+                    <td data-order="{{ combined_rank.created|date:"U" }}">{{ combined_rank.created|date:"j N Y" }}</td>
+                    <td>{{ combined_rank.combined_rank }}</td>
                     {% for phase in object.public_phases %}
                         {% get_dict_values combined_rank.evaluations phase.pk as evaluation %}
                         {% if evaluation %}

--- a/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_detail.html
@@ -64,7 +64,7 @@
                     {% for phase in object.public_phases %}
                         {% get_dict_values combined_rank.evaluations phase.pk as evaluation %}
                         {% if evaluation %}
-                            <td><a href="{% url 'evaluation:detail' challenge_short_name=challenge.short_name pk=evaluation.pk %}">{{ evaluation.rank }}</a></td>
+                            <td><a href="{% url 'evaluation:detail' challenge_short_name=challenge.short_name pk=evaluation.pk %}">{{ evaluation.rank|ordinal }}</a></td>
                         {% endif %}
                     {% endfor %}
                 </tr>

--- a/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_detail.html
@@ -57,7 +57,7 @@
             <tbody>
             {% for combined_rank in object.combined_ranks %}
                 <tr>
-                    <td>{{ forloop.counter|ordinal }}</td>
+                    <td>{{ combined_rank.rank|ordinal }}</td>
                     <td><a href="{% url 'profile-detail' username=combined_rank.user %}">{{ combined_rank.user }}</a></td>
                     <td data-order="{{ combined_rank.created|date:"U" }}">{{ combined_rank.created|date:"j N Y" }}</td>
                     <td>{{ combined_rank.combined_rank }}</td>

--- a/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_form.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "pages/challenge_settings_base.html" %}
 {% load url %}
 {% load dict_lookup %}
 {% load static %}
@@ -14,7 +14,7 @@
         <li class="breadcrumb-item"><a
                 href="{{ challenge.get_absolute_url }}">{% firstof challenge.title challenge.short_name %}</a></li>
         <li class="breadcrumb-item"><a
-                href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">Leaderboards</a></li>
+                href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=challenge.phase_set.first.slug %}">Combined Leaderboards</a></li>
         {% if object %}
             <li class="breadcrumb-item"><a
                 href="{{ object.get_absolute_url }}">{{ object.title|title }}</a></li>
@@ -24,15 +24,21 @@
     </ol>
 {% endblock %}
 
-{% block topbar2 %}
-    {% if object %}
-        {% include "evaluation/partials/phase_navbar.html" with leaderboard_nav=True %}
-    {% endif %}
-{% endblock %}
-
 {% block content %}
 
     <h2>{{ object|yesno:"Update,Create" }} {{ object.title|title }} Combined Leaderboard</h2>
+
+    {% if not object %}
+        <p>
+            Use this form to create a new combined leaderboard for your challenge.
+            Unlike the phase leaderboards, which only show the rank within that phase, the combined leaderboards combine
+            the ranks of multiple phases to calculate a new singular rank.
+        </p>
+
+        <p>
+            If a participant has not submitted to all the selected phases no combined rank is computed.
+        </p>
+    {% endif %}
 
     {% crispy form %}
 

--- a/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_form.html
@@ -36,7 +36,7 @@
         </p>
 
         <p>
-            If a participant has not submitted to all the selected phases no combined rank is computed.
+            Only participants that have submitted to all selected phases will be included in the combined leaderboard.           
         </p>
     {% endif %}
 

--- a/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_form.html
@@ -32,7 +32,7 @@
         <p>
             Use this form to create a new combined leaderboard for your challenge.
             Unlike the phase leaderboards, which only show the rank within that phase, the combined leaderboards combine
-            the ranks of multiple phases to calculate a new singular rank.
+            the ranks of multiple phases to calculate the overall rank.
         </p>
 
         <p>

--- a/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_form.html
@@ -36,7 +36,7 @@
         </p>
 
         <p>
-            Only participants that have submitted to all selected phases will be included in the combined leaderboard.           
+            Only participants that have submitted to all selected phases will be included in the combined leaderboard.
         </p>
     {% endif %}
 

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -246,19 +246,19 @@
 
                 {% if object.published %}
                     <i class="fas fa-eye"></i> This result is published on the
-                    leaderboard
+                    leaderboard(s)
                     <form method="post"
                           action="{% url 'evaluation:update' challenge_short_name=challenge.short_name pk=object.pk %}">
                         {% csrf_token %}
                         <input type="hidden" name="published"
                                value="false">
                         <button type="submit" class="btn btn-danger">
-                            Exclude this result from the leaderboard
+                            Exclude this result from the leaderboard(s)
                         </button>
                     </form>
                 {% else %}
                     <i class="fas fa-eye-slash text-danger"></i> This result is not
-                    published on the leaderboard
+                    published on the leaderboard(s)
                     <br>
                     <form method="post"
                           action="{% url 'evaluation:update' challenge_short_name=challenge.short_name pk=object.pk %}">
@@ -266,7 +266,7 @@
                         <input type="hidden" name="published"
                                value="true">
                         <button type="submit" class="btn btn-success">
-                            Publish this result on the leaderboard
+                            Publish this result on the leaderboard(s)
                         </button>
                     </form>
                 {% endif %}

--- a/app/grandchallenge/evaluation/templates/evaluation/partials/combinedleaderboard_menu_sidebar.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/partials/combinedleaderboard_menu_sidebar.html
@@ -1,0 +1,19 @@
+<li class="nav-item">
+    <a class="nav-link px-4 py-1 mb-1"
+       data-toggle="collapse"
+       data-target="#{{ combined_leaderboard.slug }}-collapse"
+       aria-expanded={% if request.resolver_match.view_name == 'evaluation:combined-leaderboard-update' and request.resolver_match.kwargs.slug == combined_leaderboard.slug %}"true"{% else %}"false"{% endif %}
+      >
+         <i class="fas fa-chevron-right mr-1"></i> <i class="fas fa-chevron-down mr-1"></i> {{ combined_leaderboard.title }}
+    </a>
+    <div class="collapse {% if request.resolver_match.view_name == 'evaluation:combined-leaderboard-update' and request.resolver_match.kwargs.slug == combined_leaderboard.slug %}show{% endif %}"
+         id="{{ combined_leaderboard.slug }}-collapse"
+         style=""
+    >
+        <ul class="nav nav-pills flex-column">
+            <li class="nav-item pl-4">
+                <a href="{% url 'evaluation:combined-leaderboard-update' slug=combined_leaderboard.slug %}" class="nav-link py-1 pl-3 {% if request.resolver_match.view_name == 'evaluation:combined-leaderboard-update' and request.resolver_match.kwargs.slug == combined_leaderboard.slug %}active{% endif %}"><i class="fas fa-cog fa-fw"></i> Settings</a>
+            </li>
+        </ul>
+    </div>
+</li>

--- a/app/grandchallenge/evaluation/templates/evaluation/partials/phase_navbar.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/partials/phase_navbar.html
@@ -14,7 +14,7 @@
             {% for combined_leaderboard in challenge.combinedleaderboard_set.all %}
                 <li class="nav-item">
                      <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name in 'evaluation:combined-leaderboard-detail,evaluation:combined-leaderboard-update' and request.resolver_match.kwargs.slug == combined_leaderboard.slug %}active{% endif %}"
-                        href="{% url 'evaluation:combined-leaderboard-detail' challenge_short_name=challenge.short_name slug=combined_leaderboard.slug %}"><i class="fa fa-medal fa-fw"></i>&nbsp;&nbsp;{{ combined_leaderboard.title|title }}</a>
+                        href="{% url 'evaluation:combined-leaderboard-detail' challenge_short_name=challenge.short_name slug=combined_leaderboard.slug %}"><i class="fa fa-trophy fa-lg fa-fw"></i>&nbsp;&nbsp;{{ combined_leaderboard.title|title }}</a>
                 </li>
             {% endfor %}
         {%  endif %}

--- a/app/grandchallenge/evaluation/templates/evaluation/partials/phase_navbar.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/partials/phase_navbar.html
@@ -10,12 +10,14 @@
        aria-expanded="false">
         Choose a Phase</a>
     <ul class="nav nav-pills col-12 mb-3">
-        {% for combined_leaderboard in challenge.combinedleaderboard_set.all %}
-            <li class="nav-item">
-                 <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name in 'evaluation:combined-leaderboard-detail,evaluation:combined-leaderboard-update' and request.resolver_match.kwargs.slug == combined_leaderboard.slug %}active{% endif %}"
-                    href="{% url 'evaluation:combined-leaderboard-detail' challenge_short_name=challenge.short_name slug=combined_leaderboard.slug %}"><i class="fa fa-medal fa-fw"></i>&nbsp;&nbsp;{{ combined_leaderboard.title|title }}</a>
-            </li>
-        {% endfor %}
+        {% if request.resolver_match.view_name in 'evaluation:combined-leaderboard-detail,evaluation:leaderboard' %}
+            {% for combined_leaderboard in challenge.combinedleaderboard_set.all %}
+                <li class="nav-item">
+                     <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name in 'evaluation:combined-leaderboard-detail,evaluation:combined-leaderboard-update' and request.resolver_match.kwargs.slug == combined_leaderboard.slug %}active{% endif %}"
+                        href="{% url 'evaluation:combined-leaderboard-detail' challenge_short_name=challenge.short_name slug=combined_leaderboard.slug %}"><i class="fa fa-medal fa-fw"></i>&nbsp;&nbsp;{{ combined_leaderboard.title|title }}</a>
+                </li>
+            {% endfor %}
+        {%  endif %}
         {% for phase in challenge.phase_set.all %}
             {% if "change_challenge" in challenge_perms or phase.public %}
                 <li class="nav-item">

--- a/app/grandchallenge/evaluation/templates/evaluation/partials/phase_navbar.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/partials/phase_navbar.html
@@ -13,7 +13,7 @@
         {% for combined_leaderboard in challenge.combinedleaderboard_set.all %}
             <li class="nav-item">
                  <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name in 'evaluation:combined-leaderboard-detail,evaluation:combined-leaderboard-update' and request.resolver_match.kwargs.slug == combined_leaderboard.slug %}active{% endif %}"
-                       href="{% url 'evaluation:combined-leaderboard-detail' challenge_short_name=challenge.short_name slug=combined_leaderboard.slug %}">{{ combined_leaderboard.title|title }}</a>
+                    href="{% url 'evaluation:combined-leaderboard-detail' challenge_short_name=challenge.short_name slug=combined_leaderboard.slug %}"><i class="fa fa-medal fa-fw"></i>&nbsp;&nbsp;{{ combined_leaderboard.title|title }}</a>
             </li>
         {% endfor %}
         {% for phase in challenge.phase_set.all %}
@@ -21,16 +21,16 @@
                 <li class="nav-item">
                     {% if leaderboard_nav %}
                         <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
-                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-trophy fa-fw"></i>&nbsp;&nbsp;{{ phase.title }}</a>
                     {% elif submission_nav %}
                         <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-create-legacy' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-detail' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
-                               href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+                               href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-upload fa-fw"></i>&nbsp;&nbsp;{{ phase.title }}</a>
                     {% elif workspaces_nav %}
                         <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.kwargs.slug == phase.slug%}active{% endif %}"
-                               href="{% url 'workspaces:create' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+                               href="{% url 'workspaces:create' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-tools fa-fw"></i>&nbsp;&nbsp;{{ phase.title }}</a>
                     {% else %}
                         <a class="nav-link mr-1 px-4 py-1 {% if object.submission.phase.slug == phase.slug %}active{% endif %}"
-                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-trophy fa-fw"></i>&nbsp;&nbsp;{{ phase.title }}</a>
                     {% endif %}
                 </li>
             {% endif %}

--- a/app/grandchallenge/pages/templates/pages/challenge_settings_base.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_settings_base.html
@@ -69,6 +69,15 @@
                         href="{% url 'evaluation:phase-create' challenge_short_name=challenge.short_name %}">
                         <i class="fas fa-plus fa-fw"></i>&nbsp;Add a new Phase</a>
                   </li>
+            <li class="navbar-header rounded bg-light pl-3 py-1 mt-2 mb-1"><a>Combined Leaderboards</a></li>
+                {% for combined_leaderboard in challenge.combinedleaderboard_set.all %}
+                    {% include 'evaluation/partials/combinedleaderboard_menu_sidebar.html' with combined_leaderboard=combined_leaderboard %}
+                {% endfor %}
+               <li class="nav-item">
+                <a class="nav-link px-4 py-1 mb-1 {% if request.resolver_match.view_name == 'evaluation:phase-create' %}active{% endif %}"
+                    href="{% url 'evaluation:combined-leaderboard-create' challenge_short_name=challenge.short_name %}">
+                    <i class="fas fa-plus fa-fw"></i>&nbsp;Add a new Combined Leaderboard</a>
+              </li>
           </ul>
     </div>
 {% endblock %}

--- a/app/tests/common_tests/test_link_visibility.py
+++ b/app/tests/common_tests/test_link_visibility.py
@@ -19,7 +19,10 @@ from tests.utils import validate_admin_only_view
     ],
 )
 def test_admins_see_links(view, client, two_challenge_sets):
-    if view == "evaluation:phase-update":
+    if view in [
+        "evaluation:phase-update",
+        "evaluation:combined-leaderboard-update",
+    ]:
         reverse_kwargs = {
             "slug": two_challenge_sets.challenge_set_1.challenge.phase_set.get().slug
         }

--- a/app/tests/common_tests/test_link_visibility.py
+++ b/app/tests/common_tests/test_link_visibility.py
@@ -14,8 +14,8 @@ from tests.utils import validate_admin_only_view
         "participants:registration-list",
         "evaluation:phase-update",
         "evaluation:phase-create",
-        "evaluation:combinedleaderboard-create",
-        "evaluation:combinedleaderboard-update",
+        "evaluation:combined-leaderboard-create",
+        "evaluation:combined-leaderboard-update",
     ],
 )
 def test_admins_see_links(view, client, two_challenge_sets):

--- a/app/tests/common_tests/test_link_visibility.py
+++ b/app/tests/common_tests/test_link_visibility.py
@@ -14,6 +14,8 @@ from tests.utils import validate_admin_only_view
         "participants:registration-list",
         "evaluation:phase-update",
         "evaluation:phase-create",
+        "evaluation:combinedleaderboard-create",
+        "evaluation:combinedleaderboard-update",
     ],
 )
 def test_admins_see_links(view, client, two_challenge_sets):

--- a/app/tests/common_tests/test_link_visibility.py
+++ b/app/tests/common_tests/test_link_visibility.py
@@ -14,15 +14,10 @@ from tests.utils import validate_admin_only_view
         "participants:registration-list",
         "evaluation:phase-update",
         "evaluation:phase-create",
-        "evaluation:combined-leaderboard-create",
-        "evaluation:combined-leaderboard-update",
     ],
 )
 def test_admins_see_links(view, client, two_challenge_sets):
-    if view in [
-        "evaluation:phase-update",
-        "evaluation:combined-leaderboard-update",
-    ]:
+    if view == "evaluation:phase-update":
         reverse_kwargs = {
             "slug": two_challenge_sets.challenge_set_1.challenge.phase_set.get().slug
         }

--- a/app/tests/evaluation_tests/test_models.py
+++ b/app/tests/evaluation_tests/test_models.py
@@ -519,6 +519,7 @@ def test_combined_leaderboards_with_non_public_components():
     assert new_ranks[2]["combined_rank"] == 8
     assert new_ranks[2]["user"] == users[2].username
 
+    # Retracting a phase should result in an empty leaderboard
     phase.public = False
     phase.save()
 

--- a/app/tests/evaluation_tests/test_models.py
+++ b/app/tests/evaluation_tests/test_models.py
@@ -596,3 +596,17 @@ def test_combined_leaderboard_updated_on_phase_change(
         phase.combinedleaderboard_set.clear()
 
     assert_callbacks(callbacks)
+
+
+@pytest.mark.parametrize(
+    "combined_ranks,expected_ranks",
+    (
+        ([], []),
+        ([10, 20, 30], [1, 2, 3]),
+        ([10, 20, 20, 30], [1, 2, 2, 4]),
+    ),
+)
+def test_combined_leaderboard_ranks(combined_ranks, expected_ranks):
+    combined_ranks = [{"combined_rank": cr} for cr in combined_ranks]
+    CombinedLeaderboard._rank_combined_rank_scores(combined_ranks)
+    assert [cr["rank"] for cr in combined_ranks] == expected_ranks


### PR DESCRIPTION
Part of the pitch:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/243

This changeset covers the following:
- Adding ordinal rank and changing the ordering/format of the columns to be more in line with regular leaderboards
- Gather the update/create forms under the challenge admin as to be equal to phase admin update/create
- Removed combined leaderboards from the submit sub-section
- Phase navigation now has icons for the sub-sections to clarify what type of subsection one is in immediately
  - Combined leaderboards have a slightly bigger icon than regular leaderboards
- Added a test to assert compliant behaviour with respect to public/non-public evaluation and phases.

# Old
<img width="1402" alt="image" src="https://github.com/comic/grand-challenge.org/assets/7871310/cf7e6cb2-12f0-4e0b-aa9f-67eaa5be34b3">

# New
<img width="1398" alt="image" src="https://github.com/comic/grand-challenge.org/assets/7871310/6830236b-0cef-4174-8fc6-0902fa4f9928">
