### PR TITLE
Add source reference to world-map statistics

### DIFF
--- a/app/grandchallenge/charts/specs.py
+++ b/app/grandchallenge/charts/specs.py
@@ -133,6 +133,12 @@ def horizontal_bar(*, values, lookup, title):
 def world_map(*, values):
     return {
         "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+        "title": {
+            "text": "The countries and their borders are sourced from Natural Earth",
+            "fontSize": "10",
+            "color": "#95a5a6",
+            "anchor": "end",
+        },
         "width": "container",
         "height": "container",
         "padding": 0,


### PR DESCRIPTION
To prevent future debate, we might as well add a reference to the source of the countries.

![image](https://github.com/comic/grand-challenge.org/assets/7871310/60f913a7-87cb-4a0d-8fdf-c4e204272df3)
