### PR TITLE
Adds a table of challenge results to the algorithm detail page

### DIFF
--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
@@ -225,12 +225,12 @@
                     </tr>
                     </thead>
                     <tbody>
-                    {% for phase, evaluation in best_evaluation_per_phase.items %}
+                    {% for evaluation in best_evaluation_per_phase %}
                         <tr>
                             <td>{{ evaluation.created|date }}</td>
-                            <td><a href="{{ phase.challenge.get_absolute_url }}">{{ phase.challenge }}</a></td>
+                            <td><a href="{{ evaluation.submission.phase.challenge.get_absolute_url }}">{{ evaluation.submission.phase.challenge }}</a></td>
                             <td>
-                                <a href="{% url 'evaluation:leaderboard' challenge_short_name=phase.challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+                                <a href="{% url 'evaluation:leaderboard' challenge_short_name=evaluation.submission.phase.challenge.short_name slug=evaluation.submission.phase.slug %}">{{ evaluation.submission.phase.title }}</a>
                             </td>
                             <td><a href="{{ evaluation.get_absolute_url }}">{{ evaluation.rank }}</a></td>
                         </tr>

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_detail.html
@@ -132,11 +132,15 @@
                     </span>
                 {% endif %}
             </div>
+
             <hr>
+
             {% if object.logo %}
                 <img class="w-50" loading="lazy" src="{{ object.logo.url }}" alt="Logo for {{ object.title }}">
             {% endif %}
+
             <h3 class="my-3">About</h3>
+
             {% if object.display_editors %}
                 <div class="row mb-2">
                     <div class="col-3 font-weight-bold">Creator{{ object.editors_group.user_set.all|pluralize }}:</div>
@@ -147,12 +151,14 @@
                     </div>
                 </div>
             {% endif %}
+
             {% if object.contact_email %}
                 <div class="row mb-2">
                     <div class="col-3 font-weight-bold">Contact email:</div>
                     <div class="col-9"><a href="mailto:{{ object.contact_email }}">{{ object.contact_email }}</a></div>
                 </div>
             {% endif %}
+
             {% if object.active_image %}
                 <div class="row mb-2">
                     <div class="col-3 font-weight-bold">Version:</div>
@@ -163,6 +169,7 @@
                     <div class="col-9">{{ object.active_image.created }}</div>
                 </div>
             {% endif %}
+
             {% if object.publications.all %}
                 <div class="row mb-2">
                     <div class="col-3 font-weight-bold">Associated publication{{ object.publications.all|pluralize }}:
@@ -180,6 +187,7 @@
                     </div>
                 </div>
             {% endif %}
+
             <div class="row mb-2">
                 <div class="col-3 font-weight-bold">Inputs:</div>
                 <div class="col-9">
@@ -191,6 +199,7 @@
                     </ul>
                 </div>
             </div>
+
             <div class="row mb-2">
                 <div class="col-3 font-weight-bold">Outputs:</div>
                 <div class="col-9">
@@ -202,6 +211,33 @@
                     </ul>
                 </div>
             </div>
+
+            {% if best_evaluation_per_phase %}
+                <h3>Challenge Performance</h3>
+
+                <table class="table table-borderless table-hover table-sm">
+                    <thead class="thead-light">
+                    <tr>
+                        <th>Date</th>
+                        <th>Challenge</th>
+                        <th>Phase</th>
+                        <th>Rank</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for phase, evaluation in best_evaluation_per_phase.items %}
+                        <tr>
+                            <td>{{ evaluation.created|date }}</td>
+                            <td><a href="{{ phase.challenge.get_absolute_url }}">{{ phase.challenge }}</a></td>
+                            <td>
+                                <a href="{% url 'evaluation:leaderboard' challenge_short_name=phase.challenge.short_name slug=phase.slug %}">{{ phase.title }}</a>
+                            </td>
+                            <td><a href="{{ evaluation.get_absolute_url }}">{{ evaluation.rank }}</a></td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            {% endif %}
 
             <h3>Model Facts</h3>
 

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -193,7 +193,9 @@ class AlgorithmDetail(ObjectPermissionRequiredMixin, DetailView):
             queryset=Evaluation.objects.select_related(
                 "submission__phase__challenge"
             )
