### PR TITLE
Generalize section rendering for workstation configuration pages

### DIFF
--- a/app/grandchallenge/workstation_configs/forms.py
+++ b/app/grandchallenge/workstation_configs/forms.py
@@ -10,60 +10,15 @@ from grandchallenge.workstation_configs.models import (
     KEY_BINDINGS_SCHEMA,
     OVERLAY_SEGMENTS_SCHEMA,
     WorkstationConfig,
-    VisualGroups,
 )
+
+from .visual_field_ordering import FORM_FIELDS, GROUPS
 
 
 class WorkstationConfigForm(ModelForm):
     class Meta:
         model = WorkstationConfig
-        fields = (
-            "title",
-            "description",
-            "image_context",
-            "window_presets",
-            "default_window_preset",
-            "default_slab_thickness_mm",
-            "default_slab_render_method",
-            "default_orientation",
-            "default_overlay_alpha",
-            "overlay_luts",
-            "default_overlay_lut",
-            "default_image_interpolation",
-            "default_limit_view_area_to_image_volume",
-            "default_overlay_interpolation",
-            "ghosting_slice_depth",
-            "overlay_segments",
-            "key_bindings",
-            "default_zoom_scale",
-            "default_brush_size",
-            "default_annotation_color",
-            "default_annotation_line_width",
-            "auto_jump_center_of_gravity",
-            "show_image_info_plugin",
-            "show_display_plugin",
-            "show_image_switcher_plugin",
-            "show_algorithm_output_plugin",
-            "show_overlay_plugin",
-            "show_annotation_statistics_plugin",
-            "show_swivel_tool",
-            "show_invert_tool",
-            "show_flip_tool",
-            "show_window_level_tool",
-            "show_reset_tool",
-            "show_overlay_selection_tool",
-            "show_lut_selection_tool",
-            "show_annotation_counter_tool",
-            "enable_contrast_enhancement",
-            "link_images",
-            "link_panning",
-            "link_zooming",
-            "link_slicing",
-            "link_orienting",
-            "link_windowing",
-            "link_inverting",
-            "link_flipping",
-        )
+        fields = FORM_FIELDS
 
         widgets = {
             "overlay_segments": JSONEditorWidget(
@@ -94,32 +49,15 @@ class WorkstationConfigForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        ordered_fields = list(self.fields.keys())
-        DEFAULT_NAME = None
-        field_set_groups: Dict[Optional[str], list] = OrderedDict(
-            (
-                (DEFAULT_NAME, []),
-                *[(k, []) for k in VisualGroups.group_map.keys()],
-            )
-        )
-        for field_name in ordered_fields:
-            for group_name, field_list in reversed(field_set_groups.items()):
-                if (
-                    DEFAULT_NAME == group_name
-                    or field_name in VisualGroups.group_map[group_name].names
-                ):
-                    field_list.append(field_name)
-                    break
-
         helper_fields = []
-        for group_name, field_list in field_set_groups.items():
-            if group := VisualGroups.group_map.get(group_name):
-                helper_fields.append(HTML(f"<h2>{group.title}</h2>"))
-                if desc := group.description:
-                    helper_fields.append(
-                        HTML(f'<p class="text-muted">{desc}</p>')
-                    )
-            helper_fields.extend(field_list)
+        for group in GROUPS:
+            filtered_fields = [fn for fn in group.names if fn in self.fields]
+            if not filtered_fields:
+                continue
+            helper_fields.append(HTML(f"<h2>{group.title}</h2>"))
+            if desc := group.description:
+                helper_fields.append(HTML(f'<p class="text-muted">{desc}</p>'))
+            helper_fields.extend(filtered_fields)
 
         self.helper = FormHelper()
         self.helper.layout = Layout(*helper_fields)

--- a/app/grandchallenge/workstation_configs/forms.py
+++ b/app/grandchallenge/workstation_configs/forms.py
@@ -1,6 +1,3 @@
-from collections import OrderedDict
-from typing import Optional, Dict
-
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Layout, Submit
 from django.forms import ModelForm

--- a/app/grandchallenge/workstation_configs/models.py
+++ b/app/grandchallenge/workstation_configs/models.py
@@ -127,6 +127,7 @@ KEY_BINDINGS_SCHEMA = {
     },
 }
 
+
 class WorkstationConfig(TitleSlugDescriptionModel, UUIDModel):
     class Orientation(models.TextChoices):
         AXIAL = "A", "Axial"
@@ -306,71 +307,58 @@ class WorkstationConfig(TitleSlugDescriptionModel, UUIDModel):
         help_text="A plugin that shows meta-data information derived from image headers "
         "as well as any configured case text for reader studies",
     )
-
     show_display_plugin = models.BooleanField(
         default=True,
         help_text="A plugin that allows control over display properties such as window preset, "
         "slab thickness, or orientation",
     )
-
     show_image_switcher_plugin = models.BooleanField(
         default=True,
         help_text="A plugin that allows switching images when viewing algorithm outputs",
     )
-
     show_algorithm_output_plugin = models.BooleanField(
         default=True,
         help_text="A plugin that shows algorithm outputs, including navigation controls",
     )
-
     show_overlay_plugin = models.BooleanField(
         default=True,
         help_text="A plugin that contains overlay-related controls, "
         "such as the overlay-selection tool and overlay-segmentation visibility",
     )
-
     show_annotation_statistics_plugin = models.BooleanField(
         default=False,
         help_text="A plugin that allows analysis of segmentations. It shows voxel value "
         "statistics of annotated areas.",
     )
-
     show_swivel_tool = models.BooleanField(
         default=False,
         help_text="A tool that allows swiveling the image around axes to view a custom orientation",
     )
-
     show_invert_tool = models.BooleanField(
         default=True,
         help_text="A tool/button that allows inverting the displayed pixel colors of an image",
     )
