### PR TITLE
Add dummy letter to upload widget ID for interfaces starting with a number

### DIFF
--- a/app/grandchallenge/cases/templates/cases/flexible_image_widget.html
+++ b/app/grandchallenge/cases/templates/cases/flexible_image_widget.html
@@ -4,7 +4,7 @@
         name="WidgetChoice-{{ widget.name }}"
         id="widgetSelect-{{ widget.name }}"
         hx-get="{% url 'cases:select-image-widget' %}"
-        hx-target="#{{ widget.name }}-area"
+        hx-target="#area-{{ widget.name }}"
         hx-trigger="widgetSelected, change"
         hx-include="[id='values-{{ widget.name }}']"
 >
@@ -23,6 +23,6 @@
     <input type="hidden" name="current_value" value="{{ widget.attrs.current_value.image.pk }}">
 </div>
 
-<div class="mt-3" id="{{ widget.name }}-area"></div>
+<div class="mt-3" id="area-{{ widget.name }}"></div>
 
 <script type="text/javascript" src="{% static "cases/js/flexible_image_widget.js" %}"></script>

--- a/app/grandchallenge/uploads/widgets.py
+++ b/app/grandchallenge/uploads/widgets.py
@@ -1,3 +1,5 @@
+import re
+
 from django.forms.widgets import HiddenInput, MultipleHiddenInput
 
 
@@ -11,8 +13,11 @@ class UserUploadWidgetMixin:
 
     def get_context(self, *args, **kwargs):
         context = super().get_context(*args, **kwargs)
+        widget_id = context["widget"]["attrs"]["id"]
+        if re.match(r"^\d", widget_id):
+            context["widget"]["attrs"]["id"] = f"X_{widget_id}"
         context["widget"]["allowed_file_types"] = {
-            "id": f"{context['widget']['attrs']['id']}AllowedFileTypes",
+            "id": f"{widget_id}AllowedFileTypes",
             "value": self.allowed_file_types,
         }
         return context

--- a/app/grandchallenge/uploads/widgets.py
+++ b/app/grandchallenge/uploads/widgets.py
@@ -15,6 +15,7 @@ class UserUploadWidgetMixin:
         context = super().get_context(*args, **kwargs)
         widget_id = context["widget"]["attrs"]["id"]
         if re.match(r"^\d", widget_id):
+            # id names cannot start with a number in CSS
             context["widget"]["attrs"]["id"] = f"X_{widget_id}"
         context["widget"]["allowed_file_types"] = {
             "id": f"{widget_id}AllowedFileTypes",

--- a/app/grandchallenge/uploads/widgets.py
+++ b/app/grandchallenge/uploads/widgets.py
@@ -1,5 +1,3 @@
-import re
-
 from django.forms.widgets import HiddenInput, MultipleHiddenInput
 
 
@@ -13,10 +11,8 @@ class UserUploadWidgetMixin:
 
     def get_context(self, *args, **kwargs):
         context = super().get_context(*args, **kwargs)
-        widget_id = context["widget"]["attrs"]["id"]
-        if re.match(r"^\d", widget_id):
-            # id names cannot start with a number in CSS
-            context["widget"]["attrs"]["id"] = f"X_{widget_id}"
+        widget_id = f'X_{context["widget"]["attrs"]["id"]}'
+        context["widget"]["attrs"]["id"] = widget_id
         context["widget"]["allowed_file_types"] = {
             "id": f"{widget_id}AllowedFileTypes",
             "value": self.allowed_file_types,

--- a/app/tests/algorithms_tests/test_forms.py
+++ b/app/tests/algorithms_tests/test_forms.py
@@ -250,7 +250,7 @@ def test_algorithm_create(client, uploaded_image):
             "anything",
             [
                 'class="user-upload"',
-                '<div id="id_anything-drag-drop"',
+                '<div id="X_id_anything-drag-drop"',
             ],
         ),
     ),


### PR DESCRIPTION
An id name cannot start with a number in CSS (despite being valid HTML). Interfaces starting with a number break our upload widget because of that. 

Closes #3256 