-            .filter(submission__algorithm_image__algorithm=self.object)
+            .filter(
+                submission__algorithm_image__algorithm=self.object, rank__gt=0
+            )
             .order_by("created"),
             codename="view_evaluation",
             user=self.request.user,

--- a/app/tests/algorithms_tests/test_views.py
+++ b/app/tests/algorithms_tests/test_views.py
@@ -1167,6 +1167,12 @@ def test_evaluations_are_filtered(client):
         submission__algorithm_image=algorithm_image,
         rank=1,
     )
+    # Ignored as there is a better submission
+    EvaluationFactory(
+        submission__phase=public_phase_public_challenge,
+        submission__algorithm_image=algorithm_image,
+        rank=2,
+    )
     # Ignored as challenge is private
     EvaluationFactory.create_batch(
         2,

--- a/app/tests/algorithms_tests/test_views.py
+++ b/app/tests/algorithms_tests/test_views.py
@@ -1160,42 +1160,33 @@ def test_evaluations_are_filtered(client):
         public=False, challenge__hidden=False
     )
 
+    # 2nd Ignored as there is an older evaluation
+    e, _ = EvaluationFactory.create_batch(
+        2,
+        submission__phase=public_phase_public_challenge,
+        submission__algorithm_image=algorithm_image,
+        rank=1,
+    )
     # Ignored as challenge is private
