### PR TITLE
Add endpoint for lowest supported gcapi version

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -150,6 +150,8 @@ CHALLENGE_NUM_SUPPORT_YEARS = int(
     os.environ.get("CHALLENGE_NUM_SUPPORT_YEARS", 5)
 )
 
+GCAPI_LOWEST_SUPPORTED_VERSION = "0.12.0"
+
 ##############################################################################
 #
 # Storage

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -150,7 +150,7 @@ CHALLENGE_NUM_SUPPORT_YEARS = int(
     os.environ.get("CHALLENGE_NUM_SUPPORT_YEARS", 5)
 )
 
-GCAPI_LOWEST_SUPPORTED_VERSION = "0.12.0"
+GCAPI_LOWEST_SUPPORTED_VERSION = "0.13.0"
 
 ##############################################################################
 #

--- a/app/grandchallenge/api/serializers.py
+++ b/app/grandchallenge/api/serializers.py
@@ -1,0 +1,5 @@
+from rest_framework import serializers
+
+
+class GCAPIVersionSerializer(serializers.Serializer):
+    lowest_supported_version = serializers.CharField()

--- a/app/grandchallenge/api/urls.py
+++ b/app/grandchallenge/api/urls.py
@@ -7,6 +7,7 @@ from grandchallenge.algorithms.views import (
     AlgorithmViewSet,
     JobViewSet,
 )
+from grandchallenge.api.views import lowest_supported_gcapi_version
 from grandchallenge.archives.views import ArchiveItemViewSet, ArchiveViewSet
 from grandchallenge.cases.views import (
     ImageViewSet,
@@ -124,6 +125,11 @@ urlpatterns = [
     path("v1/", include(router.urls)),
     path("v1/github/", github_webhook, name="github-webhook"),
     path("v1/timezone/", TimezoneAPIView.as_view(), name="timezone"),
+    path(
+        "v1/lowest_supported_gcapi_version/",
+        lowest_supported_gcapi_version,
+        name="lowest-supported-gcapi-version",
+    ),
     path(
         "",
         SpectacularSwaggerView.as_view(url_name="api:schema"),

--- a/app/grandchallenge/api/urls.py
+++ b/app/grandchallenge/api/urls.py
@@ -7,7 +7,7 @@ from grandchallenge.algorithms.views import (
     AlgorithmViewSet,
     JobViewSet,
 )
-from grandchallenge.api.views import lowest_supported_gcapi_version
+from grandchallenge.api.views import GCAPIView
 from grandchallenge.archives.views import ArchiveItemViewSet, ArchiveViewSet
 from grandchallenge.cases.views import (
     ImageViewSet,
@@ -126,9 +126,9 @@ urlpatterns = [
     path("v1/github/", github_webhook, name="github-webhook"),
     path("v1/timezone/", TimezoneAPIView.as_view(), name="timezone"),
     path(
-        "v1/lowest_supported_gcapi_version/",
-        lowest_supported_gcapi_version,
-        name="lowest-supported-gcapi-version",
+        "v1/gcapi/",
+        GCAPIView.as_view(),
+        name="gcapi",
     ),
     path(
         "",

--- a/app/grandchallenge/api/views.py
+++ b/app/grandchallenge/api/views.py
@@ -1,6 +1,21 @@
 from django.conf import settings
-from django.http import HttpResponse
+from rest_framework.generics import GenericAPIView
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from grandchallenge.api.serializers import GCAPIVersionSerializer
 
 
-def lowest_supported_gcapi_version(request):
-    return HttpResponse(settings.GCAPI_LOWEST_SUPPORTED_VERSION)
+class GCAPIView(GenericAPIView):
+    permission_classes = [AllowAny]
+    serializer_class = GCAPIVersionSerializer
+
+    def get(self, request):
+        data = {
+            "lowest_supported_version": settings.GCAPI_LOWEST_SUPPORTED_VERSION
+        }
+        serializer = self.get_serializer(data)
+        return Response(serializer.data)
+
+    def get_serializer(self, *args, **kwargs):
+        return self.serializer_class(*args, **kwargs)

--- a/app/grandchallenge/api/views.py
+++ b/app/grandchallenge/api/views.py
@@ -1,0 +1,6 @@
+from django.conf import settings
+from django.http import HttpResponse
+
+
+def lowest_supported_gcapi_version(request):
+    return HttpResponse(settings.GCAPI_LOWEST_SUPPORTED_VERSION)

--- a/app/tests/api_tests/test_urls.py
+++ b/app/tests/api_tests/test_urls.py
@@ -35,10 +35,10 @@ def check_answer_type_schema_from_response(response):
 def test_api_lowest_gcapi_version_check(client):
     response = assert_viewname_status(
         code=200,
-        url=reverse("api:lowest-supported-gcapi-version"),
+        url=reverse("api:gcapi"),
         client=client,
     )
     assert (
-        str(response.content)
-        == f"b{settings.GCAPI_LOWEST_SUPPORTED_VERSION!r}"
+        response.data["lowest_supported_version"]
+        == settings.GCAPI_LOWEST_SUPPORTED_VERSION
     )

--- a/app/tests/api_tests/test_urls.py
+++ b/app/tests/api_tests/test_urls.py
@@ -40,5 +40,5 @@ def test_api_lowest_gcapi_version_check(client):
     )
     assert (
         str(response.content)
-        == f"b'{settings.GCAPI_LOWEST_SUPPORTED_VERSION!r}'"
+        == f"b{settings.GCAPI_LOWEST_SUPPORTED_VERSION!r}"
     )

--- a/app/tests/api_tests/test_urls.py
+++ b/app/tests/api_tests/test_urls.py
@@ -1,4 +1,5 @@
 import pytest
+from django.conf import settings
 
 from grandchallenge.components.schemas import ANSWER_TYPE_SCHEMA
 from grandchallenge.subdomains.utils import reverse
@@ -28,3 +29,16 @@ def test_api_docs_generation(client, schema, content_type):
 def check_answer_type_schema_from_response(response):
     schema = response.data["definitions"]["Answer"]["properties"]["answer"]
     assert {"title": "Answer", **ANSWER_TYPE_SCHEMA} == schema
+
+
+@pytest.mark.django_db
+def test_api_lowest_gcapi_version_check(client):
+    response = assert_viewname_status(
+        code=200,
+        url=reverse("api:lowest-supported-gcapi-version"),
+        client=client,
+    )
+    assert (
+        str(response.content)
+        == f"b'{settings.GCAPI_LOWEST_SUPPORTED_VERSION!r}'"
+    )


### PR DESCRIPTION
It is set to 0.12.0 since this will probably be the version in which the version check will be included.

I'm not sure about the long URL, open to suggestions.