### PR TITLE
Fix failing algorithm usage chart to render (until resize) on Safari & Brave

### DIFF
--- a/app/grandchallenge/charts/static/js/charts/render_charts.mjs
+++ b/app/grandchallenge/charts/static/js/charts/render_charts.mjs
@@ -5,9 +5,15 @@ function renderVegaLiteChart(element) {
 }
 
 document.addEventListener("DOMContentLoaded", function(event) {
-    for (const element of document.getElementsByClassName("vega-lite-chart")) {
-        renderVegaLiteChart(element);
+
+    var tabsElement = document.getElementById("v-pills-tab");
+
+    if(tabsElement == null) {
+        for (const element of document.getElementsByClassName("vega-lite-chart")) {
+            renderVegaLiteChart(element);
+        }
     }
+
 });
 
 

--- a/app/grandchallenge/charts/static/js/charts/render_charts.mjs
+++ b/app/grandchallenge/charts/static/js/charts/render_charts.mjs
@@ -5,16 +5,18 @@ function renderVegaLiteChart(element) {
 
 document.addEventListener("DOMContentLoaded", function(event) {
 
-    var tabsElement = document.getElementById("v-pills-tab");
-
-    if(tabsElement == null) {
+    if(document.getElementById("v-pills-tab") === null) {
         for (const element of document.getElementsByClassName("vega-lite-chart")) {
             renderVegaLiteChart(element);
         }
     }
-
 });
 
+document.addEventListener("vega.render", function(event) {
+    for (const element of document.getElementsByClassName("vega-lite-chart")) {
+        renderVegaLiteChart(element);
+    }
+});
 
 // Lazy rendering
 // Tag the containers with the class 'vega-lite-chart-lazy' to only render

--- a/app/grandchallenge/charts/static/js/charts/render_charts.mjs
+++ b/app/grandchallenge/charts/static/js/charts/render_charts.mjs
@@ -1,7 +1,6 @@
 function renderVegaLiteChart(element) {
     const spec = JSON.parse(element.children[0].textContent);
     vegaEmbed(element, spec);
-    setTimeout(() => window.dispatchEvent(new Event("resize")), 1);
 }
 
 document.addEventListener("DOMContentLoaded", function(event) {

--- a/app/grandchallenge/charts/static/js/charts/render_charts.mjs
+++ b/app/grandchallenge/charts/static/js/charts/render_charts.mjs
@@ -1,6 +1,7 @@
 function renderVegaLiteChart(element) {
     const spec = JSON.parse(element.children[0].textContent);
     vegaEmbed(element, spec);
+    setTimeout(() => window.dispatchEvent(new Event("resize")), 1);
 }
 
 document.addEventListener("DOMContentLoaded", function(event) {

--- a/app/grandchallenge/core/static/js/refresh_sidebar.mjs
+++ b/app/grandchallenge/core/static/js/refresh_sidebar.mjs
@@ -44,9 +44,5 @@ $(document).ready(function() {
     });
 
     activateLocation();
-
-    for (const element of document.getElementsByClassName("vega-lite-chart")) {
-        const spec = JSON.parse(element.children[0].textContent);
-        vegaEmbed(element, spec);
-    }
+    document.dispatchEvent(new Event("vega.render"));
 });

--- a/app/grandchallenge/core/static/js/refresh_sidebar.mjs
+++ b/app/grandchallenge/core/static/js/refresh_sidebar.mjs
@@ -1,4 +1,5 @@
 $(document).ready(function() {
+
     const tabSelectors = $('#v-pills-tab a');
 
     const allowedHashes = new Set(
@@ -43,4 +44,9 @@ $(document).ready(function() {
     });
 
     activateLocation();
+
+    for (const element of document.getElementsByClassName("vega-lite-chart")) {
+        const spec = JSON.parse(element.children[0].textContent);
+        vegaEmbed(element, spec);
+    }
 });


### PR DESCRIPTION
The original issue is reported on Safari browser (WebKit-based). However, I had the same issue on Brave browser (Chromium-based), so it spans different rendering engines. Similar issue was raised before [here](https://talk.observablehq.com/t/embedding-vega-lite-charts-that-have-width-value-set-to-container-leads-to-null-width-until-window-is-resized/6120/5). The solution is to trigger a resize event after returning the chart by vega embed.