### PR TITLE
Move link to evaluation from leaderboard metrics to ordinal rank

### DIFF
--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_row.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_row.html
@@ -4,8 +4,9 @@
 {% load humanize %}
 {% load remove_whitespace %}
 {% load url %}
-
-{{ object.rank|ordinal }}
+<a href="{{ object.get_absolute_url }}">
+    {{ object.rank|ordinal }}
+</a>
 <split></split>
 
 {{ object.submission.creator|user_profile_link }}
@@ -30,50 +31,48 @@
 <split></split>
 
 {% if object.submission.phase.scoring_method_choice != object.submission.phase.ABSOLUTE %}
-    <a href="{{ object.get_absolute_url }}">
-        <b>{{ object.rank_score|floatformat }}</b>
-    </a>
+
+    <b>{{ object.rank_score|floatformat }}</b>
+
     <split></split>
 {% endif %}
 
 {% with object.metrics_json_file|get_jsonpath:object.submission.phase.score_jsonpath as metric %}
-    <a href="{{ object.get_absolute_url }}">
-        {% if object.submission.phase.scoring_method_choice == object.submission.phase.ABSOLUTE %}
-            <b>{% endif %}
-        {% filter remove_whitespace %}
-            {{ metric|floatformat:object.submission.phase.score_decimal_places }}
-            {% if object.submission.phase.score_error_jsonpath %}
-                &nbsp;±&nbsp;
-                {{ object.metrics_json_file|get_jsonpath:object.submission.phase.score_error_jsonpath|floatformat:object.submission.phase.score_decimal_places }}
-            {% endif %}
-            {% if object.submission.phase.scoring_method_choice != object.submission.phase.ABSOLUTE %}
-                &nbsp;(
-                {{ object.rank_per_metric|get_key:object.submission.phase.score_jsonpath }}
-                )
-            {% endif %}
-        {% endfilter %}
-        {% if object.submission.phase.scoring_method_choice == object.submission.phase.ABSOLUTE %}
-            </b>{% endif %}
-    </a>
+    {% if object.submission.phase.scoring_method_choice == object.submission.phase.ABSOLUTE %}
+        <b>{% endif %}
+    {% filter remove_whitespace %}
+        {{ metric|floatformat:object.submission.phase.score_decimal_places }}
+        {% if object.submission.phase.score_error_jsonpath %}
+            &nbsp;±&nbsp;
+            {{ object.metrics_json_file|get_jsonpath:object.submission.phase.score_error_jsonpath|floatformat:object.submission.phase.score_decimal_places }}
+        {% endif %}
+        {% if object.submission.phase.scoring_method_choice != object.submission.phase.ABSOLUTE %}
+            &nbsp;(
+            {{ object.rank_per_metric|get_key:object.submission.phase.score_jsonpath }}
+            )
+        {% endif %}
+    {% endfilter %}
+    {% if object.submission.phase.scoring_method_choice == object.submission.phase.ABSOLUTE %}
+        </b>{% endif %}
     <split></split>
 {% endwith %}
 
 {% for col in object.submission.phase.extra_results_columns %}
     {% with object.metrics_json_file|get_jsonpath:col.path as metric %}
-        <a href="{{ object.get_absolute_url }}">
-            {% filter remove_whitespace %}
-                {{ metric|floatformat:object.submission.phase.score_decimal_places }}
-                {% if col.error_path %}
-                    &nbsp;±&nbsp;
-                    {{ object.metrics_json_file|get_jsonpath:col.error_path|floatformat:object.submission.phase.score_decimal_places }}
-                {% endif %}
-                {% if object.submission.phase.scoring_method_choice != object.submission.phase.ABSOLUTE %}
-                    &nbsp;(
-                    {{ object.rank_per_metric|get_key:col.path }}
-                    )
-                {% endif %}
-            {% endfilter %}
-        </a>
+        {% filter remove_whitespace %}
+            <b>
+            {{ metric|floatformat:object.submission.phase.score_decimal_places }}
+            {% if col.error_path %}
+                &nbsp;±&nbsp;
+                {{ object.metrics_json_file|get_jsonpath:col.error_path|floatformat:object.submission.phase.score_decimal_places }}
+            {% endif %}
+            {% if object.submission.phase.scoring_method_choice != object.submission.phase.ABSOLUTE %}
+                &nbsp;(
+                {{ object.rank_per_metric|get_key:col.path }}
+                )
+            {% endif %}
+            </b>
+        {% endfilter %}
         <split></split>
     {% endwith %}
 {% endfor %}

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_row.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_row.html
@@ -32,14 +32,14 @@
 
 {% if object.submission.phase.scoring_method_choice != object.submission.phase.ABSOLUTE %}
 
-    <b>{{ object.rank_score|floatformat }}</b>
+    <strong>{{ object.rank_score|floatformat }}</strong>
 
     <split></split>
 {% endif %}
 
 {% with object.metrics_json_file|get_jsonpath:object.submission.phase.score_jsonpath as metric %}
     {% if object.submission.phase.scoring_method_choice == object.submission.phase.ABSOLUTE %}
-        <b>{% endif %}
+        <strong>{% endif %}
     {% filter remove_whitespace %}
         {{ metric|floatformat:object.submission.phase.score_decimal_places }}
         {% if object.submission.phase.score_error_jsonpath %}
@@ -53,14 +53,13 @@
         {% endif %}
     {% endfilter %}
     {% if object.submission.phase.scoring_method_choice == object.submission.phase.ABSOLUTE %}
-        </b>{% endif %}
+        </strong>{% endif %}
     <split></split>
 {% endwith %}
 
 {% for col in object.submission.phase.extra_results_columns %}
     {% with object.metrics_json_file|get_jsonpath:col.path as metric %}
         {% filter remove_whitespace %}
-            <b>
             {{ metric|floatformat:object.submission.phase.score_decimal_places }}
             {% if col.error_path %}
                 &nbsp;±&nbsp;
@@ -71,7 +70,6 @@
                 {{ object.rank_per_metric|get_key:col.path }}
                 )
             {% endif %}
-            </b>
         {% endfilter %}
         <split></split>
     {% endwith %}


### PR DESCRIPTION
One of the Seg.A. orgs was not too sure how to get to the evaluation details of submission during MICCAI. It struck me as something other users might have trouble with as well. There is a certain non-intuitiveness to it, so I thought to throw this suggestion out here and see what others think.

Move the link from each of the aggregate metrics to the ordinal rank.

# Current
<img width="100%" alt="image" src="https://github.com/comic/grand-challenge.org/assets/7871310/c03d1165-1d6e-464d-805f-e127102b25db">

# Suggestion
<img width="1393" alt="image" src="https://github.com/comic/grand-challenge.org/assets/7871310/3928102e-c8c4-4d31-93cc-c31c05c3b07e">

## Review note
The GitHub integrated differential seems to go haywire on this. Regular PyCharm does a better job:

<img width="1900" alt="image" src="https://github.com/comic/grand-challenge.org/assets/7871310/e62526f1-b279-4bfc-8573-9ea4aebc60cf">
