### PR TITLE
Add credit limits for algorithm editors

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1283,6 +1283,9 @@ ALGORITHMS_MAX_DEFAULT_JOBS_PER_MONTH = int(
 ALGORITHMS_MAX_NUMBER_PER_USER_PER_PHASE = int(
     os.environ.get("ALGORITHMS_MAX_NUMBER_PER_USER_PER_PHASE", "3")
 )
+ALGORITHMS_JOB_LIMIT_FOR_EDITORS = int(
+    os.environ.get("ALGORITHMS_JOB_LIMIT_FOR_EDITORS", "5")
+)
 
 # Disallow some challenge names due to subdomain or media folder clashes
 DISALLOWED_CHALLENGE_NAMES = {

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -437,12 +437,12 @@ class Algorithm(UUIDModel, TitleSlugDescriptionModel, ViewContentMixin):
                     creator__in=self.editors_group.user_set.all(),
                     algorithm_image__image_sha256=self.active_image.image_sha256,
                 ).count()
-                n_free_jobs = max(
-                    settings.ALGORITHMS_JOB_LIMIT_FOR_EDITORS - n_editor_jobs,
-                    0,
-                )
             else:
-                n_free_jobs = settings.ALGORITHMS_JOB_LIMIT_FOR_EDITORS
+                n_editor_jobs = 0
+            n_free_jobs = max(
+                settings.ALGORITHMS_JOB_LIMIT_FOR_EDITORS - n_editor_jobs,
+                0,
+            )
             user_credits += n_free_jobs * self.credits_per_job
 
         credits_left = user_credits - spent_credits

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -445,9 +445,7 @@ class Algorithm(UUIDModel, TitleSlugDescriptionModel, ViewContentMixin):
                 n_free_jobs = settings.ALGORITHMS_JOB_LIMIT_FOR_EDITORS
             user_credits += n_free_jobs * self.credits_per_job
 
-        credits_left = (
-            user_credits - spent_credits if spent_credits else user_credits
-        )
+        credits_left = user_credits - spent_credits
 
         return max(credits_left, 0) // max(self.credits_per_job, 1)
 
@@ -644,7 +642,9 @@ class JobManager(ComponentJobManager):
             .select_related("algorithm_image__algorithm")
             .exclude(algorithm_image__algorithm__editors_group__in=user_groups)
             .aggregate(
-                total=Sum("algorithm_image__algorithm__credits_per_job"),
+                total=Sum(
+                    "algorithm_image__algorithm__credits_per_job", default=0
+                ),
                 oldest=Min("created"),
             )
         )

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -427,34 +427,29 @@ class Algorithm(UUIDModel, TitleSlugDescriptionModel, ViewContentMixin):
 
     def get_jobs_limit(self, user):
         """Get the maximum number of jobs a user can schedule now"""
-        if not self.active_image:
-            return None
+        user_credits = Credit.objects.get(user=user).credits
+        spent_credits = Job.objects.spent_credits(user=user)["total"]
 
-        editor_jobs = Job.objects.filter(
-            creator__in=self.editors_group.user_set.all(),
-            status=Job.SUCCESS,
-            algorithm_image__image_sha256=self.active_image.image_sha256,
-        ).values_list("pk", flat=True)
-        user_credit = Credit.objects.get(user=user)
-        credits_left = max(user_credit.credits, 0)
-        credits_per_job = max(self.credits_per_job, 1)
+        if self.is_editor(user=user):
+            if self.active_image:
+                # Including all jobs here as failed jobs still use compute
+                n_editor_jobs = Job.objects.filter(
+                    creator__in=self.editors_group.user_set.all(),
+                    algorithm_image__image_sha256=self.active_image.image_sha256,
+                ).count()
+                n_free_jobs = max(
+                    settings.ALGORITHMS_JOB_LIMIT_FOR_EDITORS - n_editor_jobs,
+                    0,
+                )
+            else:
+                n_free_jobs = settings.ALGORITHMS_JOB_LIMIT_FOR_EDITORS
+            user_credits += n_free_jobs * self.credits_per_job
 
