### PR TITLE
Make archive items editable again

### DIFF
--- a/app/grandchallenge/archives/models.py
+++ b/app/grandchallenge/archives/models.py
@@ -359,6 +359,10 @@ class ArchiveItem(
             kwargs={"slug": self.base_object.slug, "pk": self.pk},
         )
 
+    @property
+    def is_editable(self):
+        return True
+
 
 class ArchiveItemUserObjectPermission(UserObjectPermissionBase):
     content_object = models.ForeignKey(ArchiveItem, on_delete=models.CASCADE)

--- a/app/tests/archives_tests/test_models.py
+++ b/app/tests/archives_tests/test_models.py
@@ -103,3 +103,9 @@ def test_archive_item_set_title():
         archive=ArchiveFactory(),
         title=ai0.title,
     )
+
+
+@pytest.mark.django_db
+def test_archive_item_editable():
+    ai = ArchiveItemFactory()
+    assert ai.is_editable


### PR DESCRIPTION
Fixes bug introduced in https://github.com/comic/grand-challenge.org/pull/3345 which made archive items uneditable. 