### PR TITLE
Apply lowering when cleaning Publication fields

### DIFF
--- a/app/grandchallenge/publications/fields.py
+++ b/app/grandchallenge/publications/fields.py
@@ -124,4 +124,6 @@ class IdentifierFormField(CharField):
     default_validators = [identifier_validator]
 
     def clean(self, value):
-        return super().clean(value.lower())
+        if value:
+            value = value.lower()
+        return super().clean(value)

--- a/app/grandchallenge/publications/fields.py
+++ b/app/grandchallenge/publications/fields.py
@@ -9,7 +9,7 @@ from grandchallenge.publications.utils.manubot import get_arxiv_csl
 
 # regex modified for python syntax from
 # https://www.crossref.org/blog/dois-and-matching-regular-expressions/
-DOI_REGEX = r"^10\.\d{4,9}/[-._;()/:a-z0-9]+$"
+DOI_REGEX = r"^10\.\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
 ARXIV_REGEX = r"^\d{4}\.\d{4,5}$"
 
 identifier_validator = RegexValidator(regex=f"{DOI_REGEX}|{ARXIV_REGEX}")

--- a/app/grandchallenge/publications/fields.py
+++ b/app/grandchallenge/publications/fields.py
@@ -9,7 +9,7 @@ from grandchallenge.publications.utils.manubot import get_arxiv_csl
 
 # regex modified for python syntax from
 # https://www.crossref.org/blog/dois-and-matching-regular-expressions/
-DOI_REGEX = r"^10\.\d{4,9}/[-._;()/:a-zA-Z0-9]+$"
+DOI_REGEX = r"^10\.\d{4,9}/[-._;()/:a-z0-9]+$"
 ARXIV_REGEX = r"^\d{4}\.\d{4,5}$"
 
 identifier_validator = RegexValidator(regex=f"{DOI_REGEX}|{ARXIV_REGEX}")
@@ -122,3 +122,6 @@ class IdentifierField(models.CharField):
 
 class IdentifierFormField(CharField):
     default_validators = [identifier_validator]
+
+    def clean(self, value):
+        return super().clean(value.lower())


### PR DESCRIPTION
A minor issue popped up: validation on the form field did not do a `lower()` on the identifier, meaning if any cases made it to the publication (i.e. `"10.1016/S1470-2045(24)00220-1"`) it would not validate. 

It does seem that a DOI with case 'S' should be allowed, and since 's' and 'S' are to be matched for duplication detection I've opted to clean the field rather than change the regex.

