### PR TITLE
Add object permission checker for caching permission lookup results

### DIFF
--- a/app/grandchallenge/archives/views.py
+++ b/app/grandchallenge/archives/views.py
@@ -426,22 +426,6 @@ class ArchiveItemsList(CivSetListView):
     permission_required = (
         f"{Archive._meta.app_label}.view_{ArchiveItem._meta.model_name}"
     )
-    columns = [
-        Column(title=""),
-        Column(title="Detail"),
-        Column(title="ID", sort_field="pk"),
-        Column(
-            title="Title",
-            sort_field="title",
-            optional_condition=lambda obj: bool(obj.title),
-        ),
-        *CivSetListView.columns,
-    ]
-    default_sort_column = 2
-    search_fields = [
-        "title",
-        *CivSetListView.search_fields,
-    ]
 
     @cached_property
     def base_object(self):

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -2004,6 +2004,30 @@ class CIVSetStringRepresentationMixin:
         return ", ".join(content)
 
 
+class CIVSetObjectPermissionsMixin:
+    @property
+    def view_perm(self):
+        return f"view_{self._meta.model_name}"
+
+    @property
+    def change_perm(self):
+        return f"change_{self._meta.model_name}"
+
+    @property
+    def delete_perm(self):
+        return f"delete_{self._meta.model_name}"
+
+    def save(self, *args, **kwargs):
+        adding = self._state.adding
+        super().save(*args, **kwargs)
+
+        if adding:
+            self.assign_permissions()
+
+    def assign_permissions(self):
+        pass
+
+
 class CIVForObjectMixin:
     def create_civ(self, *, ci_slug, new_value, user=None):
         ci = ComponentInterface.objects.get(slug=ci_slug)

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -2025,7 +2025,7 @@ class CIVSetObjectPermissionsMixin:
             self.assign_permissions()
 
     def assign_permissions(self):
-        pass
+        raise NotImplementedError
 
 
 class CIVForObjectMixin:

--- a/app/grandchallenge/components/templates/components/civ_set_detail.html
+++ b/app/grandchallenge/components/templates/components/civ_set_detail.html
@@ -36,7 +36,7 @@
             <i class="fas fa-eye"></i> View in viewer
         </a>
 
-        {% if update_perm in object_perms %}
+        {% if object.change_perm in object_perms %}
             <span
                 {% if object.is_editable  %}
                     title = "Edit {{ object|verbose_name }}"
@@ -54,7 +54,7 @@
 
         {% block additional_buttons %}{% endblock %}
 
-        {% if delete_perm in object_perms %}
+        {% if object.delete_perm in object_perms %}
             <span
                 {% if object.is_editable  %}
                     title = "Delete {{ object|verbose_name }}"

--- a/app/grandchallenge/components/templates/components/civ_set_row.html
+++ b/app/grandchallenge/components/templates/components/civ_set_row.html
@@ -54,16 +54,19 @@
 </ul>
 <split></split>
 
-<a class="btn btn-primary btn-sm"
-   title="View in viewer"
-   {% if object.base_object|model_name == base_model_options.READER_STUDY %}
-       {% workstation_session_control_data workstation=object.base_object.workstation context_object=object display_set=object config=object.base_object.workstation_config %}
-   {% elif object.base_object|model_name == base_model_options.ARCHIVE %}
-       {% workstation_session_control_data workstation=object.base_object.workstation context_object=object archive_item=object config=object.base_object.workstation_config %}
-   {% endif %}
->
-<i class="fas fa-fw fa-eye"></i>
-</a>
+{% if object.base_object.workstation %}
+    <a class="btn btn-primary btn-sm"
+    title="View in viewer"
+    {% if object.base_object|model_name == base_model_options.READER_STUDY %}
+        {% workstation_session_control_data workstation=object.base_object.workstation context_object=object display_set=object config=object.base_object.workstation_config %}
+    {% elif object.base_object|model_name == base_model_options.ARCHIVE %}
+        {% workstation_session_control_data workstation=object.base_object.workstation context_object=object archive_item=object config=object.base_object.workstation_config %}
+    {% endif %}
+    >
+    <i class="fas fa-fw fa-eye"></i>
+    </a>
+{% endif %}
+
 <split></split>
 
 {% if object.change_perm in object_perms %}

--- a/app/grandchallenge/components/templates/components/civ_set_row.html
+++ b/app/grandchallenge/components/templates/components/civ_set_row.html
@@ -6,7 +6,7 @@
 {% load guardian_tags %}
 {% load civ %}
 
-{% get_obj_perms request.user for object as "object_perms" %}
+{% get_obj_perms request.user for object as "object_perms" checker %}
 
 <div
      {% if object.is_editable %}
@@ -66,7 +66,7 @@
 </a>
 <split></split>
 
-{% if update_perm in object_perms %}
+{% if object.change_perm in object_perms %}
     <div
         {% if object.is_editable  %}
             title = "Edit {{ object|verbose_name }}"
@@ -84,7 +84,7 @@
 
 <split></split>
 
