### PR TITLE
Remove optional_condition for tables

### DIFF
--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -648,15 +648,8 @@ class JobsList(PaginatedTableListView):
         Column(title="Creator", sort_field="creator__username"),
         Column(title="Status", sort_field="status"),
         Column(title="Visibility", sort_field="public"),
-        Column(
-            title="Comment",
-            sort_field="comment",
-            optional_condition=lambda obj: bool(obj.comment),
-        ),
-        Column(
-            title="Result",
-            optional_condition=lambda obj: bool(obj.rendered_result_text),
-        ),
+        Column(title="Comment", sort_field="comment"),
+        Column(title="Result"),
         Column(title="Results"),
         Column(title="Viewer"),
     ]

--- a/app/grandchallenge/components/views.py
+++ b/app/grandchallenge/components/views.py
@@ -345,11 +345,7 @@ class CivSetListView(
         Column(title=""),
         Column(title="Detail"),
         Column(title="ID", sort_field="pk"),
-        Column(
-            title="Title",
-            sort_field="title",
-            optional_condition=lambda obj: bool(obj.title),
-        ),
+        Column(title="Title", sort_field="title"),
         Column(title="Values"),
         Column(title="Viewer"),
         Column(title="Edit"),

--- a/app/grandchallenge/datatables/static/js/datatables/list.mjs
+++ b/app/grandchallenge/datatables/static/js/datatables/list.mjs
@@ -45,13 +45,6 @@ $(document).ready(() => {
         ],
         ajax: {
             url: "",
-            dataSrc: json => {
-                const table = $("#ajaxDataTable").DataTable();
-                for (const [index, visible] of json.showColumns.entries()) {
-                    table.column(index).visible(visible);
-                }
-                return json.data;
-            },
         },
         ordering: true,
     });

--- a/app/grandchallenge/datatables/views.py
+++ b/app/grandchallenge/datatables/views.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from dataclasses import dataclass
 from functools import reduce
 from operator import or_
@@ -57,19 +56,12 @@ class PaginatedTableListView(ListView):
         paginator = self.get_paginator(queryset=data, per_page=page_size)
         objects = paginator.page(page)
 
-        show_columns = []
-        for c in self.columns:
-            show_columns.append(
-                c.optional_condition is None
-                or any(c.optional_condition(o) for o in objects)
-            )
         return JsonResponse(
             {
                 "draw": int(form_data.get("draw")),
                 "recordsTotal": self.object_list.count(),
                 "recordsFiltered": paginator.count,
                 "data": self.render_rows(object_list=objects),
-                "showColumns": show_columns,
             }
         )
 
@@ -102,11 +94,6 @@ class Column:
     sort_field: str = ""
     classes: tuple[str, ...] = ()
     identifier: str = ""
-
-    # A column will be hidden when the `optional_condition` evaluates to False
-    # for every object shown in the current list (page). `optional_condition`
-    # is a function that consumes the current object as argument
-    optional_condition: Callable | None = None
 
     def __post_init__(self):
         if not self.sort_field:

--- a/app/tests/core_tests/test_views.py
+++ b/app/tests/core_tests/test_views.py
@@ -41,7 +41,6 @@ def test_paginated_table_list_view_get():
         "recordsTotal": 0,
         "recordsFiltered": 0,
         "data": [],
-        "showColumns": [],
     }
 
 
@@ -62,7 +61,6 @@ def test_paginated_table_list_view_post():
         "recordsTotal": 0,
         "recordsFiltered": 0,
         "data": [],
-        "showColumns": [],
     }
 
 


### PR DESCRIPTION
Due to strange behaviour across pages. Solving this for multiple pages would involve lookups across all items.

See #2044
Closes #3523