### PR TITLE
Check if image exists before deleting civs for archive items

### DIFF
--- a/app/grandchallenge/archives/static/archives/js/archive_item_update.js
+++ b/app/grandchallenge/archives/static/archives/js/archive_item_update.js
@@ -1,0 +1,10 @@
+$('#ajaxDataTable').on( 'init.dt', function() {
+   allSelectElements = document.querySelectorAll('[id^="interfaceSelect"]');
+   allSelectElements.forEach(function(elem) {
+        elem.addEventListener("change", loadUpdateView);
+   });
+});
+
+function loadUpdateView(source) {
+    window.location.href = source.target.value
+}

--- a/app/grandchallenge/archives/tasks.py
+++ b/app/grandchallenge/archives/tasks.py
@@ -133,7 +133,9 @@ def update_archive_item_values(*, archive_item_pk, civ_pks_to_add):
             ).values_list("pk", flat=True):
                 civ_pks_to_remove.append(civ_pk)
         # for images, check if there are any CIVs with the provided image
-        if civ.interface.is_image_kind:
+        # this is necessary to enable updating the interface
+        # of a given image via the API
+        if civ.interface.is_image_kind and civ.image:
             if instance.values.filter(image=civ.image).exists():
                 for civ_pk in instance.values.filter(
                     image=civ.image

--- a/app/grandchallenge/archives/templates/archives/archive_items_list.html
+++ b/app/grandchallenge/archives/templates/archives/archive_items_list.html
@@ -30,4 +30,5 @@
 {% block script %}
     {{ block.super }}
     {% include 'workstations/partials/session-control.html' %}
+    <script src="{% static 'archives/js/archive_item_update.js' %}"></script>
 {% endblock %}

--- a/app/grandchallenge/archives/templates/archives/archive_items_row.html
+++ b/app/grandchallenge/archives/templates/archives/archive_items_row.html
@@ -18,7 +18,7 @@
 </ul>
 <split></split>
 
-<select class="form-control" onchange="location = this.value;">
+<select class="form-control" id="interfaceSelect">
     {% for interface in interfaces %}
         {% if interface not in object_interfaces %}
             <option value="{% url 'archives:item-edit' archive_slug=object.archive.slug pk=object.pk interface_slug=interface.slug %}">Add {{ interface.title }}</option>

--- a/app/tests/archives_tests/test_views.py
+++ b/app/tests/archives_tests/test_views.py
@@ -720,9 +720,14 @@ def test_archive_item_add_image(
     item = ArchiveItemFactory(archive=archive)
     editor = UserFactory()
     archive.add_editor(editor)
-    ci = ComponentInterfaceFactory(
+    ci_img = ComponentInterfaceFactory(
         kind=InterfaceKind.InterfaceKindChoices.IMAGE
     )
+    ci_value = ComponentInterfaceFactory(
+        kind=InterfaceKind.InterfaceKindChoices.BOOL
+    )
+    civ_value = ComponentInterfaceValueFactory(interface=ci_value, value=True)
+    item.values.add(civ_value)
     upload = create_upload_from_file(
         file_path=RESOURCE_PATH / "image10x10x10.mha",
         creator=editor,
@@ -735,17 +740,18 @@ def test_archive_item_add_image(
                 method=client.post,
                 reverse_kwargs={
                     "pk": item.pk,
-                    "interface_slug": ci.slug,
+                    "interface_slug": ci_img.slug,
                     "archive_slug": archive.slug,
                 },
                 user=editor,
                 follow=True,
                 data={
-                    ci.slug: upload.pk,
-                    f"WidgetChoice-{ci.slug}": WidgetChoices.IMAGE_UPLOAD.name,
+                    ci_img.slug: upload.pk,
+                    f"WidgetChoice-{ci_img.slug}": WidgetChoices.IMAGE_UPLOAD.name,
                 },
             )
     assert response.status_code == 200
+    assert item.values.count() == 2
     assert "image10x10x10.mha" == item.values.first().image.name
     old_civ = item.values.first()
 
@@ -757,14 +763,14 @@ def test_archive_item_add_image(
                 method=client.post,
                 reverse_kwargs={
                     "pk": item.pk,
-                    "interface_slug": ci.slug,
+                    "interface_slug": ci_img.slug,
                     "archive_slug": archive.slug,
                 },
                 user=editor,
                 follow=True,
                 data={
-                    ci.slug: old_civ.image.pk,
-                    f"WidgetChoice-{ci.slug}": WidgetChoices.IMAGE_SEARCH.name,
+                    ci_img.slug: old_civ.image.pk,
+                    f"WidgetChoice-{ci_img.slug}": WidgetChoices.IMAGE_SEARCH.name,
                 },
             )
     assert response.status_code == 200
@@ -781,14 +787,14 @@ def test_archive_item_add_image(
                 method=client.post,
                 reverse_kwargs={
                     "pk": item.pk,
-                    "interface_slug": ci.slug,
+                    "interface_slug": ci_img.slug,
                     "archive_slug": archive.slug,
                 },
                 user=editor,
                 follow=True,
                 data={
-                    ci.slug: image.pk,
-                    f"WidgetChoice-{ci.slug}": WidgetChoices.IMAGE_SEARCH.name,
+                    ci_img.slug: image.pk,
+                    f"WidgetChoice-{ci_img.slug}": WidgetChoices.IMAGE_SEARCH.name,
                 },
             )
     assert response.status_code == 200


### PR DESCRIPTION
When uploading a new image to an existing archive item, all non-image CIVs of that same item used to get deleted. The reason for this was that we checked for existing CIVs with the same image and deleted those. In the case of new image uploads, however, civ.image is still empty at the time of checking, and so it matched all CIVs with image=None. 

I was confused why we need this check at all. After some digging, I realized that it's necessary to enable updating of the interface of an image through the api (say from generic medical image to something more specific). This was a common use case when it was added. I'm in doubt whether we still need or want to offer this feature. It means that you can never have an archive item with the same image attached to different interfaces. Seems like a reasonable restriction to me, but it's a restriction that we don't enforce anywhere else (i.e. for display sets or jobs) as far as I know. 

Closes #3104 