### PR TITLE
Improve image value preview with counter and file suffix

### DIFF
--- a/app/grandchallenge/components/templates/components/partials/civ/file.html
+++ b/app/grandchallenge/components/templates/components/partials/civ/file.html
@@ -8,8 +8,8 @@
     <i class="fas fa-fw fa-download"
     ></i>
     {% if display_inline %}
-        Download {{ civ.interface.title | truncatechars:64 }}:
-        {{ civ.file.name|name | truncatechars:30 }}
+        {{ civ.interface.title | truncatechars:64 }}:
+        {{ civ.file.name|name | truncatechars:16 }}
     {% else %}
         Download {{ civ.file.name|name }}
     {% endif %}

--- a/app/grandchallenge/components/templates/components/partials/civ/file.html
+++ b/app/grandchallenge/components/templates/components/partials/civ/file.html
@@ -8,8 +8,8 @@
     <i class="fas fa-fw fa-download"
     ></i>
     {% if display_inline %}
-        {{ civ.interface.title | truncatechars:64 }}:
-        {{ civ.file.name|name | truncatechars:16 }}
+        {{ civ.interface.title|truncatechars:64 }}:
+        {{ civ.file.name|name|truncatechars:16 }}
     {% else %}
         Download {{ civ.file.name|name }}
     {% endif %}

--- a/app/grandchallenge/components/templates/components/partials/civ/image.html
+++ b/app/grandchallenge/components/templates/components/partials/civ/image.html
@@ -9,8 +9,8 @@
         >
         <i class="fas fa-fw fa-download"></i>
         {% if display_inline %}
-          {{ civ.interface.title|truncatechars:64 }}:
-          {{ civ.image.name|stem|truncatechars:32 }}
+            {{ civ.interface.title|truncatechars:64 }}:
+            {{ civ.image.name|stem|truncatechars:32 }}
         {% else %}
           {{ civ.interface.title }}:
           {{ civ.image.name|stem }}

--- a/app/grandchallenge/components/templates/components/partials/civ/image.html
+++ b/app/grandchallenge/components/templates/components/partials/civ/image.html
@@ -12,8 +12,8 @@
             {{ civ.interface.title|truncatechars:64 }}:
             {{ civ.image.name|stem|truncatechars:32 }}
         {% else %}
-          {{ civ.interface.title }}:
-          {{ civ.image.name|stem }}
+            {{ civ.interface.title }}:
+            {{ civ.image.name|stem }}
         {% endif %}
           ({{ file.file|suffix }})
         </a>

--- a/app/grandchallenge/components/templates/components/partials/civ/image.html
+++ b/app/grandchallenge/components/templates/components/partials/civ/image.html
@@ -13,7 +13,7 @@
           {{ civ.image.name|stem|truncatechars:32 }}
         {% else %}
           {{ civ.interface.title }}:
-          {{ civ.image.name|name|stem }}
+          {{ civ.image.name|stem }}
         {% endif %}
           ({{ file.file|suffix }})
         </a>

--- a/app/grandchallenge/components/templates/components/partials/civ/image.html
+++ b/app/grandchallenge/components/templates/components/partials/civ/image.html
@@ -9,14 +9,13 @@
         >
         <i class="fas fa-fw fa-download"></i>
         {% if display_inline %}
-            Download {{ civ.interface.title|truncatechars:64 }}{% if civ.image.files.all|length > 1 %} {{ forloop.counter }}{% endif %}:
-            {{ civ.image.name|name|truncatechars:30 }}
-            ({{ file.file|suffix|truncatechars:30 }})
+          {{ civ.interface.title|truncatechars:64 }}:
+          {{ civ.image.name|name|stem|truncatechars:32 }}
         {% else %}
-            Download {{ civ.interface.title }}{% if civ.image.files.all|length > 1 %} {{ forloop.counter }}{% endif %}:
-            {{ civ.image.name|stem}}
-            ({{ file.file|suffix }})
+          Download {{ civ.interface.title }}:
+          {{ civ.image.name|name|stem }}
         {% endif %}
