### PR TITLE
Add visibility indicator to phase/submission/leaderboard for Admins

### DIFF
--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -583,6 +583,7 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
                     )
 
         if self.has_changed("public"):
+            self.assign_permissions()
             on_commit(
                 assign_evaluation_permissions.signature(
                     kwargs={"phase_pks": [self.pk]}
@@ -748,9 +749,19 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
         assign_perm(
             "create_phase_submission", self.challenge.admins_group, self
         )
-        assign_perm(
-            "create_phase_submission", self.challenge.participants_group, self
-        )
+
+        if self.public:
+            assign_perm(
+                "create_phase_submission",
+                self.challenge.participants_group,
+                self,
+            )
+        else:
+            remove_perm(
+                "create_phase_submission",
+                self.challenge.participants_group,
+                self,
+            )
 
     def get_absolute_url(self):
         return reverse(

--- a/app/grandchallenge/evaluation/templates/evaluation/partials/combinedleaderboard_menu_sidebar.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/partials/combinedleaderboard_menu_sidebar.html
@@ -4,18 +4,21 @@
        data-target="#{{ combined_leaderboard.slug }}-collapse"
        aria-expanded={% if request.resolver_match.view_name in 'evaluation:combined-leaderboard-update,evaluation:combined-leaderboard-delete' and request.resolver_match.kwargs.slug == combined_leaderboard.slug %}"true"{% else %}"false"{% endif %}
       >
-         <i class="fas fa-chevron-right mr-1"></i> <i class="fas fa-chevron-down mr-1"></i> {{ combined_leaderboard.title }}
+        <i class="fas fa-chevron-right fa-fw"></i>
+        <i class="fas fa-chevron-down fa-fw"></i>
+        {{ combined_leaderboard.title }}
     </a>
     <div class="collapse {% if request.resolver_match.view_name in 'evaluation:combined-leaderboard-update,evaluation:combined-leaderboard-delete' and request.resolver_match.kwargs.slug == combined_leaderboard.slug %}show{% endif %}"
          id="{{ combined_leaderboard.slug }}-collapse"
-         style=""
     >
         <ul class="nav nav-pills flex-column">
             <li class="nav-item pl-4">
-                <a href="{% url 'evaluation:combined-leaderboard-update' slug=combined_leaderboard.slug %}" class="nav-link py-1 pl-3 {% if request.resolver_match.view_name == 'evaluation:combined-leaderboard-update' and request.resolver_match.kwargs.slug == combined_leaderboard.slug %}active{% endif %}"><i class="fas fa-cog fa-fw"></i> Settings</a>
+                <a href="{% url 'evaluation:combined-leaderboard-update' slug=combined_leaderboard.slug %}" class="nav-link py-1 pl-3 {% if request.resolver_match.view_name == 'evaluation:combined-leaderboard-update' and request.resolver_match.kwargs.slug == combined_leaderboard.slug %}active{% endif %}">
+                    <i class="fas fa-cog fa-fw"></i> Settings</a>
             </li>
             <li class="nav-item pl-4">
-                <a href="{% url 'evaluation:combined-leaderboard-delete' slug=combined_leaderboard.slug %}" class="nav-link py-1 pl-3 {% if request.resolver_match.view_name == 'evaluation:combined-leaderboard-delete' and request.resolver_match.kwargs.slug == combined_leaderboard.slug %}active{% endif %}"><i class="fas fa-trash fa-fw"></i> Delete</a>
+                <a href="{% url 'evaluation:combined-leaderboard-delete' slug=combined_leaderboard.slug %}" class="nav-link py-1 pl-3 {% if request.resolver_match.view_name == 'evaluation:combined-leaderboard-delete' and request.resolver_match.kwargs.slug == combined_leaderboard.slug %}active{% endif %}">
+                    <i class="fas fa-trash fa-fw"></i> Delete</a>
             </li>
         </ul>
     </div>

--- a/app/grandchallenge/evaluation/templates/evaluation/partials/phase_navbar.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/partials/phase_navbar.html
@@ -22,14 +22,14 @@
             {% if "change_challenge" in challenge_perms or phase.public %}
                 <li class="nav-item">
                     {% if leaderboard_nav %}
-                        <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
-                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-trophy fa-fw"></i>&nbsp;&nbsp;{{ phase.title }}</a>
+                        <a class="nav-link mr-1 px-4 py-1 {% if not phase.public %} text-muted {% endif %} {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-trophy fa-fw"></i>&nbsp;&nbsp;{{ phase.title }} {%if not phase.public %} <i class="fa fa-eye-slash"></i> {% endif %}</a>
                     {% elif submission_nav %}
-                        <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-detail' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
-                               href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-upload fa-fw"></i>&nbsp;&nbsp;{{ phase.title }}</a>
+                        <a class="nav-link mr-1 px-4 py-1 {% if not phase.public %} text-muted {% endif %} {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-detail' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                            href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-upload fa-fw"></i>&nbsp;&nbsp;{{ phase.title }} {%if not phase.public %} <i class="fa fa-eye-slash"></i> {% endif %}</a>
                     {% else %}
-                        <a class="nav-link mr-1 px-4 py-1 {% if object.submission.phase.slug == phase.slug %}active{% endif %}"
-                       href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-trophy fa-fw"></i>&nbsp;&nbsp;{{ phase.title }}</a>
+                        <a class="nav-link mr-1 px-4 py-1 {% if not phase.public %} text-muted {% endif %} {% if object.submission.phase.slug == phase.slug %}active{% endif %}"
+                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-trophy fa-fw"></i>&nbsp;&nbsp;{{ phase.title }} {%if not phase.public %} <i class="fa fa-eye-slash"></i> {% endif %}</a>
                     {% endif %}
                 </li>
             {% endif %}

--- a/app/grandchallenge/evaluation/templates/evaluation/partials/phase_navbar.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/partials/phase_navbar.html
@@ -26,7 +26,7 @@
                     href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-trophy fa-fw mr-1"></i>{{ phase.title }}{%if not phase.public %}<i class="fa fa-eye-slash ml-1"></i>{% endif %}</a>
                     {% elif submission_nav %}
                         <a class="nav-link mr-1 px-4 py-1 {% if not phase.public %} text-muted {% endif %} {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-detail' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
-                            href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-upload fa-fw mr-1"></i>{{ phase.title }} {%if not phase.public %}<i class="fa fa-eye-slash ml-1"></i>{% endif %}</a>
+                            href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-upload fa-fw mr-1"></i>{{ phase.title }}{%if not phase.public %}<i class="fa fa-eye-slash ml-1"></i>{% endif %}</a>
                     {% else %}
                         <a class="nav-link mr-1 px-4 py-1 {% if not phase.public %} text-muted {% endif %} {% if object.submission.phase.slug == phase.slug %}active{% endif %}"
                     href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-trophy fa-fw mr-1"></i>{{ phase.title }}{%if not phase.public %}<i class="fa fa-eye-slash ml-1"></i>{% endif %}</a>

--- a/app/grandchallenge/evaluation/templates/evaluation/partials/phase_navbar.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/partials/phase_navbar.html
@@ -14,7 +14,7 @@
             {% for combined_leaderboard in challenge.combinedleaderboard_set.all %}
                 <li class="nav-item">
                      <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name in 'evaluation:combined-leaderboard-detail,evaluation:combined-leaderboard-update,evaluation:combined-leaderboard-delete' and request.resolver_match.kwargs.slug == combined_leaderboard.slug %}active{% endif %}"
-                        href="{% url 'evaluation:combined-leaderboard-detail' challenge_short_name=challenge.short_name slug=combined_leaderboard.slug %}"><i class="fa fa-trophy fa-lg fa-fw"></i>&nbsp;&nbsp;{{ combined_leaderboard.title|title }}</a>
+                        href="{% url 'evaluation:combined-leaderboard-detail' challenge_short_name=challenge.short_name slug=combined_leaderboard.slug %}">{{ combined_leaderboard.title|title }}</a>
                 </li>
             {% endfor %}
         {%  endif %}
@@ -22,14 +22,14 @@
             {% if "change_challenge" in challenge_perms or phase.public %}
                 <li class="nav-item">
                     {% if leaderboard_nav %}
-                        <a class="nav-link mr-1 px-4 py-1 {% if not phase.public %} text-muted {% endif %} {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
-                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-trophy fa-fw mr-1"></i>{{ phase.title }}{%if not phase.public %}<i class="fa fa-eye-slash ml-1"></i>{% endif %}</a>
+                        <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}">{%if not phase.public %}<i class="fa fa-lock fa-fw mr-1"></i>{% endif %}{{ phase.title }}</a>
                     {% elif submission_nav %}
-                        <a class="nav-link mr-1 px-4 py-1 {% if not phase.public %} text-muted {% endif %} {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-detail' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
-                            href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-upload fa-fw mr-1"></i>{{ phase.title }}{%if not phase.public %}<i class="fa fa-eye-slash ml-1"></i>{% endif %}</a>
+                        <a class="nav-link mr-1 px-4 py-1 {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-detail' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
+                            href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}">{%if not phase.public %}<i class="fa fa-lock fa-fw mr-1"></i>{% endif %}{{ phase.title }}</a>
                     {% else %}
