### PR TITLE
Hide Exclude From Leaderboard when Evaluation Fails

### DIFF
--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -258,9 +258,11 @@
                         {% csrf_token %}
                         <input type="hidden" name="published"
                                value="false">
+                        {% if object.status == object.SUCCESS %}
                         <button type="submit" class="btn btn-danger">
                             Exclude this result from the leaderboard(s)
                         </button>
+                        {% endif %}
                     </form>
                 {% else %}
                     <i class="fas fa-eye-slash text-danger"></i> This result is not
@@ -271,9 +273,11 @@
                         {% csrf_token %}
                         <input type="hidden" name="published"
                                value="true">
+                        {% if object.status == object.SUCCESS %}
                         <button type="submit" class="btn btn-success">
                             Publish this result on the leaderboard(s)
                         </button>
+                        {% endif %}
                     </form>
                 {% endif %}
             </div>

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -273,11 +273,9 @@
                         {% csrf_token %}
                         <input type="hidden" name="published"
                                value="true">
-                        {% if object.status == object.SUCCESS %}
                         <button type="submit" class="btn btn-success">
                             Publish this result on the leaderboard(s)
                         </button>
-                        {% endif %}
                     </form>
                 {% endif %}
             </div>


### PR DESCRIPTION
small fix for #3025 - hides the exclude from leaderboard button on the evaluation detail page for failed evaluations

![Capture12](https://github.com/comic/grand-challenge.org/assets/14093674/1b843e15-6e70-4c7d-a7bd-b910994db8cc)
