### PR TITLE
Speed up evaluation list view

### DIFF
--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1085,6 +1085,11 @@ class Evaluation(UUIDModel, ComponentJob):
 class EvaluationUserObjectPermission(UserObjectPermissionBase):
     content_object = models.ForeignKey(Evaluation, on_delete=models.CASCADE)
 
+    def save(self, *args, **kwargs):
+        raise RuntimeError(
+            "User permissions should not be assigned for this model"
+        )
+
 
 class EvaluationGroupObjectPermission(GroupObjectPermissionBase):
     content_object = models.ForeignKey(Evaluation, on_delete=models.CASCADE)

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -799,6 +799,7 @@ class LeaderboardDetail(TeamContextMixin, PaginatedTableListView):
             queryset=queryset,
             user=self.request.user,
             codename="view_evaluation",
+            accept_user_perms=False,
         )
 
     def filter_by_date(self, queryset):

--- a/app/tests/components_tests/test_models.py
+++ b/app/tests/components_tests/test_models.py
@@ -339,25 +339,22 @@ def test_civ_updating(kind):
     civ = ComponentInterfaceValue.objects.last()
 
     # updating existing values does not work
+
+    if kind == InterfaceKindChoices.IMAGE:
+        image = ImageFactory()
+        civ.image = image
+    elif kind == InterfaceKindChoices.CSV:
+        file = ContentFile(b"Foo2", name="test2.csv")
+        civ.file = file
+    elif kind == InterfaceKindChoices.BOOL:
+        civ.value = False
+    elif kind == InterfaceKindChoices.STRING:
+        civ.value = "Foo"
+
+    civ.full_clean()
+
     with pytest.raises(ValidationError):
-        if kind == InterfaceKindChoices.IMAGE:
-            image = ImageFactory()
-            civ.image = image
-            civ.full_clean()
-            civ.save()
-        elif kind == InterfaceKindChoices.CSV:
-            file = ContentFile(b"Foo2", name="test2.csv")
-            civ.file = file
-            civ.full_clean()
-            civ.save()
-        elif kind == InterfaceKindChoices.BOOL:
-            civ.value = False
-            civ.full_clean()
-            civ.save()
-        elif kind == InterfaceKindChoices.STRING:
-            civ.value = "Foo"
-            civ.full_clean()
-            civ.save()
+        civ.save()
 
 
 @pytest.mark.django_db

--- a/app/tests/direct_messages_tests/test_signals.py
+++ b/app/tests/direct_messages_tests/test_signals.py
@@ -60,7 +60,8 @@ def test_anon_not_participant():
 
     with pytest.raises(RuntimeError) as e:
         conversation.participants.add(get_anonymous_user())
-        assert str(e) == "The Anonymous User cannot be added to this group"
+
+    assert str(e.value) == "The Anonymous User cannot be added to this group"
 
 
 @pytest.mark.django_db

--- a/app/tests/hanging_protocols_tests/test_models.py
+++ b/app/tests/hanging_protocols_tests/test_models.py
@@ -438,16 +438,20 @@ def test_view_content_validation():
         (model,),
         {"__module__": model.__module__},
     )
-    with pytest.raises(ValidationError):
-        hp = model(view_content={"test": []})
-        hp.full_clean()
+
+    hp = model(view_content={"test": []})
 
     with pytest.raises(ValidationError):
-        hp = model(view_content={"main": []})
         hp.full_clean()
 
+    hp = model(view_content={"main": []})
+
     with pytest.raises(ValidationError):
-        hp = model(view_content={"main": "test"})
+        hp.full_clean()
+
+    hp = model(view_content={"main": "test"})
+
+    with pytest.raises(ValidationError):
         hp.full_clean()
 
     hp = model(view_content={"main": ["test"]})

--- a/app/tests/reader_studies_tests/test_models.py
+++ b/app/tests/reader_studies_tests/test_models.py
@@ -416,10 +416,11 @@ def test_validate_answer():
 
     with pytest.raises(ValidationError) as e:
         Answer.validate(creator=u, question=q, answer=True, display_set=ds)
-        assert (
-            e.value.message
-            == f"User {u} has already answered this question for this display set."
-        )
+
+    assert (
+        e.value.message
+        == f"User {u} has already answered this question for this display set."
+    )
 
     ds = DisplaySetFactory(reader_study=rs)
     assert (
@@ -682,20 +683,24 @@ def test_question_interface():
     q.clean()
     q.save()
     q.refresh_from_db()
+
     assert q.interface == ci_str
+
     ci_img = ComponentInterface.objects.filter(
         kind=InterfaceKindChoices.IMAGE
     ).first()
     q.interface = ci_img
+
     with pytest.raises(ValidationError) as e:
         q.clean()
-        q.save()
 
     assert e.value.message == (
         f"The interface {ci_img} is not allowed for this "
         f"question type ({AnswerType.SINGLE_LINE_TEXT})"
     )
+
     q.refresh_from_db()
+
     assert q.interface == ci_str
 
 

--- a/app/tests/serving_tests/test_views.py
+++ b/app/tests/serving_tests/test_views.py
@@ -19,6 +19,7 @@ from tests.evaluation_tests.factories import (
 )
 from tests.factories import (
     ChallengeRequestFactory,
+    GroupFactory,
     ImageFileFactory,
     UserFactory,
 )
@@ -179,7 +180,11 @@ def test_civ_file_download(client):
     evaluation = EvaluationFactory()
     evaluation.output_interfaces.add(detection_interface)
     evaluation.outputs.add(output_civ)
-    assign_perm("view_evaluation", user1, evaluation)
+
+    group = GroupFactory()
+    group.user_set.add(user1)
+    assign_perm("view_evaluation", group, evaluation)
+
     # Evaluation inputs and outputs should always be denied
     assert (
         get_view_for_user(

--- a/app/tests/workstations_tests/test_templatetags.py
+++ b/app/tests/workstations_tests/test_templatetags.py
@@ -233,9 +233,14 @@ def test_workstation_query_for_images(settings):
 def test_workstation_session_control_data():
     wk = WorkstationFactory()
     obj = ReaderStudyFactory()
+
     with pytest.raises(TypeError):
         workstation_session_control_data()
+
+    with pytest.raises(TypeError):
         workstation_session_control_data(workstation=wk)
+
+    with pytest.raises(TypeError):
         workstation_session_control_data(context_object=obj)
 
     data = workstation_session_control_data(


### PR DESCRIPTION
This PR adds an option `accept_user_perms=True` to `filter_by_permission` which allows objects to be filtered only by group permissions. This avoids a SQL OR or UNION so should be a lot faster.

I also noticed some problems with usage of `pytest.raises`, only one statement should be included in those blocks.

Closes #3023