### PR TITLE
Take active ground truth into account for submission re-evaluation button

### DIFF
--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1177,16 +1177,11 @@ class Submission(UUIDModel):
         active_image = self.phase.active_image
         active_ground_truth = self.phase.active_ground_truth
         if active_image:
-            if active_ground_truth:
-                return Evaluation.objects.filter(
-                    submission=self,
-                    method=active_image,
-                    ground_truth=active_ground_truth,
-                ).exists()
-            else:
-                return Evaluation.objects.filter(
-                    submission=self, method=active_image
-                ).exists()
+            return Evaluation.objects.filter(
+                submission=self,
+                method=active_image,
+                ground_truth=active_ground_truth,
+            ).exists()
         else:
             # No active image, so nothing to do to evaluate with it
             return True

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1173,12 +1173,20 @@ class Submission(UUIDModel):
         unique_together = (("phase", "predictions_file", "algorithm_image"),)
 
     @cached_property
-    def is_evaluated_with_active_image(self):
+    def is_evaluated_with_active_image_and_ground_truth(self):
         active_image = self.phase.active_image
+        active_ground_truth = self.phase.active_ground_truth
         if active_image:
-            return Evaluation.objects.filter(
-                submission=self, method=active_image
-            ).exists()
+            if active_ground_truth:
+                return Evaluation.objects.filter(
+                    submission=self,
+                    method=active_image,
+                    ground_truth=active_ground_truth,
+                ).exists()
+            else:
+                return Evaluation.objects.filter(
+                    submission=self, method=active_image
+                ).exists()
         else:
             # No active image, so nothing to do to evaluate with it
             return True

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_detail.html
@@ -155,12 +155,12 @@
                 </dl>
             </div>
 
-            {% if not object.is_evaluated_with_active_image %}
+            {% if not object.is_evaluated_with_active_image_and_ground_truth %}
                 <div class="card-body">
-                    <h4 class="card-title">Re-Evaluate Submission with Active Method</h4>
+                    <h4 class="card-title">Re-Evaluate Submission with Active Method and Active Ground Truth (if applicable)</h4>
 
                     <p>
-                        This submission has not been evaluated with the active evaluation method for this phase.
+                        This submission has not been evaluated with the active evaluation method and active ground truth for this phase.
                         {% if challenge.available_compute_euro_millicents <= 0 %}
                             However, an evaluation cannot be created as this challenge has exceeded its budget.
                         {% endif %}
@@ -172,7 +172,7 @@
                             {% csrf_token %}
                             <input type="hidden" name="submission" value="{{ object.pk }}">
                             <button type="submit" class="btn btn-xs btn-primary">
-                                Re-Evaluate with the Active Method
+                                Re-Evaluate with the Active Method and Active Ground Truth
                             </button>
                         </form>
                     {% endif %}

--- a/app/tests/evaluation_tests/test_models.py
+++ b/app/tests/evaluation_tests/test_models.py
@@ -897,3 +897,51 @@ def test_read_only_fields_for_dependent_phases():
         "algorithm_outputs",
     ]
     assert p2.read_only_fields_for_dependent_phases == ["submission_kind"]
+
+
+@pytest.mark.django_db
+def test_is_evaluated_with_active_image_and_ground_truth():
+    phase = PhaseFactory()
+    s = SubmissionFactory(phase=phase)
+    EvaluationFactory(submission=s)
+    assert s.is_evaluated_with_active_image_and_ground_truth
+
+    # add a method
+    MethodFactory(
+        phase=phase,
+        is_in_registry=True,
+        is_manifest_valid=True,
+        is_desired_version=True,
+    )
+    del phase.active_image
+    del s.is_evaluated_with_active_image_and_ground_truth
+    assert not s.is_evaluated_with_active_image_and_ground_truth
+
+    EvaluationFactory(submission=s, method=phase.active_image)
+    del s.is_evaluated_with_active_image_and_ground_truth
+    assert s.is_evaluated_with_active_image_and_ground_truth
+
+    # add a ground truth
+    gt = EvaluationGroundTruthFactory(phase=phase, is_desired_version=True)
+    del phase.active_ground_truth
+    del s.is_evaluated_with_active_image_and_ground_truth
+    assert not s.is_evaluated_with_active_image_and_ground_truth
+
+    EvaluationFactory(
+        submission=s,
+        method=phase.active_image,
+        ground_truth=phase.active_ground_truth,
+    )
+    del s.is_evaluated_with_active_image_and_ground_truth
+    assert s.is_evaluated_with_active_image_and_ground_truth
+
+    # remove ground truth and also add another evaluation with another ground truth
+    gt.is_desired_version = False
+    gt.save()
+    gt2 = EvaluationGroundTruthFactory(phase=phase, is_desired_version=False)
+    EvaluationFactory(
+        submission=s, method=phase.active_image, ground_truth=gt2
+    )
+    del phase.active_ground_truth
+    del s.is_evaluated_with_active_image_and_ground_truth
+    assert s.is_evaluated_with_active_image_and_ground_truth


### PR DESCRIPTION
The "Re-evaluate submission" would only show when the method was updated, not when the ground truth was updated. 