### PR TITLE
Only email active users

### DIFF
--- a/app/grandchallenge/direct_messages/emails.py
+++ b/app/grandchallenge/direct_messages/emails.py
@@ -14,6 +14,10 @@ def get_users_to_send_new_unread_direct_messages_email():
         .objects.prefetch_related(
             "unread_direct_messages__sender", "user_profile"
         )
+        .filter(
+            user_profile__receive_notification_emails=True,
+            is_active=True,
+        )
         .annotate(
             new_unread_message_count=Count(
                 "unread_direct_messages",

--- a/app/tests/direct_messages_tests/test_emails.py
+++ b/app/tests/direct_messages_tests/test_emails.py
@@ -60,6 +60,15 @@ def test_get_users_to_send_new_unread_direct_messages_email(
     dm6 = DirectMessageFactory()
     dm6.unread_by.add(users[6])
 
+    # Inactive user should not be notified
+    DirectMessageFactory().unread_by.add(UserFactory(is_active=False))
+
+    # Opt out user should not be notified
+    opt_out_user = UserFactory()
+    opt_out_user.user_profile.receive_notification_emails = False
+    opt_out_user.user_profile.save()
+    DirectMessageFactory().unread_by.add(opt_out_user)
+
     with django_assert_max_num_queries(4):
         users_to_email = [
             {


### PR DESCRIPTION
Missing from #3108, no unintended users were emailed after deployment yesterday.