### PR TITLE
fix for carousel images being displayed with non rounded corners

### DIFF
--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -209,7 +209,7 @@ ul.socialaccount_providers > li {
   .text-truncate-container p{
       -webkit-line-clamp: 3;
   }
-  .carousel-img-container {
+  .carousel-img {
       height: 15rem;
   }
 }

--- a/app/grandchallenge/core/templates/home.html
+++ b/app/grandchallenge/core/templates/home.html
@@ -13,8 +13,8 @@
                         {% for item in news_caroussel_items %}
                             <div class="carousel-item {% if forloop.counter == 1 %}active{% endif %}">
                                 <div class="d-md-flex justify-content-center align-items-center">
-                                    <div class="col-12 col-md-3 p-0 my-3 d-md-flex carousel-img-container w-100 justify-content-center align-items-center text-center">
-                                        <a href="{{ item.get_absolute_url }}"><img class="rounded m-auto mh-100 mw-100 border-0"
+                                    <div class="col-12 col-md-3 p-0 my-3 d-md-flex w-100 justify-content-center align-items-center text-center">
+                                        <a href="{{ item.get_absolute_url }}"><img class="rounded carousel-img m-auto mh-100 mw-100 border-0"
                                              src="{{ item.logo.x20.url }}"
                                              srcset="{{ item.logo.x10.url }} 1x,
                                                      {{ item.logo.x15.url }} 1.5x,


### PR DESCRIPTION
Carousel image was being displayed without rounded corners, as it was overflowing the bounds of its surrounding div

Proposed fix is to apply the image sizing class directly to the image, rather than the containing div, forcing it to not overflow. I've altered the class name, as it no longer applies to the surrounding container (we do not use it anywhere else)

Below are pics with the altered class applied to the image div.

![capture_with_sizing](https://github.com/comic/grand-challenge.org/assets/14093674/f08197a8-394b-4fc3-8b50-751859780d43)
![Capture_with_sizing_rectange](https://github.com/comic/grand-challenge.org/assets/14093674/16f859ec-50bc-48fa-baff-cb6bda3f8d12)
![Capture_smaller_size](https://github.com/comic/grand-challenge.org/assets/14093674/1940b16c-2da2-4aaf-88d0-a5ddfcb502d4)
