### PR TITLE
Add custom celery task decorator

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -957,25 +957,10 @@ CORS_ALLOW_CREDENTIALS = True
 #
 ###############################################################################
 
-CELERY_TASK_DECORATOR_KWARGS = {
-    "acks-late-2xlarge": {
-        # For idempotent tasks that take a long time (<7200s)
-        # or require a large amount of memory
-        "acks_late": True,
-        "reject_on_worker_lost": True,
-        "queue": "acks-late-2xlarge",
-    },
-    "acks-late-micro-short": {
-        # For idempotent tasks that take a short time (<300s)
-        # and do not require a large amount of memory
-        "acks_late": True,
-        "reject_on_worker_lost": True,
-        "queue": "acks-late-micro-short",
-    },
-}
 CELERY_SOLO_QUEUES = {
-    *{q["queue"] for q in CELERY_TASK_DECORATOR_KWARGS.values()},
-    *{f"{q['queue']}-delay" for q in CELERY_TASK_DECORATOR_KWARGS.values()},
+    element
+    for queue in {"acks-late-2xlarge", "acks-late-micro-short"}
+    for element in {queue, f"{queue}-delay"}
 }
 ECS_ENABLE_CELERY_SCALE_IN_PROTECTION = strtobool(
     os.environ.get("ECS_ENABLE_CELERY_SCALE_IN_PROTECTION", "False"),

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -978,6 +978,8 @@ CELERY_WORKER_PREFETCH_MULTIPLIER = int(
     os.environ.get("CELERY_WORKER_PREFETCH_MULTIPLIER", "1")
 )
 CELERY_TASK_TIME_LIMIT = int(os.environ.get("CELERY_TASK_TIME_LIMIT", "7200"))
+# The soft time limit must always be shorter than the hard time limit
+# https://github.com/celery/celery/issues/9125
 CELERY_TASK_SOFT_TIME_LIMIT = int(0.9 * CELERY_TASK_TIME_LIMIT)
 CELERY_BROKER_TRANSPORT_OPTIONS = {
     "visibility_timeout": int(1.1 * CELERY_TASK_TIME_LIMIT)

--- a/app/grandchallenge/archives/tasks.py
+++ b/app/grandchallenge/archives/tasks.py
@@ -1,5 +1,3 @@
-from celery import shared_task
-from django.conf import settings
 from django.db import transaction
 from django.db.transaction import on_commit
 
@@ -12,9 +10,10 @@ from grandchallenge.components.models import (
 from grandchallenge.components.tasks import (
     add_image_to_component_interface_value,
 )
+from grandchallenge.core.celery import acks_late_micro_short_task
 
 
-@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
+@acks_late_micro_short_task
 def add_images_to_archive(*, upload_session_pk, archive_pk, interface_pk=None):
     with transaction.atomic():
         images = Image.objects.filter(origin_id=upload_session_pk)
@@ -42,7 +41,7 @@ def add_images_to_archive(*, upload_session_pk, archive_pk, interface_pk=None):
             item.values.set([civ])
 
 
-@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
+@acks_late_micro_short_task
 def add_images_to_archive_item(
     *, upload_session_pk, archive_item_pk, interface_pk
 ):

--- a/app/grandchallenge/challenges/tasks.py
+++ b/app/grandchallenge/challenges/tasks.py
@@ -1,4 +1,3 @@
-from celery import shared_task
 from django.contrib.auth import get_user_model
 from django.db.models import Count, Max
 
@@ -11,7 +10,7 @@ from grandchallenge.core.celery import acks_late_2xlarge_task
 from grandchallenge.evaluation.models import Evaluation, Phase
 
 
-@shared_task
+@acks_late_2xlarge_task
 def update_challenge_results_cache():
     challenges = Challenge.objects.all()
     evaluation_info = (

--- a/app/grandchallenge/challenges/tasks.py
+++ b/app/grandchallenge/challenges/tasks.py
@@ -1,5 +1,4 @@
 from celery import shared_task
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db.models import Count, Max
 
@@ -8,6 +7,7 @@ from grandchallenge.challenges.costs import (
     annotate_job_duration_and_compute_costs,
 )
 from grandchallenge.challenges.models import Challenge
+from grandchallenge.core.celery import acks_late_2xlarge_task
 from grandchallenge.evaluation.models import Evaluation, Phase
 
 
@@ -56,7 +56,7 @@ def update_challenge_results_cache():
     )
 
 
-@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-2xlarge"])
+@acks_late_2xlarge_task
 def update_compute_costs_and_storage_size():
     challenges = Challenge.objects.all()
 

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -14,7 +14,6 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 from billiard.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
 from celery import shared_task  # noqa: I251 TODO needs to be refactored
-from celery.exceptions import MaxRetriesExceededError
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -48,8 +47,6 @@ from grandchallenge.notifications.models import Notification, NotificationType
 from grandchallenge.uploads.models import UserUpload
 
 logger = logging.getLogger(__name__)
-
-MAX_RETRIES = 60 * 24  # 1 day assuming 60 seconds delay
 
 
 @acks_late_2xlarge_task
@@ -636,48 +633,13 @@ def provision_job(
         on_commit(execute_job.signature(**job.signature_kwargs).apply_async)
 
 
-def _delay(*, task, signature_kwargs):
-    """Create a task signature for the delay queue"""
-    step = task.signature(**signature_kwargs)
-    queue = step.options.get("queue", task.queue)
-    step.options["queue"] = f"{queue}-delay"
-    return step
-
-
-def _retry(*, task, signature_kwargs, retries):
-    """
-    Retry a task using the delay queue
-
-    We need to retry a task with a delay/countdown. There are several problems
-    with doing this in Celery (with SQS/Redis).
-
-    - If a countdown is used the delay features of SQS are not used
-      https://github.com/celery/kombu/issues/1074
-    - A countdown that needs to be done on the worker results backlogs
-      https://github.com/celery/celery/issues/2541
-    - The backlogs can still occur even if the countdown/eta is set to zero
-      https://github.com/celery/celery/issues/6929
-
-    This method is a workaround for these issues, that creates a new task
-    and places this on a queue which has DelaySeconds set. The downside
-    is that we need to track retries via the kwargs of the task.
-    """
-    if retries < MAX_RETRIES:
-        step = _delay(task=task, signature_kwargs=signature_kwargs)
-        step.kwargs["retries"] = retries + 1
-        on_commit(step.apply_async)
-    else:
-        raise MaxRetriesExceededError
-
-
-@acks_late_micro_short_task
+@acks_late_micro_short_task(retry_on=(RetryStep,))
 def execute_job(  # noqa: C901
     *,
     job_pk: uuid.UUID,
     job_app_label: str,
     job_model_name: str,
     backend: str,
-    retries: int = 0,
 ):
     """
     Executes the component job, can block with some backends.
@@ -715,21 +677,7 @@ def execute_job(  # noqa: C901
         )
     except RetryStep:
         job.update_status(status=job.PROVISIONED)
-        try:
-            _retry(
-                task=execute_job,
-                signature_kwargs=job.signature_kwargs,
-                retries=retries,
-            )
-            return
-        except MaxRetriesExceededError:
-            job.update_status(
-                status=job.FAILURE,
-                stdout=executor.stdout,
-                stderr=executor.stderr,
-                error_message="Time limit exceeded",
-            )
-            raise
+        raise
     except ComponentException as e:
         job = get_model_instance(
             pk=job_pk, app_label=job_app_label, model_name=job_model_name
@@ -789,9 +737,9 @@ def get_update_status_kwargs(*, executor=None):
         return {}
 
 
-@acks_late_micro_short_task
+@acks_late_micro_short_task(retry_on=(OperationalError, RetryStep))
 @transaction.atomic
-def handle_event(*, event, backend, retries=0):  # noqa: C901
+def handle_event(*, event, backend):  # noqa: C901
     """
     Receives events when tasks have stops and determines what to do next.
     In the case of transient failure the job could be scheduled again
@@ -817,30 +765,8 @@ def handle_event(*, event, backend, retries=0):  # noqa: C901
         attempt=job_params.attempt,
     ).select_for_update(nowait=True)
 
-    def retry_handle_event(*, _executor=None):
-        try:
-            _retry(
-                task=handle_event,
-                signature_kwargs={
-                    "kwargs": {"event": event, "backend": backend}
-                },
-                retries=retries,
-            )
-        except MaxRetriesExceededError:
-            job.update_status(
-                status=job.FAILURE,
-                error_message="An unexpected error occurred",
-                **get_update_status_kwargs(executor=_executor),
-            )
-            raise
-
-    try:
-        # Acquire the lock
-        job = queryset.get()
-    except OperationalError:
-        # Could not acquire locks
-        retry_handle_event()
-        return
+    # Acquire the lock
+    job = queryset.get()
 
     executor = job.get_executor(backend=backend)
 
@@ -856,12 +782,10 @@ def handle_event(*, event, backend, retries=0):  # noqa: C901
         )
         return
     except RetryStep:
-        retry_handle_event(_executor=executor)
-        return
+        raise
     except RetryTask:
         job.update_status(status=job.PROVISIONED)
-        step = _delay(task=retry_task, signature_kwargs=job.signature_kwargs)
-        on_commit(step.apply_async)
+        on_commit(retry_task.apply_async(kwargs=job.signature_kwargs))
     except ComponentException as e:
         job.update_status(
             status=job.FAILURE,
@@ -922,14 +846,13 @@ def parse_job_outputs(
         job.update_status(status=job.SUCCESS)
 
 
-@acks_late_micro_short_task
+@acks_late_micro_short_task(retry_on=(RetryStep,))
 def retry_task(
     *,
     job_pk: uuid.UUID,
     job_app_label: str,
     job_model_name: str,
     backend: str,
-    retries: int = 0,
 ):
     """Retries an existing task that was previously provisioned"""
     job = get_model_instance(
@@ -940,14 +863,7 @@ def retry_task(
     if job.status != job.PROVISIONED:
         raise PriorStepFailed("Job is not provisioned")
 
-    try:
-        executor.deprovision()
-    except RetryStep:
-        _retry(
-            task=retry_task,
-            signature_kwargs=job.signature_kwargs,
-            retries=retries,
-        )
+    executor.deprovision()
 
     with transaction.atomic():
         if job.attempt < 99:
@@ -962,28 +878,20 @@ def retry_task(
             raise RuntimeError("Maximum attempts exceeded")
 
 
-@acks_late_micro_short_task
+@acks_late_micro_short_task(retry_on=(RetryStep,))
 def deprovision_job(
     *,
     job_pk: uuid.UUID,
     job_app_label: str,
     job_model_name: str,
     backend: str,
-    retries: int = 0,
 ):
     job = get_model_instance(
         pk=job_pk, app_label=job_app_label, model_name=job_model_name
     )
-    executor = job.get_executor(backend=backend)
 
-    try:
-        executor.deprovision()
-    except RetryStep:
-        _retry(
-            task=deprovision_job,
-            signature_kwargs=job.signature_kwargs,
-            retries=retries,
-        )
+    executor = job.get_executor(backend=backend)
+    executor.deprovision()
 
 
 @shared_task
@@ -1245,10 +1153,10 @@ def add_file_to_object(
         )
 
 
-@acks_late_2xlarge_task
+@acks_late_2xlarge_task(retry_on=(OperationalError,))
 @transaction.atomic
 def assign_tarball_from_upload(
-    *, app_label, model_name, tarball_pk, field_to_copy, retries=0
+    *, app_label, model_name, tarball_pk, field_to_copy
 ):
     from grandchallenge.components.models import ImportStatusChoices
 
@@ -1256,32 +1164,15 @@ def assign_tarball_from_upload(
         app_label=app_label, model_name=model_name
     )
 
-    try:
-        # try to acquire lock
-        current_tarball = (
-            TarballModel.objects.filter(pk=tarball_pk)
-            .select_for_update(nowait=True)
-            .get()
-        )
-        peer_tarballs = current_tarball.get_peer_tarballs().select_for_update(
-            nowait=True
-        )
-    except OperationalError:
-        # failed to acquire lock
-        _retry(
-            task=assign_tarball_from_upload,
-            signature_kwargs={
-                "kwargs": {
-                    "app_label": app_label,
-                    "model_name": model_name,
-                    "tarball_pk": tarball_pk,
-                    "field_to_copy": field_to_copy,
-                },
-                "immutable": True,
-            },
-            retries=retries,
-        )
-        return
+    # try to acquire lock
+    current_tarball = (
+        TarballModel.objects.filter(pk=tarball_pk)
+        .select_for_update(nowait=True)
+        .get()
+    )
+    peer_tarballs = current_tarball.get_peer_tarballs().select_for_update(
+        nowait=True
+    )
 
     current_tarball.user_upload.copy_object(
         to_field=getattr(current_tarball, field_to_copy)

--- a/app/grandchallenge/core/cache.py
+++ b/app/grandchallenge/core/cache.py
@@ -1,2 +1,0 @@
-def _cache_key_from_method(method):
-    return f"lock.{method.__module__}.{method.__name__}"

--- a/app/grandchallenge/core/celery.py
+++ b/app/grandchallenge/core/celery.py
@@ -10,7 +10,7 @@ from redis.exceptions import LockError
 
 logger = logging.getLogger(__name__)
 
-MAX_RETRIES = 60 * 24  # 1 day assuming 60 seconds delay
+MAX_RETRIES = 12 * 24  # 1 day assuming 5 minutes delay
 
 
 def _retry(*, task, signature_kwargs, retries):

--- a/app/grandchallenge/core/celery.py
+++ b/app/grandchallenge/core/celery.py
@@ -1,0 +1,51 @@
+from functools import wraps
+
+from celery import shared_task
+from django.conf import settings
+
+
+class AcksLateTaskDecorator:
+    def __init__(self, queue):
+        if queue not in settings.CELERY_SOLO_QUEUES:
+            raise ValueError(f"Queue {queue} is not a solo queue")
+
+        if f"{queue}-delay" not in settings.CELERY_SOLO_QUEUES:
+            raise ValueError(f"Queue {queue}-delay is not a solo queue")
+
+        self.queue = queue
+
+    def __call__(self, func=None, ignore_result=False, throws=()):
+        if func is None:
+            # Called as @decorator(**extra_kwargs)
+            return lambda func: self._decorator(
+                func=func, ignore_result=ignore_result, throws=throws
+            )
+        else:
+            # Called as @decorator or @decorator(func)
+            return self._decorator(
+                func=func, ignore_result=ignore_result, throws=throws
+            )
+
+    def _decorator(self, *, func, ignore_result, throws):
+
+        @shared_task(
+            acks_late=True,
+            reject_on_worker_lost=True,
+            queue=self.queue,
+            ignore_result=ignore_result,
+            throws=throws,
+        )
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return wrapper
+
+
+# For idempotent tasks that take a long time (<7200s)
+# or require a large amount of memory
+acks_late_2xlarge_task = AcksLateTaskDecorator("acks-late-2xlarge")
+
+# For idempotent tasks that take a short time (<300s)
+# and do not require a large amount of memory
+acks_late_micro_short_task = AcksLateTaskDecorator("acks-late-micro-short")

--- a/app/grandchallenge/core/celery.py
+++ b/app/grandchallenge/core/celery.py
@@ -28,16 +28,17 @@ class AcksLateTaskDecorator:
 
     def _decorator(self, *, func, ignore_result, throws):
 
-        @shared_task(
+        task_func = shared_task(
             acks_late=True,
             reject_on_worker_lost=True,
             queue=self.queue,
             ignore_result=ignore_result,
             throws=throws,
-        )
+        )(func)
+
         @wraps(func)
         def wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
+            return task_func(*args, **kwargs)
 
         return wrapper
 

--- a/app/grandchallenge/core/celery.py
+++ b/app/grandchallenge/core/celery.py
@@ -58,11 +58,26 @@ class AcksLateTaskDecorator:
     def __call__(
         self,
         func=None,
+        *,
         ignore_result=False,
         retry_on=(),
         ignore_errors=(),
         singleton=False,
     ):
+        """
+        Decorator for Celery tasks that sets the queue and acks_late options
+
+        Args
+        ----
+            func: The function to decorate
+
+        Keyword Args
+        ------------
+            ignore_result: If the task should ignore the result
+            retry_on: A tuple of exceptions that should trigger a retry on the delay queue
+            ignore_errors: A tuple of exceptions that should be ignored
+            singleton: If the task should be run as a singleton (only one concurrent execution at a time)
+        """
         if func is None:
             # Called as @decorator(**extra_kwargs)
             return lambda func: self._decorator(

--- a/app/grandchallenge/core/celery.py
+++ b/app/grandchallenge/core/celery.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from celery import shared_task
+from celery import shared_task  # noqa: I251 Usage allowed here
 from django.conf import settings
 
 

--- a/app/grandchallenge/core/tasks.py
+++ b/app/grandchallenge/core/tasks.py
@@ -1,5 +1,4 @@
 import boto3
-from celery import shared_task
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.management import call_command
@@ -8,17 +7,18 @@ from django.utils import timezone
 
 from grandchallenge.algorithms.models import AlgorithmImage, Job
 from grandchallenge.cases.models import RawImageUploadSession
+from grandchallenge.core.celery import acks_late_micro_short_task
 from grandchallenge.evaluation.models import Evaluation, Method
 from grandchallenge.workstations.models import Session
 
 
-@shared_task
+@acks_late_micro_short_task
 def clear_sessions():
     """Clear the expired sessions stored in django_session."""
     call_command("clearsessions")
 
 
-@shared_task(ignore_result=True)
+@acks_late_micro_short_task(ignore_result=True)
 def put_cloudwatch_metrics():
     client = boto3.client(
         "cloudwatch", region_name=settings.AWS_CLOUDWATCH_REGION_NAME

--- a/app/grandchallenge/direct_messages/tasks.py
+++ b/app/grandchallenge/direct_messages/tasks.py
@@ -1,9 +1,8 @@
-from celery import shared_task
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.db.models import Count, F, Q
 
+from grandchallenge.core.celery import acks_late_micro_short_task
 from grandchallenge.profiles.models import NotificationEmailOptions
 
 
@@ -48,7 +47,7 @@ def get_new_senders(*, user):
     return sorted(list(new_senders), key=lambda s: s.pk)
 
 
-@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
+@acks_late_micro_short_task
 def send_new_unread_direct_messages_emails():
     site = Site.objects.get_current()
 

--- a/app/grandchallenge/github/tasks.py
+++ b/app/grandchallenge/github/tasks.py
@@ -9,7 +9,6 @@ from datetime import datetime, timedelta
 
 import jwt
 import requests
-from celery import shared_task
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from django.apps import apps
@@ -20,6 +19,10 @@ from django.utils.timezone import now
 
 from grandchallenge.algorithms.models import Algorithm
 from grandchallenge.codebuild.tasks import create_codebuild_build
+from grandchallenge.core.celery import (
+    acks_late_2xlarge_task,
+    acks_late_micro_short_task,
+)
 from grandchallenge.github.exceptions import GitHubBadRefreshTokenException
 
 logger = logging.getLogger(__name__)
@@ -112,7 +115,7 @@ def build_repo(ghwm_pk):
     )
 
 
-@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-2xlarge"])
+@acks_late_2xlarge_task
 def get_zipfile(*, pk):
     GitHubWebhookMessage = apps.get_model(  # noqa: N806
         app_label="github", model_name="GitHubWebhookMessage"
@@ -166,7 +169,7 @@ def get_zipfile(*, pk):
                 raise
 
 
-@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
+@acks_late_micro_short_task
 def unlink_algorithm(*, pk):
     GitHubWebhookMessage = apps.get_model(  # noqa: N806
         app_label="github", model_name="GitHubWebhookMessage"
@@ -178,7 +181,7 @@ def unlink_algorithm(*, pk):
         )
 
 
-@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
+@acks_late_micro_short_task
 def cleanup_expired_tokens():
     GitHubUserToken = apps.get_model(  # noqa: N806
         app_label="github", model_name="GitHubUserToken"
@@ -186,7 +189,7 @@ def cleanup_expired_tokens():
     GitHubUserToken.objects.filter(refresh_token_expires__lt=now()).delete()
 
 
-@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
+@acks_late_micro_short_task
 def refresh_user_token(*, pk):
     GitHubUserToken = apps.get_model(  # noqa: N806
         app_label="github", model_name="GitHubUserToken"
@@ -203,7 +206,7 @@ def refresh_user_token(*, pk):
     token.save()
 
 
-@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
+@acks_late_micro_short_task
 def refresh_expiring_user_tokens():
     """Refresh user tokens expiring in the next 1 to 28 days"""
     GitHubUserToken = apps.get_model(  # noqa: N806

--- a/app/grandchallenge/notifications/tasks.py
+++ b/app/grandchallenge/notifications/tasks.py
@@ -1,15 +1,14 @@
-from celery import shared_task
-from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db.models import Count, F, Q
 
+from grandchallenge.core.celery import acks_late_micro_short_task
 from grandchallenge.profiles.models import (
     NotificationEmailOptions,
     UserProfile,
 )
 
 
-@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
+@acks_late_micro_short_task
 def send_unread_notification_emails():
     site = Site.objects.get_current()
 

--- a/app/grandchallenge/profiles/tasks.py
+++ b/app/grandchallenge/profiles/tasks.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 
-from celery import shared_task
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sessions.models import Session
@@ -8,8 +7,10 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import Paginator
 from django.utils.timezone import now
 
+from grandchallenge.core.celery import acks_late_micro_short_task
 
-@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
+
+@acks_late_micro_short_task
 def deactivate_user(*, user_pk):
     user = (
         get_user_model().objects.select_related("verification").get(pk=user_pk)
@@ -37,7 +38,7 @@ def deactivate_user(*, user_pk):
                 s.delete()
 
 
-@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
+@acks_late_micro_short_task
 def delete_users_who_dont_login():
     """Remove users who do not sign in after USER_LOGIN_TIMEOUT_DAYS"""
     get_user_model().objects.exclude(

--- a/app/grandchallenge/publications/tasks.py
+++ b/app/grandchallenge/publications/tasks.py
@@ -1,15 +1,14 @@
 import logging
 
-from celery import shared_task
-from django.conf import settings
 from requests.exceptions import RequestException
 
+from grandchallenge.core.celery import acks_late_2xlarge_task
 from grandchallenge.publications.models import Publication
 
 logger = logging.getLogger(__name__)
 
 
-@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-2xlarge"])
+@acks_late_2xlarge_task
 def update_publication_metadata():
     pks_to_delete = []
 

--- a/app/grandchallenge/statistics/tasks.py
+++ b/app/grandchallenge/statistics/tasks.py
@@ -1,4 +1,3 @@
-from celery import shared_task
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
@@ -9,12 +8,13 @@ from grandchallenge.algorithms.models import Algorithm, Job
 from grandchallenge.archives.models import Archive
 from grandchallenge.cases.models import Image
 from grandchallenge.challenges.models import Challenge
+from grandchallenge.core.celery import acks_late_micro_short_task
 from grandchallenge.evaluation.models import Submission
 from grandchallenge.reader_studies.models import Answer, ReaderStudy
 from grandchallenge.workstations.models import Session
 
 
-@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
+@acks_late_micro_short_task
 def update_site_statistics_cache():
     public_challenges = Challenge.objects.filter(hidden=False)
 

--- a/app/grandchallenge/uploads/tasks.py
+++ b/app/grandchallenge/uploads/tasks.py
@@ -1,14 +1,14 @@
 from datetime import timedelta
 
-from celery import shared_task
 from django.conf import settings
 from django.core.paginator import Paginator
 from django.utils.timezone import now
 
+from grandchallenge.core.celery import acks_late_micro_short_task
 from grandchallenge.uploads.models import UserUpload
 
 
-@shared_task(**settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"])
+@acks_late_micro_short_task
 def delete_old_user_uploads():
     limit = now() - timedelta(days=settings.UPLOADS_TIMEOUT_DAYS)
     queryset = UserUpload.objects.filter(created__lt=limit).order_by(

--- a/app/grandchallenge/verifications/tasks.py
+++ b/app/grandchallenge/verifications/tasks.py
@@ -1,12 +1,10 @@
-from celery import shared_task
 from django.apps import apps
-from django.conf import settings
 from django.contrib.auth import get_user_model
 
+from grandchallenge.core.celery import acks_late_micro_short_task
 
-@shared_task(
-    **settings.CELERY_TASK_DECORATOR_KWARGS["acks-late-micro-short"],
-)
+
+@acks_late_micro_short_task
 def update_verification_user_set(*, usernames):
     VerificationUserSet = apps.get_model(  # noqa: N806
         app_label="verifications", model_name="VerificationUserSet"

--- a/app/tests/cases_tests/test_tasks.py
+++ b/app/tests/cases_tests/test_tasks.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
-from celery import shared_task
 from panimg.models import ImageType, PanImgFile, PostProcessorResult
 from panimg.post_processors import DEFAULT_POST_PROCESSORS
 
@@ -14,6 +13,7 @@ from grandchallenge.cases.tasks import (
     import_images,
     post_process_image,
 )
+from grandchallenge.core.celery import acks_late_micro_short_task
 from grandchallenge.core.storage import protected_s3_storage
 from tests.cases_tests import RESOURCE_PATH
 from tests.factories import UploadSessionFactory
@@ -29,7 +29,7 @@ def test_linked_task_called_with_session_pk(
 
     called = {}
 
-    @shared_task
+    @acks_late_micro_short_task
     def local_linked_task(*_, **kwargs):
         called.update(**kwargs)
 

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -16,7 +16,6 @@ from grandchallenge.components.models import (
 from grandchallenge.components.tasks import (
     _get_image_config_and_sha256,
     _repo_login_and_run,
-    _retry,
     add_file_to_object,
     add_image_to_object,
     assign_tarball_from_upload,
@@ -28,6 +27,7 @@ from grandchallenge.components.tasks import (
     upload_to_registry_and_sagemaker,
     validate_docker_image,
 )
+from grandchallenge.core.celery import _retry
 from grandchallenge.notifications.models import Notification
 from tests.algorithms_tests.factories import (
     AlgorithmFactory,
@@ -67,7 +67,7 @@ def test_retry_initial_options(django_capture_on_commit_callbacks):
     new_task = callbacks[0].__self__
 
     assert new_task.options["queue"] == "mine-delay"
-    assert new_task.kwargs == {"foo": "bar", "retries": 1}
+    assert new_task.kwargs == {"foo": "bar", "_retries": 1}
 
 
 @pytest.mark.django_db
@@ -81,7 +81,7 @@ def test_retry_initial(django_capture_on_commit_callbacks):
     new_task = callbacks[0].__self__
 
     assert new_task.options["queue"] == "acks-late-micro-short-delay"
-    assert new_task.kwargs == {"foo": "bar", "retries": 1}
+    assert new_task.kwargs == {"foo": "bar", "_retries": 1}
 
 
 @pytest.mark.django_db
@@ -95,7 +95,7 @@ def test_retry_many(django_capture_on_commit_callbacks):
     new_task = callbacks[0].__self__
 
     assert new_task.options["queue"] == "acks-late-micro-short-delay"
-    assert new_task.kwargs == {"foo": "bar", "retries": 11}
+    assert new_task.kwargs == {"foo": "bar", "_retries": 11}
 
 
 def test_retry_too_many():

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ banned-modules =
     rest_framework.permissions.IsAuthenticatedOrReadOnly = Please use grandchallenge.api.permissions.IsAuthenticatedOrReadOnly instead
     django.contrib.sitemaps.Sitemap = Please use grandchallenge.core.sitemaps.SubdomainSitemap
     django.core.mail.send_mail = Please use grandchallenge.emails.emails.send_standard_email_batch
+    celery.shared_task = Please use acks_late_2xlarge_task or acks_late_xlarge_task instead
 select =
     # B are bugbear checks (including the optionals)
     B


### PR DESCRIPTION
This PR adds an opinionated decorator for celery tasks. It reduces the possible options for a celery task. It forces us to use acks-late queues, and adds common features for running tasks as singletons, retries and error ignoring working around all of the bugs we have encountered so far in Celery.