### PR TITLE
Order combined leaderboards by non-ordinal values

### DIFF
--- a/app/grandchallenge/evaluation/static/js/evaluation/combined_ranks_table.mjs
+++ b/app/grandchallenge/evaluation/static/js/evaluation/combined_ranks_table.mjs
@@ -1,6 +1,6 @@
 document.addEventListener("DOMContentLoaded", function(event) {
     $('#combinedRanksTable').DataTable({
-        order: [[0, "asc"]],
+        order: [[0, "asc"], [2, "asc"], ],
         lengthChange: false,
         pageLength: 50,
     });

--- a/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_detail.html
@@ -59,7 +59,7 @@
             {% user_profile_links_from_usernames object.combined_ranks_users as user_profile_links %}
             {% for combined_rank in object.combined_ranks %}
                 <tr>
-                    <td data-order="{{  combined_rank.rank }}">{{ combined_rank.rank|ordinal }}</td>
+                    <td data-order="{{ combined_rank.rank }}">{{ combined_rank.rank|ordinal }}</td>
                     {% get_dict_values user_profile_links combined_rank.user as user_profile_link %}
                     <td>{{ user_profile_link }}</td>
                     <td data-order="{{ combined_rank.created|date:"U" }}">{{ combined_rank.created|date:"j N Y" }}</td>
@@ -67,7 +67,7 @@
                     {% for phase in object.public_phases %}
                         {% get_dict_values combined_rank.evaluations phase.pk as evaluation %}
                         {% if evaluation %}
-                            <td data-order="{{  evaluation.rank }}"><a href="{% url 'evaluation:detail' challenge_short_name=challenge.short_name pk=evaluation.pk %}">{{ evaluation.rank|ordinal }}</a></td>
+                            <td data-order="{{ evaluation.rank }}"><a href="{% url 'evaluation:detail' challenge_short_name=challenge.short_name pk=evaluation.pk %}">{{ evaluation.rank|ordinal }}</a></td>
                         {% endif %}
                     {% endfor %}
                 </tr>

--- a/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/combinedleaderboard_detail.html
@@ -59,7 +59,7 @@
             {% user_profile_links_from_usernames object.combined_ranks_users as user_profile_links %}
             {% for combined_rank in object.combined_ranks %}
                 <tr>
-                    <td>{{ combined_rank.rank|ordinal }}</td>
+                    <td data-order="{{  combined_rank.rank }}">{{ combined_rank.rank|ordinal }}</td>
                     {% get_dict_values user_profile_links combined_rank.user as user_profile_link %}
                     <td>{{ user_profile_link }}</td>
                     <td data-order="{{ combined_rank.created|date:"U" }}">{{ combined_rank.created|date:"j N Y" }}</td>
@@ -67,7 +67,7 @@
                     {% for phase in object.public_phases %}
                         {% get_dict_values combined_rank.evaluations phase.pk as evaluation %}
                         {% if evaluation %}
-                            <td><a href="{% url 'evaluation:detail' challenge_short_name=challenge.short_name pk=evaluation.pk %}">{{ evaluation.rank|ordinal }}</a></td>
+                            <td data-order="{{  evaluation.rank }}"><a href="{% url 'evaluation:detail' challenge_short_name=challenge.short_name pk=evaluation.pk %}">{{ evaluation.rank|ordinal }}</a></td>
                         {% endif %}
                     {% endfor %}
                 </tr>


### PR DESCRIPTION
Closes #2967 

Oversight when changing the displayed values in the DataTables for the leaderboards.

Also changes sorting slightly so that equal ranks are sorted on the creation date (earlier is better).
