### PR TITLE
Add a check for evaluations with rank 0 and missing metrics and notify admin

### DIFF
--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1427,7 +1427,10 @@ class Evaluation(UUIDModel, ComponentJob):
                 ]:
                     missing_metrics.append(metric.path)
 
-            return missing_metrics
+            if len(missing_metrics) > 0:
+                return missing_metrics
+            else:
+                return None
         return None
 
     def clean(self):

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1408,8 +1408,8 @@ class Evaluation(UUIDModel, ComponentJob):
                 return output.value
 
     @property
-    def missing_metrics_json_file(self):
-        if self.status == self.SUCCESS:
+    def missing_metrics(self):
+        if self.status == self.SUCCESS and self.rank == 0:
 
             output_values = [
                 o.value
@@ -1417,23 +1417,17 @@ class Evaluation(UUIDModel, ComponentJob):
                 if o.interface.slug == "metrics-json-file"
             ]
 
-            if len(output_values) > 0:
+            valid_metrics = self.submission.phase.valid_metrics
+            missing_metrics = []
 
-                if self.rank == 0:
+            for metric in valid_metrics:
+                if get_jsonpath(get(output_values), metric.path) in [
+                    "",
+                    None,
+                ]:
+                    missing_metrics.append(metric.path)
 
-                    valid_metrics = self.submission.phase.valid_metrics
-                    missing_metrics = []
-
-                    for metric in valid_metrics:
-
-                        if get_jsonpath(get(output_values), metric.path) in [
-                            "",
-                            None,
-                        ]:
-                            missing_metrics.append(metric.path)
-
-                    return missing_metrics
-
+            return missing_metrics
         return None
 
     def clean(self):

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -310,10 +310,13 @@
                         </form>
                     {% endif %}
 
-                    {% if object.rank == 0 %}
+                    {% if object.missing_metrics_json_file %}
                         <br>
-                        <div class="alert alert-warning mb-0">This submission has a rank 0 due to missing metric(s) from metrics.json <br>
-                        Therefore, it is not visible in the leaderboard.</div>
+                        <div class="alert alert-warning mb-0">
+                            This submission has a rank 0 due to missing metric(s) from metrics.json {{ object.missing_metrics_json_file }}
+                            <br>
+                            Therefore, it is not visible in the leaderboard.
+                        </div>
                     {% endif %}
                 </div>
             {% endif %}

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -312,7 +312,7 @@
 
                     {% if object.rank == 0 %}
                         <br>
-                        <div class="alert alert-warning">This submission has a rank 0 due to mising metric(s) from metrics.json <br>
+                        <div class="alert alert-warning mb-0">This submission has a rank 0 due to missing metric(s) from metrics.json <br>
                         Therefore, it is not visible in the leaderboard.</div>
                     {% endif %}
                 </div>

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -281,44 +281,42 @@
                 <div class="card-body">
                     <h3 class="card-title">Visibility</h3>
 
-                    {% if object.published %}
-                        <i class="fas fa-eye text-success"></i> This result is published on the
-                        leaderboard(s)
-                        <form method="post"
-                              action="{% url 'evaluation:update' challenge_short_name=challenge.short_name pk=object.pk %}">
-                            {% csrf_token %}
-                            <input type="hidden" name="published"
-                                   value="false">
-                            <button type="submit" class="btn btn-danger">
-                                <i class="fas fa-eye-slash mr-1"></i>
-                                    Exclude this result from the leaderboard(s)
-                            </button>
-                        </form>
-                    {% else %}
-                        <i class="fas fa-eye-slash text-danger"></i> This result is not
-                        published on the leaderboard(s)
-                        <br>
-                        <form method="post"
-                              action="{% url 'evaluation:update' challenge_short_name=challenge.short_name pk=object.pk %}">
-                            {% csrf_token %}
-                            <input type="hidden" name="published"
-                                   value="true">
-                            <button type="submit" class="btn btn-success">
-                                <i class="fas fa-eye mr-1"></i>
-                                Publish this result on the leaderboard(s)
-                            </button>
-                        </form>
-                    {% endif %}
-
                     {% if object.missing_metrics %}
                         <br>
                         <div class="alert alert-warning mb-0">
-                            This evaluation has missing metric(s) from metrics.json {{ object.missing_metrics }}
-                            {% if object.published %}
-                                <br>
-                                Eventhough this evaluation is published, it is not visible in the leaderboard, due to the missing metrics and thus it has a rank 0
-                            {% endif %}
+                            The metrics.json output file for this evaluation is missing the following metrics: {{ object.missing_metrics }}
                         </div>
