### PR TITLE
Ban use of `django.core.mail.send_mail`

### DIFF
--- a/app/grandchallenge/emails/emails.py
+++ b/app/grandchallenge/emails/emails.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.mail import send_mail
+from django.core.mail import send_mail  # noqa: I251
 from django.template.loader import render_to_string
 from django.utils.html import format_html
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ banned-modules =
     rest_framework.permissions.IsAuthenticated = Please use grandchallenge.api.permissions.IsAuthenticated instead
     rest_framework.permissions.IsAuthenticatedOrReadOnly = Please use grandchallenge.api.permissions.IsAuthenticatedOrReadOnly instead
     django.contrib.sitemaps.Sitemap = Please use grandchallenge.core.sitemaps.SubdomainSitemap
+    django.core.mail.send_mail = Please use grandchallenge.emails.emails.send_standard_email
 select =
     # B are bugbear checks (including the optionals)
     B


### PR DESCRIPTION
Everything should go through `grandchallenge.emails.emails.send_standard_email`