### PR TITLE
Consolidate closed phase warnings

### DIFF
--- a/app/grandchallenge/evaluation/migrations/0020_phase_public.py
+++ b/app/grandchallenge/evaluation/migrations/0020_phase_public.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             name="public",
             field=models.BooleanField(
                 default=True,
-                help_text="Uncheck this box to hide this phase's submission page and leaderboard from participants. Participants will then no longer have access to their previous submissions and evaluations from this phase if they exist, and they will no longer see the respective submit and leaderboard tabs for this phase. For you as admin these tabs remain visible.Note that hiding a phase is only possible if submissions for this phase are closed for participants.",
+                help_text="Uncheck this box to hide this phase's submission page and leaderboard from participants. Participants will then no longer have access to their previous submissions and evaluations from this phase if they exist, and they will no longer see the respective submit and leaderboard tabs for this phase. For you as admin these tabs remain visible. Note that hiding a phase is only possible if submissions for this phase are closed for participants.",
             ),
         ),
     ]

--- a/app/grandchallenge/evaluation/migrations/0031_phase_total_number_of_submissions_allowed.py
+++ b/app/grandchallenge/evaluation/migrations/0031_phase_total_number_of_submissions_allowed.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
             name="total_number_of_submissions_allowed",
             field=models.PositiveSmallIntegerField(
                 blank=True,
-                help_text="Total number of submissions allowed for this phase for all users together.",
+                help_text="Total number of successful submissions allowed for this phase for all users together.",
                 null=True,
             ),
         ),

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_list.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_list.html
@@ -22,6 +22,10 @@
 
     <h2>Submissions and Evaluations for {{ phase.title }}</h2>
 
+    {% if "change_challenge" in challenge_perms %}
+        {% include "evaluation/partials/phase_closed_warning.html" with phase=phase %}
+    {% endif %}
+
     <div class="table-responsive">
         <table class="table table-hover table-borderless table-sm" id="evaluationsTable">
             <thead class="thead-light">

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_detail.html
@@ -23,17 +23,9 @@
 {% block content %}
     <h2>{{ phase.title }} Leaderboard {{ request.GET.date }}</h2>
 
-    {% if not phase.public %}
-        <div class="alert alert-danger">This phase is no longer active. </div>
-    {% endif %}
-
     {% if "change_challenge" in challenge_perms %}
-        {% if not phase.score_jsonpath %}
-            <div class="alert alert-warning">
-                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>&nbsp;&nbsp;
-                Kindly configure the scoring feature in the phase settings, as no evaluation results can be shown without it.
-            </div>
-        {% endif %}
+        {% include "evaluation/partials/phase_closed_warning.html" with phase=phase %}
+
         <a href="{% url "evaluation:phase-update" challenge_short_name=challenge.short_name slug=phase.slug %}" class="btn btn-primary text-decoration-none">
             <i class="fa fa-edit"></i>&nbsp;&nbsp;Edit Phase Settings
         </a>

--- a/app/grandchallenge/evaluation/templates/evaluation/method_list.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/method_list.html
@@ -18,6 +18,8 @@
 
     <h2>Evaluation Methods for {{ phase.title }}</h2>
 
+    {% include "evaluation/partials/phase_closed_warning.html" with phase=phase %}
+
     <p>
         <a class="btn btn-primary"
            href="{% url 'evaluation:method-create' challenge_short_name=challenge.short_name slug=phase.slug %}">

--- a/app/grandchallenge/evaluation/templates/evaluation/partials/phase_closed_warning.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/partials/phase_closed_warning.html
@@ -1,0 +1,57 @@
+{% load url %}
+
+{% if not phase.active_image %}
+    <div class="alert alert-warning" role="alert">
+        <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+        Nobody can submit to this phase as there is no valid evaluation method.
+        Please <a href="{% url 'evaluation:method-create' challenge_short_name=challenge.short_name slug=phase.slug %}">
+        upload a method container</a>.
+    </div>
+{% endif %}
+
+{% if not phase.open_for_submissions %}
+    <div class="alert alert-warning" role="alert">
+        <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Participants are not able to submit to this phase
+        as:
+        <ul class="mb-1">
+            {% if not phase.public %}
+                <li>
+                    The phase is not public. You can update this in the <a
+                        href="{% url 'evaluation:phase-update' challenge_short_name=challenge.short_name slug=phase.slug %}">Phase
+                    Settings</a>.
+                </li>
+            {% endif %}
+            {% if not phase.submission_period_is_open_now %}
+                <li>
+                    The submission period is closed.
+                    You can update the dates in the <a
+                        href="{% url 'evaluation:phase-update' challenge_short_name=challenge.short_name slug=phase.slug %}">Phase
+                    Settings</a>.
+                </li>
+            {% endif %}
+            {% if phase.submissions_limit_per_user_per_period == 0 %}
+                <li>
+                    The individual submission limit is 0.
+                    You can update this limit in the <a
+                        href="{% url 'evaluation:phase-update' challenge_short_name=challenge.short_name slug=phase.slug %}">Phase
+                    Settings</a>.
+                </li>
+            {% endif %}
+            {% if phase.exceeds_total_number_of_submissions_allowed %}
+                <li>
+                    The total number of submissions has exceeded the budgeted limit. Please contact support.
+                </li>
+            {% endif %}
+        </ul>
+    </div>
+{% endif %}
+
+{% if not phase.score_jsonpath %}
+    <div class="alert alert-warning">
+        <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>&nbsp;&nbsp;
+        Results will not be displayed on the leaderboard as the score jsonpath is not set.
+        Please fill out your scoring details in the <a
+            href="{% url 'evaluation:phase-update' challenge_short_name=challenge.short_name slug=phase.slug %}">Phase
+        Settings</a>.
+    </div>
+{% endif %}

