### PR TITLE
Minor fix for forge JSON creation

### DIFF
--- a/app/grandchallenge/core/utils/grand_challenge_forge.py
+++ b/app/grandchallenge/core/utils/grand_challenge_forge.py
@@ -11,7 +11,7 @@ def get_forge_json_description(challenge, phase_pks=None):
     phases = challenge.phase_set.filter(
         archive__isnull=False,
         submission_kind=SubmissionKindChoices.ALGORITHM,
-    ).prefetch_related("archive", "inputs", "outputs")
+    ).prefetch_related("archive", "algorithm_inputs", "algorithm_outputs")
 
     if phase_pks is not None:
         phases = phases.filter(pk__in=phase_pks)
@@ -37,10 +37,12 @@ def get_forge_json_description(challenge, phase_pks=None):
             "slug": phase.slug,
             "archive": process_archive(phase.archive),
             "inputs": [
-                process_component_interface(ci) for ci in phase.inputs.all()
+                process_component_interface(ci)
+                for ci in phase.algorithm_inputs.all()
             ],
             "outputs": [
-                process_component_interface(ci) for ci in phase.outputs.all()
+                process_component_interface(ci)
+                for ci in phase.algorithm_outputs.all()
             ],
         }
 

--- a/app/grandchallenge/core/utils/grand_challenge_forge.py
+++ b/app/grandchallenge/core/utils/grand_challenge_forge.py
@@ -36,11 +36,11 @@ def get_forge_json_description(challenge, phase_pks=None):
         return {
             "slug": phase.slug,
             "archive": process_archive(phase.archive),
-            "inputs": [
+            "algorithm_inputs": [
                 process_component_interface(ci)
                 for ci in phase.algorithm_inputs.all()
             ],
-            "outputs": [
+            "algorithm_outputs": [
                 process_component_interface(ci)
                 for ci in phase.algorithm_outputs.all()
             ],

--- a/app/tests/core_tests/test_grand_challenge_forge.py
+++ b/app/tests/core_tests/test_grand_challenge_forge.py
@@ -65,6 +65,17 @@ def test_get_forge_json_description():
                 ]:
                     assert ci_key in component_interface
 
+    # Quick check on CI input and outputs
+    for index, ci in enumerate(
+        description["challenge"]["phases"][0]["inputs"]
+    ):
+        assert inputs[index].slug == ci["slug"]
+
+    for index, ci in enumerate(
+        description["challenge"]["phases"][0]["outputs"]
+    ):
+        assert outputs[index].slug == ci["slug"]
+
     description = get_forge_json_description(challenge, phase_pks=[phase_1.pk])
     assert len(description["challenge"]["phases"]) == 1
 

--- a/app/tests/core_tests/test_grand_challenge_forge.py
+++ b/app/tests/core_tests/test_grand_challenge_forge.py
@@ -56,23 +56,28 @@ def test_get_forge_json_description():
 
     assert len(description["challenge"]["phases"]) == 2
     for phase in description["challenge"]["phases"]:
-        for phase_key in ["slug", "archive", "inputs", "outputs"]:
+        for phase_key in [
+            "slug",
+            "archive",
+            "algorithm_inputs",
+            "algorithm_outputs",
+        ]:
             assert phase_key in phase
             for ci_key in ["slug", "kind", "super_kind", "relative_path"]:
                 for component_interface in [
-                    *phase["inputs"],
-                    *phase["outputs"],
+                    *phase["algorithm_inputs"],
+                    *phase["algorithm_outputs"],
                 ]:
                     assert ci_key in component_interface
 
     # Quick check on CI input and outputs
     for index, ci in enumerate(
-        description["challenge"]["phases"][0]["inputs"]
+        description["challenge"]["phases"][0]["algorithm_inputs"]
     ):
         assert inputs[index].slug == ci["slug"]
 
     for index, ci in enumerate(
-        description["challenge"]["phases"][0]["outputs"]
+        description["challenge"]["phases"][0]["algorithm_outputs"]
     ):
         assert outputs[index].slug == ci["slug"]
 


### PR DESCRIPTION
Fix using default input and output (and not algorithm) in forge JSON creation.

Accidentally used the `inputs` instead of the `algorithm_inputs` for generating the JSON