-                        <a class="nav-link mr-1 px-4 py-1 {% if not phase.public %} text-muted {% endif %} {% if object.submission.phase.slug == phase.slug %}active{% endif %}"
-                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-trophy fa-fw mr-1"></i>{{ phase.title }}{%if not phase.public %}<i class="fa fa-eye-slash ml-1"></i>{% endif %}</a>
+                        <a class="nav-link mr-1 px-4 py-1 {% if object.submission.phase.slug == phase.slug %}active{% endif %}"
+                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}">{%if not phase.public %}<i class="fa fa-lock fa-fw mr-1"></i>{% endif %}{{ phase.title }}</a>
                     {% endif %}
                 </li>
             {% endif %}

--- a/app/grandchallenge/evaluation/templates/evaluation/partials/phase_navbar.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/partials/phase_navbar.html
@@ -23,13 +23,13 @@
                 <li class="nav-item">
                     {% if leaderboard_nav %}
                         <a class="nav-link mr-1 px-4 py-1 {% if not phase.public %} text-muted {% endif %} {% if request.resolver_match.view_name == 'evaluation:leaderboard' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
-                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-trophy fa-fw"></i>&nbsp;&nbsp;{{ phase.title }} {%if not phase.public %} <i class="fa fa-eye-slash"></i> {% endif %}</a>
+                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-trophy fa-fw mr-1"></i>{{ phase.title }}{%if not phase.public %}<i class="fa fa-eye-slash ml-1"></i>{% endif %}</a>
                     {% elif submission_nav %}
                         <a class="nav-link mr-1 px-4 py-1 {% if not phase.public %} text-muted {% endif %} {% if request.resolver_match.view_name == 'evaluation:submission-create' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:submission-detail' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"
