### PR TITLE
Hide activate button for images when import in progress

### DIFF
--- a/app/grandchallenge/algorithms/templates/algorithms/algorithmimage_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithmimage_detail.html
@@ -39,7 +39,7 @@
         </a><br>
     {% endif %}
 
-    {% if object.is_manifest_valid and not object.is_desired_version and "change_algorithm" in algorithm_perms %}
+    {% if object.is_manifest_valid and not object.algorithm.image_upload_in_progress and not object.is_desired_version and "change_algorithm" in algorithm_perms %}
         <div class="my-2">Activating an image will result in this image being used for future algorithm runs:</div>
         <div class="mb-2">{% crispy image_activate_form %}</div>
     {% endif %}


### PR DESCRIPTION
Hides the "activate image" button for all images when an import for the algorithm is ongoing.

Closes #3022 