### PR TITLE
Opt out of buildkit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ build_web_dist:
 			-f dockerfiles/web-base/Dockerfile \
 			.; \
 	}
-	docker build \
+	DOCKER_BUILDKIT=0 docker build \
 		--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
 		--build-arg COMMIT_ID=$(GIT_COMMIT_ID) \
 		--build-arg POETRY_HASH=$(POETRY_HASH) \


### PR DESCRIPTION
Buildkit does not support custom networks, so fall back to the default build. Speculative fix.

See #2969