-                            href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-upload fa-fw"></i>&nbsp;&nbsp;{{ phase.title }} {%if not phase.public %} <i class="fa fa-eye-slash"></i> {% endif %}</a>
+                            href="{% url 'evaluation:submission-create' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-upload fa-fw mr-1"></i>{{ phase.title }} {%if not phase.public %}<i class="fa fa-eye-slash ml-1"></i>{% endif %}</a>
                     {% else %}
                         <a class="nav-link mr-1 px-4 py-1 {% if not phase.public %} text-muted {% endif %} {% if object.submission.phase.slug == phase.slug %}active{% endif %}"
-                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-trophy fa-fw"></i>&nbsp;&nbsp;{{ phase.title }} {%if not phase.public %} <i class="fa fa-eye-slash"></i> {% endif %}</a>
+                    href="{% url 'evaluation:leaderboard' challenge_short_name=challenge.short_name slug=phase.slug %}"><i class="fa fa-trophy fa-fw mr-1"></i>{{ phase.title }}{%if not phase.public %}<i class="fa fa-eye-slash ml-1"></i>{% endif %}</a>
                     {% endif %}
                 </li>
             {% endif %}

--- a/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
+++ b/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
@@ -6,7 +6,7 @@
     >
         <i class="fas fa-chevron-right fa-fw"></i>
         <i class="fas fa-chevron-down fa-fw"></i>
-        {% if not phase.public %}<i class="fas fa-lock" title="Not Public"></i>{% endif%}
+        {% if not phase.public %}<i class="fas fa-lock" title="Not Public"></i>{% endif %}
         {{ phase.title }}
     </a>
     <div class="collapse {% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}show{% endif %}"

--- a/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
+++ b/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
@@ -1,6 +1,7 @@
 <li class="nav-item">
     <a class="nav-link px-4 py-1 mb-1" data-toggle="collapse" data-target="#{{ phase.slug }}-collapse" aria-expanded={% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}"true"{% else %}"false"{% endif %}>
