### PR TITLE
Remove the legacy submission creation form

### DIFF
--- a/app/grandchallenge/evaluation/forms.py
+++ b/app/grandchallenge/evaluation/forms.py
@@ -6,11 +6,9 @@ from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.db.models.functions import Lower
 from django.forms import CheckboxInput, HiddenInput, ModelChoiceField
 from django.utils.html import format_html
 from django.utils.text import format_lazy
-from django_select2.forms import Select2Widget
 from django_summernote.widgets import SummernoteInplaceWidget
 
 from grandchallenge.algorithms.forms import UserAlgorithmsForPhaseMixin
@@ -499,32 +497,6 @@ class SubmissionForm(
         model = Submission
         fields = submission_fields
         widgets = {"creator": forms.HiddenInput, "phase": forms.HiddenInput}
-
-
-class LegacySubmissionForm(SubmissionForm):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.fields[
-            "creator"
-        ].queryset = self._phase.challenge.participants_group.user_set.all().order_by(
-            Lower("username")
-        )
-
-    def clean(self):
-        if Evaluation.objects.filter(
-            submission__phase__challenge=self._phase.challenge,
-            status=Evaluation.EXECUTING_PREREQUISITES,
-        ).exists():
-            raise ValidationError(
-                "An evaluation for this challenge is still running, please "
-                "wait for it to finish."
-            )
-
-        return super().clean()
-
-    class Meta(SubmissionForm.Meta):
-        widgets = {"creator": Select2Widget, "phase": forms.HiddenInput}
 
 
 class CombinedLeaderboardForm(SaveFormInitMixin, forms.ModelForm):

--- a/app/grandchallenge/evaluation/templates/evaluation/partials/phase_navbar.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/partials/phase_navbar.html
@@ -25,7 +25,7 @@
                         <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
                        href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-trophy fa-fw"></i>&nbsp;&nbsp;{{ phase.title }}</a>
                     {% elif submission_nav %}
-                        <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-create-legacy' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-detail' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                        <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-detail' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
                                href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-upload fa-fw"></i>&nbsp;&nbsp;{{ phase.title }}</a>
                     {% elif workspaces_nav %}
                         <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.kwargs.slug == phase.slug%}active{% endif %}"

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_form.html
@@ -40,49 +40,38 @@
 
     {% if "change_challenge" in challenge_perms %}
 
-        {% if request.resolver_match.view_name != "evaluation:submission-create-legacy" %}
-
-            <div class="alert alert-info" role="alert">
-                <p>
-                    Challenge participants will be allowed to create
-                    {{ phase.submissions_limit_per_user_per_period }} submission{{ phase.submissions_limit_per_user_per_period|pluralize }}
-                    {% if phase.submission_limit_period %}
-                        per {% if phase.submission_limit_period > 1 %}{{ phase.submission_limit_period }}{% endif %}
-                        day{{ phase.submission_limit_period|pluralize }}
-                    {% else %}
-                        in total
-                    {% endif %}
-                    {% if phase.submissions_open_at and phase.submissions_close_at %}between {{ phase.submissions_open_at }} ({{ TIME_ZONE }}) and {{ phase.submissions_close_at }} ({{ TIME_ZONE }})
-                    {% elif phase.submissions_open_at and not phase.submissions_close_at %} from {{ phase.submissions_open_at }} ({{ TIME_ZONE }}) onwards
-                    {% elif not phase.submissions_open_at and  phase.submissions_close_at %} until {{ phase.submissions_close_at }} ({{ TIME_ZONE }})
-                    {% endif %}
-                    to this phase.</p>
-                    <p>You can change the submission limit and period and the submission start and end dates in
-                    <a href="{% url 'evaluation:phase-update' challenge_short_name=challenge.short_name slug=phase.slug %}">
-                        Phase Settings</a>.
-                </p>
-                {% if phase.submission_kind == phase.SubmissionKindChoices.ALGORITHM %}
-                    <p>
-                        For each submission, {{ phase.count_valid_archive_items }}
-                        algorithm job{{ phase.count_valid_archive_items|pluralize }} will be created
-                        from the {{ phase.count_valid_archive_items }} valid item{{ phase.count_valid_archive_items|pluralize }}
-                        in <a href="{{ phase.archive.get_absolute_url }}">{{ phase.archive }}</a>.
-                        Each individual algorithm job will have a time limit of {{ phase.algorithm_time_limit|naturaldelta }}.
-                    </p>
+        <div class="alert alert-info" role="alert">
+            <p>
+                Challenge participants will be allowed to create
+                {{ phase.submissions_limit_per_user_per_period }} submission{{ phase.submissions_limit_per_user_per_period|pluralize }}
+                {% if phase.submission_limit_period %}
+                    per {% if phase.submission_limit_period > 1 %}{{ phase.submission_limit_period }}{% endif %}
+                    day{{ phase.submission_limit_period|pluralize }}
+                {% else %}
+                    in total
                 {% endif %}
+                {% if phase.submissions_open_at and phase.submissions_close_at %}between {{ phase.submissions_open_at }} ({{ TIME_ZONE }}) and {{ phase.submissions_close_at }} ({{ TIME_ZONE }})
+                {% elif phase.submissions_open_at and not phase.submissions_close_at %} from {{ phase.submissions_open_at }} ({{ TIME_ZONE }}) onwards
+                {% elif not phase.submissions_open_at and  phase.submissions_close_at %} until {{ phase.submissions_close_at }} ({{ TIME_ZONE }})
+                {% endif %}
+                to this phase.</p>
+            <p>You can change the submission limit and period and the submission start and end dates in
+                <a href="{% url 'evaluation:phase-update' challenge_short_name=challenge.short_name slug=phase.slug %}">
+                    Phase Settings</a>.
+            </p>
+            {% if phase.submission_kind == phase.SubmissionKindChoices.ALGORITHM %}
                 <p>