-
     show_flip_tool = models.BooleanField(
         default=True,
         help_text="A tool/button that allows vertical flipping/mirroring of an image",
     )
-
     show_window_level_tool = models.BooleanField(
         default=True,
         help_text="A tool that allows selection of window presets and changing the window width/center",
     )
-
     show_reset_tool = models.BooleanField(
         default=True,
         help_text="A tool/button that resets all display properties of the images to defaults",
     )
-
     show_overlay_selection_tool = models.BooleanField(
         default=True,
         help_text="A tool that allows switching overlay images when viewing algorithm outputs",
     )
-
     show_lut_selection_tool = models.BooleanField(
         default=True,
         verbose_name="Show overlay-lut selection tool",
         help_text="A tool that allows switching between the overlay-lut presets",
     )
-
     show_annotation_counter_tool = models.BooleanField(
         default=True,
         help_text="A tool that can be used to show summary statistics of annotations within an area",
@@ -400,7 +388,6 @@ class WorkstationConfig(TitleSlugDescriptionModel, UUIDModel):
         default=True,
         help_text="When orienting and the images are linked, they share any new orientation",
     )
-
     link_windowing = models.BooleanField(
         default=True,
         help_text="When changing window setting and the images are linked, they share any new window width/center",

--- a/app/grandchallenge/workstation_configs/models.py
+++ b/app/grandchallenge/workstation_configs/models.py
@@ -1,7 +1,3 @@
-from collections import OrderedDict
-from functools import cached_property
-from typing import Sequence, Dict, List, Optional
-
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.validators import (
@@ -131,56 +127,6 @@ KEY_BINDINGS_SCHEMA = {
     },
 }
 
-
-class Group:
-    title: str
-    description: Optional[str]
-    items: List[models.Field]
-
-    @cached_property
-    def names(self):
-        return tuple(i.name for i in self.items)
-
-    def __init__(self, *, title, description=None):
-        self.title = title
-        self.description = description
-        self.items = []
-
-    def __set_name__(self, owner, name):
-        owner.group_map[name] = self
-
-    def add_to_group(self, other):
-        self.items.append(other)
-        if "names" in vars(self):
-            del vars(self)["names"]
-
-
-class VisualGroups:
-    __instance = None
-
-    group_map: Dict[str, Group] = OrderedDict()
-    _default = Group(title="")
-    annotations = Group(
-        title="Annotations and Overlays",
-        description="Behavior or visualization settings for annotations and overlays.",
-    )
-    plugins_tools = Group(
-        title="Plugin and Tools",
-        description="Plugins are components of the viewer, whereas tools are "
-        "(generally) contained within plugins.",
-    )
-    linking = Group(
-        title="Linking Configuration",
-        description="Linked images share tool interactions and display properties, "
-        "it is possible to manually (un)link them during viewing.",
-    )
-
-    def __new__(cls) -> "VisualGroups":
-        if not (result := cls.__instance):
-            cls.__instance = result = super().__new__(cls)
-        return result
-
-
 class WorkstationConfig(TitleSlugDescriptionModel, UUIDModel):
     class Orientation(models.TextChoices):
         AXIAL = "A", "Axial"
@@ -260,7 +206,6 @@ class WorkstationConfig(TitleSlugDescriptionModel, UUIDModel):
         blank=False,
         help_text="The number of slices a polygon annotation should remain visible for on slices surrounding the annotation slice.",
     )
-    VisualGroups().annotations.add_to_group(ghosting_slice_depth)
 
     overlay_luts = models.ManyToManyField(
         to="LookUpTable",
@@ -269,7 +214,6 @@ class WorkstationConfig(TitleSlugDescriptionModel, UUIDModel):
         help_text="The preset look-up tables options that are used to project overlay-image values to "
         "displayed pixel colors",
     )
-    VisualGroups().annotations.add_to_group(overlay_luts)
 
     default_overlay_lut = models.ForeignKey(
         to="LookUpTable",
@@ -278,7 +222,6 @@ class WorkstationConfig(TitleSlugDescriptionModel, UUIDModel):
         on_delete=models.SET_NULL,
         help_text="The look-up table that is applied when an overlay image is first shown",
     )
-    VisualGroups().annotations.add_to_group(default_overlay_lut)
 
     default_overlay_interpolation = models.CharField(
         max_length=2,
@@ -287,7 +230,6 @@ class WorkstationConfig(TitleSlugDescriptionModel, UUIDModel):
         blank=True,
         help_text="The method used to interpolate multiple voxels of overlay images and project them to screen pixels",
     )
-    VisualGroups().annotations.add_to_group(default_overlay_interpolation)
 
     default_image_interpolation = models.CharField(
         max_length=2,
@@ -314,7 +256,6 @@ class WorkstationConfig(TitleSlugDescriptionModel, UUIDModel):
         ],
         help_text="The alpha value used for setting the degree of opacity for displayed pixels of overlay images",
     )
-    VisualGroups().annotations.add_to_group(default_overlay_alpha)
 
     overlay_segments = models.JSONField(
         default=list,
@@ -322,7 +263,6 @@ class WorkstationConfig(TitleSlugDescriptionModel, UUIDModel):
         validators=[JSONValidator(schema=OVERLAY_SEGMENTS_SCHEMA)],
         help_text="The schema that defines how categories of values in the overlay images are differentiated",
     )
-    VisualGroups().annotations.add_to_group(overlay_segments)
 
     key_bindings = models.JSONField(
         default=list,
@@ -348,160 +288,133 @@ class WorkstationConfig(TitleSlugDescriptionModel, UUIDModel):
         validators=[MinValueValidator(limit_value=1e-6)],  # 1 nm
         help_text="Default brush diameter in millimeters for creating annotations",
     )
