### PR TITLE
Fix json editor initialization

### DIFF
--- a/app/grandchallenge/core/static/js/jsoneditor_widget.mjs
+++ b/app/grandchallenge/core/static/js/jsoneditor_widget.mjs
@@ -26,17 +26,25 @@ function initialize_jsoneditor_widget(jsoneditorWidgetID) {
     }
 }
 
-function search_for_jsoneditor_widgets() {
-    const jsoneditorWidgets = document.getElementsByClassName("jsoneditorWidget");
+function search_for_jsoneditor_widgets(elem) {
+    let jsoneditorWidgets;
+    if (elem === undefined) {
+        jsoneditorWidgets = document.getElementsByClassName("jsoneditorWidget");
+    } else {
+        jsoneditorWidgets = elem.getElementsByClassName("jsoneditorWidget");
+    }
     for (let jsoneditorWidget of jsoneditorWidgets) {
-        initialize_jsoneditor_widget(jsoneditorWidget.dataset.widgetId);
+        if (jsoneditorWidget.querySelector('.jsoneditor-mode-tree') === null) {
+            // only initialize the widget if it hasn't been initialized yet
+            initialize_jsoneditor_widget(jsoneditorWidget.dataset.widgetId);
+        }
     }
 }
 
 document.addEventListener("DOMContentLoaded", function(event) {
-    search_for_jsoneditor_widgets()
+    htmx.onLoad((elem) => {
+        search_for_jsoneditor_widgets(elem)
+    });
 });
 
-htmx.onLoad(function () {
-    search_for_jsoneditor_widgets()
-});
+search_for_jsoneditor_widgets();


### PR DESCRIPTION
Closes #3162 

Fix for the issue was to call `htmx.onLoad` only after all DOM content is loaded. For the display set views to work then, the `search_for_jsoneditor_widgets` needs to be called outside of the event listener as well though. Finally, I'm making sure that in case the function gets called multiple times, we only initialize the widget once and only for the relevant element (if it is triggered by an htmx load event).