### PR TITLE
Fix display set value updating 

### DIFF
--- a/app/grandchallenge/reader_studies/forms.py
+++ b/app/grandchallenge/reader_studies/forms.py
@@ -762,4 +762,5 @@ class DisplaySetInterfacesCreateForm(Form):
             self.fields[selected_interface.slug] = InterfaceFormField(
                 instance=selected_interface,
                 user=user,
+                required=True,
             ).field

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -14,7 +14,7 @@ from django.core.validators import (
     RegexValidator,
 )
 from django.db import models
-from django.db.models import Avg, Count, Q, Sum
+from django.db.models import Avg, Count, Q, QuerySet, Sum
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.utils.functional import cached_property
@@ -26,6 +26,7 @@ from simple_history.models import HistoricalRecords
 from stdimage import JPEGField
 
 from grandchallenge.anatomy.models import BodyStructure
+from grandchallenge.cases.models import Image, RawImageUploadSession
 from grandchallenge.components.models import (
     ComponentInterface,
     ComponentInterfaceValue,
@@ -914,6 +915,71 @@ class DisplaySet(UUIDModel):
             ).values_list("image__name", flat=True)[0]
         except (KeyError, IndexError):
             return self.values.values_list("image__name", flat=True).first()
+
+    def create_civ(self, ci_slug, new_value, user=None):
+        ci = ComponentInterface.objects.get(slug=ci_slug)
+        current_civ = self.values.filter(interface=ci).first()
+        if ci.is_json_kind and not ci.requires_file:
+            return self.create_civ_for_value(ci, current_civ, new_value)
+        elif ci.is_image_kind:
+            return self.create_civ_for_image(ci, current_civ, new_value, user)
+        elif ci.requires_file:
+            return self.create_civ_for_file(current_civ, new_value)
+        else:
+            NotImplementedError(f"CIV creation for {ci} not handled.")
+
+    def create_civ_for_value(self, ci, current_civ, new_value):
+        current_value = current_civ.value if current_civ else None
+        if new_value and current_value != new_value:
+            self.values.remove(current_civ)
+            civ = ComponentInterfaceValue.objects.create(
+                interface=ci, value=new_value
+            )
+            civ.full_clean()
+            self.values.add(civ)
+        elif not new_value:
+            # if the new value is None, remove the old CIV from the display set
+            self.values.remove(current_civ)
+
+    def create_civ_for_image(self, ci, current_civ, new_value, user):
+        current_image = current_civ.image if current_civ else None
+        if isinstance(new_value, Image) and current_image != new_value:
+            self.values.remove(current_civ)
+            civ, created = ComponentInterfaceValue.objects.get_or_create(
+                interface=ci, image=new_value
+            )
+            if created:
+                civ.full_clean()
+            self.values.add(civ)
+        elif isinstance(new_value, QuerySet):
+            # Local import to avoid circular dependency
+            from grandchallenge.reader_studies.tasks import (
+                add_image_to_display_set,
+            )
+
+            us = RawImageUploadSession.objects.create(
+                creator=user,
+            )
+            us.user_uploads.set(new_value)
+            us.process_images(
+                linked_task=add_image_to_display_set.signature(
+                    kwargs={
+                        "display_set_pk": self.pk,
+                        "interface_pk": str(ci.pk),
+                    },
+                    immutable=True,
+                )
+            )
+
+    def create_civ_for_file(self, current_civ, new_value):
+        # in this case, new_value is an instance of a CIV already (or None)
+        if new_value and current_civ != new_value:
+            self.values.remove(current_civ)
+            self.values.add(new_value)
+        elif not new_value:
+            # if no new value is provided (user selects '---' in dropdown)
+            # delete old CIV
+            self.values.remove(current_civ)
 
 
 class DisplaySetUserObjectPermission(UserObjectPermissionBase):

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -1411,13 +1411,12 @@ class DisplaySetUpdate(
         for ci_slug, new_value in form.cleaned_data.items():
             if ci_slug == "order":
                 continue
-            with transaction.atomic():
-                instance, assigned_civs = self.create_civ_for_value(
-                    instance=instance,
-                    ci_slug=ci_slug,
-                    new_value=new_value,
-                    assigned_civs=assigned_civs,
-                )
+            instance, assigned_civs = self.create_civ_for_value(
+                instance=instance,
+                ci_slug=ci_slug,
+                new_value=new_value,
+                assigned_civs=assigned_civs,
+            )
         instance.values.remove(*assigned_civs)
 
         if (

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -1406,19 +1406,14 @@ class DisplaySetUpdate(
         fields do not match the model fields: the model only has a `values`
         fields, whereas the form has a field for each value in those values.
         """
-        instance = self.get_object()
-        assigned_civs = []
         for ci_slug, new_value in form.cleaned_data.items():
             if ci_slug == "order":
                 continue
-            instance, assigned_civs = self.create_civ(
-                instance=instance,
+            self.create_civ(
                 ci_slug=ci_slug,
                 new_value=new_value,
-                assigned_civs=assigned_civs,
             )
-        instance.values.remove(*assigned_civs)
-
+        instance = self.get_object()
         if (
             form.cleaned_data.get("order")
             and form.cleaned_data["order"] != instance.order
@@ -1428,12 +1423,11 @@ class DisplaySetUpdate(
 
         return HttpResponseRedirect(self.get_success_url())
 
-    def create_civ_for_value(
-        self, instance, ci, current_civ, new_value, assigned_civs
-    ):
+    def create_civ_for_value(self, ci, current_civ, new_value):
+        instance = self.get_object()
         current_value = current_civ.value if current_civ else None
         if new_value and current_value != new_value:
-            assigned_civs.append(current_civ)
+            instance.values.remove(current_civ)
             civ = ComponentInterfaceValue.objects.create(
                 interface=ci, value=new_value
             )
@@ -1441,15 +1435,18 @@ class DisplaySetUpdate(
             instance.values.add(civ)
         elif not new_value:
             # if the new value is None, remove the old CIV from the display set
-            assigned_civs.append(current_civ)
-        return instance, assigned_civs
+            instance.values.remove(current_civ)
 
     def create_civ_for_image(
-        self, instance, ci, current_civ, new_value, assigned_civs
+        self,
+        ci,
+        current_civ,
+        new_value,
     ):
+        instance = self.get_object()
         current_image = current_civ.image if current_civ else None
         if isinstance(new_value, Image) and current_image != new_value:
-            assigned_civs.append(current_civ)
+            instance.values.remove(current_civ)
             civ, created = ComponentInterfaceValue.objects.get_or_create(
                 interface=ci, image=new_value
             )
@@ -1470,43 +1467,30 @@ class DisplaySetUpdate(
                     immutable=True,
                 )
             )
-        return instance, assigned_civs
 
-    def create_civ_for_file(
-        self, instance, ci, current_civ, new_value, assigned_civs
-    ):
+    def create_civ_for_file(self, ci, current_civ, new_value):
+        instance = self.get_object()
         # in this case, new_value is an instance of a CIV already (or None)
         if new_value and current_civ != new_value:
-            assigned_civs.append(current_civ)
-            # If there is already a value for the provided civ's interface in
-            # this display set, remove it from this display set. Cast to list
-            # to evaluate immediately.
-            assigned_civs += list(
-                instance.values.exclude(pk=new_value.pk).filter(interface=ci)
-            )
-            # Add the provided civ to the current display set
+            instance.values.remove(current_civ)
             instance.values.add(new_value)
         elif not new_value:
             # if no new value is provided (user selects '---' in dropdown)
             # delete old CIV
-            assigned_civs.append(current_civ)
-        return instance, assigned_civs
+            instance.values.remove(current_civ)
 
-    def create_civ(self, instance, ci_slug, new_value, assigned_civs):
+    def create_civ(self, ci_slug, new_value):
+        instance = self.get_object()
         ci = ComponentInterface.objects.get(slug=ci_slug)
         current_civ = instance.values.filter(interface=ci).first()
         if ci.is_json_kind and not ci.requires_file:
-            return self.create_civ_for_value(
-                instance, ci, current_civ, new_value, assigned_civs
-            )
+            return self.create_civ_for_value(ci, current_civ, new_value)
         elif ci.is_image_kind:
-            return self.create_civ_for_image(
-                instance, ci, current_civ, new_value, assigned_civs
-            )
+            return self.create_civ_for_image(ci, current_civ, new_value)
         elif ci.requires_file:
-            return self.create_civ_for_file(
-                instance, ci, current_civ, new_value, assigned_civs
-            )
+            return self.create_civ_for_file(ci, current_civ, new_value)
+        else:
+            NotImplementedError(f"CIV creation for {ci} not handled.")
 
 
 class DisplaySetFilesUpdate(ObjectPermissionRequiredMixin, FormView):

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -1650,11 +1650,7 @@ class DisplaySetInterfacesCreate(ObjectPermissionRequiredMixin, FormView):
         interface = form.cleaned_data["interface"]
         value = form.cleaned_data[interface.slug]
         if self.display_set:
-            try:
-                self.update_display_set(interface, value)
-            except ValidationError as e:
-                form.add_error(interface.slug, str(e))
-                return self.form_invalid(form)
+            self.update_display_set(interface, value)
         return super().form_valid(form)
 
     def get_success_url(self):

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -809,20 +809,16 @@ def test_display_set_interfaces_create(
 
     assert not ds.values.filter(interface=ci_value).exists()
     old_civ_count = ComponentInterfaceValue.objects.count()
-    headers = {"HTTP_HX-Request": "true"}
     response = get_view_for_user(
         viewname="reader-studies:display-set-interfaces-create",
         client=client,
         reverse_kwargs={"pk": ds.pk, "slug": rs.slug},
-        data={"interface": str(ci_value.pk), ci_value.slug: '{"foo": "bar"}'},
+        data={"interface": str(ci_value.pk), ci_value.slug: ""},
         user=u1,
         method=client.post,
-        **headers,
     )
     assert "JSON does not fulfill schema" in str(response.content)
-    # This shouldn't be true, but currently is
-    # (only when the request is issued as an HTMX request though!):
-    assert ComponentInterfaceValue.objects.count() == old_civ_count + 1
+    assert ComponentInterfaceValue.objects.count() == old_civ_count
 
     response = get_view_for_user(
         viewname="reader-studies:display-set-interfaces-create",

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -817,7 +817,7 @@ def test_display_set_interfaces_create(
         user=u1,
         method=client.post,
     )
-    assert "JSON does not fulfill schema" in str(response.content)
+    assert "This field is required" in str(response.content)
     assert ComponentInterfaceValue.objects.count() == old_civ_count
 
     response = get_view_for_user(

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -5,6 +5,7 @@ from guardian.shortcuts import assign_perm
 from requests import put
 
 from grandchallenge.cases.widgets import WidgetChoices
+from grandchallenge.components.models import ComponentInterfaceValue
 from grandchallenge.notifications.models import Notification
 from grandchallenge.reader_studies.models import Answer, DisplaySet, Question
 from tests.cases_tests import RESOURCE_PATH
@@ -388,37 +389,17 @@ def test_display_set_detail(client):
 
 
 @pytest.mark.django_db
-def test_display_set_update(client):
+def test_display_set_update_permissions(client):
     u1, u2 = UserFactory.create_batch(2)
     rs = ReaderStudyFactory()
-    ds1, ds2 = DisplaySetFactory.create_batch(2, reader_study=rs)
+    ds1 = DisplaySetFactory(reader_study=rs)
     rs.add_editor(u1)
-    ci_json = ComponentInterfaceFactory(kind="JSON")
-    ci_json_file = ComponentInterfaceFactory(
-        kind="JSON", store_in_database=False
-    )
-    ci_img = ComponentInterfaceFactory(kind="IMG")
-    im1, im2 = ImageFactory.create_batch(2)
-    assign_perm("cases.view_image", u1, im2)
-    civ_json = ComponentInterfaceValueFactory(
-        interface=ci_json, value={"foo": "bar"}
-    )
-    civ_img = ComponentInterfaceValueFactory(interface=ci_img, image=im1)
-    civ_json_file = ComponentInterfaceValueFactory(interface=ci_json_file)
-    ds1.values.set([civ_json, civ_json_file, civ_img])
-
-    civ_img_new = ComponentInterfaceValueFactory(interface=ci_img, image=im2)
-    civ_json_file_new = ComponentInterfaceValueFactory(interface=ci_json_file)
-    ds2.values.add(civ_img_new, civ_json_file_new)
-
-    assert DisplaySet.objects.count() == 2
     response = get_view_for_user(
         viewname="reader-studies:display-set-update",
         client=client,
         reverse_kwargs={"pk": ds1.pk, "slug": rs.slug},
         user=u2,
     )
-
     assert response.status_code == 403
 
     response = get_view_for_user(
@@ -427,9 +408,39 @@ def test_display_set_update(client):
         reverse_kwargs={"pk": ds1.pk, "slug": rs.slug},
         user=u1,
     )
-
     assert response.status_code == 200
 
+
+@pytest.mark.django_db
+def test_display_set_update(client):
+    user = UserFactory()
+    rs = ReaderStudyFactory()
+    ds1, ds2 = DisplaySetFactory.create_batch(2, reader_study=rs)
+    rs.add_editor(user)
+    # 3 interfaces of different types
+    ci_json = ComponentInterfaceFactory(kind="JSON")
+    ci_json_file = ComponentInterfaceFactory(
+        kind="JSON", store_in_database=False
+    )
+    ci_img = ComponentInterfaceFactory(kind="IMG")
+    # create CIVs for those interfaces
+    im1, im2 = ImageFactory.create_batch(2)
+    assign_perm("cases.view_image", user, im2)
+    civ_json = ComponentInterfaceValueFactory(
+        interface=ci_json, value={"foo": "bar"}
+    )
+    civ_img = ComponentInterfaceValueFactory(interface=ci_img, image=im1)
+    civ_json_file = ComponentInterfaceValueFactory(interface=ci_json_file)
+
+    # add 3 CIVs to display set
+    ds1.values.set([civ_json, civ_json_file, civ_img])
+
+    # create new civs to update old ones
+    civ_img_new = ComponentInterfaceValueFactory(interface=ci_img, image=im2)
+    civ_json_file_new = ComponentInterfaceValueFactory(interface=ci_json_file)
+    ds2.values.set([civ_json_file_new, civ_img_new])
+
+    # test updating of all 3 interface types
     response = get_view_for_user(
         viewname="reader-studies:display-set-update",
         client=client,
@@ -441,18 +452,60 @@ def test_display_set_update(client):
             ci_json_file.slug: str(civ_json_file_new.pk),
             "order": 11,
         },
-        user=u1,
+        user=user,
         method=client.post,
     )
-
     assert response.status_code == 302
     assert ds1.values.count() == 3
     assert not ds1.values.filter(pk=civ_img.pk).exists()
     assert ds1.values.filter(pk=civ_img_new.pk).exists()
-
     assert not ds1.values.filter(pk=civ_json_file.pk).exists()
     assert ds1.values.filter(pk=civ_json_file_new.pk).exists()
     assert ds1.values.get(interface=ci_json).value == {"foo": "new"}
+
+    n_civs_old = ComponentInterfaceValue.objects.count()
+    # test saving without any changes
+    response = get_view_for_user(
+        viewname="reader-studies:display-set-update",
+        client=client,
+        reverse_kwargs={"pk": ds1.pk, "slug": rs.slug},
+        data={
+            ci_json.slug: '{"foo": "new"}',
+            ci_img.slug: str(im2.pk),
+            f"WidgetChoice-{ci_img.slug}": WidgetChoices.IMAGE_SEARCH.name,
+            ci_json_file.slug: str(civ_json_file_new.pk),
+            "order": 11,
+        },
+        user=user,
+        method=client.post,
+    )
+    assert response.status_code == 302
+    # no new CIVs have been created
+    assert n_civs_old == ComponentInterfaceValue.objects.count()
+    assert ds1.values.count() == 3
+    assert ds1.values.filter(pk=civ_img_new.pk).exists()
+    assert ds1.values.filter(pk=civ_json_file_new.pk).exists()
+    assert ds1.values.get(interface=ci_json).value == {"foo": "new"}
+
+    # test removing json file and json value interface values
+    response = get_view_for_user(
+        viewname="reader-studies:display-set-update",
+        client=client,
+        reverse_kwargs={"pk": ds1.pk, "slug": rs.slug},
+        data={
+            ci_img.slug: str(im2.pk),
+            f"WidgetChoice-{ci_img.slug}": WidgetChoices.IMAGE_SEARCH.name,
+            "order": 11,
+        },
+        user=user,
+        method=client.post,
+    )
+    assert response.status_code == 302
+    assert ds1.values.count() == 1
+    assert n_civs_old == ComponentInterfaceValue.objects.count()
+    assert ds1.values.filter(pk=civ_img_new.pk).exists()
+    assert not ds1.values.filter(pk=civ_json_file_new.pk).exists()
+    assert not ds1.values.filter(interface=ci_json).exists()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes the following issues:
- when partially updating the values of a DS, (json) file type interface values used to get deleted when they were unchanged
- deleting the value of a json interface would result in the creation of an empty CIV 
- for values of json interfaces, a new CIV would be created regardless of whether they passed validation, again resulting in empty CIVs when validation failed

Part of #3087 