-    VisualGroups().annotations.add_to_group(default_brush_size)
 
     default_annotation_color = HexColorField(
         blank=True,
         null=True,
         help_text="Default color for displaying and creating annotations",
     )
-    VisualGroups().annotations.add_to_group(default_annotation_color)
 
     default_annotation_line_width = PositiveSmallIntegerField(
         blank=True,
         null=True,
         help_text="Default line width in pixels for displaying and creating annotations",
     )
-    VisualGroups().annotations.add_to_group(default_annotation_line_width)
 
     show_image_info_plugin = models.BooleanField(
         default=True,
         help_text="A plugin that shows meta-data information derived from image headers "
         "as well as any configured case text for reader studies",
     )
-    VisualGroups().plugins_tools.add_to_group(show_image_info_plugin)
 
     show_display_plugin = models.BooleanField(
         default=True,
         help_text="A plugin that allows control over display properties such as window preset, "
         "slab thickness, or orientation",
     )
-    VisualGroups().plugins_tools.add_to_group(show_display_plugin)
 
     show_image_switcher_plugin = models.BooleanField(
         default=True,
         help_text="A plugin that allows switching images when viewing algorithm outputs",
     )
-    VisualGroups().plugins_tools.add_to_group(show_image_switcher_plugin)
 
     show_algorithm_output_plugin = models.BooleanField(
         default=True,
         help_text="A plugin that shows algorithm outputs, including navigation controls",
     )
-    VisualGroups().plugins_tools.add_to_group(show_image_switcher_plugin)
 
     show_overlay_plugin = models.BooleanField(
         default=True,
         help_text="A plugin that contains overlay-related controls, "
         "such as the overlay-selection tool and overlay-segmentation visibility",
     )
-    VisualGroups().plugins_tools.add_to_group(show_overlay_plugin)
 
     show_annotation_statistics_plugin = models.BooleanField(
         default=False,
         help_text="A plugin that allows analysis of segmentations. It shows voxel value "
         "statistics of annotated areas.",
     )
-    VisualGroups().plugins_tools.add_to_group(
-        show_annotation_statistics_plugin
-    )
 
     show_swivel_tool = models.BooleanField(
         default=False,
         help_text="A tool that allows swiveling the image around axes to view a custom orientation",
     )
-    VisualGroups().plugins_tools.add_to_group(show_swivel_tool)
 
     show_invert_tool = models.BooleanField(
         default=True,
         help_text="A tool/button that allows inverting the displayed pixel colors of an image",
     )
-    VisualGroups().plugins_tools.add_to_group(show_invert_tool)
 
     show_flip_tool = models.BooleanField(
         default=True,
         help_text="A tool/button that allows vertical flipping/mirroring of an image",
     )
-    VisualGroups().plugins_tools.add_to_group(show_flip_tool)
 
     show_window_level_tool = models.BooleanField(
         default=True,
         help_text="A tool that allows selection of window presets and changing the window width/center",
     )
-    VisualGroups().plugins_tools.add_to_group(show_window_level_tool)
 
     show_reset_tool = models.BooleanField(
         default=True,
         help_text="A tool/button that resets all display properties of the images to defaults",
     )
-    VisualGroups().plugins_tools.add_to_group(show_reset_tool)
 
     show_overlay_selection_tool = models.BooleanField(
         default=True,
         help_text="A tool that allows switching overlay images when viewing algorithm outputs",
     )
-    VisualGroups().plugins_tools.add_to_group(show_overlay_selection_tool)
 
     show_lut_selection_tool = models.BooleanField(
         default=True,
         verbose_name="Show overlay-lut selection tool",
         help_text="A tool that allows switching between the overlay-lut presets",
     )
-    VisualGroups().plugins_tools.add_to_group(show_lut_selection_tool)
 
     show_annotation_counter_tool = models.BooleanField(
         default=True,
         help_text="A tool that can be used to show summary statistics of annotations within an area",
     )
-    VisualGroups().plugins_tools.add_to_group(show_lut_selection_tool)
 
     link_images = models.BooleanField(
         default=True,
         help_text="Start with the images linked",
     )
-    VisualGroups().linking.add_to_group(link_images)
 
     link_panning = models.BooleanField(
         default=True,
         help_text="When panning and the images are linked, they share any new position",
     )
-    VisualGroups().linking.add_to_group(link_panning)
 
     link_zooming = models.BooleanField(
         default=True,
         help_text="When zooming and the images are linked, they share any new zoom level",
     )
-    VisualGroups().linking.add_to_group(link_zooming)
 
     link_slicing = models.BooleanField(
         default=True,
         help_text="When scrolling and the images are linked, they share any slice changes",
     )
-    VisualGroups().linking.add_to_group(link_slicing)
 
     link_orienting = models.BooleanField(
         default=True,
         help_text="When orienting and the images are linked, they share any new orientation",
     )
-    VisualGroups().linking.add_to_group(link_orienting)
 
     link_windowing = models.BooleanField(
         default=True,
         help_text="When changing window setting and the images are linked, they share any new window width/center",
     )
-    VisualGroups().linking.add_to_group(link_windowing)
 
     link_inverting = models.BooleanField(
         default=True,
         help_text="When inverting images and the images are linked, they share any new invert state",
     )
-    VisualGroups().linking.add_to_group(link_inverting)
 
     link_flipping = models.BooleanField(
         default=True,
         help_text="When flipping images and the images are linked, they share any new flip state",
     )
-    VisualGroups().linking.add_to_group(link_flipping)
 
     enable_contrast_enhancement = models.BooleanField(
         default=False,
@@ -509,7 +422,6 @@ class WorkstationConfig(TitleSlugDescriptionModel, UUIDModel):
         help_text="A tool that uses image preprocessing to enhance contrast. "
         "It is mainly used for viewing eye-fundus images",
     )
