### PR TITLE
Fix sometimes having an partial URL as hash

### DIFF
--- a/app/grandchallenge/core/static/js/refresh_sidebar.mjs
+++ b/app/grandchallenge/core/static/js/refresh_sidebar.mjs
@@ -1,30 +1,51 @@
-if (window.location.hash === "" || window.location.hash === '#information') {
-  $('#information').addClass('active');
-  $('#v-pills-information-tab').addClass('active');
-}
+$(document).ready(function() {
+    const tabSelectors = $('#v-pills-tab a');
 
-$('#v-pills-tab a').click(function () {
-  const tab = $(this);
-  tab.siblings().removeClass('active');
-  tab.tab('show');
+    const allowedHashes = new Set(
+        tabSelectors.map(function() {
+            let href = this.getAttribute('href');
+            return href.startsWith('#') ? href.substring(1) : null;
+        }).get().filter(hash => hash !== null)
+    );
+
+    function isValidHash(hash) {
+        return allowedHashes.has(hash);
+    }
+
+    tabSelectors.click(function () {
+        const tab = $(this);
+        tab.siblings().removeClass('active');
+        tab.tab('show');
+    });
+
+    $("ul.nav-pills > a").on("shown.bs.tab", (e) => {
+        const hash = $(e.target).attr("href").substring(1);
+        if (isValidHash(hash)) {
+            history.pushState(null, null, `#${hash}`);
+        }
+    });
+
+    function activateLocation() {
+        const hash = window.location.hash.substring(1);
+        if (isValidHash(hash)) {
+            const tab = $(`#v-pills-tab a[href="#${hash}"]`);
+            tab.siblings().removeClass('active');
+            tab.tab('show');
+        } else {
+            // Fallback to a default tab if the hash is not valid
+            const defaultTab = $('#v-pills-tab a[href="#information"]');
+            defaultTab.siblings().removeClass('active');
+            defaultTab.tab('show');
+        }
+    }
+
+    window.addEventListener('popstate', function (event) {
+        activateLocation();
+    });
+
+    window.addEventListener('pageshow', function(event) {
+        activateLocation();
+    });
+
+    activateLocation();
 });
-
-// store the currently selected tab in the hash value
-$("ul.nav-pills > a").on("shown.bs.tab", (e) => {
-  const href = $(e.target).attr("href");
-  const newUrl = new URL(href, window.location);
-  history.pushState(null, null, newUrl.hash);
-});
-
-function activateLocation() {
-  const hash = encodeURIComponent(window.location.hash.substring(1));
-  const tab = $(`#v-pills-tab a[href="#${hash}"]`);
-  tab.siblings().removeClass('active');
-  tab.tab('show');
-}
-
-window.addEventListener('popstate', function (event) {
-  activateLocation();
-});
-
-activateLocation();

--- a/app/grandchallenge/core/static/js/refresh_sidebar.mjs
+++ b/app/grandchallenge/core/static/js/refresh_sidebar.mjs
@@ -4,7 +4,7 @@ $(document).ready(function() {
     const allowedHashes = new Set(
         tabSelectors.map(function() {
             let href = this.getAttribute('href');
-            return href.startsWith('#') ? href.substring(1) : null;
+            return href.startsWith('#') ? href : null;
         }).get().filter(hash => hash !== null)
     );
 
@@ -12,21 +12,10 @@ $(document).ready(function() {
         return allowedHashes.has(hash);
     }
 
-    tabSelectors.click(function () {
-        const tab = $(this);
-        tab.siblings().removeClass('active');
-        tab.tab('show');
-
-        const hash = tab.attr("href").substring(1);
-        if (isValidHash(hash)) {
-            history.pushState(null, null, `#${hash}`);
-        }
-    });
-
     function activateLocation() {
-        const hash = window.location.hash.substring(1);
+        const hash = window.location.hash;
         if (isValidHash(hash)) {
-            const tab = $(`#v-pills-tab a[href="#${hash}"]`);
+            const tab = $(`#v-pills-tab a[href="${hash}"]`);
             tab.siblings().removeClass('active');
             tab.tab('show');
         } else {
@@ -36,6 +25,14 @@ $(document).ready(function() {
             defaultTab.tab('show');
         }
     }
+
+    tabSelectors.click(function () {
+        const hash = $(this).attr("href");
+        if (isValidHash(hash)) {
+            history.pushState(null, null, hash);
+            activateLocation();
+        }
+    });
 
     window.addEventListener('popstate', function (event) {
         activateLocation();

--- a/app/grandchallenge/core/static/js/refresh_sidebar.mjs
+++ b/app/grandchallenge/core/static/js/refresh_sidebar.mjs
@@ -16,10 +16,8 @@ $(document).ready(function() {
         const tab = $(this);
         tab.siblings().removeClass('active');
         tab.tab('show');
-    });
 
-    $("ul.nav-pills > a").on("shown.bs.tab", (e) => {
-        const hash = $(e.target).attr("href").substring(1);
+        const hash = tab.attr("href").substring(1);
         if (isValidHash(hash)) {
             history.pushState(null, null, `#${hash}`);
         }

--- a/app/grandchallenge/core/static/js/refresh_sidebar.mjs
+++ b/app/grandchallenge/core/static/js/refresh_sidebar.mjs
@@ -11,8 +11,9 @@ $('#v-pills-tab a').click(function () {
 
 // store the currently selected tab in the hash value
 $("ul.nav-pills > a").on("shown.bs.tab", (e) => {
-  const newUrl = $(e.target).attr("href").substring(1);
-  history.pushState(null, null, `#${newUrl}`);
+  const href = $(e.target).attr("href");
+  const newUrl = new URL(href, window.location);
+  history.pushState(null, null, newUrl.hash);
 });
 
 function activateLocation() {
@@ -22,7 +23,7 @@ function activateLocation() {
   tab.tab('show');
 }
 
-window.addEventListener('popstate', function(event) {
+window.addEventListener('popstate', function (event) {
   activateLocation();
 });
 


### PR DESCRIPTION
Closes: #3385 

The `href` attribute was never parsed as a URL and incorrectly assumed to always be a hash-only string.