### PR TITLE
Added a fix for charts not appearing in result logs

### DIFF
--- a/app/grandchallenge/algorithms/static/algorithms/js/display_result_text.mjs
+++ b/app/grandchallenge/algorithms/static/algorithms/js/display_result_text.mjs
@@ -13,7 +13,7 @@ $('#resultInfoModal').on('show.bs.modal', function (event) {
     modal.find('#resultDetailLink').attr("href", `${button.data("pk")}/`);
 })
 
-$('[href="#v-pills-logs"]').on('shown.bs.tab', function (event) {
+$('#v-pills-logs-tab').on('shown.bs.tab', function (event) {
     // a resize is needed when switching to the logs tab to make the vega chart load correctly
     window.dispatchEvent(new Event('resize'))
 })


### PR DESCRIPTION
A fix for #2893 - Algorithm job runtime metrics do not seem to be present

The charts were present on the page, but not rendering

As per https://vega.github.io/vega-lite/docs/size.html#specifying-responsive-width-and-height 
Vega charts need a resize event called if the container size gets altered - this happens when we switch tabs

I've tried to minimise the number of these events, by setting it to trigger only when the logs tab loads. 

Other options:
We could load the chart only when users swap to the tab - this would probably mean a faster initial page load, but more calls to the server if users swap back and forth between logs and info

Setting the chart to display:inline, but with visible:hidden means the overlay shows up with mouseover