-    VisualGroups().plugins_tools.add_to_group(enable_contrast_enhancement)
 
     auto_jump_center_of_gravity = models.BooleanField(
         default=True,

--- a/app/grandchallenge/workstation_configs/models.py
+++ b/app/grandchallenge/workstation_configs/models.py
@@ -159,6 +159,7 @@ class VisualGroups:
     __instance = None
 
     group_map: Dict[str, Group] = OrderedDict()
+    _default = Group(title="")
     annotations = Group(
         title="Annotations and Overlays",
         description="Behavior or visualization settings for annotations and overlays.",

--- a/app/grandchallenge/workstation_configs/templates/workstation_configs/workstationconfig_detail.html
+++ b/app/grandchallenge/workstation_configs/templates/workstation_configs/workstationconfig_detail.html
@@ -25,7 +25,9 @@
         <p>{{ object.description }}</p>
     {% endif %}
 
-    {% for group_name, group in groups.items %}
+    <p class="text-muted">Hover over the configuration for more information</p>
+
+    {% for group in groups %}
         <h2>{{ group.title }}</h2>
         {% if group.description %}
             <p class="text-muted">{{ group.description }}</p>
@@ -33,313 +35,36 @@
 
         <table class="table table-hover my-3">
         {% for name in group.names %}
-            <tr data-toggle="tooltip" title="{% get_help_text object name %}">
-                <td class="font-weight-bold">{% get_verbose_name object name %}</td>
-                <td>
-                    {% if name == "default_image_interpolation" %}
-                        {{ object.get_default_image_interpolation_display }}
-                    {% elif name == "default_overlay_interpolation" %}
-                        {{ object.get_default_overlay_interpolation_display }}
-                    {% elif object|field_type:name == "BooleanField" %}
-                        <i class="fas {% if object|field_value:name %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-                    {% elif object|field_type:name == "JSONField" %}
-                        {{ object|field_value:name|json_dumps }}
-                    {% elif object|field_type:name == "HexColorField" %}
-                        {{ object|field_value:name }}
-                        {% if object|field_value:name %}
-                            <div class="color-box" style="background-color: {{ object|field_value:name }}"></div>
+            {% if name in shown_field_names %}
+                <tr data-toggle="tooltip" title="{% get_help_text object name %}">
+                    <td class="font-weight-bold">{% get_verbose_name object name %}</td>
+                    <td>
+                        {% if name == "default_image_interpolation" %}
+                            {{ object.get_default_image_interpolation_display }}
+                        {% elif name == "default_overlay_interpolation" %}
+                            {{ object.get_default_overlay_interpolation_display }}
+                        {% elif object|field_type:name == "BooleanField" %}
+                            <i class="fas {% if object|field_value:name %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
+                        {% elif object|field_type:name == "JSONField" %}
+                            {{ object|field_value:name|json_dumps }}
+                        {% elif object|field_type:name == "HexColorField" %}
+                            {{ object|field_value:name }}
+                            {% if object|field_value:name %}
+                                <div class="color-box" style="background-color: {{ object|field_value:name }}"></div>
+                            {% endif %}
+                        {% elif object|field_type:name == "ManyToManyField" %}
+                            {% for x in object|field_value:name %}
+                                <div>{{ x }}</div>
+                            {% endfor %}
+                        {% else %}
+                            {{ object|field_value:name }}
                         {% endif %}
-                    {% elif object|field_type:name == "ManyToManyField" %}
-                        {% for x in object|field_value:name %}
-                            <div>{{ x }}</div>
-                        {% endfor %}
-                    {% else %}
-                        {{ object|field_value:name }}
-                    {% endif %}
-                </td>
-                <td>
-                    {{ object|field_type:name }}
-                </td>
-            </tr>
+                    </td>
+                </tr>
+            {% endif %}
         {% endfor %}
         </table>
     {% endfor %}
-
-    <h1>====================================</h1>
-
-    <p class="text-muted">Hover over the configuration for more information</p>
-    <table class="table table-hover my-3">
-        <tr data-toggle="tooltip" title="{% get_help_text object 'image_context' %}">
-            <td class="font-weight-bold">Image context</td>
-            <td>{{ object.get_image_context_display }}</td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'window_presets' %}">
-            <td class="font-weight-bold">Window presets</td>
-            <td>
-                {% for x in object.window_presets.all %}
-                    <div>{{ x }}</div>
-                {% endfor %}
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'default_window_preset' %}">
-            <td class="font-weight-bold">Default window preset</td>
-            <td>{{ object.default_window_preset }}</td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'default_slab_thickness_mm' %}">
-            <td class="font-weight-bold">Default slab thickness (mm)</td>
-            <td>{{ object.default_slab_thickness_mm }}</td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'default_slab_render_method' %}">
-            <td class="font-weight-bold">Default slab render method</td>
-            <td>{{ object.get_default_slab_render_method_display }}</td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'default_orientation' %}">
-            <td class="font-weight-bold">Default orientation</td>
-            <td>{{ object.get_default_orientation_display }}</td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'default_image_interpolation' %}">
-            <td class="font-weight-bold">Default image interpolation</td>
-            <td>{{ object.get_default_image_interpolation_display }}</td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'default_limit_view_area_to_image_volume' %}">
-            <td class="font-weight-bold">Default limiting the view-area to an image volume</td>
-            <td>
-                <i class="fas {% if object.default_limit_view_area_to_image_volume %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'key_bindings' %}">
-            <td class="font-weight-bold">Key bindings</td>
-            <td>
-                <pre>{{ object.key_bindings|json_dumps }}</pre>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'default_zoom_scale' %}">
-            <td class="font-weight-bold">Default zoom scale</td>
-            <td>{{ object.default_zoom_scale }}</td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'auto_jump_center_of_gravity' %}">
-            <td class="font-weight-bold">Jump to first center of gravity</td>
-            <td>
-                <i class="fas {% if object.auto_jump_center_of_gravity %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-    </table>
-
-    <h2>Annotations and Overlays</h2>
-
-    <p class="text-muted">Behavior or visualization settings for annotations and overlays.</p>
-
-    <table class="table table-hover my-3" >
-        <tr data-toggle="tooltip" title="{% get_help_text object 'default_brush_size' %}">
-            <td class="font-weight-bold">Default brush size (mm)</td>
-            <td>{{ object.default_brush_size }}</td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'default_annotation_color' %}">
-            <td class="font-weight-bold">Default annotation color</td>
-            <td>
-                {{ object.default_annotation_color }}
-                {% if object.default_annotation_color %}
-                    <div class="color-box" style="background-color: {{ object.default_annotation_color }}"></div>
-                {% endif %}
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'default_annotation_line_width' %}">
-            <td class="font-weight-bold">Default annotation line width</td>
-            <td>{{ object.default_annotation_line_width }}</td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'ghosting_slice_depth' %}">
-            <td class="font-weight-bold">Ghosting Slice Depth</td>
-            <td>{{ object.ghosting_slice_depth }}</td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'default_overlay_lut' %}">
-            <td class="font-weight-bold">Default overlay lookup table</td>
-            <td>{{ object.default_overlay_lut }}</td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'overlay_luts' %}">
-            <td class="font-weight-bold">Overlay lookup tables</td>
-            <td>
-                {% for x in object.overlay_luts.all %}
-                    <div>{{ x }}</div>
-                {% endfor %}
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'overlay_segments' %}">
-            <td class="font-weight-bold">Overlay segments</td>
-            <td>
-                <pre>{{ object.overlay_segments|json_dumps }}</pre>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'default_overlay_alpha' %}">
-            <td class="font-weight-bold">Default overlay alpha</td>
-            <td>{{ object.default_overlay_alpha }}</td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'default_overlay_interpolation' %}">
-            <td class="font-weight-bold">Default overlay interpolation</td>
-            <td>{{ object.get_default_overlay_interpolation_display }}</td>
-        </tr>
-    </table>
-
-    <h2>Plugin and Tools</h2>
-
-    <p class="text-muted">Plugins are components of the viewer, whereas tools are (generally) contained within plugins.</p>
-
-    <table class="table table-hover my-3" >
-        <tr data-toggle="tooltip" title="{% get_help_text object 'show_image_info_plugin' %}">
-            <td class="font-weight-bold">Image info plugin</td>
-            <td>
-                <i class="fas {% if object.show_image_info_plugin %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'show_display_plugin' %}">
-            <td class="font-weight-bold">Display plugin</td>
-            <td>
-                <i class="fas {% if object.show_display_plugin %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'show_image_switcher_plugin' %}">
-            <td class="font-weight-bold">Image switcher plugin</td>
-            <td>
-                <i class="fas {% if object.show_image_switcher_plugin %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'show_algorithm_output_plugin' %}">
-            <td class="font-weight-bold">Algorithm output plugin</td>
-            <td>
-                <i class="fas {% if object.show_algorithm_output_plugin %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'show_overlay_plugin' %}">
-            <td class="font-weight-bold">Overlay plugin</td>
-            <td>
-                <i class="fas {% if object.show_overlay_plugin %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'show_annotation_statistics_plugin' %}">
-            <td class="font-weight-bold">Annotation statistics plugin</td>
-            <td>
-                <i class="fas {% if object.show_annotation_statistics_plugin %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'show_swivel_tool' %}">
-            <td class="font-weight-bold">Swivel tool</td>
-            <td>
-                <i class="fas {% if object.show_swivel_tool %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'show_invert_tool' %}">
-            <td class="font-weight-bold">Invert tool</td>
-            <td>
-                <i class="fas {% if object.show_invert_tool %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'show_flip_tool' %}">
-            <td class="font-weight-bold">Flip tool</td>
-            <td>
-                <i class="fas {% if object.show_flip_tool %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'show_window_level_tool' %}">
-            <td class="font-weight-bold">Window level tool</td>
-            <td>
-                <i class="fas {% if object.show_window_level_tool %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'show_reset_tool' %}">
-            <td class="font-weight-bold">Reset tool</td>
-            <td>
-                <i class="fas {% if object.show_reset_tool %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'show_overlay_selection_tool' %}">
-            <td class="font-weight-bold">Overlay selection tool</td>
-            <td>
-                <i class="fas {% if object.show_overlay_selection_tool %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'show_lut_selection_tool' %}">
-            <td class="font-weight-bold">Show overlay-LUT selection tool</td>
-            <td>
-                <i class="fas {% if object.show_lut_selection_tool %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'show_annotation_counter_tool' %}">
-            <td class="font-weight-bold">Annotation counter tool</td>
-            <td>
-                <i class="fas {% if object.show_annotation_counter_tool %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'enable_contrast_enhancement' %}">
-            <td class="font-weight-bold">Contrast-enhancement preprocessing tool</td>
-            <td>
-                <i class="fas {% if object.enable_contrast_enhancement %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-    </table>
-
-    <h2>Linking Configuration</h2>
-
-    <p class="text-muted">Linked images share tool interactions and display properties,
-        it is possible to manually (un)link them during viewing.</p>
-
-
-    <table class="table table-hover my-3" >
-
-        <tr data-toggle="tooltip" title="{% get_help_text object 'link_images' %}">
-            <td class="font-weight-bold">Start with images linked</td>
-            <td>
-                <i class="fas {% if object.link_images %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'link_panning' %}">
-            <td class="font-weight-bold">Panning</td>
-            <td>
-                <i class="fas {% if object.link_panning %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-
-        <tr data-toggle="tooltip" title="{% get_help_text object 'link_zooming' %}">
-            <td class="font-weight-bold">Zooming</td>
-            <td>
-                <i class="fas {% if object.link_zooming %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-
-        <tr data-toggle="tooltip" title="{% get_help_text object 'link_slicing' %}">
-            <td class="font-weight-bold">Slicing</td>
-            <td>
-                <i class="fas {% if object.link_slicing %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-
-        <tr data-toggle="tooltip" title="{% get_help_text object 'link_orienting' %}">
-            <td class="font-weight-bold">Orienting</td>
-            <td>
-                <i class="fas {% if object.link_orienting %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-
-        <tr data-toggle="tooltip" title="{% get_help_text object 'link_windowing' %}">
-            <td class="font-weight-bold">Windowing</td>
-            <td>
-                <i class="fas {% if object.link_windowing %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-
-        <tr data-toggle="tooltip" title="{% get_help_text object 'link_inverting' %}">
-            <td class="font-weight-bold">Inverting</td>
-            <td>
-                <i class="fas {% if object.link_inverting %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-
-        <tr data-toggle="tooltip" title="{% get_help_text object 'link_flipping' %}">
-            <td class="font-weight-bold">Flipping</td>
-            <td>
-                <i class="fas {% if object.link_flipping %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
-            </td>
-        </tr>
-    </table>
-
 
     {% if "change_workstationconfig" in config_perms %}
         <div class="d-flex justify-content-start align-items-center">

