### PR TITLE
Show result text in job list

### DIFF
--- a/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
@@ -54,9 +54,7 @@
 {{ object.comment }}
 <split></split>
 
-<div class="child-mb-0 text-left">
-    {{ object.rendered_result_text }}
-</div>
+{{ object.rendered_result_text }}
 
 <split></split>
 <ul class="list-unstyled mb-0 text-left">

--- a/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
@@ -54,7 +54,7 @@
 {{ object.comment }}
 <split></split>
 
-<div class="child-mb-0 text-left">
+<div class="child-p-mb-0 text-left">
     {{ object.rendered_result_text }}
 </div>
 

--- a/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
@@ -54,6 +54,9 @@
 {{ object.comment }}
 <split></split>
 
+{{ object.rendered_result_text }}
+
+<split></split>
 <ul class="list-unstyled mb-0 text-left">
     {% if object.error_message %}
 

--- a/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
@@ -54,7 +54,9 @@
 {{ object.comment }}
 <split></split>
 
-{{ object.rendered_result_text }}
+<div class="child-mb-0 text-left">
+    {{ object.rendered_result_text }}
+</div>
 
 <split></split>
 <ul class="list-unstyled mb-0 text-left">

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -653,6 +653,10 @@ class JobsList(PaginatedTableListView):
             sort_field="comment",
             optional_condition=lambda obj: bool(obj.comment),
         ),
+        Column(
+            title="Result",
+            optional_condition=lambda obj: bool(obj.rendered_result_text),
+        ),
         Column(title="Results"),
         Column(title="Viewer"),
     ]

--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -10,7 +10,7 @@ p {
     line-height: 1.6;
 }
 
