### PR TITLE
Do not leave jobs in executing states after unclean exits

### DIFF
--- a/app/grandchallenge/components/backends/exceptions.py
+++ b/app/grandchallenge/components/backends/exceptions.py
@@ -21,3 +21,7 @@ class RetryTask(ComponentBaseException):
 
 class TaskCancelled(ComponentBaseException):
     """Raised if a task has been cancelled"""
+
+
+class UncleanExit(ComponentBaseException):
+    """Raised if the process did not exit cleanly"""


### PR DESCRIPTION
This still logs the problem to Sentry for investigation, but puts the job in a Failed state.