### PR TITLE
Add a Save and add another button to CIV forms

### DIFF
--- a/app/grandchallenge/archives/views.py
+++ b/app/grandchallenge/archives/views.py
@@ -598,9 +598,6 @@ class ArchiveItemCreateView(
             kwargs={"slug": self.base_object.slug},
         )
 
-    def get_success_url(self):
-        return self.return_url
-
 
 class ArchiveItemInterfaceCreate(InterfacesCreateBaseView):
     def get_required_permissions(self, request):

--- a/app/grandchallenge/components/templates/components/civ_set_form.html
+++ b/app/grandchallenge/components/templates/components/civ_set_form.html
@@ -47,6 +47,7 @@
           hx-target="body"
           id="obj-form"
           hx-indicator="#hx-save-indicator"
+          hx-disabled-elt="find input"
     >
       {% csrf_token %}
       {{ form|crispy }}

--- a/app/grandchallenge/components/templates/components/civ_set_form.html
+++ b/app/grandchallenge/components/templates/components/civ_set_form.html
@@ -87,8 +87,24 @@
                   Loading...
               </div>
           </button>
+          <button type="submit"
+                  name="submit"
+                  value="SaveAndAddAnother"
+                  class="btn btn-outline-primary"
+                  hx-enable-me
+                  disabled
+            >
+              <div class="d-none" hx-display-me>
+                  <span id="hx-save-indicator" class="htmx-indicator spinner-border spinner-border-sm"></span>
+                   Save and add another
+              </div>
+              <div hx-hide-me>
+                  <span class="spinner-border spinner-border-sm"></span>
+                  Loading...
+              </div>
+            </button>
+          </div>
         </div>
-      </div>
     </form>
 {% endblock %}
 

--- a/app/grandchallenge/components/views.py
+++ b/app/grandchallenge/components/views.py
@@ -240,6 +240,15 @@ class CIVSetFormMixin:
     def new_interface_url(self):
         raise NotImplementedError
 
+    def get_success_url(self):
+        print("### TEST", self.request.POST)
+        if (
+            self.request.method == "POST"
+            and self.request.POST.get("submit") == "SaveAndAddAnother"
+        ):
+            return self.form_url
+        return self.return_url
+
 
 class InterfacesCreateBaseView(ObjectPermissionRequiredMixin, TemplateView):
     form_class = SingleCIVForm

--- a/app/grandchallenge/components/views.py
+++ b/app/grandchallenge/components/views.py
@@ -241,7 +241,6 @@ class CIVSetFormMixin:
         raise NotImplementedError
 
     def get_success_url(self):
-        print("### TEST", self.request.POST)
         if (
             self.request.method == "POST"
             and self.request.POST.get("submit") == "SaveAndAddAnother"

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -1408,9 +1408,6 @@ class DisplaySetCreate(
             kwargs={"slug": self.base_object.slug},
         )
 
-    def get_success_url(self):
-        return self.return_url
-
 
 class DisplaySetDelete(CIVSetDelete):
     model = DisplaySet


### PR DESCRIPTION
Inspired by the admin interface, if a user needs to add a few display sets / archive items in a sequence this cuts the clicks by 50%.

![image](https://github.com/comic/grand-challenge.org/assets/7871310/8ada2f7c-d892-4d6c-833f-dd79c48e8a4e)


Ofc, this isn't a problem if you add, say 5 ... but at 10/20 this is a nice addition while using the GC-api might be a step too far.