### PR TITLE
Enable archive item deletion through the API

### DIFF
--- a/app/grandchallenge/archives/apps.py
+++ b/app/grandchallenge/archives/apps.py
@@ -20,6 +20,10 @@ def init_archiveitem_permissions(*_, **__):
         f"{ArchiveItem._meta.app_label}.add_{ArchiveItem._meta.model_name}",
         g,
     )
+    assign_perm(
+        f"{ArchiveItem._meta.app_label}.delete_{ArchiveItem._meta.model_name}",
+        g,
+    )
 
 
 class ArchivesConfig(AppConfig):

--- a/app/grandchallenge/archives/models.py
+++ b/app/grandchallenge/archives/models.py
@@ -282,12 +282,22 @@ class ArchiveItem(CIVForObjectMixin, UUIDModel):
         assign_perm(
             f"view_{self._meta.model_name}", self.archive.users_group, self
         )
-        # Archive editors and uploaders can change this archive item
+        # Archive editors and uploaders can change and delete this archive item
         assign_perm(
             f"change_{self._meta.model_name}", self.archive.editors_group, self
         )
         assign_perm(
             f"change_{self._meta.model_name}",
+            self.archive.uploaders_group,
+            self,
+        )
+        assign_perm(
+            f"delete_{self._meta.model_name}",
+            self.archive.editors_group,
+            self,
+        )
+        assign_perm(
+            f"delete_{self._meta.model_name}",
             self.archive.uploaders_group,
             self,
         )

--- a/app/grandchallenge/archives/views.py
+++ b/app/grandchallenge/archives/views.py
@@ -20,7 +20,11 @@ from django.views.generic import (
 from django_filters.rest_framework import DjangoFilterBackend
 from guardian.mixins import LoginRequiredMixin
 from rest_framework.decorators import action
-from rest_framework.mixins import CreateModelMixin, UpdateModelMixin
+from rest_framework.mixins import (
+    CreateModelMixin,
+    DestroyModelMixin,
+    UpdateModelMixin,
+)
 from rest_framework.permissions import DjangoObjectPermissions
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
@@ -680,7 +684,7 @@ class ArchiveViewSet(ReadOnlyModelViewSet):
 
 
 class ArchiveItemViewSet(
-    CreateModelMixin, UpdateModelMixin, ReadOnlyModelViewSet
+    CreateModelMixin, UpdateModelMixin, ReadOnlyModelViewSet, DestroyModelMixin
 ):
     queryset = ArchiveItem.objects.all().prefetch_related(
         "archive__hanging_protocol",

--- a/app/tests/archives_tests/test_views.py
+++ b/app/tests/archives_tests/test_views.py
@@ -849,3 +849,25 @@ def test_archive_item_add_value(
             )
     assert response.status_code == 200
     assert ArchiveItem.objects.get().values.first().value
+
+
+@pytest.mark.django_db
+def test_api_archive_item_deletion(client):
+    archive = ArchiveFactory()
+    editor = UserFactory()
+    archive.add_editor(editor)
+    i1, i2 = ArchiveItemFactory.create_batch(2, archive=archive)
+
+    assert ArchiveItem.objects.count() == 2
+
+    response = get_view_for_user(
+        viewname="api:archives-item-detail",
+        reverse_kwargs={"pk": i1.pk},
+        user=editor,
+        client=client,
+        method=client.delete,
+    )
+    assert response.status_code == 204
+    assert ArchiveItem.objects.count() == 1
+    assert i1 not in ArchiveItem.objects.all()
+    assert i2 in ArchiveItem.objects.all()


### PR DESCRIPTION
Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/274

After merging this, permissions for existing archive items need to be updated by running `assign_permissions()` on all items. 