### PR TITLE
Simplify json error reporting

### DIFF
--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1049,7 +1049,7 @@ def add_file_to_component_interface_value(
             civ.full_clean()
         except ValidationError as e:
             civ.delete()
-            error = str(e)
+            error = str(e.message)
         else:
             user_upload.copy_object(to_field=civ.file)
             civ.save()
@@ -1200,7 +1200,7 @@ def add_file_to_object(
             civ = ComponentInterfaceValue.objects.get(pk=civ_pk)
             object.values.remove(civ)
     except ValidationError as e:
-        error = str(e)
+        error = str(e.message)
 
     if error is not None:
         Notification.send(
@@ -1209,7 +1209,7 @@ def add_file_to_object(
             message=f"File for interface {interface.title} failed validation.",
             target=object.base_object,
             description=(
-                f"File for interface {interface.title} added to {object_pk} "
-                f"in {object.base_object.title} failed validation:\n{error}."
+                f"File for interface {interface.title} "
+                f"failed validation:\n{error}."
             ),
         )

--- a/app/grandchallenge/core/validators.py
+++ b/app/grandchallenge/core/validators.py
@@ -161,7 +161,9 @@ class JSONValidator:
         try:
             validate(value, self.schema, registry=self.registry)
         except JSONValidationError as e:
-            raise ValidationError(f"JSON does not fulfill schema: {e}")
+            raise ValidationError(
+                f"JSON does not fulfill schema: instance {e.message.replace(str(e.instance), '')}"
+            )
 
     def __eq__(self, other):
         return isinstance(other, JSONValidator) and self.schema == other.schema

--- a/app/grandchallenge/core/validators.py
+++ b/app/grandchallenge/core/validators.py
@@ -162,7 +162,7 @@ class JSONValidator:
             validate(value, self.schema, registry=self.registry)
         except JSONValidationError as e:
             raise ValidationError(
-                f"JSON does not fulfill schema: instance {e.message.replace(str(e.instance), '')}"
+                f"JSON does not fulfill schema: instance {e.message.replace(str(e.instance) + ' ', '')}"
             )
 
     def __eq__(self, other):

--- a/app/tests/components_tests/test_serializers.py
+++ b/app/tests/components_tests/test_serializers.py
@@ -346,7 +346,7 @@ def test_civ_post_value_required(kind):
 
     # verify
     assert not serializer.is_valid()
-    assert "JSON does not fulfill schema: None is not of type" in str(
+    assert "JSON does not fulfill schema: instance is not of type" in str(
         serializer.errors["__all__"][0]
     )
 


### PR DESCRIPTION
Json validation errors used to include the instance (the submitted json), the schema and the error. This changes the reporting to only print the error message without the schema and instance. This is a temporary fix until this is implemented: https://github.com/python-jsonschema/jsonschema/issues/1218 

It also standardizes the message for `FILE_COPY_STATUS` notifications, opting for the less verbose version. 