### PR TITLE
Lock objects when provisioning

### DIFF
--- a/app/tests/resources/gc_demo_algorithm/Dockerfile
+++ b/app/tests/resources/gc_demo_algorithm/Dockerfile
@@ -12,6 +12,7 @@ RUN python3 -m pip install pynvml psutil
 
 ADD copy_io.py .
 
+ARG BUILD_TIME
 ENV BUILD_TIME=${BUILD_TIME}
 
 ENTRYPOINT ["python", "copy_io.py"]


### PR DESCRIPTION
Implementation extracted from #3465

We will now longer know if a particular job is actively being provisioned due to using locks which require long running transactions. I have not found a way to break up the transaction or start mid-way without maintaining the lock.