### PR TITLE
Fix algorithm fixture

### DIFF
--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -272,9 +272,6 @@ class Algorithm(UUIDModel, TitleSlugDescriptionModel, HangingProtocolMixin):
 
         super().save(*args, **kwargs)
 
-        if adding:
-            self.set_default_interfaces()
-
         self.assign_permissions()
         self.assign_workstation_permissions()
 
@@ -292,25 +289,6 @@ class Algorithm(UUIDModel, TitleSlugDescriptionModel, HangingProtocolMixin):
         self.users_group = Group.objects.create(
             name=f"{self._meta.app_label}_{self._meta.model_name}_{self.pk}_users"
         )
-
-    def set_default_interfaces(self):
-        if not self.inputs.exists():
-            self.inputs.set(
-                [
-                    ComponentInterface.objects.get(
-                        slug=DEFAULT_INPUT_INTERFACE_SLUG
-                    )
-                ]
-            )
-        if not self.outputs.exists():
-            self.outputs.set(
-                [
-                    ComponentInterface.objects.get(slug="results-json-file"),
-                    ComponentInterface.objects.get(
-                        slug=DEFAULT_OUTPUT_INTERFACE_SLUG
-                    ),
-                ]
-            )
 
     def assign_permissions(self):
         # Editors and users can view this algorithm

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -57,9 +57,6 @@ from grandchallenge.workstations.models import Workstation
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_INPUT_INTERFACE_SLUG = "generic-medical-image"
-DEFAULT_OUTPUT_INTERFACE_SLUG = "generic-overlay"
-
 JINJA_ENGINE = sandbox.ImmutableSandboxedEnvironment()
 
 

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -71,8 +71,6 @@ from grandchallenge.workstation_configs.models import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_OUTPUT_INTERFACE_SLUG = "generic-overlay"
-
 
 class InterfaceKindChoices(models.TextChoices):
     """Interface kind choices."""

