### PR TITLE
Only allow linking algorithms with active image to archive

### DIFF
--- a/app/grandchallenge/algorithms/tasks.py
+++ b/app/grandchallenge/algorithms/tasks.py
@@ -217,6 +217,9 @@ def create_algorithm_jobs_for_archive(
                 logger.info(f"Retrying task due to: {error}")
                 retry_with_delay()
                 raise
+            except RuntimeError:
+                # don't schedule jobs for algorithms without an active image
+                continue
 
 
 def create_algorithm_jobs(
@@ -255,6 +258,9 @@ def create_algorithm_jobs(
     time_limit
         The time limit for the Job
     """
+    if not algorithm_image:
+        raise RuntimeError("Algorithm image required to create jobs.")
+
     civ_sets = filter_civs_for_algorithm(
         civ_sets=civ_sets, algorithm_image=algorithm_image
     )

--- a/app/tests/algorithms_tests/test_tasks.py
+++ b/app/tests/algorithms_tests/test_tasks.py
@@ -57,6 +57,10 @@ class TestCreateAlgorithmJobs:
         create_algorithm_jobs(algorithm_image=ai, civ_sets=[])
         assert Job.objects.count() == 0
 
+    def test_no_algorithm_image_errors_out(self):
+        with pytest.raises(RuntimeError):
+            create_algorithm_jobs(algorithm_image=None, civ_sets=[])
+
     def test_civ_existing_does_nothing(self):
         image = ImageFactory()
         ai = AlgorithmImageFactory()

--- a/app/tests/archives_tests/test_forms.py
+++ b/app/tests/archives_tests/test_forms.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import Permission
 
 from grandchallenge.algorithms.models import Job
 from grandchallenge.archives.forms import (
+    ArchiveForm,
     ArchiveItemCreateForm,
     ArchiveItemUpdateForm,
 )
@@ -488,3 +489,24 @@ def test_archive_items_to_reader_study_update_form(client, settings):
         sorted(list(ds.values.values_list("pk", flat=True)))
         for ds in rs.display_sets.all()
     ) == sorted([[civ1.pk], [civ2.pk], [civ1.pk, civ3.pk], [civ2.pk, civ4.pk]])
+
+
+@pytest.mark.django_db
+def test_archive_update_form_algorithm_queryset():
+    alg1, alg2, alg3 = AlgorithmFactory.create_batch(3)
+    user = UserFactory()
+    for alg in [alg1, alg2]:
+        alg.add_editor(user)
+    archive = ArchiveFactory()
+
+    AlgorithmImageFactory(
+        algorithm=alg1,
+        is_desired_version=True,
+        is_manifest_valid=True,
+        is_in_registry=True,
+    )
+
+    form = ArchiveForm(instance=archive, user=user)
+    assert alg1 in form.fields["algorithms"].queryset
+    assert alg2 not in form.fields["algorithms"].queryset
+    assert alg3 not in form.fields["algorithms"].queryset


### PR DESCRIPTION
At the moment, users can add algorithms without an active image to an archive. When doing so, `create_algorithm_jobs_for_archive` will fail to schedule jobs for those algorithms because of the missing image. 

This PR catches the error and skips over algorithms without an active image. 
I also propose to limit the algorithm choices in the archive form to those with active images. 