+
+                    {% else %}
+
+                        {% if object.published %}
+                            <i class="fas fa-eye text-success"></i> This result is published on the
+                            leaderboard(s)
+                            <form method="post"
+                                action="{% url 'evaluation:update' challenge_short_name=challenge.short_name pk=object.pk %}">
+                                {% csrf_token %}
+                                <input type="hidden" name="published"
+                                    value="false">
+                                <button type="submit" class="btn btn-danger">
+                                    <i class="fas fa-eye-slash mr-1"></i>
+                                        Exclude this result from the leaderboard(s)
+                                </button>
+                            </form>
+                        {% else %}
+                            <i class="fas fa-eye-slash text-danger"></i> This result is not
+                            published on the leaderboard(s)
+                            <br>
+                            <form method="post"
+                                action="{% url 'evaluation:update' challenge_short_name=challenge.short_name pk=object.pk %}">
+                                {% csrf_token %}
+                                <input type="hidden" name="published"
+                                    value="true">
+                                <button type="submit" class="btn btn-success">
+                                    <i class="fas fa-eye mr-1"></i>
+                                    Publish this result on the leaderboard(s)
+                                </button>
+                            </form>
+                        {% endif %}
                     {% endif %}
                 </div>
             {% endif %}

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load remove_whitespace %}
 {% load url %}
 {% load profiles %}
 {% load evaluation_extras %}
@@ -284,7 +285,7 @@
                     {% if object.missing_metrics %}
 
                         <i class="fas fa-eye-slash text-danger"></i> This result is not
-                        visible on the leaderboard(s) <br> because the metrics.json output file for this evaluation is missing the following metrics: {{ object.missing_metrics }}
+                        visible on the leaderboard(s) because the metrics.json output file for this evaluation is missing the following metrics: {{ object.missing_metrics|oxford_comma }}
                         <br>
 
                     {% else %}

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -282,10 +282,10 @@
                     <h3 class="card-title">Visibility</h3>
 
                     {% if object.missing_metrics %}
+
+                        <i class="fas fa-eye-slash text-danger"></i> This result is not
+                        visible on the leaderboard(s) <br> because the metrics.json output file for this evaluation is missing the following metrics: {{ object.missing_metrics }}
                         <br>
-                        <div class="alert alert-warning mb-0">
-                            The metrics.json output file for this evaluation is missing the following metrics: {{ object.missing_metrics }}
-                        </div>
 
                     {% else %}
 

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -57,6 +57,12 @@
             </span>
         </dd>
 
+        {% if object.rank == 0 %}
+            <div class="alert alert-warning">Some metrics are missing from metrics.json <br>
+            Therefore, this submission is not visible in the leaderboard.</div>
+
+        {% endif %}
+
         <dt>User</dt>
         <dd>
             {{ object.submission.creator|user_profile_link }}

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -310,12 +310,14 @@
                         </form>
                     {% endif %}
 
-                    {% if object.missing_metrics_json_file %}
+                    {% if object.missing_metrics %}
                         <br>
                         <div class="alert alert-warning mb-0">
-                            This submission has a rank 0 due to missing metric(s) from metrics.json {{ object.missing_metrics_json_file }}
-                            <br>
-                            Therefore, it is not visible in the leaderboard.
+                            This evaluation has missing metric(s) from metrics.json {{ object.missing_metrics }}
+                            {% if object.published %}
+                                <br>
+                                Eventhough this evaluation is published, it is not visible in the leaderboard, due to the missing metrics and thus it has a rank 0
+                            {% endif %}
                         </div>
                     {% endif %}
                 </div>

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -57,12 +57,6 @@
             </span>
         </dd>
 
-        {% if object.rank == 0 %}
-            <div class="alert alert-warning">Some metrics are missing from metrics.json <br>
-            Therefore, this submission is not visible in the leaderboard.</div>
-
-        {% endif %}
-
         <dt>User</dt>
         <dd>
             {{ object.submission.creator|user_profile_link }}
@@ -314,6 +308,12 @@
                                 Publish this result on the leaderboard(s)
                             </button>
                         </form>
+                    {% endif %}
+
+                    {% if object.rank == 0 %}
+                        <br>
+                        <div class="alert alert-warning">This submission has a rank 0 due to mising metric(s) from metrics.json <br>
+                        Therefore, it is not visible in the leaderboard.</div>
                     {% endif %}
                 </div>
             {% endif %}

--- a/app/tests/evaluation_tests/test_models.py
+++ b/app/tests/evaluation_tests/test_models.py
@@ -704,6 +704,15 @@ def test_combined_leaderboard_ranks(combined_ranks, expected_ranks):
         (
             Evaluation.SUCCESS,
             0,
+            {
+                "acc": {"std": 0.1, "mean": 0.0},
+                "dice": {"std": 0.2, "mean": 0.5},
+            },
+            None,
+        ),
+        (
+            Evaluation.SUCCESS,
+            0,
             {"acc": {"std": 0.1, "mean": 0.0}},
             ["dice.mean"],
         ),