--- a/app/tests/algorithms_tests/test_forms.py
+++ b/app/tests/algorithms_tests/test_forms.py
@@ -179,13 +179,6 @@ def test_algorithm_create(client, uploaded_image):
     "slug, content_parts",
     (
         (
-            None,
-            [
-                '<select class="custom-select"',
-                'name="WidgetChoice-generic-medical-image"',
-            ],
-        ),
-        (
             "generic-overlay",
             [
                 '<select class="custom-select"',
@@ -318,7 +311,6 @@ def test_create_job_json_input_field_validation(
 @pytest.mark.parametrize(
     "slug, content_parts",
     (
-        (None, ['class="invalid-feedback"', "This field is required."]),
         (
             "generic-overlay",
             ['class="invalid-feedback"', "This field is required."],
@@ -352,8 +344,7 @@ def create_algorithm_with_input(slug):
     VerificationFactory(user=creator, is_verified=True)
     alg = AlgorithmFactory()
     alg.add_editor(user=creator)
-    if slug:
-        alg.inputs.set([ComponentInterface.objects.get(slug=slug)])
+    alg.inputs.set([ComponentInterface.objects.get(slug=slug)])
     return alg, creator
 
 

--- a/app/tests/algorithms_tests/test_models.py
+++ b/app/tests/algorithms_tests/test_models.py
@@ -10,7 +10,6 @@ from grandchallenge.algorithms.models import Algorithm, Job
 from grandchallenge.components.models import (
     ComponentInterface,
     ComponentInterfaceValue,
-    InterfaceKind,
 )
 from grandchallenge.credits.models import Credit
 from tests.algorithms_tests.factories import (
@@ -57,16 +56,11 @@ def test_group_deletion_reverse(group):
 
 
 @pytest.mark.django_db
-def test_default_interfaces_created():
+def test_no_default_interfaces_created():
     a = AlgorithmFactory()
 
-    assert {i.kind for i in a.inputs.all()} == {
-        InterfaceKind.InterfaceKindChoices.IMAGE
-    }
-    assert {o.kind for o in a.outputs.all()} == {
-        InterfaceKind.InterfaceKindChoices.ANY,
-        InterfaceKind.InterfaceKindChoices.HEAT_MAP,
-    }
+    assert {i.kind for i in a.inputs.all()} == set()
+    assert {o.kind for o in a.outputs.all()} == set()
 
 
 @pytest.mark.django_db

--- a/app/tests/algorithms_tests/test_permissions.py
+++ b/app/tests/algorithms_tests/test_permissions.py
@@ -382,9 +382,13 @@ class TestJobPermissions:
         im = ImageFactory()
         s.image_set.set([im])
 
-        civ = ComponentInterfaceValueFactory(
-            image=im, interface=ai.algorithm.inputs.get()
+        input_interface = ComponentInterface.objects.get(
+            slug="generic-medical-image"
         )
+        civ = ComponentInterfaceValueFactory(
+            image=im, interface=input_interface
+        )
+
         archive_item = ArchiveItemFactory(archive=archive)
         with django_capture_on_commit_callbacks(execute=True):
             archive_item.values.add(civ)
@@ -436,9 +440,13 @@ class TestJobPermissions:
         im = ImageFactory()
         s.image_set.set([im])
 
-        civ = ComponentInterfaceValueFactory(
-            image=im, interface=ai.algorithm.inputs.get()
+        input_interface = ComponentInterface.objects.get(
+            slug="generic-medical-image"
         )
+        civ = ComponentInterfaceValueFactory(
+            image=im, interface=input_interface
+        )
+
         archive_item = ArchiveItemFactory(archive=archive)
         with django_capture_on_commit_callbacks(execute=True):
             archive_item.values.add(civ)
@@ -488,8 +496,11 @@ class TestJobPermissions:
         im = ImageFactory()
         s.image_set.set([im])
 
+        input_interface = ComponentInterface.objects.get(
+            slug="generic-medical-image"
+        )
         civ = ComponentInterfaceValueFactory(
-            image=im, interface=ai.algorithm.inputs.get()
+            image=im, interface=input_interface
         )
         archive_item = ArchiveItemFactory(archive=archive)
         with django_capture_on_commit_callbacks(execute=True):

--- a/app/tests/algorithms_tests/test_tasks.py
+++ b/app/tests/algorithms_tests/test_tasks.py
@@ -9,7 +9,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.base import ContentFile, File
 from requests import put
 
-from grandchallenge.algorithms.models import DEFAULT_INPUT_INTERFACE_SLUG, Job
+from grandchallenge.algorithms.models import Job
 from grandchallenge.algorithms.tasks import (
     create_algorithm_jobs,
     execute_algorithm_job_for_inputs,
@@ -50,9 +50,7 @@ from tests.utils import get_view_for_user, recurse_callbacks
 class TestCreateAlgorithmJobs:
     @property
     def default_input_interface(self):
-        return ComponentInterface.objects.get(
-            slug=DEFAULT_INPUT_INTERFACE_SLUG
-        )
+        return ComponentInterface.objects.get(slug="generic-medical-image")
 
     def test_no_images_does_nothing(self):
         ai = AlgorithmImageFactory()
@@ -76,9 +74,11 @@ class TestCreateAlgorithmJobs:
     def test_creates_job_correctly(self):
         ai = AlgorithmImageFactory()
         image = ImageFactory()
-        civ = ComponentInterfaceValueFactory(
-            image=image, interface=ai.algorithm.inputs.get()
+        interface = ComponentInterface.objects.get(
+            slug="generic-medical-image"
         )
+        ai.algorithm.inputs.set([interface])
+        civ = ComponentInterfaceValueFactory(image=image, interface=interface)
         assert Job.objects.count() == 0
         jobs = create_algorithm_jobs(algorithm_image=ai, civ_sets=[{civ}])
         assert Job.objects.count() == 1
@@ -86,7 +86,7 @@ class TestCreateAlgorithmJobs:
         assert j.algorithm_image == ai
         assert j.creator is None
         assert (
-            j.inputs.get(interface__slug=DEFAULT_INPUT_INTERFACE_SLUG).image
+            j.inputs.get(interface__slug="generic-medical-image").image
             == image
         )
         assert j.pk == jobs[0].pk
@@ -94,9 +94,10 @@ class TestCreateAlgorithmJobs:
     def test_is_idempotent(self):
         ai = AlgorithmImageFactory()
         image = ImageFactory()
-        civ = ComponentInterfaceValueFactory(
-            image=image, interface=ai.algorithm.inputs.get()
+        interface = ComponentInterface.objects.get(
+            slug="generic-medical-image"
         )
+        civ = ComponentInterfaceValueFactory(image=image, interface=interface)
         assert Job.objects.count() == 0
         create_algorithm_jobs(algorithm_image=ai, civ_sets=[{civ}])
         assert Job.objects.count() == 1
@@ -106,9 +107,10 @@ class TestCreateAlgorithmJobs:
 
     def test_extra_viewer_groups(self):
         ai = AlgorithmImageFactory()
-        civ = ComponentInterfaceValueFactory(
-            interface=ai.algorithm.inputs.get()
+        interface = ComponentInterface.objects.get(
+            slug="generic-medical-image"
         )
+        civ = ComponentInterfaceValueFactory(interface=interface)
         groups = (GroupFactory(), GroupFactory(), GroupFactory())
         jobs = create_algorithm_jobs(
             algorithm_image=ai, civ_sets=[{civ}], extra_viewer_groups=groups
@@ -129,12 +131,9 @@ def test_no_jobs_workflow(django_capture_on_commit_callbacks):
 def test_jobs_workflow(django_capture_on_commit_callbacks):
     ai = AlgorithmImageFactory()
     images = [ImageFactory(), ImageFactory()]
+    interface = ComponentInterface.objects.get(slug="generic-medical-image")
     civ_sets = [
-        {
-            ComponentInterfaceValueFactory(
-                image=im, interface=ai.algorithm.inputs.get()
-            )
-        }
+        {ComponentInterfaceValueFactory(image=im, interface=interface)}
         for im in images
     ]
     with django_capture_on_commit_callbacks() as callbacks:
@@ -173,13 +172,24 @@ def test_algorithm(
     image_file = ImageFileFactory(
         file__from_path=Path(__file__).parent / "resources" / "input_file.tif"
     )
-    civ = ComponentInterfaceValueFactory(
-        image=image_file.image, interface=alg.algorithm.inputs.get(), file=None
+
+    input_interface = ComponentInterface.objects.get(
+        slug="generic-medical-image"
     )
-    assert civ.interface.slug == "generic-medical-image"
+    json_result_interface = ComponentInterface.objects.get(
+        slug="results-json-file"
+    )
+    heatmap_interface = ComponentInterface.objects.get(slug="generic-overlay")
+    alg.algorithm.inputs.set([input_interface])
+    alg.algorithm.outputs.set([json_result_interface, heatmap_interface])
+
+    civ = ComponentInterfaceValueFactory(
+        image=image_file.image, interface=input_interface, file=None
+    )
 
     with django_capture_on_commit_callbacks() as callbacks:
         create_algorithm_jobs(algorithm_image=alg, civ_sets=[{civ}])
+
     recurse_callbacks(
         callbacks=callbacks,
         django_capture_on_commit_callbacks=django_capture_on_commit_callbacks,
@@ -199,16 +209,13 @@ def test_algorithm(
     # The job should have two ComponentInterfaceValues,
     # one for the results.json and one for output.tif
     assert len(jobs[0].outputs.all()) == 2
-    json_result_interface = ComponentInterface.objects.get(
-        slug="results-json-file"
-    )
+
     json_result_civ = jobs[0].outputs.get(interface=json_result_interface)
     assert json_result_civ.value == {
         "entity": "out.tif",
         "metrics": {"abnormal": 0.19, "normal": 0.81},
     }
 
-    heatmap_interface = ComponentInterface.objects.get(slug="generic-overlay")
     heatmap_civ = jobs[0].outputs.get(interface=heatmap_interface)
 
     assert heatmap_civ.image.name == "output.tif"
@@ -227,11 +234,12 @@ def test_algorithm(
         file__from_path=Path(__file__).parent / "resources" / "input_file.tif"
     )
     civ = ComponentInterfaceValueFactory(
-        image=image_file.image, interface=alg.algorithm.inputs.get(), file=None
+        image=image_file.image, interface=input_interface, file=None
     )
 
     with django_capture_on_commit_callbacks() as callbacks:
         create_algorithm_jobs(algorithm_image=alg, civ_sets=[{civ}])
+
     recurse_callbacks(
         callbacks=callbacks,
         django_capture_on_commit_callbacks=django_capture_on_commit_callbacks,
@@ -253,7 +261,7 @@ def test_algorithm(
 
 @pytest.mark.django_db
 def test_algorithm_with_invalid_output(
-    client, algorithm_image, settings, django_capture_on_commit_callbacks
+    algorithm_image, settings, django_capture_on_commit_callbacks
 ):
     # Override the celery settings
     settings.task_eager_propagates = (True,)
@@ -275,19 +283,25 @@ def test_algorithm_with_invalid_output(
     alg.refresh_from_db()
 
     # Make sure the job fails when trying to upload an invalid file
+    input_interface = ComponentInterface.objects.get(
+        slug="generic-medical-image"
+    )
     detection_interface = ComponentInterfaceFactory(
         store_in_database=False,
         relative_path="some_text.txt",
         slug="detection-json-file",
         kind=ComponentInterface.Kind.ANY,
     )
+    alg.algorithm.inputs.add(input_interface)
     alg.algorithm.outputs.add(detection_interface)
     alg.save()
+
     image_file = ImageFileFactory(
         file__from_path=Path(__file__).parent / "resources" / "input_file.tif"
     )
+
     civ = ComponentInterfaceValueFactory(
-        image=image_file.image, interface=alg.algorithm.inputs.get(), file=None
+        image=image_file.image, interface=input_interface, file=None
     )
 
     with django_capture_on_commit_callbacks() as callbacks:
@@ -310,7 +324,6 @@ def test_algorithm_with_invalid_output(
 
 @pytest.mark.django_db
 def test_algorithm_multiple_inputs(
-    client,
     algorithm_io_image,
     settings,
     component_interfaces,
@@ -399,7 +412,7 @@ def test_algorithm_multiple_inputs(
 
 @pytest.mark.django_db
 def test_algorithm_input_image_multiple_files(
-    client, settings, component_interfaces, django_capture_on_commit_callbacks
+    settings, component_interfaces, django_capture_on_commit_callbacks
 ):
     # Override the celery settings
     settings.task_eager_propagates = (True,)
@@ -418,7 +431,7 @@ def test_algorithm_input_image_multiple_files(
 
     ImageFactory(origin=us)
     ImageFactory(origin=us)
-    ci = ComponentInterface.objects.get(slug=DEFAULT_INPUT_INTERFACE_SLUG)
+    ci = ComponentInterface.objects.get(slug="generic-medical-image")
 
     civ = ComponentInterfaceValue.objects.create(interface=ci)
 
@@ -442,7 +455,7 @@ def test_algorithm_input_image_multiple_files(
 
 @pytest.mark.django_db
 def test_algorithm_input_user_upload(
-    client, settings, component_interfaces, django_capture_on_commit_callbacks
+    settings, component_interfaces, django_capture_on_commit_callbacks
 ):
     # Override the celery settings
     settings.task_eager_propagates = (True,)
@@ -518,7 +531,7 @@ def test_add_image_to_component_interface_value():
     us = RawImageUploadSessionFactory()
     ImageFactory(origin=us)
     ImageFactory(origin=us)
-    ci = ComponentInterface.objects.get(slug=DEFAULT_INPUT_INTERFACE_SLUG)
+    ci = ComponentInterface.objects.get(slug="generic-medical-image")
 
     civ = ComponentInterfaceValueFactory(interface=ci, image=None, file=None)
 
@@ -541,7 +554,7 @@ def test_add_image_to_component_interface_value():
 
 
 @pytest.mark.django_db
-def test_execute_algorithm_job_for_inputs(client, settings):
+def test_execute_algorithm_job_for_inputs(settings):
     # Override the celery settings
     settings.task_eager_propagates = (True,)
     settings.task_always_eager = (True,)
@@ -553,7 +566,7 @@ def test_execute_algorithm_job_for_inputs(client, settings):
     alg.algorithm.add_editor(creator)
 
     # create the job without value for the ComponentInterfaceValues
-    ci = ComponentInterface.objects.get(slug=DEFAULT_INPUT_INTERFACE_SLUG)
+    ci = ComponentInterface.objects.get(slug="generic-medical-image")
     civ = ComponentInterfaceValue.objects.create(interface=ci)
     job = Job.objects.create(
         creator=creator, algorithm_image=alg, input_civ_set=[civ]

--- a/scripts/development_fixtures.py
+++ b/scripts/development_fixtures.py
@@ -1,6 +1,5 @@
 import base64
 import itertools
-import json
 import logging
 import random
 
@@ -22,7 +21,7 @@ from machina.apps.forum.models import Forum
 from grandchallenge.algorithms.models import Algorithm, AlgorithmImage, Job
 from grandchallenge.anatomy.models import BodyRegion, BodyStructure
 from grandchallenge.archives.models import Archive, ArchiveItem
-from grandchallenge.cases.models import Image
+from grandchallenge.cases.models import Image, ImageFile
 from grandchallenge.challenges.models import Challenge, ChallengeSeries
 from grandchallenge.components.models import (
     ComponentInterface,
@@ -50,7 +49,10 @@ from grandchallenge.reader_studies.models import (
 from grandchallenge.task_categories.models import TaskType
 from grandchallenge.verifications.models import Verification
 from grandchallenge.workstations.models import Workstation
-from scripts.algorithm_evaluation_fixtures import _gc_demo_algorithm
+from scripts.algorithm_evaluation_fixtures import (
+    _gc_demo_algorithm,
+    _uploaded_image_file,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -328,36 +330,39 @@ def _create_task_types_regions_modalities(users):
 
 
 def _create_algorithm_demo(users):
-    cases_image = Image(
+    cases_image = Image.objects.create(
         name="test_image.mha",
-        modality=ImagingModality.objects.get(modality="MR"),
-        width=128,
-        height=128,
-        color_space="RGB",
+        width=10,
+        height=10,
     )
-    cases_image.save()
+
+    im_file = ImageFile.objects.create(image=cases_image)
+
+    with _uploaded_image_file() as f:
+        im_file.file.save("test_image.mha", f)
+        im_file.save()
+
+    (input_civ, _) = ComponentInterfaceValue.objects.get_or_create(
+        interface=ComponentInterface.objects.get(slug="generic-medical-image"),
+        image=cases_image,
+    )
 
     algorithm = Algorithm.objects.create(
         title="Test Algorithm",
         logo=create_uploaded_image(),
         repo_name="github-username/repo-name",
+        contact_email="example@example.org",
+        display_editors=True,
+        result_template="{% for key, value in results.items() %}\n{{ key }}:  {{ value }}\n{% endfor %}",
     )
     algorithm.editors_group.user_set.add(users["algorithm"], users["demo"])
     algorithm.users_group.user_set.add(users["algorithmuser"])
-    algorithm.result_template = (
-        "{% for key, value in results.metrics.items() -%}"
-        "{{ key }}  {{ value }}"
-        "{% endfor %}"
+    algorithm.inputs.set(
+        [ComponentInterface.objects.get(slug="generic-medical-image")]
     )
-    detection_interface = ComponentInterface(
-        store_in_database=False,
-        relative_path="detection_results.json",
-        slug="detection-results",
-        title="Detection Results",
-        kind=ComponentInterface.Kind.ANY,
+    algorithm.outputs.set(
+        [ComponentInterface.objects.get(slug="results-json-file")]
     )
-    detection_interface.save()
-    algorithm.outputs.add(detection_interface)
 
     algorithm_image = AlgorithmImage(
         creator=users["algorithm"], algorithm=algorithm
@@ -367,66 +372,30 @@ def _create_algorithm_demo(users):
         algorithm_image.image.save("algorithm_io.tar", container)
 
     results = [
-        {"cancer_score": 0.5},
-        {"cancer_score": 0.6},
-        {"cancer_score": 0.7},
+        {"score": 0.5},
+        {"score": 0.6},
+        {"score": 0.7},
     ]
 
-    detections = [
-        {
-            "detected points": [
-                {"type": "Point", "start": [0, 1, 2], "end": [3, 4, 5]}
-            ]
-        },
-        {
-            "detected points": [
-                {"type": "Point", "start": [6, 7, 8], "end": [9, 10, 11]}
-            ]
-        },
-        {
-            "detected points": [
-                {"type": "Point", "start": [12, 13, 14], "end": [15, 16, 17]}
-            ]
-        },
-    ]
-    for res, det in zip(results, detections, strict=True):
-        _create_job_result(users, algorithm_image, cases_image, res, det)
+    for result in results:
+        algorithms_job = Job.objects.create(
+            creator=users["algorithm"],
+            algorithm_image=algorithm_image,
+            status=Evaluation.SUCCESS,
+        )
+
+        algorithms_job.inputs.add(input_civ)
+
+        algorithms_job.outputs.add(
+            ComponentInterfaceValue.objects.create(
+                interface=ComponentInterface.objects.get(
+                    slug="results-json-file"
+                ),
+                value=result,
+            )
+        )
 
     return algorithm
-
-
-def _create_job_result(users, algorithm_image, cases_image, result, detection):
-    algorithms_job = Job(
-        creator=users["algorithm"],
-        algorithm_image=algorithm_image,
-        status=Evaluation.SUCCESS,
-    )
-    algorithms_job.save()
-    algorithms_job.inputs.add(
-        ComponentInterfaceValue.objects.create(
-            interface=ComponentInterface.objects.get(
-                slug="generic-medical-image"
-            ),
-            image=cases_image,
-        )
-    )
-    algorithms_job.outputs.add(
-        ComponentInterfaceValue.objects.create(
-            interface=ComponentInterface.objects.get(slug="results-json-file"),
-            value=result,
-        )
-    )
-    civ = ComponentInterfaceValue.objects.create(
-        interface=ComponentInterface.objects.get(slug="detection-results")
-    )
-    civ.file.save(
-        "detection_results.json",
-        ContentFile(
-            bytes(json.dumps(detection, ensure_ascii=True, indent=2), "utf-8")
-        ),
-    )
-
-    algorithms_job.outputs.add(civ)
 
 
 def _create_workstation(users):


### PR DESCRIPTION
I have fixed a couple of things in the development fixtures that were bugging me:

- Warning emails emitted by Celery on startup comic/grand-challenge.org@487beff16798623eac0ea916d0ca47898ada7566
- Couldn't run a job using the fixture algorithm comic/grand-challenge.org@77f4cddbefadc193fcb744d455da9c39128c68b2

Now, a developer can create algorithm jobs for the algorithm fixture without having to upload anything. These jobs will succeed. Also, the algorithm form no longer displays warnings.

I removed setting the default interfaces as I think this was a legacy thing from when we would not get users to define them. It should be properly deprecated now.