--- a/app/grandchallenge/workstation_configs/templates/workstation_configs/workstationconfig_detail.html
+++ b/app/grandchallenge/workstation_configs/templates/workstation_configs/workstationconfig_detail.html
@@ -5,7 +5,7 @@
 {% load workstations %}
 {% load guardian_tags %}
 {% load evaluation_extras %}
-{% load get_help_text %}
+{% load workstation_config_tags %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
@@ -24,6 +24,48 @@
     {% if object.description %}
         <p>{{ object.description }}</p>
     {% endif %}
+
+    {% for group_name, group in groups.items %}
+        <h2>{{ group.title }}</h2>
+        {% if group.description %}
+            <p class="text-muted">{{ group.description }}</p>
+        {% endif %}
+
+        <table class="table table-hover my-3">
+        {% for name in group.names %}
+            <tr data-toggle="tooltip" title="{% get_help_text object name %}">
+                <td class="font-weight-bold">{% get_verbose_name object name %}</td>
+                <td>
+                    {% if name == "default_image_interpolation" %}
+                        {{ object.get_default_image_interpolation_display }}
+                    {% elif name == "default_overlay_interpolation" %}
+                        {{ object.get_default_overlay_interpolation_display }}
+                    {% elif object|field_type:name == "BooleanField" %}
+                        <i class="fas {% if object|field_value:name %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
+                    {% elif object|field_type:name == "JSONField" %}
+                        {{ object|field_value:name|json_dumps }}
+                    {% elif object|field_type:name == "HexColorField" %}
+                        {{ object|field_value:name }}
+                        {% if object|field_value:name %}
+                            <div class="color-box" style="background-color: {{ object|field_value:name }}"></div>
+                        {% endif %}
+                    {% elif object|field_type:name == "ManyToManyField" %}
+                        {% for x in object|field_value:name %}
+                            <div>{{ x }}</div>
+                        {% endfor %}
+                    {% else %}
+                        {{ object|field_value:name }}
+                    {% endif %}
+                </td>
+                <td>
+                    {{ object|field_type:name }}
+                </td>
+            </tr>
+        {% endfor %}
+        </table>
+    {% endfor %}
+
+    <h1>====================================</h1>
 
     <p class="text-muted">Hover over the configuration for more information</p>
     <table class="table table-hover my-3">

--- a/app/grandchallenge/workstation_configs/templates/workstation_configs/workstationconfig_detail.html
+++ b/app/grandchallenge/workstation_configs/templates/workstation_configs/workstationconfig_detail.html
@@ -65,36 +65,6 @@
                 <i class="fas {% if object.default_limit_view_area_to_image_volume %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
             </td>
         </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'default_overlay_alpha' %}">