-        <i class="fas fa-chevron-right mr-1"></i> <i class="fas fa-chevron-down mr-1"></i> {{ phase.title }} <i class="fas {% if phase.public %}fa-eye text-success{% else %}fa-eye-slash text-danger{% endif%} ml-1" title="{% if not phase.public %}Not{% endif%} Public"></i>
+        <i class="fas fa-chevron-right mr-1"></i><i class="fas fa-chevron-down mr-1"></i>{{ phase.title }}<i class="fas {% if phase.public %}fa-eye text-success{% else %}fa-eye-slash text-danger{% endif%} ml-1" title="{% if not phase.public %}Not{% endif%} Public"></i>
+
 
     </a>
     <div class="collapse {% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}show{% endif %}" id="{{ phase.slug }}-collapse" style="">

--- a/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
+++ b/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
@@ -1,8 +1,6 @@
 <li class="nav-item">
     <a class="nav-link px-4 py-1 mb-1" data-toggle="collapse" data-target="#{{ phase.slug }}-collapse" aria-expanded={% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}"true"{% else %}"false"{% endif %}>
         <i class="fas fa-chevron-right mr-1"></i><i class="fas fa-chevron-down mr-1"></i>{{ phase.title }}<i class="fas {% if phase.public %}fa-eye text-success{% else %}fa-eye-slash text-danger{% endif%} ml-1" title="{% if not phase.public %}Not{% endif%} Public"></i>
-
-
     </a>
     <div class="collapse {% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}show{% endif %}" id="{{ phase.slug }}-collapse" style="">
         <ul class="nav nav-pills flex-column">

--- a/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
+++ b/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
@@ -1,6 +1,7 @@
 <li class="nav-item">
     <a class="nav-link px-4 py-1 mb-1" data-toggle="collapse" data-target="#{{ phase.slug }}-collapse" aria-expanded={% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}"true"{% else %}"false"{% endif %}>
-         <i class="fas fa-chevron-right mr-1"></i> <i class="fas fa-chevron-down mr-1"></i> {{ phase.title }}
+        <i class="fas fa-chevron-right mr-1"></i> <i class="fas fa-chevron-down mr-1"></i> {{ phase.title }} <i class="fas {% if phase.public %}fa-eye text-success{% else %}fa-eye-slash text-danger{% endif%} ml-1" title="{% if not phase.public %}Not{% endif%} Public"></i>
+
     </a>
     <div class="collapse {% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}show{% endif %}" id="{{ phase.slug }}-collapse" style="">
         <ul class="nav nav-pills flex-column">

--- a/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
+++ b/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
@@ -6,7 +6,7 @@
     >
         <i class="fas fa-chevron-right fa-fw"></i>
         <i class="fas fa-chevron-down fa-fw"></i>
-        {% if not phase.public %}<i class="fas fa-lock" title="Not Public"></i>{% endif %}
+        {% if not phase.public %}<i class="fas fa-lock" title="Phase is private"></i>{% endif %}
         {{ phase.title }}
     </a>
     <div class="collapse {% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}show{% endif %}"

--- a/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
+++ b/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
@@ -1,20 +1,40 @@
 <li class="nav-item">
-    <a class="nav-link px-4 py-1 mb-1" data-toggle="collapse" data-target="#{{ phase.slug }}-collapse" aria-expanded={% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}"true"{% else %}"false"{% endif %}>
-        <i class="fas fa-chevron-right mr-1"></i><i class="fas fa-chevron-down mr-1"></i>{% if not phase.public %}<i class="fas fa-lock ml-1 mr-1" title="Not Public"></i>{% endif%}{{ phase.title }}
+    <a class="nav-link px-4 py-1 mb-1"
+       data-toggle="collapse"
+       data-target="#{{ phase.slug }}-collapse"
+       aria-expanded={% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}"true"{% else %}"false"{% endif %}
+    >
+        <i class="fas fa-chevron-right fa-fw"></i>
+        <i class="fas fa-chevron-down fa-fw"></i>
+        {% if not phase.public %}<i class="fas fa-lock" title="Not Public"></i>{% endif%}
+        {{ phase.title }}
     </a>
