### PR TITLE
Add user profile links to combined leaderboards

### DIFF
--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1104,6 +1104,10 @@ class CombinedLeaderboard(TitleSlugDescriptionModel, UUIDModel):
             return []
 
     @property
+    def combined_ranks_users(self):
+        return [cr["user"] for cr in self.combined_ranks]
+
+    @property
     def combined_ranks_created(self):
         combined_ranks = self._combined_ranks_object
         if combined_ranks is not None:

--- a/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_detail.html
@@ -71,12 +71,12 @@
                         {% endif %}
                     {% endfor %}
                 </tr>
+            {% endfor %}
                 <tfoot>
                     <th colspan="5" class="text-muted" style="font-size: 0.85rem;">
                         This leaderboard was updated at {{ object.combined_ranks_created|date:"P" }} on {{ object.combined_ranks_created|date:"N j, Y" }}
                     </th>
                 </tfoot>
-            {% endfor %}
             </tbody>
         </table>
     </div>

--- a/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_detail.html
@@ -3,6 +3,7 @@
 {% load dict_lookup %}
 {% load static %}
 {% load humanize %}
+{% load profiles %}
 
 {% block title %}{{ object.title|title}} Leaderboard - {{ block.super }}{% endblock %}
 
@@ -55,10 +56,12 @@
             </tr>
             </thead>
             <tbody>
+            {% user_profile_links_from_usernames object.combined_ranks_users as user_profile_links %}
             {% for combined_rank in object.combined_ranks %}
                 <tr>
                     <td>{{ combined_rank.rank|ordinal }}</td>
-                    <td><a href="{% url 'profile-detail' username=combined_rank.user %}">{{ combined_rank.user }}</a></td>
+                    {% get_dict_values user_profile_links combined_rank.user as user_profile_link %}
+                    <td>{{ user_profile_link }}</td>
                     <td data-order="{{ combined_rank.created|date:"U" }}">{{ combined_rank.created|date:"j N Y" }}</td>
                     <td>{{ combined_rank.combined_rank }}</td>
                     {% for phase in object.public_phases %}

--- a/app/grandchallenge/profiles/templatetags/profiles.py
+++ b/app/grandchallenge/profiles/templatetags/profiles.py
@@ -61,8 +61,16 @@ def user_profile_link(user: AbstractUser | None) -> str:
 
 @register.filter
 def user_profile_link_username(username: str) -> str:
+    return user_profile_links_from_usernames([username])[username]
+
+
+@register.simple_tag
+def user_profile_links_from_usernames(usernames):
     User = get_user_model()  # noqa: N806
-    return user_profile_link(User.objects.get(username=username))
+    users = User.objects.filter(username__in=usernames).select_related(
+        "user_profile", "verification"
+    )
+    return {user.username: user_profile_link(user) for user in users}
 
 
 @register.filter

--- a/app/tests/profiles_tests/test_templatetags.py
+++ b/app/tests/profiles_tests/test_templatetags.py
@@ -1,0 +1,18 @@
+import pytest
+
+from grandchallenge.profiles.templatetags.profiles import (
+    user_profile_links_from_usernames,
+)
+from tests.factories import UserFactory
+
+
+@pytest.mark.django_db
+def test_user_profile_links_from_usernames(django_assert_max_num_queries):
+    users = UserFactory.create_batch(4)
+    with django_assert_max_num_queries(
+        2,  # User model getter requires a single query + actual queryset
+    ):
+        user_profile_links = user_profile_links_from_usernames(
+            [user.username for user in users]
+        )
+    assert len(user_profile_links.keys()) == len(users)


### PR DESCRIPTION
Part of the pitch:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/243

This adds a nice-to-have user profile link to the combined leaderboards. I've made sure everything goes in a single query to the DB.