### PR TITLE
Use `PYTHONUNBUFFERED` in container environment

### DIFF
--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -373,6 +373,7 @@ def _get_shim_env_vars(*, original_config):
             val=entrypoint
         ),
         "no_proxy": "amazonaws.com",
+        "PYTHONUNBUFFERED": "1",
     }
 
 


### PR DESCRIPTION
Logs are often not being flushed from the users process so force this in case they're using Python (which most are).