-    <div class="collapse {% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}show{% endif %}" id="{{ phase.slug }}-collapse" style="">
+    <div class="collapse {% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}show{% endif %}"
+         id="{{ phase.slug }}-collapse">
         <ul class="nav nav-pills flex-column">
             <li class="nav-item pl-4">
-                <a href="{% url 'evaluation:phase-update' slug=phase.slug %}" class="nav-link py-1 pl-3 {% if request.resolver_match.view_name == 'evaluation:phase-update' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"><i class="fas fa-cog fa-fw"></i> Settings</a>
+                <a href="{% url 'evaluation:phase-update' slug=phase.slug %}"
+                   class="nav-link py-1 pl-3 {% if request.resolver_match.view_name == 'evaluation:phase-update' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}">
+                    <i class="fas fa-cog fa-fw"></i> Settings
+                </a>
             </li>
             <li class="nav-item pl-4">
-                <a href="{% url "evaluation:method-list" slug=phase.slug %}" class="nav-link py-1 pl-3 {% if request.resolver_match.view_name in 'evaluation:method-list,evaluation:method-create,evaluation:method-update' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:method-detail' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"><i class="fab fa-docker fa-fw"></i> Evaluation Methods</a>
+                <a href="{% url "evaluation:method-list" slug=phase.slug %}"
+                   class="nav-link py-1 pl-3 {% if request.resolver_match.view_name in 'evaluation:method-list,evaluation:method-create,evaluation:method-update' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:method-detail' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}">
+                    <i class="fab fa-docker fa-fw"></i> Evaluation Methods
+                </a>
             </li>
             <li class="nav-item pl-4">
-                <a href="{% url "evaluation:ground-truth-list" slug=phase.slug %}" class="nav-link py-1 pl-3 {% if request.resolver_match.view_name in 'evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}"><i class="fas fa-cube fa-fw"></i> Ground Truths</a>
+                <a href="{% url "evaluation:ground-truth-list" slug=phase.slug %}"
+                   class="nav-link py-1 pl-3 {% if request.resolver_match.view_name in 'evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update' and request.resolver_match.kwargs.slug == phase.slug or request.resolver_match.view_name == 'evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}active{% endif %}">
+                    <i class="fas fa-cube fa-fw"></i> Ground Truths
+                </a>
             </li>
             <li class="nav-item pl-4">
-                <a href="{% url "evaluation:evaluation-admin-list" slug=phase.slug %}" class="nav-link py-1 pl-3 {% if request.resolver_match.view_name == 'evaluation:evaluation-admin-list' and request.resolver_match.kwargs.slug == phase.slug %} active {% endif %}"><i class="fas fa-list fa-fw"></i> Submissions & Evaluations</a>
+                <a href="{% url "evaluation:evaluation-admin-list" slug=phase.slug %}"
+                   class="nav-link py-1 pl-3 {% if request.resolver_match.view_name == 'evaluation:evaluation-admin-list' and request.resolver_match.kwargs.slug == phase.slug %} active {% endif %}">
+                    <i class="fas fa-list fa-fw"></i> Submissions & Evaluations
+                </a>
             </li>
         </ul>
     </div>

--- a/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
+++ b/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
@@ -1,6 +1,6 @@
 <li class="nav-item">
     <a class="nav-link px-4 py-1 mb-1" data-toggle="collapse" data-target="#{{ phase.slug }}-collapse" aria-expanded={% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}"true"{% else %}"false"{% endif %}>
-        <i class="fas fa-chevron-right mr-1"></i><i class="fas fa-chevron-down mr-1"></i>{{ phase.title }}<i class="fas {% if phase.public %}fa-eye text-success{% else %}fa-eye-slash text-danger{% endif%} ml-1" title="{% if not phase.public %}Not{% endif%} Public"></i>
+        <i class="fas fa-chevron-right mr-1"></i><i class="fas fa-chevron-down mr-1"></i>{% if not phase.public %}<i class="fas fa-lock ml-1 mr-1" title="Not Public"></i>{% endif%}{{ phase.title }}
     </a>
     <div class="collapse {% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}show{% endif %}" id="{{ phase.slug }}-collapse" style="">
         <ul class="nav nav-pills flex-column">

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -588,23 +588,11 @@ def test_hidden_phase_visible_for_admins_but_not_participants(client):
             user=u,
         )
 
