### PR TITLE
Update UI running algorithm card to reflect average job duration

### DIFF
--- a/app/grandchallenge/algorithms/static/algorithms/js/job_session.mjs
+++ b/app/grandchallenge/algorithms/static/algorithms/js/job_session.mjs
@@ -28,23 +28,21 @@ function handleJobStatus(job) {
     if (jobStatus === "succeeded") {
         setCardCompleteMessage(cards.job, "View Results");
     } else if (["started", "provisioning", "provisioned"].includes(jobStatus)) {
-        setCardActiveMessage(cards.job, `Job is queued for execution`);
-        setTimeout(function () {
-            getJobStatus(job.api_url)
-        }, Math.floor(Math.random() * timeout) + 100);
+        setCardActiveMessage(cards.job, `Job is being provisioned`);
     } else if (["executing", "executed", "parsing outputs"].includes(jobStatus)) {
         setCardActiveMessage(cards.job, `Job is being executed <br> Average job duration: ${moment.duration(averageJobDuration).humanize()}`);
-        setTimeout(function () {
-            getJobStatus(job.api_url)
-        }, Math.floor(Math.random() * timeout) + 100);
     } else if (jobStatus === "queued" || jobStatus === "re-queued") {
         setCardAwaitingMessage(cards.job, "Queued");
-        setTimeout(function () {
-            getJobStatus(job.api_url)
-        }, Math.floor(Math.random() * timeout) + 100);
     } else {
         setCardErrorMessage(cards.job, "Errored");
     }
+
+    if(["started", "provisioning", "provisioned", "executing", "executed", "parsing outputs", "queued", "re-queued"].includes(jobStatus)){
+        setTimeout(function () {
+            getJobStatus(job.api_url)
+        }, Math.floor(Math.random() * timeout) + 100);
+    }
+
 }
 
 function handleImageImports(jobStatus, imageInputs) {

--- a/app/grandchallenge/algorithms/static/algorithms/js/job_session.mjs
+++ b/app/grandchallenge/algorithms/static/algorithms/js/job_session.mjs
@@ -25,12 +25,10 @@ function handleJobStatus(job) {
 
     handleImageImports(jobStatus, imageInputs)
 
-    let estimatedRemainingTime = averageJobDuration;
-
     if (jobStatus === "succeeded") {
         setCardCompleteMessage(cards.job, "View Results");
     } else if (["started", "provisioning", "provisioned", "executing", "executed", "parsing outputs"].includes(jobStatus)) {
-        setCardActiveMessage(cards.job, `Started, ${moment.duration(estimatedRemainingTime).humanize()} remaining`);
+        setCardActiveMessage(cards.job, `Job queued for execution! <br> Average job duration: ${moment.duration(averageJobDuration).humanize()}`);
         setTimeout(function () {
             getJobStatus(job.api_url)
         }, Math.floor(Math.random() * timeout) + 100);

--- a/app/grandchallenge/algorithms/static/algorithms/js/job_session.mjs
+++ b/app/grandchallenge/algorithms/static/algorithms/js/job_session.mjs
@@ -27,8 +27,13 @@ function handleJobStatus(job) {
 
     if (jobStatus === "succeeded") {
         setCardCompleteMessage(cards.job, "View Results");
-    } else if (["started", "provisioning", "provisioned", "executing", "executed", "parsing outputs"].includes(jobStatus)) {
-        setCardActiveMessage(cards.job, `Job queued for execution! <br> Average job duration: ${moment.duration(averageJobDuration).humanize()}`);
+    } else if (["started", "provisioning", "provisioned"].includes(jobStatus)) {
+        setCardActiveMessage(cards.job, `Job is queued for execution!`);
+        setTimeout(function () {
+            getJobStatus(job.api_url)
+        }, Math.floor(Math.random() * timeout) + 100);
+    } else if (["executing", "executed", "parsing outputs"].includes(jobStatus)) {
+        setCardActiveMessage(cards.job, `Job is being executed! <br> Average job duration: ${moment.duration(averageJobDuration).humanize()}`);
         setTimeout(function () {
             getJobStatus(job.api_url)
         }, Math.floor(Math.random() * timeout) + 100);

--- a/app/grandchallenge/algorithms/static/algorithms/js/job_session.mjs
+++ b/app/grandchallenge/algorithms/static/algorithms/js/job_session.mjs
@@ -28,12 +28,12 @@ function handleJobStatus(job) {
     if (jobStatus === "succeeded") {
         setCardCompleteMessage(cards.job, "View Results");
     } else if (["started", "provisioning", "provisioned"].includes(jobStatus)) {
-        setCardActiveMessage(cards.job, `Job is queued for execution!`);
+        setCardActiveMessage(cards.job, `Job is queued for execution`);
         setTimeout(function () {
             getJobStatus(job.api_url)
         }, Math.floor(Math.random() * timeout) + 100);
     } else if (["executing", "executed", "parsing outputs"].includes(jobStatus)) {
-        setCardActiveMessage(cards.job, `Job is being executed! <br> Average job duration: ${moment.duration(averageJobDuration).humanize()}`);
+        setCardActiveMessage(cards.job, `Job is being executed <br> Average job duration: ${moment.duration(averageJobDuration).humanize()}`);
         setTimeout(function () {
             getJobStatus(job.api_url)
         }, Math.floor(Math.random() * timeout) + 100);


### PR DESCRIPTION
Since running a job involves different stages other than executing the algorithm on the selected image(s) (e.g. container pulling time, provisioning and parsing times), the time viewed in the card is very optimistic. 

Therefore, it would be better (James suggestion) not to say how long is remaining, rather how long a successful job has taken on average.

This small UI update PR changes the message in the algorithm running card based on the status of the job. If the status is one of ("started", "provisioning", "provisioned"), it will show a message that the job is being provisioned.

![Screenshot 2024-07-25 at 09 41 00](https://github.com/user-attachments/assets/90372774-1a39-45b5-b8e6-904642eee4e9)


Otherwise, if the job has a status as one of ("executing", "executed", "parsing outputs"), it will show a message  reflecting the average job duration and informing the user the the job is already being executed. 

![Screenshot 2024-07-25 at 09 42 13](https://github.com/user-attachments/assets/eaf19552-3375-4307-8681-4608a704f474)


closes #3429 

