### PR TITLE
Reject container images saved with Docker 25

### DIFF
--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -531,11 +531,16 @@ def _get_image_config_file(
         )
 
     if config_filename.endswith(".json"):
-        # Docker v2 container image
+        # Docker <25 container image
         image_sha256 = config_filename.split(".")[0]
     else:
-        # OCI container image
-        image_sha256 = image_manifest["Config"].split("/")[-1]
+        # Docker >=25 container image
+        # image_sha256 = image_manifest["Config"].split("/")[-1]
+        raise ValidationError(
+            "Images saved with Docker version 25 or greater are not "
+            "currently supported. Please use Docker version 24 or less "
+            "to save your container image."
+        )
 
     if len(image_sha256) != 64:
         raise ValidationError(

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -429,7 +429,16 @@ def test_add_file_to_object(settings, object_type):
 
 @pytest.mark.parametrize(
     "container_image_file",
-    ("hello-scratch-oci.tar.gz", "hello-scratch-docker-v2.tar.gz"),
+    (
+        "hello-scratch-docker-v2.tar.gz",
+        pytest.param(
+            "hello-scratch-oci.tar.gz",
+            marks=pytest.mark.xfail(
+                reason="crane cannot push docker 25 images https://github.com/google/go-containerregistry/issues/1870",
+                strict=True,
+            ),
+        ),
+    ),
 )
 @pytest.mark.django_db
 def test_get_image_config_and_sha256(container_image_file):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,7 +217,7 @@ services:
       - workstations
 
   registry:
-    image: registry:2.7
+    image: registry:2
     ports:
       - "127.0.0.1:5000:5000"
     environment:


### PR DESCRIPTION
Wait until a fix for https://github.com/google/go-containerregistry/issues/1870 is available.