-        if view_name in [
-            "submission-list",
-            "submission-create",
-            "submission-detail",
-        ]:
-            icon = "upload"
-        else:
-            icon = "trophy"
-
         assert response.status_code == status
         if status == 200:
+            assert f"</i>{visible_phase.title}</a>" in str(response.content)
             assert (
-                f'<i class="fa fa-{icon} fa-fw mr-1"></i>{visible_phase.title}'
-                in str(response.content)
-            )
-            assert (
-                f'<i class="fa fa-{icon} fa-fw mr-1"></i>{hidden_phase.title}'
+                f'</i>{hidden_phase.title}<i class="fa fa-eye-slash ml-1"></i></a>'
                 not in str(response.content)
             )
 
@@ -617,12 +605,9 @@ def test_hidden_phase_visible_for_admins_but_not_participants(client):
             user=ch.admins_group.user_set.first(),
         )
         assert response.status_code == 200
+        assert f"{visible_phase.title}</a>" in str(response.content)
         assert (
-            f'<i class="fa fa-{icon} fa-fw mr-1"></i>{visible_phase.title}'
-            in str(response.content)
-        )
-        assert (
-            f'<i class="fa fa-{icon} fa-fw mr-1"></i>{hidden_phase.title}'
+            f'{hidden_phase.title}<i class="fa fa-eye-slash ml-1"></i></a>'
             in str(response.content)
         )
 

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -590,8 +590,8 @@ def test_hidden_phase_visible_for_admins_but_not_participants(client):
 
         assert response.status_code == status
         if status == 200:
-            assert f"{visible_phase.title}</a>" in str(response.content)
-            assert f"{hidden_phase.title}</a>" not in str(response.content)
+            assert visible_phase.title in str(response.content)
+            assert hidden_phase.title not in str(response.content)
 
         # for the admin both phases are visible and they have access to submissions
         # and evals from both phases
@@ -602,8 +602,8 @@ def test_hidden_phase_visible_for_admins_but_not_participants(client):
             user=ch.admins_group.user_set.first(),
         )
         assert response.status_code == 200
-        assert f"{visible_phase.title}</a>" in str(response.content)
-        assert f"{hidden_phase.title}</a>" in str(response.content)
+        assert visible_phase.title in str(response.content)
+        assert hidden_phase.title in str(response.content)
 
 
 @pytest.mark.django_db

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -590,9 +590,9 @@ def test_hidden_phase_visible_for_admins_but_not_participants(client):
 
         assert response.status_code == status
         if status == 200:
-            assert f"</i>{visible_phase.title}</a>" in str(response.content)
+            assert f"{visible_phase.title}</a>" in str(response.content)
             assert (
-                f'</i>{hidden_phase.title}<i class="fa fa-eye-slash ml-1"></i></a>'
+                f'<i class="fa fa-lock fa-fw mr-1"></i>{hidden_phase.title}</a>'
                 not in str(response.content)
             )
 
@@ -607,7 +607,7 @@ def test_hidden_phase_visible_for_admins_but_not_participants(client):
         assert response.status_code == 200
         assert f"{visible_phase.title}</a>" in str(response.content)
         assert (
-            f'{hidden_phase.title}<i class="fa fa-eye-slash ml-1"></i></a>'
+            f'<i class="fa fa-lock fa-fw mr-1"></i>{hidden_phase.title}</a>'
             in str(response.content)
         )
 

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -587,13 +587,25 @@ def test_hidden_phase_visible_for_admins_but_not_participants(client):
             reverse_kwargs={"challenge_short_name": ch.short_name, **kwargs},
             user=u,
         )
+
+        if view_name in [
+            "submission-list",
+            "submission-create",
+            "submission-detail",
+        ]:
+            icon = "upload"
+        else:
+            icon = "trophy"
+
         assert response.status_code == status
         if status == 200:
