### PR TITLE
Add `image_pk_description_map` to serializers

### DIFF
--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1,4 +1,5 @@
 import json
+from collections import OrderedDict
 
 from actstream.models import Follow
 from django.conf import settings
@@ -882,18 +883,19 @@ class DisplaySet(UUIDModel):
         return f"{url}{pqs.path}?{pqs.query_string}"
 
     @property
-    def description(self) -> str:
+    def image_pk_description_map(self) -> OrderedDict[str, str]:
         case_text = self.reader_study.case_text
-        if case_text:
-            return "".join(
-                [
-                    md2html(case_text[val.image.name])
-                    for val in self.values.all()
-                    if val.image and val.image.name in case_text
-                ]
-            )
-        else:
-            return ""
+        if not case_text:
+            return OrderedDict()
+        return OrderedDict(
+            (str(val.image.id), md2html(case_text[val.image.name]))
+            for val in self.values.all()
+            if val.image and val.image.name in case_text
+        )
+
+    @property
+    def description(self) -> str:
+        return "".join(self.image_pk_description_map.values())
 
     @property
     def standard_index(self) -> int:

--- a/app/grandchallenge/reader_studies/serializers.py
+++ b/app/grandchallenge/reader_studies/serializers.py
@@ -124,6 +124,7 @@ class DisplaySetSerializer(HyperlinkedModelSerializer):
             "optional_hanging_protocols",
             "view_content",
             "description",
+            "image_pk_description_map",
             "index",
         )
 

--- a/app/tests/reader_studies_tests/test_models.py
+++ b/app/tests/reader_studies_tests/test_models.py
@@ -397,6 +397,9 @@ def test_description_is_scrubbed(client):
     assert (
         response.json()["description"] == "<p><b>My Help Text</b>naughty</p>"
     )
+    assert response.json()["image_pk_description_map"] == {
+        str(im.id): "<p><b>My Help Text</b>naughty</p>"
+    }
 
 
 @pytest.mark.django_db
@@ -670,8 +673,11 @@ def test_display_set_description():
     rs.case_text["no_image"] = "not an image"
     rs.save()
 
-    for ds in rs.display_sets.all():
+    for i_ds, ds in enumerate(rs.display_sets.all()):
         assert ds.description == result[ds.pk]
+        assert ds.image_pk_description_map == {
+            str(images[i_ds].pk): result[ds.pk]
+        }
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Adds `image_pk_description_map` field to serialized display-set data.

Needed for https://github.com/DIAGNijmegen/rse-roadmap/issues/265 where we want to show individual case texts on each view item, so the catch-all `description` field does not suffice anymore.

The map is using the `image.pk` as a key and maps each image to the _rendered_ markdown (html). The `description` field needs to remain in place for now to service older workstations.

Other than that, I hope that `image_pk_description_map` is not too cryptic of a name...