+          ({{ file.file|suffix }})
         </a>
     </li>
   {% endfor %}

--- a/app/grandchallenge/components/templates/components/partials/civ/image.html
+++ b/app/grandchallenge/components/templates/components/partials/civ/image.html
@@ -15,7 +15,7 @@
             {{ civ.interface.title }}:
             {{ civ.image.name|stem }}
         {% endif %}
-          ({{ file.file|suffix }})
+        ({{ file.file|suffix }})
         </a>
     </li>
   {% endfor %}

--- a/app/grandchallenge/components/templates/components/partials/civ/image.html
+++ b/app/grandchallenge/components/templates/components/partials/civ/image.html
@@ -9,10 +9,11 @@
         >
         <i class="fas fa-fw fa-download"></i>
         {% if display_inline %}
-            Download {{ civ.interface.title|truncatechars:64 }}:
+            Download {{ civ.interface.title|truncatechars:64 }}{% if civ.image.files.all|length > 1 %} {{ forloop.counter }}{% endif %}:
             {{ civ.image.name|name|truncatechars:30 }}
+            ({{ file.file|suffix|truncatechars:30 }})
         {% else %}
-            Download {{ civ.interface.title }}:
+            Download {{ civ.interface.title }}{% if civ.image.files.all|length > 1 %} {{ forloop.counter }}{% endif %}:
             {{ civ.image.name|stem}}
             ({{ file.file|suffix }})
         {% endif %}

--- a/app/grandchallenge/components/templates/components/partials/civ/image.html
+++ b/app/grandchallenge/components/templates/components/partials/civ/image.html
@@ -12,7 +12,7 @@
           {{ civ.interface.title|truncatechars:64 }}:
           {{ civ.image.name|name|stem|truncatechars:32 }}
         {% else %}
-          Download {{ civ.interface.title }}:
+          {{ civ.interface.title }}:
           {{ civ.image.name|name|stem }}
         {% endif %}
           ({{ file.file|suffix }})

--- a/app/grandchallenge/components/templates/components/partials/civ/image.html
+++ b/app/grandchallenge/components/templates/components/partials/civ/image.html
@@ -10,7 +10,7 @@
         <i class="fas fa-fw fa-download"></i>
         {% if display_inline %}
           {{ civ.interface.title|truncatechars:64 }}:
-          {{ civ.image.name|name|stem|truncatechars:32 }}
+          {{ civ.image.name|stem|truncatechars:32 }}
         {% else %}
           {{ civ.interface.title }}:
           {{ civ.image.name|name|stem }}

--- a/app/grandchallenge/components/templates/components/partials/civ/modal_base.html
+++ b/app/grandchallenge/components/templates/components/partials/civ/modal_base.html
@@ -9,7 +9,7 @@
         <i
                 class="fas fa-fw fa-eye"
         ></i>
-        Inspect {{ civ.interface.title | truncatechars:64 }}
+        {{ civ.interface.title | truncatechars:64 }}
     </div>
     {% block preview %}{% endblock %}
 </a>

--- a/app/grandchallenge/components/templates/components/partials/civ/modal_base.html
+++ b/app/grandchallenge/components/templates/components/partials/civ/modal_base.html
@@ -9,7 +9,7 @@
         <i
                 class="fas fa-fw fa-eye"
         ></i>
-        {{ civ.interface.title | truncatechars:64 }}
+        {{ civ.interface.title|truncatechars:64 }}
     </div>
     {% block preview %}{% endblock %}
 </a>


### PR DESCRIPTION
Fixes: #3412 

## Before
<img width="1445" alt="before" src="https://github.com/comic/grand-challenge.org/assets/7871310/be778a5e-b473-44ca-a3c8-1b752380fa12">

## After
![image](https://github.com/comic/grand-challenge.org/assets/7871310/3602d3c0-16e6-4c93-8265-2a18553a4069)