-            <td class="font-weight-bold">Default overlay alpha</td>
-            <td>{{ object.default_overlay_alpha }}</td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'ghosting_slice_depth' %}">
-            <td class="font-weight-bold">Ghosting Slice Depth</td>
-            <td>{{ object.ghosting_slice_depth }}</td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'overlay_luts' %}">
-            <td class="font-weight-bold">Overlay lookup tables</td>
-            <td>
-                {% for x in object.overlay_luts.all %}
-                    <div>{{ x }}</div>
-                {% endfor %}
-            </td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'default_overlay_lut' %}">
-            <td class="font-weight-bold">Default overlay lookup table</td>
-            <td>{{ object.default_overlay_lut }}</td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'default_overlay_interpolation' %}">
-            <td class="font-weight-bold">Default overlay interpolation</td>
-            <td>{{ object.get_default_overlay_interpolation_display }}</td>
-        </tr>
-        <tr data-toggle="tooltip" title="{% get_help_text object 'overlay_segments' %}">
-            <td class="font-weight-bold">Overlay segments</td>
-            <td>
-                <pre>{{ object.overlay_segments|json_dumps }}</pre>
-            </td>
-        </tr>
         <tr data-toggle="tooltip" title="{% get_help_text object 'key_bindings' %}">
             <td class="font-weight-bold">Key bindings</td>
             <td>
@@ -105,6 +75,19 @@
             <td class="font-weight-bold">Default zoom scale</td>
             <td>{{ object.default_zoom_scale }}</td>
         </tr>
