### PR TITLE
Ensure latest challenges requests are shown on top in request table

### DIFF
--- a/app/grandchallenge/challenges/static/js/challenges/challengerequest_list_table.mjs
+++ b/app/grandchallenge/challenges/static/js/challenges/challengerequest_list_table.mjs
@@ -1,6 +1,6 @@
 document.addEventListener("DOMContentLoaded", function(event) {
     $('#challengeRequestsTable').DataTable({
-        order: [[3, "asc"]],
+        order: [[3, "desc"]],
         lengthChange: false,
         pageLength: 50,
         columnDefs: [


### PR DESCRIPTION
Closes: #2991

It used to be sorted on the creation date. However, I inverted the sorting when introducing Datatables.js.