-{% if delete_perm in object_perms %}
+{% if object.delete_perm in object_perms %}
     <div
         {% if object.is_editable  %}
             title = "Delete {{ object|verbose_name }}"

--- a/app/grandchallenge/core/guardian.py
+++ b/app/grandchallenge/core/guardian.py
@@ -1,6 +1,7 @@
-from functools import partial
+from functools import cached_property, partial
 
 from django.contrib.auth.models import Permission
+from guardian.core import ObjectPermissionChecker
 from guardian.mixins import (  # noqa: I251
     PermissionListMixin as PermissionListMixinOrig,
 )
@@ -29,6 +30,19 @@ get_objects_for_group = partial(
 
 class PermissionListMixin(PermissionListMixinOrig):
     get_objects_for_user_extra_kwargs = {"accept_global_perms": False}
+
+
+class ObjectPermissionCheckerMixin:
+    request = None
+
+    @cached_property
+    def permission_checker(self):
+        return ObjectPermissionChecker(user_or_group=self.request.user)
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context["checker"] = self.permission_checker
+        return context
 
 
 class ObjectPermissionRequiredMixin(PermissionRequiredMixin):

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -26,6 +26,7 @@ from stdimage import JPEGField
 from grandchallenge.anatomy.models import BodyStructure
 from grandchallenge.components.models import (
     CIVForObjectMixin,
+    CIVSetObjectPermissionsMixin,
     CIVSetStringRepresentationMixin,
     ComponentInterface,
     ComponentInterfaceValue,
@@ -792,7 +793,10 @@ def delete_reader_study_groups_hook(*_, instance: ReaderStudy, using, **__):
 
 
 class DisplaySet(
-    CIVSetStringRepresentationMixin, CIVForObjectMixin, UUIDModel
+    CIVSetStringRepresentationMixin,
+    CIVSetObjectPermissionsMixin,
+    CIVForObjectMixin,
+    UUIDModel,
 ):
     reader_study = models.ForeignKey(
         ReaderStudy, related_name="display_sets", on_delete=models.PROTECT
@@ -803,31 +807,24 @@ class DisplaySet(
     order = models.PositiveIntegerField(default=0)
     title = models.CharField(max_length=255, default="", blank=True)
 
-    def save(self, *args, **kwargs):
-        adding = self._state.adding
-        super().save(*args, **kwargs)
-
-        if adding:
-            self.assign_permissions()
-
     def assign_permissions(self):
         assign_perm(
-            f"delete_{self._meta.model_name}",
+            self.delete_perm,
             self.reader_study.editors_group,
             self,
         )
         assign_perm(
-            f"change_{self._meta.model_name}",
+            self.change_perm,
             self.reader_study.editors_group,
             self,
         )
         assign_perm(
-            f"view_{self._meta.model_name}",
+            self.view_perm,
             self.reader_study.editors_group,
             self,
         )
         assign_perm(
-            f"view_{self._meta.model_name}",
+            self.view_perm,
             self.reader_study.readers_group,
             self,
         )

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -385,6 +385,13 @@ class ReaderStudyDisplaySetList(CivSetListView):
     model = DisplaySet
     permission_required = f"{ReaderStudy._meta.app_label}.change_{DisplaySet._meta.model_name}"  # change instead of view permission so that readers don't get access
 
+    default_sort_column = 4
+
+    search_fields = [
+        "order",
+        *CivSetListView.search_fields,
+    ]
+
     @property
     def columns(self):
         columns = CivSetListView.columns.copy()
@@ -393,13 +400,6 @@ class ReaderStudyDisplaySetList(CivSetListView):
             Column(title="Order", sort_field="order"),
         )
         return columns
-
-    default_sort_column = 4
-
-    search_fields = [
-        "order",
-        *CivSetListView.search_fields,
-    ]
 
     @cached_property
     def base_object(self):

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -384,22 +384,19 @@ class ReaderStudyStatistics(
 class ReaderStudyDisplaySetList(CivSetListView):
     model = DisplaySet
     permission_required = f"{ReaderStudy._meta.app_label}.change_{DisplaySet._meta.model_name}"  # change instead of view permission so that readers don't get access
-    columns = [
-        Column(title=""),
-        Column(title="Detail"),
-        Column(title="ID", sort_field="pk"),
-        Column(
-            title="Title",
-            sort_field="title",
-            optional_condition=lambda obj: bool(obj.title),
-        ),
-        Column(title="Order", sort_field="order"),
-        *CivSetListView.columns,
-    ]
+
+    @property
+    def columns(self):
+        columns = CivSetListView.columns.copy()
+        columns.insert(
+            4,
+            Column(title="Order", sort_field="order"),
+        )
+        return columns
 
     default_sort_column = 4
+
     search_fields = [
-        "title",
         "order",
         *CivSetListView.search_fields,
     ]


### PR DESCRIPTION
Closes: #3388

Adds an object permission checker to the CIVSetList to more efficiently look up per-object permissions.

In addition:
 - It also adds a minor abstraction for the permission codenames
 - Pulls the "Title" column definition into the generic CIVSetList, this was initially combined with the new permission checker but I scraped this because of too much added complexity. Left the abstraction though.

