### PR TITLE
Handle bad GitHub refresh tokens

### DIFF
--- a/app/grandchallenge/github/exceptions.py
+++ b/app/grandchallenge/github/exceptions.py
@@ -1,0 +1,2 @@
+class GitHubBadRefreshTokenException(Exception):
+    pass

--- a/app/grandchallenge/github/models.py
+++ b/app/grandchallenge/github/models.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from django.utils.text import get_valid_filename
 
 from grandchallenge.core.storage import private_s3_storage
+from grandchallenge.github.exceptions import GitHubBadRefreshTokenException
 from grandchallenge.github.tasks import get_zipfile, unlink_algorithm
 from grandchallenge.github.utils import CloneStatusChoices
 
@@ -62,7 +63,7 @@ class GitHubUserToken(models.Model):
             if payload["error"] == "bad_refresh_token":
                 # User has deleted their installation, they need
                 # to start the auth process again
-                self.delete()
+                raise GitHubBadRefreshTokenException
             else:
                 raise RuntimeError(payload["error"])
         else:


### PR DESCRIPTION
Can occur if the user deletes the installation or their account.