--- a/app/grandchallenge/evaluation/templates/evaluation/phase_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/phase_form.html
@@ -26,6 +26,8 @@
             Use this form to create a new phase for your challenge with a separate evaluation method.
             For instance, you could have a training and test phase, or have a phase for each task.
         </p>
+    {% else %}
+        {% include "evaluation/partials/phase_closed_warning.html" with phase=object %}
     {% endif %}
 
     {% crispy form %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -35,6 +35,8 @@
 
     {% if "change_challenge" in challenge_perms %}
 
+        {% include "evaluation/partials/phase_closed_warning.html" with phase=phase %}
+
         {% if request.resolver_match.view_name != "evaluation:submission-create-legacy" %}
 
             <div class="alert alert-info" role="alert">
@@ -67,16 +69,6 @@
                     if you would like to create a submission on the behalf of one of the participants of this challenge.
                 </p>
             </div>
-            {% if phase.inconsistent_submission_information %}
-                <div class="alert alert-warning pb-1" role="alert">
-                        <p><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> The submission limit for this phase is 0, but the start and end dates indicate that this phase should be open to submissions now. The submission limit needs to be above 0 for participants to submit to this phase.</p>
-                </div>
-            {% endif %}
-            {% if not phase.active_image %}
-                <div class="alert alert-danger pb-1" role="alert">
-                    <p><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> There is no valid evaluation method for this phase. Please upload a method container <a href="{% url 'evaluation:method-create' challenge_short_name=challenge.short_name slug=phase.slug %}">here</a>. </p>
-                </div>
-            {% endif %}
 
         {% endif %}
 

--- a/app/tests/challenges_tests/test_models.py
+++ b/app/tests/challenges_tests/test_models.py
@@ -6,8 +6,9 @@ from django.db.models import ProtectedError
 from machina.apps.forum_conversation.models import Topic
 
 from grandchallenge.challenges.models import Challenge
+from grandchallenge.evaluation.models import Evaluation
 from grandchallenge.notifications.models import Notification
-from tests.evaluation_tests.factories import PhaseFactory, SubmissionFactory
+from tests.evaluation_tests.factories import EvaluationFactory, PhaseFactory
 from tests.factories import ChallengeFactory, UserFactory
 from tests.notifications_tests.factories import TopicFactory
 
@@ -100,10 +101,31 @@ def test_submission_limit_status():
         4, total_number_of_submissions_allowed=10
     )
     p5 = PhaseFactory()
-    SubmissionFactory.create_batch(10, phase=p1)
-    SubmissionFactory.create_batch(4, phase=p2)
-    SubmissionFactory.create_batch(8, phase=p3)
-    SubmissionFactory.create_batch(12, phase=p4)
+
+    admin = UserFactory()
+    p3.challenge.add_admin(user=admin)
+
+    EvaluationFactory.create_batch(
+        10, submission__phase=p1, status=Evaluation.SUCCESS
+    )
+    EvaluationFactory.create_batch(
+        4, submission__phase=p2, status=Evaluation.SUCCESS
+    )
+    EvaluationFactory.create_batch(
+        10, submission__phase=p2, status=Evaluation.FAILURE
+    )
+    EvaluationFactory.create_batch(
+        8, submission__phase=p3, status=Evaluation.SUCCESS
+    )
+    EvaluationFactory.create_batch(
+        8,
+        submission__phase=p3,
+        submission__creator=admin,
+        status=Evaluation.SUCCESS,
+    )
+    EvaluationFactory.create_batch(
+        12, submission__phase=p4, status=Evaluation.SUCCESS
+    )
 
     assert p1.percent_of_total_submissions_allowed == 100
     assert p2.percent_of_total_submissions_allowed == 40


### PR DESCRIPTION
The logic of `percent_of_total_submissions_allowed` is updated to allow for admin submissions, and does not count cancellations or failures. For the most part they tend to fail after one case so are not a big part of the costs.

Closes #2976