### PR TITLE
Remove inline event handler for notification bulk update

### DIFF
--- a/app/grandchallenge/notifications/static/js/notifications/bulk_delete_update.js
+++ b/app/grandchallenge/notifications/static/js/notifications/bulk_delete_update.js
@@ -1,6 +1,8 @@
-window.toggleCheckboxes = function toggleCheckboxes(source) {
+document.getElementById("SelectCheckboxes").addEventListener("click", toggleCheckboxes);
+
+function toggleCheckboxes(source) {
     $('input[name="checkbox"]').each(function () {
-        this.checked = source.checked;
+        this.checked = source.srcElement.checked;
     })
     const nChecked = $('input[name="checkbox"]:checked').length
     if (nChecked == 0) {

--- a/app/grandchallenge/notifications/static/js/notifications/bulk_delete_update.js
+++ b/app/grandchallenge/notifications/static/js/notifications/bulk_delete_update.js
@@ -2,7 +2,7 @@ document.getElementById("SelectCheckboxes").addEventListener("click", toggleChec
 
 function toggleCheckboxes(source) {
     $('input[name="checkbox"]').each(function () {
-        this.checked = source.srcElement.checked;
+        this.checked = source.target.checked;
     })
     const nChecked = $('input[name="checkbox"]:checked').length
     if (nChecked == 0) {

--- a/app/grandchallenge/notifications/templates/actstream/follow_list.html
+++ b/app/grandchallenge/notifications/templates/actstream/follow_list.html
@@ -23,7 +23,7 @@
 
     <div class="row">
         <div class="col-6">
-            <input class="checkbox-inline ml-3 mt-3" type="checkbox" id="SelectCheckboxes" onClick="toggleCheckboxes(this)"/>
+            <input class="checkbox-inline ml-3 mt-3" type="checkbox" id="SelectCheckboxes"/>
             <label class="form-check-label ml-1" id="LabelSelectAll" for="SelectCheckboxes">
                 Select all
             </label>

--- a/app/grandchallenge/notifications/templates/notifications/notification_list.html
+++ b/app/grandchallenge/notifications/templates/notifications/notification_list.html
@@ -23,7 +23,7 @@
     </div>
         <div class="row">
         <div class="col-6">
-            <input class="checkbox-inline ml-3 mt-3" type="checkbox" id="SelectCheckboxes" onClick="toggleCheckboxes(this)"/>
+            <input class="checkbox-inline ml-3 mt-3" type="checkbox" id="SelectCheckboxes"/>
             <label class="form-check-label ml-1" id="LabelSelectAll" for="SelectCheckboxes">
                 Select all
             </label>


### PR DESCRIPTION
With the introduction of a CSP, the "Select all" button, for which we used an inline event handler, no longer worked. This fixes that.

Closes #3091 