### PR TITLE
Add planned start date to the challenge request overview

### DIFF
--- a/app/grandchallenge/challenges/admin.py
+++ b/app/grandchallenge/challenges/admin.py
@@ -10,6 +10,8 @@ from grandchallenge.challenges.models import (
     Challenge,
     ChallengeGroupObjectPermission,
     ChallengeRequest,
+    ChallengeRequestGroupObjectPermission,
+    ChallengeRequestUserObjectPermission,
     ChallengeSeries,
     ChallengeUserObjectPermission,
 )
@@ -128,4 +130,10 @@ class ChallengeRequestAdmin(ModelAdmin):
 
 admin.site.register(ChallengeUserObjectPermission, UserObjectPermissionAdmin)
 admin.site.register(ChallengeGroupObjectPermission, GroupObjectPermissionAdmin)
+admin.site.register(
+    ChallengeRequestUserObjectPermission, UserObjectPermissionAdmin
+)
+admin.site.register(
+    ChallengeRequestGroupObjectPermission, GroupObjectPermissionAdmin
+)
 admin.site.register(ChallengeSeries)

--- a/app/grandchallenge/challenges/templates/challenges/challengerequest_list.html
+++ b/app/grandchallenge/challenges/templates/challenges/challengerequest_list.html
@@ -23,6 +23,7 @@
                 <th class="datatables-non-sortable"></th>
                 <th class="text-center">Acronym</th>
                 <th class="text-center">Creator</th>
+                <th class="text-center">Planned start date</th>
                 <th class="text-center">Submission date</th>
                 <th class="text-center">Status</th>
                 <th class="text-center">Contact</th>
@@ -36,6 +37,7 @@
                         </td>
                         <td class="text-center align-middle">{{ object.short_name }}</td>
                         <td class="text-center align-middle">{{ object.creator|user_profile_link }}</td>
+                        <td class="text-center align-middle" data-order="{{ object.start_date|date:'U' }}">{{ object.start_date|date:'F j, Y' }}</td>
                         {% if object.status == object.ChallengeRequestStatusChoices.ACCEPTED %}
                             <td class="text-center align-middle" data-order="{{ object.created|date:'U' }}"><span class="badge p-2 badge-primary">{{ object.created|date:'F j, Y' }}</span></td>
                             <td class="text-center align-middle"><span class="badge p-2 badge-success">Accepted</span></td>
@@ -52,7 +54,7 @@
                             {% endif %}
                             </td>
                         {% endif %}
-                        <td class="text-center align-middle"><a href="mailto:{{ object.contact_email }}"> {{ object.contact_email }}</a></td>
+                        <td class="text-center align-middle"><a class="btn btn-primary btn-sm" href="mailto:{{ object.contact_email }}"> <i class="fas fa-envelope" aria-hidden="true"></i></a></td>
                     </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
This adds the planned start date to the challenge request overview:
![image](https://github.com/comic/grand-challenge.org/assets/30069334/4f162a87-0ccc-4b1c-9fee-6935bfd24433)


Also adds the direct permission tables to the admin. 