### PR TITLE
Reduce queries starting jobs

### DIFF
--- a/app/grandchallenge/algorithms/signals.py
+++ b/app/grandchallenge/algorithms/signals.py
@@ -94,11 +94,13 @@ def update_group_permissions(
         else:
             groups = model.objects.filter(pk__in=pk_set)
 
-    operation = assign_perm if "add" in action else remove_perm
-
-    for job in jobs:
-        for group in groups:
-            operation("view_job", group, job)
+    if "add" in action:
+        for job in jobs:
+            assign_perm("view_job", groups, job)
+    else:
+        for job in jobs:
+            for g in groups:
+                remove_perm("view_job", g, job)
 
     queryset = ComponentInterfaceValue.objects.filter(
         image__isnull=False

--- a/app/grandchallenge/algorithms/signals.py
+++ b/app/grandchallenge/algorithms/signals.py
@@ -52,6 +52,10 @@ def update_input_image_permissions(
                 pk__in=pk_set, image__isnull=False
             )
 
+    component_interface_values = component_interface_values.select_related(
+        "image"
+    )
+
     _update_image_permissions(
         jobs=jobs,
         component_interface_values=component_interface_values,

--- a/app/grandchallenge/algorithms/tasks.py
+++ b/app/grandchallenge/algorithms/tasks.py
@@ -190,6 +190,11 @@ def create_algorithm_jobs_for_archive(
         else:
             archive_items = archive.items.all()
 
+        civ_sets = [
+            {*ai.values.all()}
+            for ai in archive_items.prefetch_related("values__interface")
+        ]
+
         for algorithm in algorithms:
             try:
                 with cache.lock(
@@ -200,12 +205,7 @@ def create_algorithm_jobs_for_archive(
                     create_algorithm_jobs(
                         algorithm_image=algorithm.active_image,
                         algorithm_model=algorithm.active_model,
-                        civ_sets=[
-                            {*ai.values.all()}
-                            for ai in archive_items.prefetch_related(
-                                "values__interface"
-                            )
-                        ],
+                        civ_sets=civ_sets,
                         extra_viewer_groups=archive_groups,
                         # NOTE: no emails in case the logs leak data
                         # to the algorithm editors

--- a/app/grandchallenge/cases/models.py
+++ b/app/grandchallenge/cases/models.py
@@ -539,8 +539,8 @@ class Image(UUIDModel):
         groups_missing_perms = expected_groups - current_groups
         groups_with_extra_perms = current_groups - expected_groups
 
-        for g in groups_missing_perms:
-            assign_perm("view_image", g, self)
+        if groups_missing_perms:
+            assign_perm("view_image", list(groups_missing_perms), self)
 
         for g in groups_with_extra_perms:
             remove_perm("view_image", g, self)

--- a/app/grandchallenge/evaluation/tasks.py
+++ b/app/grandchallenge/evaluation/tasks.py
@@ -174,7 +174,11 @@ def create_algorithm_jobs_for_evaluation(
     Evaluation = apps.get_model(  # noqa: N806
         app_label="evaluation", model_name="Evaluation"
     )
-    evaluation = Evaluation.objects.get(pk=evaluation_pk)
+    evaluation = Evaluation.objects.select_related(
+        "submission__phase__challenge",
+        "submission__algorithm_image__algorithm",
+        "submission__phase__archive",
+    ).get(pk=evaluation_pk)
 
     if evaluation.status not in {
         evaluation.PENDING,

--- a/app/grandchallenge/evaluation/tasks.py
+++ b/app/grandchallenge/evaluation/tasks.py
@@ -218,6 +218,12 @@ def create_algorithm_jobs_for_evaluation(
 
     evaluation.update_status(status=Evaluation.EXECUTING_PREREQUISITES)
 
+    civ_sets = [
+        {*ai.values.all()}
+        for ai in evaluation.submission.phase.archive.items.prefetch_related(
+            "values__interface"
+        )
+    ]
     try:
         # Method is expensive so only allow one process at a time
         with cache.lock(
@@ -228,12 +234,7 @@ def create_algorithm_jobs_for_evaluation(
             jobs = create_algorithm_jobs(
                 algorithm_image=evaluation.submission.algorithm_image,
                 algorithm_model=evaluation.submission.algorithm_model,
-                civ_sets=[
-                    {*ai.values.all()}
-                    for ai in evaluation.submission.phase.archive.items.prefetch_related(
-                        "values__interface"
-                    )
-                ],
+                civ_sets=civ_sets,
                 extra_viewer_groups=viewer_groups,
                 extra_logs_viewer_groups=viewer_groups,
                 task_on_success=task_on_success,


### PR DESCRIPTION
Part of the pitch:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/331

Collection of small optimisations, effectively reducing the number of database queries. Since all queries we've recorded for a single job creation are ~2ms, there is only the number of queries to reduce during Job creation.

`Main` number of queries => PR number of queries
1 job: 
- 104 => 81 (-22%)

32 jobs (batch limit)
- Main: 2402 => 1910 (-20%)

In theory, this should push things to ~35 jobs/min on production (up from ~30 jobs/min).