### PR TITLE
Fix for carousel display at small + medium sizes

### DIFF
--- a/app/grandchallenge/core/templates/home.html
+++ b/app/grandchallenge/core/templates/home.html
@@ -12,16 +12,16 @@
                     <div class="carousel-inner m-0 px-0">
                         {% for item in news_caroussel_items %}
                             <div class="carousel-item {% if forloop.counter == 1 %}active{% endif %}">
-                                <div class="d-md-flex d-sm-inline-flex justify-content-center align-items-center">
-                                    <div class="col-12 col-md-3 p-0 my-3 d-md-flex d-sm-inline-flex carousel-img-container w-100 justify-content-center align-items-center">
-                                        <a href="{{ item.get_absolute_url }}"><img class="rounded m-auto mh-100 mw-100 border-0"
+                                <div class="d-md-flex justify-content-center align-items-center">
+                                    <div class="col-12 col-md-3 p-0 my-3 d-md-flex carousel-img-container w-100 justify-content-center align-items-center">
+                                        <a href="{{ item.get_absolute_url }}"><img class="rounded m-auto mh-100 mw-100 border-0 img-flex"
                                              src="{{ item.logo.x20.url }}"
                                              srcset="{{ item.logo.x10.url }} 1x,
                                                      {{ item.logo.x15.url }} 1.5x,
                                                       {{ item.logo.x20.url }} 2x"
                                              alt="{{ item.title }}" loading="lazy"></a>
                                     </div>
-                                    <div class="col-12 col-md-7 text-primary text-truncate-container">
+                                    <div class="col-12 col-md-7 text-primary">
                                         <a class="stretched-link text-decoration-none text-primary"
                                            href="{{ item.get_absolute_url }}">
                                             <h4 class="p-3">{{ item.title }}</h4>

--- a/app/grandchallenge/core/templates/home.html
+++ b/app/grandchallenge/core/templates/home.html
@@ -14,14 +14,14 @@
                             <div class="carousel-item {% if forloop.counter == 1 %}active{% endif %}">
                                 <div class="d-md-flex justify-content-center align-items-center">
                                     <div class="col-12 col-md-3 p-0 my-3 d-md-flex carousel-img-container w-100 justify-content-center align-items-center text-center">
-                                        <a href="{{ item.get_absolute_url }}"><img class="rounded m-auto mh-100 mw-100 border-0 img-flex"
+                                        <a href="{{ item.get_absolute_url }}"><img class="rounded m-auto mh-100 mw-100 border-0"
                                              src="{{ item.logo.x20.url }}"
                                              srcset="{{ item.logo.x10.url }} 1x,
                                                      {{ item.logo.x15.url }} 1.5x,
                                                       {{ item.logo.x20.url }} 2x"
                                              alt="{{ item.title }}" loading="lazy"></a>
                                     </div>
-                                    <div class="col-12 col-md-7 text-primary">
+                                    <div class="col-12 col-md-7 text-primary text-truncate-container">
                                         <a class="stretched-link text-decoration-none text-primary"
                                            href="{{ item.get_absolute_url }}">
                                             <h4 class="p-3">{{ item.title }}</h4>

--- a/app/grandchallenge/core/templates/home.html
+++ b/app/grandchallenge/core/templates/home.html
@@ -13,7 +13,7 @@
                         {% for item in news_caroussel_items %}
                             <div class="carousel-item {% if forloop.counter == 1 %}active{% endif %}">
                                 <div class="d-md-flex justify-content-center align-items-center">
-                                    <div class="col-12 col-md-3 p-0 my-3 d-md-flex carousel-img-container w-100 justify-content-center align-items-center">
+                                    <div class="col-12 col-md-3 p-0 my-3 d-md-flex carousel-img-container w-100 justify-content-center align-items-center text-center">
                                         <a href="{{ item.get_absolute_url }}"><img class="rounded m-auto mh-100 mw-100 border-0 img-flex"
                                              src="{{ item.logo.x20.url }}"
                                              srcset="{{ item.logo.x10.url }} 1x,


### PR DESCRIPTION
There's a few tweaks in here to hopefully improve the display of the carousel

There were two main issues that were making it look not great on small screens:
1) Images and text were being cut off - removed d-sm-inline-flex, so small and medium breakpoints look the same.
2) images were not centered on small screen sizes - fixed by adding text-justify

I'd tried a variety of things at the medium breakpoint to try and fix the images being cut off, but there seemed to be consistent issues with image resizing, or display of text. It seems like making the medium and small page sizes look the same might be the cleanest solution.

Adding text-justify fixed the images not being centered

This is all pretty subjective, so I'm leaving James as the reviewer

Before (medium breakpoint)
<img width="749" alt="medium_break_before" src="https://github.com/comic/grand-challenge.org/assets/14093674/1836ed50-9901-40a4-948a-adc03dd91281">

After (medium breakpoint) 


![grand_challenge_748px](https://github.com/comic/grand-challenge.org/assets/14093674/1f2052dd-2e7d-4ac3-9b54-42918f976608)



Before (small breakpoint)

<img width="505" alt="small_break_before" src="https://github.com/comic/grand-challenge.org/assets/14093674/9ecd251d-a9ac-4301-9356-4c79834145f4">

After (small breakpoint)


![grand_challenge_post_500px](https://github.com/comic/grand-challenge.org/assets/14093674/67634385-a175-4491-bd95-257baaafa6f4)