--- a/app/tests/evaluation_tests/test_models.py
+++ b/app/tests/evaluation_tests/test_models.py
@@ -691,8 +691,7 @@ def test_combined_leaderboard_ranks(combined_ranks, expected_ranks):
 @pytest.mark.parametrize(
     "eval_status, eval_rank, eval_metrics_json_file_value, expected_missing_metrics",
     (
-        (Evaluation.FAILURE, 0, None, None),
-        (Evaluation.SUCCESS, 0, None, None),
+        (Evaluation.FAILURE, 0, {"acc": {"std": 0.1, "mean": 0.0}}, None),
         (
             Evaluation.SUCCESS,
             1,

--- a/app/tests/evaluation_tests/test_models.py
+++ b/app/tests/evaluation_tests/test_models.py
@@ -723,7 +723,7 @@ def test_combined_leaderboard_ranks(combined_ranks, expected_ranks):
     ),
 )
 @pytest.mark.django_db
-def test_evaluation_missing_metrics_json_file(
+def test_evaluation_missing_metrics(
     eval_status,
     eval_rank,
     eval_metrics_json_file_value,
@@ -753,7 +753,7 @@ def test_evaluation_missing_metrics_json_file(
 
         evaluation.outputs.set([civ])
 
-    arr = evaluation.missing_metrics_json_file
+    arr = evaluation.missing_metrics
 
     assert arr == expected_missing_metrics
 

--- a/app/tests/evaluation_tests/test_models.py
+++ b/app/tests/evaluation_tests/test_models.py
@@ -688,6 +688,76 @@ def test_combined_leaderboard_ranks(combined_ranks, expected_ranks):
     assert [cr["rank"] for cr in combined_ranks] == expected_ranks
 
 
+@pytest.mark.parametrize(
+    "eval_status, eval_rank, eval_metrics_json_file_value, expected_missing_metrics",
+    (
+        (Evaluation.FAILURE, 0, None, None),
+        (Evaluation.SUCCESS, 0, None, None),
+        (
+            Evaluation.SUCCESS,
+            1,
+            {
+                "acc": {"std": 0.1, "mean": 0.0},
+                "dice": {"std": 0.2, "mean": 0.5},
+            },
+            None,
+        ),
+        (
+            Evaluation.SUCCESS,
+            0,
+            {"acc": {"std": 0.1, "mean": 0.0}},
+            ["dice.mean"],
+        ),
+        (
+            Evaluation.SUCCESS,
+            0,
+            {"dice": {"std": 0.2, "mean": 0.5}},
+            ["acc.mean"],
+        ),
+        (
+            Evaluation.SUCCESS,
+            0,
+            {"cosine": {"std": 0.1, "mean": 0.0}},
+            ["acc.mean", "dice.mean"],
+        ),
+    ),
+)
+@pytest.mark.django_db
+def test_evaluation_missing_metrics_json_file(
+    eval_status,
+    eval_rank,
+    eval_metrics_json_file_value,
+    expected_missing_metrics,
+):
+
+    phase = PhaseFactory(
+        challenge__hidden=False,
+        public=True,
+        score_jsonpath="acc.mean",
+        score_title="Accuracy Mean",
+        extra_results_columns=[
+            {"path": "dice.mean", "order": "asc", "title": "Dice mean"}
+        ],
+    )
+
+    evaluation = EvaluationFactory(
+        submission__phase=phase, rank=eval_rank, status=eval_status
+    )
+
+    if eval_metrics_json_file_value is not None:
+
+        ci = ComponentInterface.objects.get(slug="metrics-json-file")
+        civ = ComponentInterfaceValueFactory(
+            interface=ci, value=eval_metrics_json_file_value
+        )
+
+        evaluation.outputs.set([civ])
+
+    arr = evaluation.missing_metrics_json_file
+
+    assert arr == expected_missing_metrics
+
+
 @pytest.mark.django_db
 def test_count_valid_archive_items():
     archive = ArchiveFactory()

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -1461,7 +1461,7 @@ def test_ground_truth_version_management(settings, client):
 
 
 @pytest.mark.django_db
-def test_evaluation_details(client):
+def test_evaluation_details_zero_rank_message(client):
 
     participant = UserFactory()
 

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -16,6 +16,7 @@ from grandchallenge.components.models import (
     ImportStatusChoices,
     InterfaceKindChoices,
 )
+from grandchallenge.core.templatetags.remove_whitespace import oxford_comma
 from grandchallenge.evaluation.models import CombinedLeaderboard, Evaluation
 from grandchallenge.evaluation.tasks import update_combined_leaderboard
 from grandchallenge.evaluation.utils import SubmissionKindChoices
@@ -1499,6 +1500,9 @@ def test_evaluation_details_zero_rank_message(client):
     assert str(evaluation.pk) in response.rendered_content
     assert str(phase.challenge.short_name) in response.rendered_content
     assert (
-        "metrics.json output file for this evaluation is missing"
+        """This result is not
+                        visible on the leaderboard(s) because the metrics.json output file for this evaluation is missing the following metrics: {}""".format(
+            oxford_comma(evaluation.missing_metrics)
+        )
         in response.rendered_content
     )

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -1464,13 +1464,8 @@ def test_ground_truth_version_management(settings, client):
 @pytest.mark.django_db
 def test_evaluation_details_zero_rank_message(client):
 
-    participant = UserFactory()
-
-    challenge = ChallengeFactory(hidden=False, creator=participant)
-
     phase = PhaseFactory(
         challenge__hidden=False,
-        public=True,
         score_jsonpath="acc.mean",
         score_title="Accuracy Mean",
         extra_results_columns=[
@@ -1496,16 +1491,13 @@ def test_evaluation_details_zero_rank_message(client):
         reverse_kwargs={
             "pk": evaluation.pk,
         },
-        user=challenge.creator,
-        challenge=challenge,
+        user=phase.challenge.creator,
+        challenge=phase.challenge,
     )
 
     assert response.status_code == 200
-
     assert str(evaluation.pk) in response.rendered_content
-
-    assert str(challenge.short_name) in response.rendered_content
-
+    assert str(phase.challenge.short_name) in response.rendered_content
     assert (
         "metrics.json output file for this evaluation is missing"
         in response.rendered_content

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -20,10 +20,7 @@ from grandchallenge.evaluation.tasks import update_combined_leaderboard
 from grandchallenge.evaluation.utils import SubmissionKindChoices
 from grandchallenge.invoices.models import PaymentStatusChoices
 from grandchallenge.workstations.models import Workstation
-from tests.algorithms_tests.factories import (
-    AlgorithmFactory,
-    AlgorithmImageFactory,
-)
+from tests.algorithms_tests.factories import AlgorithmFactory
 from tests.archives_tests.factories import ArchiveFactory
 from tests.components_tests.factories import ComponentInterfaceFactory
 from tests.evaluation_tests.factories import (
@@ -1467,23 +1464,10 @@ def test_evaluation_details_zero_rank_message(client):
 
     challenge = ChallengeFactory(hidden=False, creator=participant)
 
-    challenge.add_participant(participant)
-
-    challenge.add_admin(participant)
-
     phase = PhaseFactory(challenge=challenge, public=True)
 
-    method = MethodFactory(phase=phase)
-
-    algorithm_image = AlgorithmImageFactory()
-    algorithm_image.algorithm.add_editor(user=participant)
-
-    submission = SubmissionFactory(
-        phase=phase, creator=participant, algorithm_image=algorithm_image
-    )
-
     evaluation = EvaluationFactory(
-        method=method, submission=submission, rank=0, status=Evaluation.SUCCESS
+        submission__phase=phase, rank=0, status=Evaluation.SUCCESS
     )
 
     response = get_view_for_user(
@@ -1500,10 +1484,6 @@ def test_evaluation_details_zero_rank_message(client):
     assert response.status_code == 200
 
     assert str(evaluation.pk) in response.rendered_content
-
-    assert str(submission.pk) in response.rendered_content
-
-    assert str(method.pk) in response.rendered_content
 
     assert str(challenge.short_name) in response.rendered_content
 

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -1507,6 +1507,6 @@ def test_evaluation_details_zero_rank_message(client):
     assert str(challenge.short_name) in response.rendered_content
 
     assert (
-        "This submission has a rank 0 due to missing metric"
+        "metrics.json output file for this evaluation is missing"
         in response.rendered_content
     )


### PR DESCRIPTION
Implementing a solution to check for missing metrics and notify the admin on the Evaluation detail page. Missing metrics lead to keep the evaluation rank as zero and thus not showing in the leaderboard even when it is finished with success and published.

A property is added to the Evaluation mode to check for missing metrics in metrics.json. Moreover, a message is added to the details view notifying the admin on which metrics are missing. Model and View tests are provided for both functionalities.

![Screenshot 2024-07-29 at 11 44 48](https://github.com/user-attachments/assets/ed435792-5c32-4c73-9b7d-720942d0a165)



closes #3346 