### PR TITLE
Allow solo workers on non TaskPool pools

### DIFF
--- a/app/config/celery.py
+++ b/app/config/celery.py
@@ -4,7 +4,6 @@ from math import ceil
 
 import requests
 from celery import Celery
-from celery.concurrency.solo import TaskPool
 from celery.exceptions import ImproperlyConfigured
 from celery.signals import celeryd_after_setup, task_postrun, task_prerun
 from django.conf import settings
@@ -30,8 +29,8 @@ def check_configuration(*, instance, **__):
     if any(q in instance.app.amqp.queues for q in settings.CELERY_SOLO_QUEUES):
         if instance.concurrency != 1:
             raise ImproperlyConfigured("Worker concurrency must be 1")
-        elif not isinstance(instance.pool, TaskPool):
-            raise ImproperlyConfigured("Worker must use the solo task pool")
+        elif instance.autoscale is not None:
+            raise ImproperlyConfigured("Worker autoscaling must be disabled")
         elif not instance.task_events:
             raise ImproperlyConfigured("Worker must send task events")
         else:

--- a/app/config/celery.py
+++ b/app/config/celery.py
@@ -33,6 +33,8 @@ def check_configuration(*, instance, **__):
             raise ImproperlyConfigured("Worker autoscaling must be disabled")
         elif not instance.task_events:
             raise ImproperlyConfigured("Worker must send task events")
+        elif instance.prefetch_multiplier != 1:
+            raise ImproperlyConfigured("Worker prefetch multiplier must be 1")
         else:
             celery_app.is_solo_worker = True
             logger.info("Worker solo setup OK")

--- a/app/tests/algorithms_tests/test_tasks.py
+++ b/app/tests/algorithms_tests/test_tasks.py
@@ -141,6 +141,7 @@ def test_jobs_workflow(django_capture_on_commit_callbacks):
     assert len(callbacks) == 2
 
 
+@pytest.mark.flaky(reruns=3)
 @pytest.mark.django_db
 def test_algorithm(
     algorithm_image, settings, django_capture_on_commit_callbacks


### PR DESCRIPTION
There is no reason to restrict solo execution to TaskPools, just need to check that the concurrency is set and the autoscaling is off. Also adds a check to ensure the prefetch multiplier is unset.