### PR TITLE
Make the answer_type choice explicit for questions

### DIFF
--- a/app/grandchallenge/reader_studies/forms.py
+++ b/app/grandchallenge/reader_studies/forms.py
@@ -300,7 +300,10 @@ class QuestionForm(SaveFormInitMixin, DynamicFormMixin, ModelForm):
                 "hx-target": "#id_interface",
             }
         )
-        self.fields["answer_type"].choices = AnswerType.choices
+        self.fields["answer_type"].choices = [
+            *BLANK_CHOICE_DASH,
+            *AnswerType.choices,
+        ]
 
         self.helper = FormHelper()
         self.helper.form_tag = True

--- a/app/grandchallenge/reader_studies/forms.py
+++ b/app/grandchallenge/reader_studies/forms.py
@@ -364,7 +364,7 @@ class QuestionForm(SaveFormInitMixin, DynamicFormMixin, ModelForm):
         if answer_type is None:
             return ComponentInterface.objects.none()
         return ComponentInterface.objects.filter(
-            kind__in=ANSWER_TYPE_TO_INTERFACE_KIND_MAP[answer_type]
+            kind__in=ANSWER_TYPE_TO_INTERFACE_KIND_MAP.get(answer_type, [])
         )
 
     def widget_choices(self):

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1040,6 +1040,7 @@ class QuestionWidgetKindChoices(models.TextChoices):
 
 
 ANSWER_TYPE_TO_QUESTION_WIDGET = {
+    "": [],  # Blank answer type
     AnswerType.TEXT: [
         QuestionWidgetKindChoices.TEXT_INPUT,
         QuestionWidgetKindChoices.TEXT_AREA,

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1040,7 +1040,6 @@ class QuestionWidgetKindChoices(models.TextChoices):
 
 
 ANSWER_TYPE_TO_QUESTION_WIDGET = {
-    "": [],  # Blank answer type
     AnswerType.TEXT: [
         QuestionWidgetKindChoices.TEXT_INPUT,
         QuestionWidgetKindChoices.TEXT_AREA,

--- a/app/tests/reader_studies_tests/test_forms.py
+++ b/app/tests/reader_studies_tests/test_forms.py
@@ -1394,12 +1394,16 @@ def test_display_set_add_interface_form():
                 ("SELECT_MULTIPLE", "Select Multiple"),
             ],
         ),
+        (None, BLANK_CHOICE_DASH),
         (AnswerType.MASK, BLANK_CHOICE_DASH),
     ),
 )
 def test_question_form_answer_widget_choices(answer_type, choices):
     form = QuestionForm(
-        reader_study=ReaderStudyFactory(), initial={"answer_type": answer_type}
+        reader_study=ReaderStudyFactory(),
+        initial=(
+            {"answer_type": answer_type} if answer_type is not None else {}
+        ),
     )
     assert form.widget_choices() == choices
 


### PR DESCRIPTION
This PR will have the question creation form start with a blank answer.

As a side effect, it fixes a bug with the widget choices being empty at first load. Now them being empty is correct =P