### PR TITLE
set passwords correctly in development fixtures

### DIFF
--- a/scripts/development_fixtures.py
+++ b/scripts/development_fixtures.py
@@ -117,7 +117,6 @@ def _create_users(usernames):
             username=username,
             email=f"{username}@example.com",
             is_active=True,
-            password=username,
         )
 
         EmailAddress.objects.create(
@@ -131,6 +130,7 @@ def _create_users(usernames):
             user=user, is_verified=True, email=user.email
         )
         user.user_profile.receive_newsletter = True
+        user.set_password(username)
         user.user_profile.save()
         users[username] = user
 

--- a/scripts/development_fixtures.py
+++ b/scripts/development_fixtures.py
@@ -118,6 +118,7 @@ def _create_users(usernames):
             email=f"{username}@example.com",
             is_active=True,
         )
+        user.set_password(username)
 
         EmailAddress.objects.create(
             user=user,
@@ -130,7 +131,6 @@ def _create_users(usernames):
             user=user, is_verified=True, email=user.email
         )
         user.user_profile.receive_newsletter = True
-        user.set_password(username)
         user.user_profile.save()
         users[username] = user
 


### PR DESCRIPTION
fix for development fixtures - sets password properly

It is the same as the method used before the cleanup of development fixtures