### PR TITLE
Fix broken Runtime metrics charts

### DIFF
--- a/app/grandchallenge/charts/static/js/charts/render_charts.mjs
+++ b/app/grandchallenge/charts/static/js/charts/render_charts.mjs
@@ -4,15 +4,6 @@ function renderVegaLiteChart(element) {
 }
 
 document.addEventListener("DOMContentLoaded", function(event) {
-
-    if(document.getElementById("v-pills-tab") === null) {
-        for (const element of document.getElementsByClassName("vega-lite-chart")) {
-            renderVegaLiteChart(element);
-        }
-    }
-});
-
-document.addEventListener("vega.render", function(event) {
     for (const element of document.getElementsByClassName("vega-lite-chart")) {
         renderVegaLiteChart(element);
     }

--- a/app/grandchallenge/core/static/js/refresh_sidebar.mjs
+++ b/app/grandchallenge/core/static/js/refresh_sidebar.mjs
@@ -44,5 +44,5 @@ $(document).ready(function() {
     });
 
     activateLocation();
-    document.dispatchEvent(new Event("vega.render"));
+    window.dispatchEvent(new Event('resize'))
 });


### PR DESCRIPTION
This relates to #3460 where the rendering event was limited to pages loading [refresh_sidebar.mjs](https://github.com/comic/grand-challenge.org/blob/main/app/grandchallenge/core/static/js/refresh_sidebar.mjs) or pages without tabs (#v-pills-tab). The fix removed those limitations and added a Resize event dispatch which solves the related issue #3460.

closes #3470 