### PR TITLE
Add CIVSet bulk delete view

### DIFF
--- a/app/grandchallenge/components/forms.py
+++ b/app/grandchallenge/components/forms.py
@@ -1,9 +1,18 @@
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import ButtonHolder, Layout, Submit
 from dal import autocomplete
 from dal.widgets import Select
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
-from django.forms import Form, HiddenInput, ModelChoiceField, ModelForm
+from django.forms import (
+    CheckboxSelectMultiple,
+    Form,
+    HiddenInput,
+    ModelChoiceField,
+    ModelForm,
+    ModelMultipleChoiceField,
+)
 
 from grandchallenge.algorithms.models import AlgorithmImage
 from grandchallenge.components.form_fields import InterfaceFormField
@@ -327,3 +336,29 @@ class NewFileUploadForm(Form):
         self.fields[interface.slug].widget = UserUploadSingleWidget(
             allowed_file_types=interface.file_mimetypes
         )
+
+
+class CIVSetDeleteForm(Form):
+    civ_sets_to_delete = ModelMultipleChoiceField(
+        queryset=None,
+        label="",
+        widget=CheckboxSelectMultiple,
+    )
+
+    def __init__(self, *args, queryset, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        # prepend button since the list of objects can be long
+        self.helper.layout = Layout(
+            ButtonHolder(
+                Submit(
+                    "save",
+                    "Yes, I confirm that I want to delete all of the below selected items.",
+                    css_class="border-danger bg-danger mb-3",
+                )
+            ),
+            "civ_sets_to_delete",
+        )
+
+        self.fields["civ_sets_to_delete"].queryset = queryset
+        self.fields["civ_sets_to_delete"].initial = queryset

--- a/app/grandchallenge/components/templates/components/civ_set_delete_confirm.html
+++ b/app/grandchallenge/components/templates/components/civ_set_delete_confirm.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags %}
+{% load meta_attr %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{{ base_object.list_url }}">{{ base_object|verbose_name_plural|title }}</a></li>
+        <li class="breadcrumb-item"><a href="{{ base_object.get_absolute_url }}">{{ base_object }}</a></li>
+        <li class="breadcrumb-item active" aria-current="page"><a href="{{ base_object.civ_sets_list_url }}">{{ base_object.civ_set_model|verbose_name_plural|title }}</a></li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <h1>Delete {{ base_object.title }} {{ base_object.civ_set_model|verbose_name_plural|title }}</h1>
+    {% if delete_count == 0 %}
+        <p>No editable {{ base_object.civ_set_model|verbose_name_plural }} selected.</p>
+    {% else %}
+        <h4 class="text-danger font-weight-bold my-3">Are you sure you want to delete the following {{ delete_count }} {{ base_object.civ_set_model|verbose_name_plural }}?</h4>
+        {% crispy form %}
+    {% endif %}
+{% endblock %}

--- a/app/grandchallenge/components/templates/components/civ_set_list.html
+++ b/app/grandchallenge/components/templates/components/civ_set_list.html
@@ -37,7 +37,7 @@
                 id="delete"
                 hx-get="{{ base_object.bulk_delete_url }}"
                 hx-push-url="{{ base_object.bulk_delete_url }}"
-                hx-vals='{"delete_all": "True"}'
+                hx-vals='{"delete-all": "True"}'
                 hx-target="body"
         > Delete all {{ base_object.civ_set_model|verbose_name_plural }}</button>
     </p>

--- a/app/grandchallenge/components/templates/components/civ_set_list.html
+++ b/app/grandchallenge/components/templates/components/civ_set_list.html
@@ -22,9 +22,29 @@
            href="{{ base_object.create_civ_set_batch_url }}"
         ><i class="fas fa-fw fa-plus"></i> Add Image-Only {{ base_object.civ_set_model|verbose_name_plural|title }} (batch)
         </a>
+        <button class="btn btn-danger"
+                name="delete"
+                type="button"
+                id="delete"
+                hx-get="{{ base_object.bulk_delete_url }}"
+                hx-push-url="{{ base_object.bulk_delete_url }}"
+                hx-include="[id='civ-set-table']"
+                hx-target="body"
+        > Delete selected</button>
+        <button class="btn btn-danger"
+                name="delete"
+                type="button"
+                id="delete"
+                hx-get="{{ base_object.bulk_delete_url }}"
+                hx-push-url="{{ base_object.bulk_delete_url }}"
+                hx-vals='{"delete_all": "True"}'
+                hx-target="body"
+        > Delete all {{ base_object.civ_set_model|verbose_name_plural }}</button>
     </p>
 
-    {{ block.super }}
+    <form id="civ-set-table">
+        {{ block.super }}
+    </form>
 
 {% endblock %}
 

--- a/app/grandchallenge/components/templates/components/civ_set_row.html
+++ b/app/grandchallenge/components/templates/components/civ_set_row.html
@@ -7,6 +7,15 @@
 
 {% get_obj_perms request.user for object as "object_perms" %}
 
+
+<input class="checkbox pr-1 mr-1"
+       name="selected-for-deletion"
+       value="{{ object.id }}"
+       type="checkbox"
+       {% if not object.is_editable %} disabled {% endif %}
+>
+<split></split>
+
 {{ object.pk }}
 <split></split>
 

--- a/app/grandchallenge/components/views.py
+++ b/app/grandchallenge/components/views.py
@@ -393,9 +393,7 @@ class CIVSetBulkDeleteView(LoginRequiredMixin, FormView):
     def selected_objects(self):
         # Selecting happens on the ListView through a GET request to this view
         # on POST the selected objects are part of the form field
-        if self.request.method != "GET":
-            return None
-        else:
+        if self.request.method == "GET":
             delete_all = self.request.GET.get("delete-all", None)
             if delete_all:
                 return self.get_queryset()
@@ -406,6 +404,8 @@ class CIVSetBulkDeleteView(LoginRequiredMixin, FormView):
                 # filtering the original queryset
                 # so that only objects with permission are included
                 return self.get_queryset().filter(pk__in=selected)
+        else:
+            return None
 
     def get(self, request, *args, **kwargs):
         return self.render_to_response(self.get_context_data())

--- a/app/grandchallenge/components/views.py
+++ b/app/grandchallenge/components/views.py
@@ -367,11 +367,7 @@ class CIVSetBulkDeleteView(LoginRequiredMixin, FormView):
         context.update(
             {
                 "base_object": self.base_object,
-                "delete_count": (
-                    self.selected_objects.count()
-                    if self.selected_objects
-                    else 0
-                ),
+                "delete_count": (self.selected_objects.count()),
             }
         )
         return context
@@ -405,7 +401,7 @@ class CIVSetBulkDeleteView(LoginRequiredMixin, FormView):
                 # so that only objects with permission are included
                 return self.get_queryset().filter(pk__in=selected)
         else:
-            return None
+            return self.model.objects.none()
 
     def get(self, request, *args, **kwargs):
         return self.render_to_response(self.get_context_data())

--- a/app/grandchallenge/components/views.py
+++ b/app/grandchallenge/components/views.py
@@ -354,6 +354,7 @@ class CIVSetBulkDeleteView(LoginRequiredMixin, FormView):
         raise NotImplementedError
 
     def get_queryset(self, *args, **kwargs):
+        # subset by permission
         permission = f"{self.model._meta.app_label}.delete_{self.model._meta.model_name}"
         return get_objects_for_user(
             user=self.request.user,
@@ -395,7 +396,7 @@ class CIVSetBulkDeleteView(LoginRequiredMixin, FormView):
         if self.request.method != "GET":
             return None
         else:
-            delete_all = self.request.GET.get("delete_all", None)
+            delete_all = self.request.GET.get("delete-all", None)
             if delete_all:
                 return self.get_queryset()
             else:

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -717,6 +717,13 @@ class ReaderStudy(
         )
 
     @property
+    def bulk_delete_url(self):
+        return reverse(
+            "reader-studies:display-sets-bulk-delete",
+            kwargs={"slug": self.slug},
+        )
+
+    @property
     def list_url(self):
         return reverse("reader-studies:list")
 

--- a/app/grandchallenge/reader_studies/urls.py
+++ b/app/grandchallenge/reader_studies/urls.py
@@ -6,6 +6,7 @@ from grandchallenge.reader_studies.views import (
     AddQuestionToReaderStudy,
     AnswersRemoveForUser,
     AnswersRemoveGroundTruth,
+    DisplaySetBulkDeleteView,
     DisplaySetCreateView,
     DisplaySetDeleteView,
     DisplaySetFilesUpdate,
@@ -81,6 +82,11 @@ urlpatterns = [
         "<slug>/display-sets/create/",
         AddDisplaySetsToReaderStudy.as_view(),
         name="display-sets-create",
+    ),
+    path(
+        "<slug>/display-sets/delete/",
+        DisplaySetBulkDeleteView.as_view(),
+        name="display-sets-bulk-delete",
     ),
     path(
         "<slug>/display-sets/create-single/",

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -58,6 +58,7 @@ from grandchallenge.components.serializers import (
     ComponentInterfaceValuePostSerializer,
 )
 from grandchallenge.components.views import (
+    CIVSetBulkDeleteView,
     CIVSetDeleteView,
     CIVSetFormMixin,
     CivSetListView,
@@ -383,6 +384,7 @@ class ReaderStudyDisplaySetList(CivSetListView):
     model = DisplaySet
     permission_required = f"{ReaderStudy._meta.app_label}.change_{DisplaySet._meta.model_name}"  # change instead of view permission so that readers don't get access
     columns = [
+        Column(title=""),
         Column(title="DisplaySet ID", sort_field="pk"),
         Column(title="Order", sort_field="order"),
         *CivSetListView.columns,
@@ -1426,3 +1428,20 @@ class DisplaySetDeleteView(CIVSetDeleteView):
     permission_required = (
         f"{ReaderStudy._meta.app_label}.delete_{DisplaySet._meta.model_name}"
     )
+
+
+class DisplaySetBulkDeleteView(CIVSetBulkDeleteView):
+    model = DisplaySet
+
+    @property
+    def base_object(self):
+        return ReaderStudy.objects.get(slug=self.kwargs["slug"])
+
+    def get_queryset(self, *args, **kwargs):
+        qs = super().get_queryset()
+        return self.base_object.civ_sets_related_manager.filter(
+            pk__in=[ds.pk for ds in qs if ds.is_editable]
+        )
+
+    def get_success_url(self):
+        return self.base_object.civ_sets_list_url

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -389,7 +389,7 @@ class ReaderStudyDisplaySetList(CivSetListView):
         Column(title="Order", sort_field="order"),
         *CivSetListView.columns,
     ]
-    default_sort_column = 1
+    default_sort_column = 2
 
     @cached_property
     def base_object(self):


### PR DESCRIPTION
This adds a bulk delete view for CIV sets and implements this for display sets.

A user can select a subset of (editable) display sets or all display sets (for the given reader study):
![image](https://github.com/comic/grand-challenge.org/assets/30069334/34e7eb65-b3d8-4c73-b3f9-3ff85b5ed846)

... and needs to confirm their selection for actual deletion to happen.
![image](https://github.com/comic/grand-challenge.org/assets/30069334/5c1edb78-d845-4cfd-aa2f-f7a590f0c2b4)

The initial selection of items is sent to a FormView via a GET request. The FormView prepopulates the multi-model select field on the confirmation form with the preselected items and renders that. The user could deselect a few of the options on the confirmation view if they wanted, upon submission, the items are deleted. 


The approach presented here aligns with how the Django admin does things. I also played around with an alternative implementation where the list view is essentially a form with just one `ModelMultipleChoiceField` using the `CheckboxSelectMultiple` widget to select items. Customizing the display of the items in the select widget to show all the other information that is currently displayed, however, was messy and nearly impossible to align to make it looks like a table. Also, enabling sorting and filtering would require a lot of custom code. So dropped that option. 


Closes #3169