### PR TITLE
Update makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ build_web_test:
 
 build_web_dist:
 	@docker pull $(GRAND_CHALLENGE_WEB_BASE_REPOSITORY_URI):$(PYTHON_VERSION)-$(POETRY_HASH) || { \
-		docker buildx build \
+		docker build \
 			--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
 			--target base \
 			-t $(GRAND_CHALLENGE_WEB_BASE_REPOSITORY_URI):$(PYTHON_VERSION)-$(POETRY_HASH) \


### PR DESCRIPTION
Do not use buildx for the dist container as it does not support custom networks
See also this [commit](https://github.com/comic/grand-challenge.org/commit/f3bf654753c43cc6ae466347bbcdc0fa3f352297). I think the update to poetry caused a new docker build of the web-base image, which fails due to the use of dockerx.