### PR TITLE
Add link to status page in footer

### DIFF
--- a/app/grandchallenge/core/templates/grandchallenge/partials/footer.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/footer.html
@@ -29,6 +29,13 @@
                                 Statistics
                             </a>
                         </li>
+                        <li class="my-1">
+                            <a class="text-muted"
+                               href="https://diagnijmegen.github.io/rse-grand-challenge-status/"
+                               target="_blank">
+                                Status
+                            </a>
+                        </li>
                     </ul>
                 </div>
                 <div class="col-sm-6 col-md-3 p-3">


### PR DESCRIPTION
We should wait to deploy this until the page is fully ready (when example incidents are removed and default components finalized).