-        if (
-            self.is_editor(user=user)
-            and len(editor_jobs) < settings.ALGORITHMS_JOB_LIMIT_FOR_EDITORS
-        ):
-            return (
-                (credits_left // credits_per_job)
-                + settings.ALGORITHMS_JOB_LIMIT_FOR_EDITORS
-                - len(editor_jobs)
-            )
-        else:
-            jobs = Job.objects.exclude(
-                pk__in=editor_jobs[: settings.ALGORITHMS_JOB_LIMIT_FOR_EDITORS]
-            ).spent_credits(user=user)
-            if jobs["total"]:
-                credits_left = credits_left - jobs["total"]
-            return max(credits_left, 0) // credits_per_job
+        credits_left = (
+            user_credits - spent_credits if spent_credits else user_credits
+        )
+
+        return max(credits_left, 0) // max(self.credits_per_job, 1)
 
     @cached_property
     def user_statistics(self):
@@ -640,12 +635,14 @@ class JobManager(ComponentJobManager):
     def spent_credits(self, user):
         now = timezone.now()
         period = timedelta(days=30)
+        user_groups = Group.objects.filter(user=user)
 
         return (
             self.filter(creator=user, created__range=[now - period, now])
             .distinct()
             .order_by("created")
             .select_related("algorithm_image__algorithm")
+            .exclude(algorithm_image__algorithm__editors_group__in=user_groups)
             .aggregate(
                 total=Sum("algorithm_image__algorithm__credits_per_job"),
                 oldest=Min("created"),

--- a/app/grandchallenge/algorithms/templates/algorithms/job_form_create.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_form_create.html
@@ -3,6 +3,7 @@
 {% load url %}
 {% load bleach %}
 {% load random_encode %}
+{% load guardian_tags %}
 
 {% block title %}
     Try-out Algorithm - {{ block.super }}
@@ -31,7 +32,7 @@
     <h2>Try-out Algorithm</h2>
 
     {{ algorithm.job_create_page_markdown|md2html }}
-
+    {% get_obj_perms request.user for algorithm as "algorithm_perms" %}
     {% if form.jobs_limit < 1 %}
         <p>
             You have run out of credits to try this algorithm.
@@ -44,12 +45,18 @@
             Select the data that you would like to run the algorithm on.
         </p>
         <p>
-            {% if form.jobs_limit > 0 %}
+            {% if 'change_algorithm' in algorithm_perms %}
+                <p>As an editor, you can test and debug your algorithm in total {{ editors_job_limit }} times per unique algorithm image.
+                    Failed runs do not count towards this limit.
+                    You share these credits with all other editors of this algorithm.
+                    Once you have reached the limit, any extra jobs will be deducted from your personal algorithm credits,
+                    of which you get {{ request.user.user_credit.credits }} per month.</p>
+            {% elif form.jobs_limit > 0 %}
                 You receive {{ request.user.user_credit.credits }} credits per month.
-                Using this algorithm requires {{ algorithm.credits_per_job }}
-                credit{{ algorithm.credits_per_job|pluralize }} per job.
-                You can create up to {{ form.jobs_limit }} job{{ form.jobs_limit|pluralize }} for this algorithm.
             {% endif %}
+            Using this algorithm requires {{ algorithm.credits_per_job }}
+            credit{{ algorithm.credits_per_job|pluralize }} per job.
+            You can currently create up to {{ form.jobs_limit }} job{{ form.jobs_limit|pluralize }} for this algorithm.
         </p>
 
         <form method="POST">

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import (
     PermissionRequiredMixin,
@@ -464,7 +465,12 @@ class JobCreate(
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
-        context.update({"algorithm": self.algorithm})
+        context.update(
+            {
+                "algorithm": self.algorithm,
+                "editors_job_limit": settings.ALGORITHMS_JOB_LIMIT_FOR_EDITORS,
+            }
+        )
         return context
 
     def form_valid(self, form):

--- a/app/tests/algorithms_tests/test_forms.py
+++ b/app/tests/algorithms_tests/test_forms.py
@@ -427,6 +427,12 @@ class TestJobCreateLimits:
         algorithm = AlgorithmFactory(credits_per_job=100)
         algorithm.inputs.clear()
         user = UserFactory()
+        AlgorithmImageFactory(
+            algorithm=algorithm,
+            is_manifest_valid=True,
+            is_in_registry=True,
+            is_desired_version=True,
+        )
 
         user.user_credit.credits = 0
         user.user_credit.save()
@@ -436,7 +442,6 @@ class TestJobCreateLimits:
         assert not form.is_valid()
         assert form.errors == {
             "__all__": ["You have run out of algorithm credits"],
-            "algorithm_image": ["This field is required."],
         }
 
     def test_form_valid_for_editor(self):

--- a/app/tests/algorithms_tests/test_serializers.py
+++ b/app/tests/algorithms_tests/test_serializers.py
@@ -263,8 +263,24 @@ class TestJobCreateLimits:
             },
             context={"request": request},
         )
-
         assert serializer.is_valid()
+        assert algorithm_image.algorithm.get_jobs_limit(user=user) == 5
+
+        AlgorithmJobFactory.create_batch(
+            5,
+            algorithm_image=algorithm_image,
+            creator=user,
+            status=Job.SUCCESS,
+        )
+        serializer = JobPostSerializer(
+            data={
+                "algorithm": algorithm_image.algorithm.api_url,
+                "inputs": [],
+            },
+            context={"request": request},
+        )
+        assert not serializer.is_valid()
+        assert algorithm_image.algorithm.get_jobs_limit(user=user) == 0
 
     def test_form_valid_with_credits(self, rf):
         algorithm_image = AlgorithmImageFactory(


### PR DESCRIPTION
This adds credit limits for algorithm editor through an environment variable with a default of 5. See pitch for more details.

I have not yet made verification required for the view or the `add_editor` method since that touches a lot of tests and hence seemed better to do seperately.

Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/215