### PR TITLE
Small typo on Ground-Truth form

### DIFF
--- a/app/grandchallenge/evaluation/forms.py
+++ b/app/grandchallenge/evaluation/forms.py
@@ -707,7 +707,7 @@ class EvaluationGroundTruthForm(SaveFormInitMixin, ModelForm):
         queryset=None,
         help_text=(
             ".tar.gz file of the ground truth that will be extracted"
-            " to /opt/ml/input/data/ground_truth/ during inference"
+            " to /opt/ml/input/data/ground_truth/ during evaluation"
         ),
     )
     creator = ModelChoiceField(


### PR DESCRIPTION
Replace 'inference' with 'evaluation' to not confuse challenge organizers.