-    EvaluationFactory(
+    EvaluationFactory.create_batch(
+        2,
         submission__phase=public_phase_private_challenge,
         submission__algorithm_image=algorithm_image,
+        rank=1,
     )
-    EvaluationFactory(
-        submission__phase=public_phase_private_challenge,
-        submission__algorithm_image=algorithm_image,
-    )
-
-    # 2nd ignored as there is an older evaluation
-    e = EvaluationFactory(
-        submission__phase=public_phase_public_challenge,
-        submission__algorithm_image=algorithm_image,
-    )
-    EvaluationFactory(
-        submission__phase=public_phase_public_challenge,
-        submission__algorithm_image=algorithm_image,
-    )
-
     # Ignored as phase is private
-    EvaluationFactory(
+    EvaluationFactory.create_batch(
+        2,
         submission__phase=private_phase_private_challenge,
         submission__algorithm_image=algorithm_image,
+        rank=1,
     )
-    EvaluationFactory(
-        submission__phase=private_phase_private_challenge,
-        submission__algorithm_image=algorithm_image,
-    )
-    EvaluationFactory(
+    # Ignored as phase is private
+    EvaluationFactory.create_batch(
+        2,
         submission__phase=private_phase_public_challenge,
         submission__algorithm_image=algorithm_image,
-    )
-    EvaluationFactory(
-        submission__phase=private_phase_public_challenge,
-        submission__algorithm_image=algorithm_image,
+        rank=1,
     )
 
     response = get_view_for_user(

--- a/app/tests/algorithms_tests/test_views.py
+++ b/app/tests/algorithms_tests/test_views.py
@@ -29,6 +29,7 @@ from tests.components_tests.factories import (
     ComponentInterfaceFactory,
     ComponentInterfaceValueFactory,
 )
+from tests.evaluation_tests.factories import EvaluationFactory, PhaseFactory
 from tests.factories import ImageFactory, UserFactory
 from tests.reader_studies_tests.factories import ReaderStudyFactory
 from tests.uploads_tests.factories import (
@@ -1137,3 +1138,75 @@ def test_job_time_limit(client):
 
     assert job.algorithm_image == algorithm_image
     assert job.time_limit == 600
+
+
+@pytest.mark.django_db
+def test_evaluations_are_filtered(client):
+    user = UserFactory()
+
+    algorithm_image = AlgorithmImageFactory()
+    algorithm_image.algorithm.add_editor(user=user)
+
+    public_phase_private_challenge = PhaseFactory(
+        public=True, challenge__hidden=True
+    )
+    public_phase_public_challenge = PhaseFactory(
+        public=True, challenge__hidden=False
+    )
+    private_phase_private_challenge = PhaseFactory(
+        public=False, challenge__hidden=True
+    )
+    private_phase_public_challenge = PhaseFactory(
+        public=False, challenge__hidden=False
+    )
+
+    # Ignored as challenge is private
+    EvaluationFactory(
+        submission__phase=public_phase_private_challenge,
+        submission__algorithm_image=algorithm_image,
+    )
+    EvaluationFactory(
+        submission__phase=public_phase_private_challenge,
+        submission__algorithm_image=algorithm_image,
+    )
+
+    # 2nd ignored as there is an older evaluation
+    e = EvaluationFactory(
+        submission__phase=public_phase_public_challenge,
+        submission__algorithm_image=algorithm_image,
+    )
+    EvaluationFactory(
+        submission__phase=public_phase_public_challenge,
+        submission__algorithm_image=algorithm_image,
+    )
+
+    # Ignored as phase is private
+    EvaluationFactory(
+        submission__phase=private_phase_private_challenge,
+        submission__algorithm_image=algorithm_image,
+    )
+    EvaluationFactory(
+        submission__phase=private_phase_private_challenge,
+        submission__algorithm_image=algorithm_image,
+    )
+    EvaluationFactory(
+        submission__phase=private_phase_public_challenge,
+        submission__algorithm_image=algorithm_image,
+    )
+    EvaluationFactory(
+        submission__phase=private_phase_public_challenge,
+        submission__algorithm_image=algorithm_image,
+    )
+
+    response = get_view_for_user(
+        viewname="algorithms:detail",
+        client=client,
+        reverse_kwargs={
+            "slug": algorithm_image.algorithm.slug,
+        },
+        user=user,
+    )
+
+    assert response.context["best_evaluation_per_phase"] == {
+        public_phase_public_challenge: e
+    }

--- a/app/tests/algorithms_tests/test_views.py
+++ b/app/tests/algorithms_tests/test_views.py
@@ -1153,6 +1153,9 @@ def test_evaluations_are_filtered(client):
     public_phase_public_challenge = PhaseFactory(
         public=True, challenge__hidden=False
     )
+    public_phase_public_challenge_2 = PhaseFactory(
+        public=True, challenge__hidden=False
+    )
     private_phase_private_challenge = PhaseFactory(
         public=False, challenge__hidden=True
     )
@@ -1165,13 +1168,13 @@ def test_evaluations_are_filtered(client):
         2,
         submission__phase=public_phase_public_challenge,
         submission__algorithm_image=algorithm_image,
-        rank=1,
+        rank=2,
     )
     # Ignored as there is a better submission
     EvaluationFactory(
         submission__phase=public_phase_public_challenge,
         submission__algorithm_image=algorithm_image,
-        rank=2,
+        rank=3,
     )
     # Ignored as challenge is private
     EvaluationFactory.create_batch(
@@ -1194,6 +1197,12 @@ def test_evaluations_are_filtered(client):
         submission__algorithm_image=algorithm_image,
         rank=1,
     )
+    e2, _ = EvaluationFactory.create_batch(
+        2,
+        submission__phase=public_phase_public_challenge_2,
+        submission__algorithm_image=algorithm_image,
+        rank=5,
+    )
 
     response = get_view_for_user(
         viewname="algorithms:detail",
@@ -1204,6 +1213,4 @@ def test_evaluations_are_filtered(client):
         user=user,
     )
 
-    assert response.context["best_evaluation_per_phase"] == {
-        public_phase_public_challenge: e
-    }
+    assert [*response.context["best_evaluation_per_phase"]] == [e, e2]


### PR DESCRIPTION
I do some sorting in Python as I couldn't quite work out how to do this only in the db and the number of evaluations per algorithm should be small. Checked for extra queries but that page is kindof heavy with the statistics, should clean that up.

See https://github.com/DIAGNijmegen/rse-roadmap/issues/279