### PR TITLE
Disable delete all display sets button when answers exist

### DIFF
--- a/app/grandchallenge/components/templates/components/civ_set_list.html
+++ b/app/grandchallenge/components/templates/components/civ_set_list.html
@@ -39,6 +39,10 @@
                 hx-push-url="{{ base_object.bulk_delete_url }}"
                 hx-vals='{"delete-all": "True"}'
                 hx-target="body"
+                {% if delete_all_disabled_message %}
+                    disabled
+                    title="{{ delete_all_disabled_message }}"
+                {% endif %}
         > Delete all {{ base_object.civ_set_model|verbose_name_plural }}</button>
     </p>
 

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -404,6 +404,18 @@ class ReaderStudyDisplaySetList(CivSetListView):
     def base_object(self):
         return get_object_or_404(ReaderStudy, slug=self.kwargs["slug"])
 
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+
+        if Answer.objects.filter(
+            question__reader_study=self.base_object
+        ).exists():
+            context["delete_all_disabled_message"] = (
+                "Cannot delete all display sets: first you need to delete all of the answers for this reader study"
+            )
+
+        return context
+
     def get_queryset(self):
         queryset = super().get_queryset()
         return (

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -791,25 +791,11 @@ def test_display_set_bulk_delete_permissions(client):
 
 @pytest.mark.django_db
 def test_display_set_delete_all_button_disabled(client):
-
     editor = UserFactory()
     rs = ReaderStudyFactory()
     rs.add_editor(editor)
 
-    ds = DisplaySetFactory(reader_study=rs)
-
-    q = QuestionFactory(
-        reader_study=rs,
-        question_text="question_text",
-        answer_type=Question.AnswerType.TEXT,
-    )
-
-    AnswerFactory(
-        creator=editor,
-        question=q,
-        answer="question_answer",
-        display_set=ds,
-    )
+    AnswerFactory(question__reader_study=rs)
 
     response = get_view_for_user(
         client=client,

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -798,19 +798,6 @@ def test_display_set_delete_all_button_disabled(client):
 
     ds = DisplaySetFactory(reader_study=rs)
 
-    response = get_view_for_user(
-        client=client,
-        viewname="reader-studies:display_sets",
-        reverse_kwargs={"slug": rs.slug},
-        user=editor,
-    )
-
-    assert response.status_code == 200
-    assert (
-        "Cannot delete all display sets: first you need to delete all of the answers for this reader study"
-        not in str(response.rendered_content)
-    )
-
     q = QuestionFactory(
         reader_study=rs,
         question_text="question_text",


### PR DESCRIPTION
The message was extended, asking the user to delete all answers before trying to delete the display sets.

closes #3502 