### PR TITLE
Address PR feedback for CategoricalOptions form

### DIFF
--- a/app/grandchallenge/core/layout.py
+++ b/app/grandchallenge/core/layout.py
@@ -5,8 +5,16 @@ from django.template.loader import render_to_string
 class Formset(LayoutObject):
     template = "layout/formset.html"
 
-    def __init__(self, formset):
-        self.formset = formset
+    def __init__(self, *args, formset, can_add_another, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._formset = formset
+        self._can_add_another = can_add_another
 
     def render(self, *args, **kwargs):
-        return render_to_string(self.template, {"formset": self.formset})
+        return render_to_string(
+            self.template,
+            {
+                "formset": self._formset,
+                "can_add_another": self._can_add_another,
+            },
+        )

--- a/app/grandchallenge/core/templates/layout/formset.html
+++ b/app/grandchallenge/core/templates/layout/formset.html
@@ -7,7 +7,11 @@
 
 {% crispy formset %}
 
-<button type="button" class="btn btn-primary" id="add-form-row-{{ formset.prefix }}">
+<button type="button"
+        class="btn btn-primary"
+        id="add-form-row-{{ formset.prefix }}"
+        {% if not can_add_another %}disabled{% endif %}
+>
     Add another
 </button>
 


### PR DESCRIPTION
Quick implementation to address the PR feedback before I go. Not extensively tested but see what you think! This:

- only adds an extra field on create
- when not fully editable: disables the add button and removes the delete checkboxes