+        <tr data-toggle="tooltip" title="{% get_help_text object 'auto_jump_center_of_gravity' %}">
+            <td class="font-weight-bold">Jump to first center of gravity</td>
+            <td>
+                <i class="fas {% if object.auto_jump_center_of_gravity %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
+            </td>
+        </tr>
+    </table>
+
+    <h2>Annotations and Overlays</h2>
+
+    <p class="text-muted">Behavior or visualization settings for annotations and overlays.</p>
+
+    <table class="table table-hover my-3" >
         <tr data-toggle="tooltip" title="{% get_help_text object 'default_brush_size' %}">
             <td class="font-weight-bold">Default brush size (mm)</td>
             <td>{{ object.default_brush_size }}</td>
@@ -122,11 +105,35 @@
             <td class="font-weight-bold">Default annotation line width</td>
             <td>{{ object.default_annotation_line_width }}</td>
         </tr>
-         <tr data-toggle="tooltip" title="{% get_help_text object 'auto_jump_center_of_gravity' %}">
-            <td class="font-weight-bold">Jump to first center of gravity</td>
+        <tr data-toggle="tooltip" title="{% get_help_text object 'ghosting_slice_depth' %}">
+            <td class="font-weight-bold">Ghosting Slice Depth</td>
+            <td>{{ object.ghosting_slice_depth }}</td>
+        </tr>
+        <tr data-toggle="tooltip" title="{% get_help_text object 'default_overlay_lut' %}">
+            <td class="font-weight-bold">Default overlay lookup table</td>
+            <td>{{ object.default_overlay_lut }}</td>
+        </tr>
+        <tr data-toggle="tooltip" title="{% get_help_text object 'overlay_luts' %}">
+            <td class="font-weight-bold">Overlay lookup tables</td>
             <td>
-                <i class="fas {% if object.auto_jump_center_of_gravity %}fa-check-circle{% else %}fa-times-circle{% endif %}"></i>
+                {% for x in object.overlay_luts.all %}
+                    <div>{{ x }}</div>
+                {% endfor %}
             </td>
+        </tr>
+        <tr data-toggle="tooltip" title="{% get_help_text object 'overlay_segments' %}">
+            <td class="font-weight-bold">Overlay segments</td>
+            <td>
+                <pre>{{ object.overlay_segments|json_dumps }}</pre>
+            </td>
+        </tr>
+        <tr data-toggle="tooltip" title="{% get_help_text object 'default_overlay_alpha' %}">
+            <td class="font-weight-bold">Default overlay alpha</td>
+            <td>{{ object.default_overlay_alpha }}</td>
+        </tr>
+        <tr data-toggle="tooltip" title="{% get_help_text object 'default_overlay_interpolation' %}">
+            <td class="font-weight-bold">Default overlay interpolation</td>
+            <td>{{ object.get_default_overlay_interpolation_display }}</td>
         </tr>
     </table>
 

--- a/app/grandchallenge/workstation_configs/templatetags/get_help_text.py
+++ b/app/grandchallenge/workstation_configs/templatetags/get_help_text.py
@@ -1,8 +1,0 @@
-from django import template
-
-register = template.Library()
-
-
-@register.simple_tag
-def get_help_text(obj, field):
-    return obj._meta.get_field(field).help_text

--- a/app/grandchallenge/workstation_configs/templatetags/workstation_config_tags.py
+++ b/app/grandchallenge/workstation_configs/templatetags/workstation_config_tags.py
@@ -1,0 +1,27 @@
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag
+def get_help_text(obj, field):
+    return obj._meta.get_field(field).help_text
+
+
+@register.simple_tag
+def get_verbose_name(obj, field):
+    return obj._meta.get_field(field).verbose_name.capitalize()
+
+
+@register.filter(name="field_type")
+def field_type(obj, field_name):
+    field = obj._meta.get_field(field_name)
+    return type(field).__name__
+
+
+@register.filter(name="field_value")
+def field_value(obj, name):
+    result = getattr(obj, name, None)
+    if isinstance(result, object) and hasattr(result, "all"):
+        result = result.all()
+    return result

--- a/app/grandchallenge/workstation_configs/views.py
+++ b/app/grandchallenge/workstation_configs/views.py
@@ -19,7 +19,7 @@ from grandchallenge.workstation_configs.serializers import (
     WorkstationConfigSerializer,
 )
 
-from .visual_field_ordering import GROUPS, DETAIL_FIELDS
+from .visual_field_ordering import DETAIL_FIELDS, GROUPS
 
 
 class WorkstationConfigViewSet(ReadOnlyModelViewSet):

--- a/app/grandchallenge/workstation_configs/views.py
+++ b/app/grandchallenge/workstation_configs/views.py
@@ -14,7 +14,10 @@ from grandchallenge.api.permissions import IsAuthenticated
 from grandchallenge.core.guardian import ObjectPermissionRequiredMixin
 from grandchallenge.subdomains.utils import reverse
 from grandchallenge.workstation_configs.forms import WorkstationConfigForm
-from grandchallenge.workstation_configs.models import WorkstationConfig
+from grandchallenge.workstation_configs.models import (
+    WorkstationConfig,
+    VisualGroups,
+)
 from grandchallenge.workstation_configs.serializers import (
     WorkstationConfigSerializer,
 )
@@ -42,6 +45,11 @@ class WorkstationConfigCreate(PermissionRequiredMixin, CreateView):
 
 class WorkstationConfigDetail(LoginRequiredMixin, DetailView):
     model = WorkstationConfig
