### PR TITLE
Encourage usage of `.gz` rather than `.xz`

### DIFF
--- a/app/grandchallenge/algorithms/migrations/0001_initial.py
+++ b/app/grandchallenge/algorithms/migrations/0001_initial.py
@@ -176,7 +176,7 @@ class Migration(migrations.Migration):
                     "image",
                     models.FileField(
                         blank=True,
-                        help_text=".tar.xz archive of the container image produced from the command 'docker save IMAGE | xz -T0 -c > IMAGE.tar.xz'. See https://docs.docker.com/engine/reference/commandline/save/",
+                        help_text=".tar.gz archive of the container image produced from the command 'docker save IMAGE | gzip -c > IMAGE.tar.gz'. See https://docs.docker.com/engine/reference/commandline/save/",
                         storage=grandchallenge.core.storage.PrivateS3Storage(),
                         upload_to=grandchallenge.components.models.docker_image_path,
                         validators=[

--- a/app/grandchallenge/components/forms.py
+++ b/app/grandchallenge/components/forms.py
@@ -35,8 +35,8 @@ class ContainerImageForm(SaveFormInitMixin, ModelForm):
         label="Container Image",
         queryset=None,
         help_text=(
-            ".tar.xz archive of the container image produced from the command "
-            "'docker save IMAGE | xz -T0 -c > IMAGE.tar.xz'. See "
+            ".tar.gz archive of the container image produced from the command "
+            "'docker save IMAGE | gzip -c > IMAGE.tar.gz'. See "
             "https://docs.docker.com/engine/reference/commandline/save/"
         ),
     )

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -1737,8 +1737,8 @@ class ComponentImage(FieldChangeMixin, models.Model):
             )
         ],
         help_text=(
-            ".tar.xz archive of the container image produced from the command "
-            "'docker save IMAGE | xz -T0 -c > IMAGE.tar.xz'. See "
+            ".tar.gz archive of the container image produced from the command "
+            "'docker save IMAGE | gzip -c > IMAGE.tar.gz'. See "
             "https://docs.docker.com/engine/reference/commandline/save/"
         ),
         storage=private_s3_storage,

--- a/app/grandchallenge/evaluation/migrations/0001_initial.py
+++ b/app/grandchallenge/evaluation/migrations/0001_initial.py
@@ -519,7 +519,7 @@ class Migration(migrations.Migration):
                     "image",
                     models.FileField(
                         blank=True,
-                        help_text=".tar.xz archive of the container image produced from the command 'docker save IMAGE | xz -T0 -c > IMAGE.tar.xz'. See https://docs.docker.com/engine/reference/commandline/save/",
+                        help_text=".tar.gz archive of the container image produced from the command 'docker save IMAGE | gzip -c > IMAGE.tar.gz'. See https://docs.docker.com/engine/reference/commandline/save/",
                         storage=grandchallenge.core.storage.PrivateS3Storage(),
                         upload_to=grandchallenge.components.models.docker_image_path,
                         validators=[

--- a/app/grandchallenge/workstations/migrations/0001_squashed_0011_auto_20201001_0758.py
+++ b/app/grandchallenge/workstations/migrations/0001_squashed_0011_auto_20201001_0758.py
@@ -125,7 +125,7 @@ class Migration(migrations.Migration):
                     "image",
                     models.FileField(
                         blank=True,
-                        help_text=".tar.xz archive of the container image produced from the command 'docker save IMAGE | xz -T0 -c > IMAGE.tar.xz'. See https://docs.docker.com/engine/reference/commandline/save/",
+                        help_text=".tar.gz archive of the container image produced from the command 'docker save IMAGE | gzip -c > IMAGE.tar.gz'. See https://docs.docker.com/engine/reference/commandline/save/",
                         storage=grandchallenge.core.storage.PrivateS3Storage(),
                         upload_to=grandchallenge.components.models.docker_image_path,
                         validators=[


### PR DESCRIPTION
`.xz` takes far longer to extract, especially for large images.