-.child-mb-0>* {
+.child-p-mb-0 > p {
     margin-bottom: 0;
 }
 

--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -10,10 +10,6 @@ p {
     line-height: 1.6;
 }
 
-.child-mb-0>* {
-    margin-bottom: 0;
-}
-
 .jumbotron {
     text-shadow: 0.1rem 0.1rem 0.2rem #000000;
 }
@@ -29,8 +25,7 @@ p {
 }
 
 /* fix modal display with overflow-y: scroll on html */
-.modal,
-.modal-open {
+.modal, .modal-open {
     padding-right: 0 !important;
 }
 
@@ -57,12 +52,12 @@ p {
     flex-wrap: wrap;
 }
 
-.row.equal-height>[class*='col-'] {
+.row.equal-height > [class*='col-'] {
     display: flex;
     flex-direction: column;
 }
 
-.row.equal-height>[class*='col-'] .card {
+.row.equal-height > [class*='col-'] .card {
     flex: 1;
 }
 
@@ -101,7 +96,7 @@ dl.inline dt:after {
     color: var(--light);
 }
 
-.breadcrumb-item>a {
+.breadcrumb-item > a {
     color: var(--secondary);
 }
 
@@ -109,7 +104,7 @@ dl.inline dt:after {
 .select2-container,
 .select2-container li:only-child,
 .select2-container input:placeholder-shown {
-    width: 100% !important;
+  width: 100% !important;
 }
 
 .console {
@@ -122,25 +117,23 @@ ul.socialaccount_providers {
     padding: 0;
 }
 
-ul.socialaccount_providers>li {
+ul.socialaccount_providers > li {
     min-width: 19rem;
 }
 
-.nav-pills>li>.nav-link {
+.nav-pills > li > .nav-link {
     color: #000;
 }
-
-.nav-pills>li>.nav-link:hover {
+.nav-pills > li > .nav-link:hover {
     border-radius: 1.2rem;
     color: #000;
     background-color: #ecf0f1;
 }
-
-.nav-pills>li>.nav-link.active {
+.nav-pills > li > .nav-link.active {
     border-radius: 1.2rem;
 }
 
-.nav-tabs>.nav-item>.nav-link {
+.nav-tabs > .nav-item > .nav-link {
     color: #000;
     border-top: 0 transparent;
     border-right: 0 transparent;
@@ -148,12 +141,12 @@ ul.socialaccount_providers>li {
     border-bottom: 0.25rem solid transparent;
 }
 
-.nav-tabs>.nav-item>.nav-link:hover {
+.nav-tabs > .nav-item > .nav-link:hover {
     border: inherit;
     border-bottom: 0.25rem solid #f0f0f0;
 }
 
-.nav-tabs>.nav-item>.nav-link.active {
+.nav-tabs > .nav-item > .nav-link.active {
     border: inherit;
     font-weight: bold;
     border-bottom: 0.25rem solid #2c3e50;
@@ -163,7 +156,7 @@ ul.socialaccount_providers>li {
     padding: 0;
 }
 
-.challengeDropdown>.nav-link {
+.challengeDropdown > .nav-link {
     color: #000;
 }
 
@@ -177,43 +170,40 @@ ul.socialaccount_providers>li {
     padding-bottom: 0.2rem;
 }
 
-.phaseButton:focus,
-.phaseButton:hover {
-    box-shadow: none !important;
+.phaseButton:focus, .phaseButton:hover {
+    box-shadow:none !important;
 }
 
 .gc-card {
     border-radius: 0.9rem;
 }
 
-.gc-card:hover,
-.gc-card:focus-within {
+.gc-card:hover, .gc-card:focus-within {
     box-shadow: 0 0 1rem 0 rgba(0, 0, 0, 0.2);
 }
 
 /* Reset card shadow when above-stretched-link elements are focused */
 .gc-card:has(.above-stretched-link:focus) {
-    box-shadow: none;
+  box-shadow: none;
 }
 
-.gc-card .card-img-top {
+.gc-card .card-img-top{
     border-top-left-radius: 0.9rem;
     border-top-right-radius: 0.9rem;
 }
 
-.carousel-control-next,
-.carousel-control-prev {
+.carousel-control-next, .carousel-control-prev {
     width: 3rem;
 }
 
 .documentation-sidebar {
-    top: 5rem;
+    top:5rem;
     z-index: 1;
 }
 
 .thumbnail {
-    max-height: 90px;
-    max-width: 90px;
+    max-height:90px;
+    max-width:90px;
 }
 
 .box-shadow {
@@ -228,23 +218,20 @@ ul.socialaccount_providers>li {
 }
 
 a[aria-expanded=true] .fa-chevron-right {
-    display: none;
+   display: none;
 }
-
 a[aria-expanded=false] .fa-chevron-down {
-    display: none;
+   display: none;
 }
 
 
 /* htmx */
 .htmx-indicator {
-    display: none;
+    display:none;
 }
-
 .htmx-request .htmx-indicator {
     display: inline-block;
 }
-
 .htmx-request.htmx-indicator {
     display: inline-block;
 }

--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -10,6 +10,10 @@ p {
     line-height: 1.6;
 }
 
+.child-mb-0>* {
+    margin-bottom: 0;
+}
+
 .jumbotron {
     text-shadow: 0.1rem 0.1rem 0.2rem #000000;
 }
@@ -25,7 +29,8 @@ p {
 }
 
 /* fix modal display with overflow-y: scroll on html */
-.modal, .modal-open {
+.modal,
+.modal-open {
     padding-right: 0 !important;
 }
 
@@ -52,12 +57,12 @@ p {
     flex-wrap: wrap;
 }
 
-.row.equal-height > [class*='col-'] {
+.row.equal-height>[class*='col-'] {
     display: flex;
     flex-direction: column;
 }
 
-.row.equal-height > [class*='col-'] .card {
+.row.equal-height>[class*='col-'] .card {
     flex: 1;
 }
 
@@ -96,7 +101,7 @@ dl.inline dt:after {
     color: var(--light);
 }
 
-.breadcrumb-item > a {
+.breadcrumb-item>a {
     color: var(--secondary);
 }
 
@@ -104,7 +109,7 @@ dl.inline dt:after {
 .select2-container,
 .select2-container li:only-child,
 .select2-container input:placeholder-shown {
-  width: 100% !important;
+    width: 100% !important;
 }
 
 .console {
@@ -117,23 +122,25 @@ ul.socialaccount_providers {
     padding: 0;
 }
 
-ul.socialaccount_providers > li {
+ul.socialaccount_providers>li {
     min-width: 19rem;
 }
 
-.nav-pills > li > .nav-link {
+.nav-pills>li>.nav-link {
     color: #000;
 }
-.nav-pills > li > .nav-link:hover {
+
+.nav-pills>li>.nav-link:hover {
     border-radius: 1.2rem;
     color: #000;
     background-color: #ecf0f1;
 }
-.nav-pills > li > .nav-link.active {
+
+.nav-pills>li>.nav-link.active {
     border-radius: 1.2rem;
 }
 
-.nav-tabs > .nav-item > .nav-link {
+.nav-tabs>.nav-item>.nav-link {
     color: #000;
     border-top: 0 transparent;
     border-right: 0 transparent;
@@ -141,12 +148,12 @@ ul.socialaccount_providers > li {
     border-bottom: 0.25rem solid transparent;
 }
 
-.nav-tabs > .nav-item > .nav-link:hover {
+.nav-tabs>.nav-item>.nav-link:hover {
     border: inherit;
     border-bottom: 0.25rem solid #f0f0f0;
 }
 
-.nav-tabs > .nav-item > .nav-link.active {
+.nav-tabs>.nav-item>.nav-link.active {
     border: inherit;
     font-weight: bold;
     border-bottom: 0.25rem solid #2c3e50;
@@ -156,7 +163,7 @@ ul.socialaccount_providers > li {
     padding: 0;
 }
 
-.challengeDropdown > .nav-link {
+.challengeDropdown>.nav-link {
     color: #000;
 }
 
@@ -170,40 +177,43 @@ ul.socialaccount_providers > li {
     padding-bottom: 0.2rem;
 }
 
-.phaseButton:focus, .phaseButton:hover {
-    box-shadow:none !important;
+.phaseButton:focus,
+.phaseButton:hover {
+    box-shadow: none !important;
 }
 
 .gc-card {
     border-radius: 0.9rem;
 }
 
-.gc-card:hover, .gc-card:focus-within {
+.gc-card:hover,
+.gc-card:focus-within {
     box-shadow: 0 0 1rem 0 rgba(0, 0, 0, 0.2);
 }
 
 /* Reset card shadow when above-stretched-link elements are focused */
 .gc-card:has(.above-stretched-link:focus) {
-  box-shadow: none;
+    box-shadow: none;
 }
 
-.gc-card .card-img-top{
+.gc-card .card-img-top {
     border-top-left-radius: 0.9rem;
     border-top-right-radius: 0.9rem;
 }
 
-.carousel-control-next, .carousel-control-prev {
+.carousel-control-next,
+.carousel-control-prev {
     width: 3rem;
 }
 
 .documentation-sidebar {
-    top:5rem;
+    top: 5rem;
     z-index: 1;
 }
 
 .thumbnail {
-    max-height:90px;
-    max-width:90px;
+    max-height: 90px;
+    max-width: 90px;
 }
 
 .box-shadow {
@@ -218,20 +228,23 @@ ul.socialaccount_providers > li {
 }
 
 a[aria-expanded=true] .fa-chevron-right {
-   display: none;
+    display: none;
 }
+
 a[aria-expanded=false] .fa-chevron-down {
-   display: none;
+    display: none;
 }
 
 
 /* htmx */
 .htmx-indicator {
-    display:none;
+    display: none;
 }
+
 .htmx-request .htmx-indicator {
     display: inline-block;
 }
+
 .htmx-request.htmx-indicator {
     display: inline-block;
 }

--- a/app/grandchallenge/core/static/css/core.css
+++ b/app/grandchallenge/core/static/css/core.css
@@ -10,6 +10,10 @@ p {
     line-height: 1.6;
 }
 
+.child-mb-0>* {
+    margin-bottom: 0;
+}
+
 .jumbotron {
     text-shadow: 0.1rem 0.1rem 0.2rem #000000;
 }

--- a/app/tests/algorithms_tests/test_views.py
+++ b/app/tests/algorithms_tests/test_views.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 from django.contrib.auth.models import Group
-from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.core.files.base import ContentFile
 from django.utils import timezone
 from django.utils.text import slugify
@@ -20,9 +19,6 @@ from grandchallenge.components.models import (
     InterfaceKind,
 )
 from grandchallenge.subdomains.utils import reverse
-from grandchallenge.workstations.templatetags.workstations import (
-    workstation_session_control_data,
-)
 from tests.algorithms_tests.factories import (
     AlgorithmFactory,
     AlgorithmImageFactory,
@@ -1413,13 +1409,6 @@ def test_job_list_row_template_ajax_renders(client):
         time_limit=algorithm.time_limit,
     )
 
-    ctrl_data = workstation_session_control_data(
-        workstation=algorithm.workstation,
-        context_object=algorithm,
-        algorithm_job=job,
-        config=algorithm.workstation_config,
-    )
-
     headers = {"HTTP_X_REQUESTED_WITH": "XMLHttpRequest"}
 
     response = get_view_for_user(
@@ -1444,28 +1433,10 @@ def test_job_list_row_template_ajax_renders(client):
         "algorithms:job-detail",
         kwargs={"slug": job.algorithm_image.algorithm.slug, "pk": job.pk},
     )
-    job_created = str(naturaltime(job.created))
 
     response_content = json.loads(response.content.decode("utf-8"))
 
     assert response.status_code == 200
-
     assert response_content["recordsTotal"] == 1
-
     assert len(response_content["data"]) == 1
-
     assert job_details_url in response_content["data"][0][0]
-
-    assert job_created in response_content["data"][0][1]
-
-    assert editor.username in response_content["data"][0][2]
-
-    assert job.get_status_display() in response_content["data"][0][3]
-
-    assert "Result and images are private" in response_content["data"][0][4]
-
-    assert job.comment in response_content["data"][0][5]
-
-    assert "Empty" in response_content["data"][0][6]
-
-    assert ctrl_data in response_content["data"][0][7]

--- a/app/tests/archives_tests/test_views.py
+++ b/app/tests/archives_tests/test_views.py
@@ -3,7 +3,6 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from django.contrib.humanize.templatetags.humanize import naturaltime
 from guardian.shortcuts import assign_perm, remove_perm
 from requests import put
 
@@ -15,9 +14,6 @@ from grandchallenge.archives.views import (
 from grandchallenge.cases.widgets import WidgetChoices
 from grandchallenge.components.models import ComponentInterface, InterfaceKind
 from grandchallenge.subdomains.utils import reverse
-from grandchallenge.workstations.templatetags.workstations import (
-    workstation_session_control_data,
-)
 from tests.algorithms_tests.factories import AlgorithmJobFactory, Job
 from tests.archives_tests.factories import (
     ArchiveFactory,
@@ -1352,7 +1348,7 @@ def test_archive_item_list_database_hits(
 
 
 @pytest.mark.django_db
-def test_job_list_row_template_ajax_renders(client):
+def test_item_job_list_row_template_ajax_renders(client):
     archive = ArchiveFactory()
     editor = UserFactory()
     archive.add_editor(editor)
@@ -1371,15 +1367,6 @@ def test_job_list_row_template_ajax_renders(client):
         creator=editor, status=Job.SUCCESS, time_limit=60
     )
     job.inputs.set([civ])
-
-    algorithm = job.algorithm_image.algorithm
-
-    ctrl_data = workstation_session_control_data(
-        workstation=algorithm.workstation,
-        context_object=algorithm,
-        algorithm_job=job,
-        config=algorithm.workstation_config,
-    )
 
     headers = {"HTTP_X_REQUESTED_WITH": "XMLHttpRequest"}
 
@@ -1406,28 +1393,10 @@ def test_job_list_row_template_ajax_renders(client):
         "algorithms:job-detail",
         kwargs={"slug": job.algorithm_image.algorithm.slug, "pk": job.pk},
     )
-    job_created = str(naturaltime(job.created))
 
     response_content = json.loads(response.content.decode("utf-8"))
 
     assert response.status_code == 200
-
     assert response_content["recordsTotal"] == 1
-
     assert len(response_content["data"]) == 1
-
     assert job_details_url in response_content["data"][0][0]
-
-    assert job_created in response_content["data"][0][1]
-
-    assert algorithm.title in response_content["data"][0][2]
-
-    assert job.get_status_display() in response_content["data"][0][3]
-
-    assert "Result and images are private" in response_content["data"][0][4]
-
-    assert job.comment in response_content["data"][0][5]
-
-    assert "Empty" in response_content["data"][0][6]
-
-    assert ctrl_data in response_content["data"][0][7]


### PR DESCRIPTION
Closes: #3495

Re-adds the rendered result text for direct viewing in the job lists. This used to be cramped with the status and results. It is now in its own column. 

The alternative was adding it directly to the results list, but this makes it clearer that it is a singular representation of the result.

Extra CSS was needed to ensure the forcefully added `<p>` in the template rendering does not line out weirdly:

# Pre-CSS
<img width="614" alt="image" src="https://github.com/user-attachments/assets/a545d595-621c-4730-afe8-bbfb80039c5f">

# Post-CSS
<img width="597" alt="image" src="https://github.com/user-attachments/assets/afc4a7b0-27f5-4e8a-b30f-0b7703ae6299">