-                    As an admin for this challenge you can create as many submissions as you like as long as there is budget available.
+                    For each submission, {{ phase.count_valid_archive_items }}
+                    algorithm job{{ phase.count_valid_archive_items|pluralize }} will be created
+                    from the {{ phase.count_valid_archive_items }} valid item{{ phase.count_valid_archive_items|pluralize }}
+                    in <a href="{{ phase.archive.get_absolute_url }}">{{ phase.archive }}</a>.
+                    Each individual algorithm job will have a time limit of {{ phase.algorithm_time_limit|naturaldelta }}.
                 </p>
-                <hr>
-                <p class="mb-0">
-                    Please use
-                    <a href="{% url 'evaluation:submission-create-legacy' challenge_short_name=challenge.short_name slug=phase.slug %}">
-                        this form</a>
-                    if you would like to create a submission on the behalf of one of the participants of this challenge.
-                </p>
-            </div>
-
-        {% endif %}
+            {% endif %}
+            <p>
+                As an admin for this challenge you can create as many submissions as you like as long as there is budget available.
+            </p>
+        </div>
 
         {% crispy form %}
 

--- a/app/grandchallenge/evaluation/urls.py
+++ b/app/grandchallenge/evaluation/urls.py
@@ -12,7 +12,6 @@ from grandchallenge.evaluation.views import (
     EvaluationUpdate,
     LeaderboardDetail,
     LeaderboardRedirect,
-    LegacySubmissionCreate,
     MethodCreate,
     MethodDetail,
     MethodList,
@@ -85,11 +84,6 @@ urlpatterns = [
         "<slug>/submissions/create/",
         SubmissionCreate.as_view(),
         name="submission-create",
-    ),
-    path(
-        "<slug>/submissions/create-legacy/",
-        LegacySubmissionCreate.as_view(),
-        name="submission-create-legacy",
     ),
     path(
         "<slug>/submissions/<uuid:pk>/",

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -36,7 +36,6 @@ from grandchallenge.direct_messages.forms import ConversationForm
 from grandchallenge.evaluation.forms import (
     CombinedLeaderboardForm,
     EvaluationForm,
-    LegacySubmissionForm,
     MethodForm,
     MethodUpdateForm,
     PhaseCreateForm,
@@ -282,18 +281,24 @@ class MethodUpdate(
         return context
 
 
-class SubmissionCreateBase(SuccessMessageMixin, CreateView):
-    """
-    Base class for the submission creation forms.
-
-    It has no permissions, do not use it directly! See the subclasses.
-    """
-
+class SubmissionCreate(
+    LoginRequiredMixin,
+    ObjectPermissionRequiredMixin,
+    SuccessMessageMixin,
+    CreateView,
+):
     model = Submission
     success_message = (
         "Your submission was successful. "
         "Your result will appear on the leaderboard when it is ready."
     )
+    form_class = SubmissionForm
+    permission_required = "create_phase_submission"
+    raise_exception = True
+    login_url = reverse_lazy("account_login")
+
+    def get_permission_object(self):
+        return self.phase
 
     @cached_property
     def phase(self):
@@ -326,30 +331,6 @@ class SubmissionCreateBase(SuccessMessageMixin, CreateView):
                 "challenge_short_name": self.object.phase.challenge.short_name
             },
         )
-
-
-class SubmissionCreate(
-    LoginRequiredMixin, ObjectPermissionRequiredMixin, SubmissionCreateBase
-):
-    form_class = SubmissionForm
-    permission_required = "create_phase_submission"
-    raise_exception = True
-    login_url = reverse_lazy("account_login")
-
-    def get_permission_object(self):
-        return self.phase
-
-
-class LegacySubmissionCreate(
-    LoginRequiredMixin, ObjectPermissionRequiredMixin, SubmissionCreateBase
-):
-    form_class = LegacySubmissionForm
-    permission_required = "change_challenge"
-    raise_exception = True
-    login_url = reverse_lazy("account_login")
-
-    def get_permission_object(self):
-        return self.request.challenge
 
 
 class SubmissionList(LoginRequiredMixin, PermissionListMixin, ListView):

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -54,7 +54,6 @@ class TestLoginViews:
                 {"pk": e.method.pk, "slug": e.submission.phase.slug},
             ),
             ("submission-create", {"slug": e.submission.phase.slug}),
-            ("submission-create-legacy", {"slug": e.submission.phase.slug}),
             ("submission-list", {}),
             (
                 "submission-detail",
@@ -142,12 +141,6 @@ class TestObjectPermissionRequiredViews:
                 {"slug": e.submission.phase.slug},
                 "create_phase_submission",
                 e.submission.phase,
-            ),
-            (
-                "submission-create-legacy",
-                {"slug": e.submission.phase.slug},
-                "change_challenge",
-                e.submission.phase.challenge,
             ),
             (
                 "evaluation-create",


### PR DESCRIPTION
This was only really useful for type 1 challenges (which are no longer a focus) as the challenge are usually not editors of the participants algorithms, and it complicates the submission limit tracking. Creating such submissions is possible for the editor, they can then ask us to re-assign the user if needs be.