### PR TITLE
Make HX indicators robust against validation failures

### DIFF
--- a/app/grandchallenge/components/static/components/js/htmx/display-me.mjs
+++ b/app/grandchallenge/components/static/components/js/htmx/display-me.mjs
@@ -7,5 +7,4 @@ function displayElements() {
 }
 
 document.addEventListener('htmx:load', displayElements);
-
-displayElements();
+document.addEventListener('DOMContentLoaded', displayElements);

--- a/app/grandchallenge/components/static/components/js/htmx/display-me.mjs
+++ b/app/grandchallenge/components/static/components/js/htmx/display-me.mjs
@@ -1,6 +1,11 @@
-document.addEventListener('DOMContentLoaded', (event) => {
-    let elements = document.querySelectorAll('[hx-display-me]');
-    elements.forEach(function(element) {
+function displayElements() {
+    const elements = document.querySelectorAll('[hx-display-me]');
+    elements.forEach(function (element) {
         element.classList.remove('d-none');
+        element.removeAttribute('hx-display-me');
     });
-})
+}
+
+document.addEventListener('htmx:load', displayElements);
+
+displayElements();

--- a/app/grandchallenge/components/static/components/js/htmx/enable-me.mjs
+++ b/app/grandchallenge/components/static/components/js/htmx/enable-me.mjs
@@ -1,6 +1,11 @@
-document.addEventListener('DOMContentLoaded', (event) => {
-    let elements = document.querySelectorAll('[hx-enable-me]');
+function enableElements() {
+    const elements = document.querySelectorAll('[hx-enable-me]');
     elements.forEach(function (element) {
         element.removeAttribute('disabled');
+        element.removeAttribute('hx-enable-me');
     });
-});
+}
+
+document.addEventListener('htmx:load', enableElements);
+
+enableElements();

--- a/app/grandchallenge/components/static/components/js/htmx/enable-me.mjs
+++ b/app/grandchallenge/components/static/components/js/htmx/enable-me.mjs
@@ -7,5 +7,4 @@ function enableElements() {
 }
 
 document.addEventListener('htmx:load', enableElements);
-
-enableElements();
+document.addEventListener('DOMContentLoaded', enableElements);

--- a/app/grandchallenge/components/static/components/js/htmx/hide-me.mjs
+++ b/app/grandchallenge/components/static/components/js/htmx/hide-me.mjs
@@ -7,5 +7,4 @@ function hideElements() {
 }
 
 document.addEventListener('htmx:load', hideElements);
-
-hideElements();
+document.addEventListener('DOMContentLoaded', hideElements);

--- a/app/grandchallenge/components/static/components/js/htmx/hide-me.mjs
+++ b/app/grandchallenge/components/static/components/js/htmx/hide-me.mjs
@@ -1,6 +1,11 @@
-document.addEventListener('DOMContentLoaded', (event) => {
-    let elements = document.querySelectorAll('[hx-hide-me]');
-    elements.forEach(function(element) {
+function hideElements() {
+    const elements = document.querySelectorAll('[hx-hide-me]');
+    elements.forEach(function (element) {
         element.classList.add('d-none');
+        element.removeAttribute('hx-hide-me');
     });
-});
+}
+
+document.addEventListener('htmx:load', hideElements);
+
+hideElements();

--- a/app/grandchallenge/core/forms.py
+++ b/app/grandchallenge/core/forms.py
@@ -76,7 +76,7 @@ class UniqueTitleCreateFormMixin:
         title = self.cleaned_data.get("title")
         if title and self.unique_title_query(title).exists():
             raise ValidationError(
-                f"An {self.model._meta.verbose_name} already exists with this title"
+                f"There is already an existing {self.model._meta.verbose_name} with this title"
             )
         return title
 


### PR DESCRIPTION
When adding a title to a display set / archive item that already exists, the validation error causes a partial update of the DOM, messing the the states of the 'Save' button.

This then shows the permanent state of 'Loading...':
![image](https://github.com/comic/grand-challenge.org/assets/7871310/8e9d1de6-cd3d-4505-8bcd-76046322b347)

The indicators handlers now:
- Listen  (also) to: [htmx:load](https://htmx.org/events/#htmx:load)
- Cleanup after themselves to make them robust for multiple subsequent calls