### PR TITLE
Add external evaluators group to challenges

### DIFF
--- a/app/grandchallenge/challenges/migrations/0037_external_evaluators_group.py
+++ b/app/grandchallenge/challenges/migrations/0037_external_evaluators_group.py
@@ -1,0 +1,38 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def create_external_evaluators_groups(apps, schema_editor):
+    Challenge = apps.get_model("challenges", "Challenge")  # noqa: N806
+    Group = apps.get_model("auth", "Group")  # noqa: N806
+
+    challenges = Challenge.objects.all()
+    for challenge in challenges:
+        external_evaluators_group = Group.objects.create(
+            name=f"{challenge.short_name}_external_evaluators"
+        )
+        challenge.external_evaluators_group = external_evaluators_group
+    challenges.bulk_update(challenges, ["external_evaluators_group"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("auth", "0012_alter_user_first_name_max_length"),
+        ("challenges", "0036_challenge_is_suspended"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="challenge",
+            name="external_evaluators_group",
+            field=models.OneToOneField(
+                editable=False,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="external_evaluators_of_challenge",
+                to="auth.group",
+            ),
+        ),
+        migrations.RunPython(create_external_evaluators_groups, elidable=True),
+    ]

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -340,6 +340,13 @@ class Challenge(ChallengeBase):
         on_delete=models.PROTECT,
         related_name="participants_of_challenge",
     )
+    external_evaluators_group = models.OneToOneField(
+        Group,
+        editable=False,
+        null=True,
+        on_delete=models.PROTECT,
+        related_name="external_evaluators_of_challenge",
+    )
     forum = models.OneToOneField(
         Forum, editable=False, on_delete=models.PROTECT
     )
@@ -552,8 +559,12 @@ class Challenge(ChallengeBase):
         participants_group = Group.objects.create(
             name=f"{self.short_name}_participants"
         )
+        external_evaluators_group = Group.objects.create(
+            name=f"{self.short_name}_external_evaluators"
+        )
         self.admins_group = admins_group
         self.participants_group = participants_group
+        self.external_evaluators_group = external_evaluators_group
 
     def create_forum(self):
         f, created = Forum.objects.get_or_create(


### PR DESCRIPTION
First tiny PR to add the `external_evaluators_group` to the challenge model. This needs to happen in two steps: first, add the field as nullable and do a data migration to create this group for all existing challenges. That's what this PR does. In the next PR (together with all the other model changes for the pitch), we make the field non-nullable. 

Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/310