### PR TITLE
Remove usage of datetime.now

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1,7 +1,7 @@
 import os
 import re
 import socket
-from datetime import datetime, timedelta
+from datetime import timedelta
 from itertools import product
 from pathlib import Path
 from subprocess import CalledProcessError
@@ -12,6 +12,7 @@ from disposable_email_domains import blocklist
 from django.contrib.messages import constants as messages
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse
+from django.utils.timezone import now
 from machina import MACHINA_MAIN_STATIC_DIR, MACHINA_MAIN_TEMPLATE_DIR
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
@@ -769,7 +770,7 @@ BLEACH_ALLOWED_PROTOCOLS = ["http", "https", "mailto"]
 BLEACH_STRIP = strtobool(os.environ.get("BLEACH_STRIP", "True"))
 
 # The markdown processor
-MARKDOWNX_MEDIA_PATH = datetime.now().strftime("i/%Y/%m/%d/")
+MARKDOWNX_MEDIA_PATH = now().strftime("i/%Y/%m/%d/")
 MARKDOWNX_MARKDOWN_EXTENSIONS = [
     "markdown.extensions.fenced_code",
     "markdown.extensions.tables",

--- a/app/grandchallenge/github/tasks.py
+++ b/app/grandchallenge/github/tasks.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import tempfile
 import zipfile
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import jwt
 import requests
@@ -36,10 +36,10 @@ def get_repo_url(payload):
     private_key = serialization.load_pem_private_key(
         key_bytes, password=None, backend=default_backend()
     )
-    now = datetime.now()
+    current_time = now()
     msg = {
-        "iat": int(now.timestamp()) - 60,
-        "exp": int(now.timestamp()) + 60 * 5,
+        "iat": int(current_time.timestamp()) - 60,
+        "exp": int(current_time.timestamp()) + 60 * 5,
         "iss": settings.GITHUB_APP_ID,
     }
     token = jwt.encode(msg, private_key, algorithm="RS256")

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 max-line-length = 79
 docstring-convention = numpy
 max-complexity = 10
+ban-relative-imports = true
 banned-modules =
     guardian.shortcuts.get_objects_for_group = Please use grandchallenge.core.guardian.get_objects_for_group instead
     guardian.shortcuts.get_objects_for_user = Please use grandchallenge.core.guardian.get_objects_for_user instead
@@ -13,6 +14,7 @@ banned-modules =
     django.contrib.sitemaps.Sitemap = Please use grandchallenge.core.sitemaps.SubdomainSitemap
     django.core.mail.send_mail = Please use grandchallenge.emails.emails.send_standard_email_batch
     celery.shared_task = Please use acks_late_2xlarge_task or acks_late_xlarge_task instead
+    datetime.datetime.now = Please use django.utils.timezone.now instead
 select =
     # B are bugbear checks (including the optionals)
     B


### PR DESCRIPTION
This doesn't catch usages of `datetime.now` due to an existing bug in `flake8-tidy-imports` but I might try to fix that.