-            assert f"</i>&nbsp;&nbsp;{visible_phase.title}" in str(
-                response.content
+            assert (
+                f'<i class="fa fa-{icon} fa-fw mr-1"></i>{visible_phase.title}'
+                in str(response.content)
             )
-            assert f"</i>&nbsp;&nbsp;{hidden_phase.title}" not in str(
-                response.content
+            assert (
+                f'<i class="fa fa-{icon} fa-fw mr-1"></i>{hidden_phase.title}'
+                not in str(response.content)
             )
 
         # for the admin both phases are visible and they have access to submissions
@@ -605,10 +617,14 @@ def test_hidden_phase_visible_for_admins_but_not_participants(client):
             user=ch.admins_group.user_set.first(),
         )
         assert response.status_code == 200
-        assert f"</i>&nbsp;&nbsp;{visible_phase.title}" in str(
-            response.content
+        assert (
+            f'<i class="fa fa-{icon} fa-fw mr-1"></i>{visible_phase.title}'
+            in str(response.content)
         )
-        assert f"</i>&nbsp;&nbsp;{hidden_phase.title}" in str(response.content)
+        assert (
+            f'<i class="fa fa-{icon} fa-fw mr-1"></i>{hidden_phase.title}'
+            in str(response.content)
+        )
 
 
 @pytest.mark.django_db

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -589,8 +589,12 @@ def test_hidden_phase_visible_for_admins_but_not_participants(client):
         )
         assert response.status_code == status
         if status == 200:
-            assert f"{visible_phase.title}</a>" in str(response.content)
-            assert f"{hidden_phase.title}</a>" not in str(response.content)
+            assert f"</i>&nbsp;&nbsp;{visible_phase.title}" in str(
+                response.content
+            )
+            assert f"</i>&nbsp;&nbsp;{hidden_phase.title}" not in str(
+                response.content
+            )
 
         # for the admin both phases are visible and they have access to submissions
         # and evals from both phases
@@ -601,8 +605,10 @@ def test_hidden_phase_visible_for_admins_but_not_participants(client):
             user=ch.admins_group.user_set.first(),
         )
         assert response.status_code == 200
-        assert f"{visible_phase.title}</a>" in str(response.content)
-        assert f"{hidden_phase.title}</a>" in str(response.content)
+        assert f"</i>&nbsp;&nbsp;{visible_phase.title}" in str(
+            response.content
+        )
+        assert f"</i>&nbsp;&nbsp;{hidden_phase.title}" in str(response.content)
 
 
 @pytest.mark.django_db

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -569,13 +569,13 @@ def test_hidden_phase_visible_for_admins_but_not_participants(client):
         ("leaderboard", {"slug": visible_phase.slug}, 200),
         # hidden phase
         ("detail", {"pk": e2.pk}, 403),
-        ("submission-create", {"slug": hidden_phase.slug}, 200),
+        ("submission-create", {"slug": hidden_phase.slug}, 403),
         (
             "submission-detail",
             {"pk": e2.submission.pk, "slug": e2.submission.phase.slug},
             403,
         ),
-        ("leaderboard", {"slug": hidden_phase.slug}, 200),
+        ("leaderboard", {"slug": hidden_phase.slug}, 403),
     ]:
         # for participants only the visible phase tab is visible
         # and they do not have access to the detail pages of their evals and

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -591,10 +591,7 @@ def test_hidden_phase_visible_for_admins_but_not_participants(client):
         assert response.status_code == status
         if status == 200:
             assert f"{visible_phase.title}</a>" in str(response.content)
-            assert (
-                f'<i class="fa fa-lock fa-fw mr-1"></i>{hidden_phase.title}</a>'
-                not in str(response.content)
-            )
+            assert f"{hidden_phase.title}</a>" not in str(response.content)
 
         # for the admin both phases are visible and they have access to submissions
         # and evals from both phases
@@ -606,10 +603,7 @@ def test_hidden_phase_visible_for_admins_but_not_participants(client):
         )
         assert response.status_code == 200
         assert f"{visible_phase.title}</a>" in str(response.content)
-        assert (
-            f'<i class="fa fa-lock fa-fw mr-1"></i>{hidden_phase.title}</a>'
-            in str(response.content)
-        )
+        assert f"{hidden_phase.title}</a>" in str(response.content)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Adding indicators for visibility status for challenge admins to make it easier to see which phase, phase submissions, and phase leaderboards are public/not public.

![Screenshot 2024-08-08 at 11 54 19](https://github.com/user-attachments/assets/e5ffd502-c0c7-47cb-9e52-23e4635b2e21)


![Screenshot 2024-08-08 at 11 54 27](https://github.com/user-attachments/assets/b5b05fe2-6446-47df-a6eb-02c1af09880b)


![Screenshot 2024-08-08 at 11 54 35](https://github.com/user-attachments/assets/96d5f8fb-8c7f-48c9-b16d-b6e32d098e18)


closes #3020 