### PR TITLE
Update cost fixtures docker compose service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ cost_fixtures:
 	docker compose run \
 		-v $(shell readlink -f ./scripts/):/app/scripts:ro \
 		--rm \
-		web \
+		celery_worker_evaluation \
 		python manage.py runscript cost_fixtures
 
 component_interface_value_fixtures:


### PR DESCRIPTION
The cost_fixtures task in Makefile uses the "web" service of the docker-compose file which does not mount the docker socket to the container. However, since this task requires building a docker image, it won't be able to perform it from "web" and require the "celery_worker_evaluation" service instead.