### PR TITLE
Fix not being able to edit challenges in django admin

### DIFF
--- a/app/grandchallenge/challenges/admin.py
+++ b/app/grandchallenge/challenges/admin.py
@@ -26,6 +26,7 @@ from grandchallenge.core.utils.grand_challenge_forge import (
 @admin.register(Challenge)
 class ChallengeAdmin(ModelAdmin):
     readonly_fields = (
+        "short_name",
         "creator",
         "challenge_forge_json",
     )


### PR DESCRIPTION
The short name was blocking any editing.

See teams: https://teams.microsoft.com/l/message/19:cd97152db8544ca1b74c6990e24ec446@thread.tacv2/1706785498300?tenantId=b208fe69-471e-48c4-8d87-025e9b9a157f&groupId=45c973c4-5543-45ad-a8b8-79ea596e6c69&parentMessageId=1706785498300&teamName=Research%20Software%20Engineering&channelName=grand-challenge-dev&createdTime=1706785498300&allowXTenantAccess=false

Setting `editable` to `False` doesn't quite work since the `ChallengeBase` is used for both `Challenge` and `ChallengeRequest` models. 
