### PR TITLE
Only show prerequisite jobs when unsuccessful

### DIFF
--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -203,7 +203,7 @@
         <div class="card card-danger border-danger">
             <div class="card-header bg-danger text-white">Evaluation Admin</div>
 
-            {% if incomplete_jobs and object.status != object.SUCCESS %}
+            {% if object.status != object.SUCCESS and incomplete_jobs %}
                 <div class="card-body">
                     <h3 class="card-title">Prerequisite Jobs</h3>
 

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -203,7 +203,7 @@
         <div class="card card-danger border-danger">
             <div class="card-header bg-danger text-white">Evaluation Admin</div>
 
-            {% if incomplete_jobs %}
+            {% if incomplete_jobs and object.status != object.SUCCESS %}
                 <div class="card-body">
                     <h3 class="card-title">Prerequisite Jobs</h3>
 


### PR DESCRIPTION
This doesn't completely solve the bug as the queryset is too complex to be included in a view. It's a corner case that can mostly be solved by only displaying the jobs when the evaluation is unsuccessful.

Closes #3019