+
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(
+            **kwargs, groups=VisualGroups().group_map
+        )
 
 
 class WorkstationConfigUpdate(

--- a/app/grandchallenge/workstation_configs/views.py
+++ b/app/grandchallenge/workstation_configs/views.py
@@ -14,13 +14,12 @@ from grandchallenge.api.permissions import IsAuthenticated
 from grandchallenge.core.guardian import ObjectPermissionRequiredMixin
 from grandchallenge.subdomains.utils import reverse
 from grandchallenge.workstation_configs.forms import WorkstationConfigForm
-from grandchallenge.workstation_configs.models import (
-    WorkstationConfig,
-    VisualGroups,
-)
+from grandchallenge.workstation_configs.models import WorkstationConfig
 from grandchallenge.workstation_configs.serializers import (
     WorkstationConfigSerializer,
 )
+
+from .visual_field_ordering import GROUPS, DETAIL_FIELDS
 
 
 class WorkstationConfigViewSet(ReadOnlyModelViewSet):
@@ -48,7 +47,7 @@ class WorkstationConfigDetail(LoginRequiredMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         return super().get_context_data(
-            **kwargs, groups=VisualGroups().group_map
+            **kwargs, groups=GROUPS, shown_field_names=DETAIL_FIELDS
         )
 
 

--- a/app/grandchallenge/workstation_configs/visual_field_ordering.py
+++ b/app/grandchallenge/workstation_configs/visual_field_ordering.py
@@ -1,10 +1,7 @@
-from typing import List, Optional
-
-
 class Group:
     title: str
-    description: Optional[str]
-    names: List[str]
+    description: str | None
+    names: list[str]
 
     def __init__(self, *, title, description=None):
         self.title = title
@@ -78,7 +75,7 @@ ABSOLUTE_FIELD_ORDER = [
 ]
 
 
-def _construct_groups() -> List[Group]:
+def _construct_groups() -> list[Group]:
     current_group = Group(title="")
 
     i = 0

--- a/app/grandchallenge/workstation_configs/visual_field_ordering.py
+++ b/app/grandchallenge/workstation_configs/visual_field_ordering.py
@@ -1,0 +1,103 @@
+from typing import List, Optional
+
+
+class Group:
+    title: str
+    description: Optional[str]
+    names: List[str]
+
+    def __init__(self, *, title, description=None):
+        self.title = title
+        self.description = description
+        self.names = []
+
+    def add_to_group(self, other):
+        self.names.append(other)
+
+
+ABSOLUTE_FIELD_ORDER = [
+    "title",
+    "description",
+    "image_context",
+    "window_presets",
+    "default_window_preset",
+    "default_slab_thickness_mm",
+    "default_slab_render_method",
+    "default_orientation",
+    "default_image_interpolation",
+    "default_limit_view_area_to_image_volume",
+    "key_bindings",
+    "default_zoom_scale",
+    Group(
+        title="Annotations and Overlays",
+        description="Behavior or visualization settings for annotations and overlays.",
+    ),
+    "overlay_luts",
+    "default_overlay_lut",
+    "default_overlay_alpha",
+    "default_overlay_interpolation",
+    "ghosting_slice_depth",
+    "overlay_segments",
+    "default_brush_size",
+    "default_annotation_color",
+    "default_annotation_line_width",
+    "auto_jump_center_of_gravity",
+    Group(
+        title="Plugin and Tools",
+        description="Plugins are components of the viewer, whereas tools are "
+        "(generally) contained within plugins.",
+    ),
+    "show_image_info_plugin",
+    "show_display_plugin",
+    "show_image_switcher_plugin",
+    "show_algorithm_output_plugin",
+    "show_overlay_plugin",
+    "show_annotation_statistics_plugin",
+    "show_swivel_tool",
+    "show_invert_tool",
+    "show_flip_tool",
+    "show_window_level_tool",
+    "show_reset_tool",
+    "show_overlay_selection_tool",
+    "show_lut_selection_tool",
+    "show_annotation_counter_tool",
+    "enable_contrast_enhancement",
+    Group(
+        title="Linking Configuration",
+        description="Linked images share tool interactions and display properties, "
+        "it is possible to manually (un)link them during viewing.",
+    ),
+    "link_images",
+    "link_panning",
+    "link_zooming",
+    "link_slicing",
+    "link_orienting",
+    "link_windowing",
+    "link_inverting",
+    "link_flipping",
+]
+
+
+def _construct_groups() -> List[Group]:
+    current_group = Group(title="")
+
+    i = 0
+    while i < len(ABSOLUTE_FIELD_ORDER):
+        if isinstance(ABSOLUTE_FIELD_ORDER[i], Group):
+            yield current_group
+            current_group = ABSOLUTE_FIELD_ORDER.pop(i)
+        else:
+            current_group.add_to_group(ABSOLUTE_FIELD_ORDER[i])
+            i += 1
+
+    yield current_group
+
+
+GROUPS = tuple(_construct_groups())
+
+
+FORM_FIELDS = list(ABSOLUTE_FIELD_ORDER)
+
+DETAIL_FIELDS = list(ABSOLUTE_FIELD_ORDER)
+DETAIL_FIELDS.remove("title")
+DETAIL_FIELDS.remove("description")


### PR DESCRIPTION
## Problem

There currently is huge hand-written template html file to add nice sections to the workstation configuration detail page:

![image](https://github.com/comic/grand-challenge.org/assets/11632379/29ba6312-b460-4ce3-86b0-e69821e56a64)

However, when clicking "edit", the edit form does not have these sections, even though they are quite handy for such a massive page with many many different configuration options. Also the order of entries differs from the details page. A very confusing situation.

## Solution

- I moved the grouping into the python code, specifically a module called `visual_field_ordering`. This defines a list of names that should be rendered on the different pages (edit form vs details) as well information about the sections 
- The hand-written details template was replaced with a generic one that includes special handling for the different field types using some added template-filters and tags