### PR TITLE
Use size as reported by the registry

### DIFF
--- a/app/tests/components_tests/test_models.py
+++ b/app/tests/components_tests/test_models.py
@@ -1180,7 +1180,9 @@ def test_validate_voxel_values():
 
 
 @pytest.mark.django_db
-def test_can_execute():
+def test_can_execute(mocker):
+    mocker.patch.object(AlgorithmImage, "size_in_registry", 100)
+
     ai = AlgorithmImageFactory()
 
     assert ai.can_execute is False

--- a/app/tests/workstations_tests/test_permissions.py
+++ b/app/tests/workstations_tests/test_permissions.py
@@ -5,7 +5,11 @@ from django.conf import settings
 from django.contrib.auth.models import Group
 from guardian.shortcuts import get_perms
 
-from grandchallenge.workstations.models import Session, Workstation
+from grandchallenge.workstations.models import (
+    Session,
+    Workstation,
+    WorkstationImage,
+)
 from tests.factories import SessionFactory, UserFactory, WorkstationFactory
 from tests.utils import get_view_for_user
 
@@ -48,8 +52,14 @@ def test_create_view_permission(client):
     ],
 )
 def test_workstation_editor_permissions(
-    client, two_workstation_sets, viewname, authenticated_staff_user
+    client,
+    two_workstation_sets,
+    viewname,
+    authenticated_staff_user,
+    mocker,
 ):
+    mocker.patch.object(WorkstationImage, "size_in_registry", 100)
+
     tests = (
         (two_workstation_sets.ws1.editor, 200),
         (two_workstation_sets.ws1.user, 403),
@@ -94,8 +104,10 @@ def test_workstation_editor_permissions(
     ],
 )
 def test_workstation_user_permissions(
-    client, two_workstation_sets, viewname, authenticated_staff_user
+    client, two_workstation_sets, viewname, authenticated_staff_user, mocker
 ):
+    mocker.patch.object(WorkstationImage, "size_in_registry", 100)
+
     tests = (
         (two_workstation_sets.ws1.editor, 200),
         (two_workstation_sets.ws1.user, 200),
@@ -140,8 +152,10 @@ def test_workstation_user_permissions(
     ],
 )
 def test_workstation_redirect_permissions(
-    client, two_workstation_sets, viewname, authenticated_staff_user
+    client, two_workstation_sets, viewname, authenticated_staff_user, mocker
 ):
+    mocker.patch.object(WorkstationImage, "size_in_registry", 100)
+
     # Make ws1 the default
     Workstation.objects.get(slug=settings.DEFAULT_WORKSTATION_SLUG).delete()
 


### PR DESCRIPTION
There was no difference in performance compared to using the boto3 client, so implemented a method that works for all registries.

See https://github.com/DIAGNijmegen/rse-roadmap/issues/254