### PR TITLE
Fix bug with first names for individual messages

### DIFF
--- a/app/grandchallenge/direct_messages/models.py
+++ b/app/grandchallenge/direct_messages/models.py
@@ -85,7 +85,9 @@ def email_subscribed_users_about_new_message(
 ):
     if action != "post_add" or reverse:
         return
+
     site = Site.objects.get_current()
+
     for user in (
         instance.unread_by.select_related("user_profile")
         .filter(

--- a/app/grandchallenge/notifications/tasks.py
+++ b/app/grandchallenge/notifications/tasks.py
@@ -39,4 +39,7 @@ def send_unread_notification_emails():
     )
 
     for profile in profiles.iterator():
-        profile.dispatch_unread_notifications_email(site=site)
+        profile.dispatch_unread_notifications_email(
+            site=site,
+            unread_notification_count=profile.unread_notification_count,
+        )


### PR DESCRIPTION
I noticed that `dispatch_unread_direct_messages_email` was being sent a user instance when it expected a first name string, this would have worked but you would have had the strange thing of "<User object 'James'> just sent you a direct message" in the emails.

Also:

- Make all arguments required (better to check with `if x is None` when you have optional kwargs, but in this case I didn't see a reason to keep the default of None as the work was better suited to be done near the places the dispatch methods were called)
- Remove circular dependency workaround