### PR TITLE
Allow reader study editors to message their readers

### DIFF
--- a/app/grandchallenge/direct_messages/views.py
+++ b/app/grandchallenge/direct_messages/views.py
@@ -30,6 +30,7 @@ from grandchallenge.direct_messages.models import (
     DirectMessageUnreadBy,
     Mute,
 )
+from grandchallenge.reader_studies.models import ReaderStudy
 from grandchallenge.subdomains.utils import reverse
 
 
@@ -42,11 +43,17 @@ class ConversationCreate(LoginRequiredMixin, UserPassesTestMixin, CreateView):
         if settings.ANONYMOUS_USER_NAME == self.kwargs["username"]:
             return False
         else:
-            # Only challenge admins can message their participants
-            return Challenge.objects.filter(
-                admins_group__user=self.request.user,
-                participants_group__user__username=self.kwargs["username"],
-            ).exists()
+            # Only challenge or reader study admins can message their participants
+            return (
+                Challenge.objects.filter(
+                    admins_group__user=self.request.user,
+                    participants_group__user__username=self.kwargs["username"],
+                ).exists()
+                or ReaderStudy.objects.filter(
+                    editors_group__user=self.request.user,
+                    readers_group__user__username=self.kwargs["username"],
+                ).exists()
+            )
 
     def get_form_kwargs(self, *args, **kwargs):
         form_kwargs = super().get_form_kwargs(*args, **kwargs)

--- a/app/grandchallenge/groups/templates/groups/partials/user_list.html
+++ b/app/grandchallenge/groups/templates/groups/partials/user_list.html
@@ -4,10 +4,23 @@
 <ul class="list-group list-group-flush mb-3">
     {% for user in users %}
         <li class="list-group-item">
-            <div class="d-flex justify-content-between align-items-center">
-                <div>{{ user|user_profile_link }}</div>
-                <div>
-                    {% if user != request.user %}
+            <div class="d-flex align-items-center">
+                <div class="mr-auto">
+                    {{ user|user_profile_link }}
+                </div>
+                {% if user != request.user %}
+                    {% if display_direct_message_link %}
+                        <div>
+                            <form method="post"
+                                  action="{% url 'direct_messages:conversation-create' username=user.username %}">
+                                {% csrf_token %}
+                                <button class="btn btn btn-primary" type="submit">
+                                    <i class="far fa-comment"></i>&nbsp;Message User
+                                </button>
+                            </form>
+                        </div>
+                    {% endif %}
+                    <div>
                         <form action="{{ edit_url }}" method="POST">
                             {% csrf_token %}
                             {% for field in form %}
@@ -21,8 +34,8 @@
                                 Remove
                             </button>
                         </form>
-                    {% endif %}
-                </div>
+                    </div>
+                {% endif %}
             </div>
         </li>
     {% empty %}

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -284,7 +284,7 @@
                 </p>
 
                 {% url 'reader-studies:readers-update' slug=object.slug as readers_update_url %}
-                {% include "groups/partials/user_list.html" with role_name="readers" edit_url=readers_update_url form=editor_remove_form users=readers %}
+                {% include "groups/partials/user_list.html" with role_name="readers" edit_url=readers_update_url form=editor_remove_form users=readers display_direct_message_link=True %}
             </div>
 
             <div class="tab-pane fade"


### PR DESCRIPTION
Adds a link on the readers list page to allow editors to DM their readers.

<img width="823" alt="Screenshot 2024-02-13 at 07 56 16" src="https://github.com/comic/grand-challenge.org/assets/12661555/472a40d0-1dea-497e-ad53-4f095e9512fe">

Closes https://github.com/DIAGNijmegen/rse-roadmap/issues/298