### PR TITLE
Update algorithm job detail API: add url and algorithm, remove algorithm_title

### DIFF
--- a/app/grandchallenge/algorithms/serializers.py
+++ b/app/grandchallenge/algorithms/serializers.py
@@ -84,7 +84,6 @@ class JobSerializer(serializers.ModelSerializer):
     """Serializer without hyperlinks for internal use"""
 
     algorithm_image = StringRelatedField()
-    algorithm = StringRelatedField()
 
     inputs = ComponentInterfaceValueSerializer(many=True)
     outputs = ComponentInterfaceValueSerializer(many=True)
@@ -113,7 +112,6 @@ class JobSerializer(serializers.ModelSerializer):
             "url",
             "api_url",
             "algorithm_image",
-            "algorithm",
             "inputs",
             "outputs",
             "status",
@@ -143,7 +141,10 @@ class HyperlinkedJobSerializer(JobSerializer):
     outputs = HyperlinkedComponentInterfaceValueSerializer(many=True)
 
     class Meta(JobSerializer.Meta):
-        pass
+        fields = [
+            *JobSerializer.Meta.fields,
+            "algorithm",
+        ]
 
 
 class JobPostSerializer(JobSerializer):

--- a/app/grandchallenge/algorithms/serializers.py
+++ b/app/grandchallenge/algorithms/serializers.py
@@ -84,13 +84,13 @@ class JobSerializer(serializers.ModelSerializer):
     """Serializer without hyperlinks for internal use"""
 
     algorithm_image = StringRelatedField()
+    algorithm = StringRelatedField()
+
     inputs = ComponentInterfaceValueSerializer(many=True)
     outputs = ComponentInterfaceValueSerializer(many=True)
 
     status = CharField(source="get_status_display", read_only=True)
-    algorithm_title = CharField(
-        source="algorithm_image.algorithm.title", read_only=True
-    )
+    url = URLField(source="get_absolute_url", read_only=True)
     hanging_protocol = HangingProtocolSerializer(
         source="algorithm_image.algorithm.hanging_protocol",
         read_only=True,
@@ -110,13 +110,14 @@ class JobSerializer(serializers.ModelSerializer):
         model = Job
         fields = [
             "pk",
+            "url",
             "api_url",
             "algorithm_image",
+            "algorithm",
             "inputs",
             "outputs",
             "status",
             "rendered_result_text",
-            "algorithm_title",
             "started_at",
             "completed_at",
             "hanging_protocol",
@@ -132,6 +133,12 @@ class HyperlinkedJobSerializer(JobSerializer):
         queryset=AlgorithmImage.objects.all(),
         view_name="api:algorithms-image-detail",
     )
+    algorithm = HyperlinkedRelatedField(
+        source="algorithm_image.algorithm",
+        view_name="api:algorithm-detail",
+        read_only=True,
+    )
+
     inputs = HyperlinkedComponentInterfaceValueSerializer(many=True)
     outputs = HyperlinkedComponentInterfaceValueSerializer(many=True)
 

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -862,7 +862,11 @@ class JobViewSet(
 ):
     queryset = (
         Job.objects.all()
-        .prefetch_related("outputs__interface", "inputs__interface")
+        .prefetch_related(
+            "outputs__interface",
+            "inputs__interface",
+            "algorithm_image__algorithm__optional_hanging_protocols",
+        )
         .select_related(
             "algorithm_image__algorithm__hanging_protocol",
         )

--- a/app/tests/algorithms_tests/test_serializers.py
+++ b/app/tests/algorithms_tests/test_serializers.py
@@ -18,14 +18,14 @@ from tests.factories import ImageFactory, UserFactory
 
 
 @pytest.mark.django_db
-def test_algorithm_title_on_job_serializer(rf):
+def test_algorithm_relations_on_job_serializer(rf):
     job = AlgorithmJobFactory()
     serializer = HyperlinkedJobSerializer(
-        job, context={"request": rf.get("/foo")}
+        job, context={"request": rf.get("/foo", secure=True)}
     )
+    assert serializer.data["algorithm_image"] == job.algorithm_image.api_url
     assert (
-        serializer.data["algorithm_title"]
-        == job.algorithm_image.algorithm.title
+        serializer.data["algorithm"] == job.algorithm_image.algorithm.api_url
     )
 
 


### PR DESCRIPTION
Part of the pitch:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/314

This PR adds a `url` to the job detail API to directly link to the regular detail view. To be added to CIRRUS.

It also removes `algorithm_title` and replaces it with a hyperlinked relation to the algorithm itself. The rationale is that the title has no place in this serialisation. However, to get the title, a requester would need to traverse via the `AlgorithmImage`, which only admins of an algorithm would have access to (?). Adding a direct rel to the algorithm enables a callee to retrieve the algorithm title via a secondary call to get details on the algorithm. The algorithm details are public.

