### PR TITLE
switch `pre-commit` | bot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,22 +11,6 @@ concurrency:
 
 jobs:
 
-  precommit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - uses: actions/checkout@v3
-      - name: Install pre-commit
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install pre-commit virtualenv!=20.0.6
-          pre-commit install
-      - name: Run static code inspections
-        run: pre-commit run --all-files
-
   django-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,12 @@
+default_language_version:
+  python: python3
+
+ci:
+  autofix_prs: true
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit suggestions"
+  autoupdate_schedule: quarterly
+  # submodules: true
+
 repos:
   - repo: https://github.com/adamchainz/django-upgrade
     rev: 1.13.0


### PR DESCRIPTION
I would suggest switching to a [pre-commit bot](https://github.com/marketplace/pre-commit-ci), which would also commit fixes within each PR, which overall simplifies endorsing formatting and maintenance. Note that pre-commit is already used by this repo, and the bot is free for all public projects :)