### PR TITLE
Reduce memory usage of cleanup tasks

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1190,10 +1190,6 @@ CELERY_BEAT_SCHEDULE = {
         "task": "grandchallenge.github.tasks.cleanup_expired_tokens",
         "schedule": crontab(hour=0, minute=30),
     },
-    "cleanup_celery_backend": {
-        "task": "grandchallenge.core.tasks.cleanup_celery_backend",
-        "schedule": crontab(hour=0, minute=45),
-    },
     "clear_sessions": {
         "task": "grandchallenge.browser_sessions.tasks.clear_sessions",
         "schedule": crontab(hour=1, minute=0),
@@ -1233,6 +1229,10 @@ CELERY_BEAT_SCHEDULE = {
     "cleanup_sent_raw_emails": {
         "task": "grandchallenge.emails.tasks.cleanup_sent_raw_emails",
         "schedule": crontab(hour=6, minute=0),
+    },
+    "cleanup_celery_backend": {
+        "task": "grandchallenge.core.tasks.cleanup_celery_backend",
+        "schedule": timedelta(hours=1),
     },
     "update_compute_costs_and_storage_size": {
         "task": "grandchallenge.challenges.tasks.update_compute_costs_and_storage_size",

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1178,29 +1178,13 @@ INTERACTIVE_ALGORITHMS_LAMBDA_FUNCTIONS = json.loads(
 )
 
 CELERY_BEAT_SCHEDULE = {
-    "delete_users_who_dont_login": {
-        "task": "grandchallenge.profiles.tasks.delete_users_who_dont_login",
-        "schedule": crontab(hour=0, minute=0),
-    },
     "refresh_expiring_user_tokens": {
         "task": "grandchallenge.github.tasks.refresh_expiring_user_tokens",
         "schedule": crontab(hour=0, minute=15),
     },
-    "cleanup_expired_tokens": {
-        "task": "grandchallenge.github.tasks.cleanup_expired_tokens",
-        "schedule": crontab(hour=0, minute=30),
-    },
-    "clear_sessions": {
-        "task": "grandchallenge.browser_sessions.tasks.clear_sessions",
-        "schedule": crontab(hour=1, minute=0),
-    },
     "update_publication_metadata": {
         "task": "grandchallenge.publications.tasks.update_publication_metadata",
         "schedule": crontab(hour=1, minute=30),
-    },
-    "delete_old_user_uploads": {
-        "task": "grandchallenge.uploads.tasks.delete_old_user_uploads",
-        "schedule": crontab(hour=2, minute=0),
     },
     "remove_inactive_container_images": {
         "task": "grandchallenge.components.tasks.remove_inactive_container_images",
@@ -1226,9 +1210,25 @@ CELERY_BEAT_SCHEDULE = {
         "task": "grandchallenge.statistics.tasks.update_site_statistics_cache",
         "schedule": crontab(hour=5, minute=30),
     },
+    "delete_users_who_dont_login": {
+        "task": "grandchallenge.profiles.tasks.delete_users_who_dont_login",
+        "schedule": timedelta(hours=1),
+    },
+    "delete_old_user_uploads": {
+        "task": "grandchallenge.uploads.tasks.delete_old_user_uploads",
+        "schedule": timedelta(hours=1),
+    },
+    "clear_sessions": {
+        "task": "grandchallenge.browser_sessions.tasks.clear_sessions",
+        "schedule": timedelta(hours=1),
+    },
+    "cleanup_expired_tokens": {
+        "task": "grandchallenge.github.tasks.cleanup_expired_tokens",
+        "schedule": timedelta(hours=1),
+    },
     "cleanup_sent_raw_emails": {
         "task": "grandchallenge.emails.tasks.cleanup_sent_raw_emails",
-        "schedule": crontab(hour=6, minute=0),
+        "schedule": timedelta(hours=1),
     },
     "cleanup_celery_backend": {
         "task": "grandchallenge.core.tasks.cleanup_celery_backend",

--- a/app/grandchallenge/browser_sessions/tasks.py
+++ b/app/grandchallenge/browser_sessions/tasks.py
@@ -12,10 +12,10 @@ def logout_privileged_users():
     BrowserSession.objects.filter(
         user__is_staff=True,
         created__lt=now() - settings.SESSION_PRIVILEGED_USER_TIMEOUT,
-    ).delete()
+    ).only("pk").delete()
 
 
 @acks_late_micro_short_task
 @transaction.atomic
 def clear_sessions():
-    BrowserSession.objects.filter(expire_date__lt=now()).delete()
+    BrowserSession.objects.filter(expire_date__lt=now()).only("pk").delete()

--- a/app/grandchallenge/core/tasks.py
+++ b/app/grandchallenge/core/tasks.py
@@ -20,8 +20,8 @@ from grandchallenge.workstations.models import Session
 @transaction.atomic
 def cleanup_celery_backend():
     """Cleanup the Celery backend."""
-    TaskResult.objects.filter(
-        date_created__lt=now() - timedelta(days=7)
+    TaskResult.objects.filter(date_created__lt=now() - timedelta(days=7)).only(
+        "pk"
     ).delete()
 
 

--- a/app/grandchallenge/core/tasks.py
+++ b/app/grandchallenge/core/tasks.py
@@ -11,15 +11,12 @@ from django_celery_results.models import TaskResult
 
 from grandchallenge.algorithms.models import AlgorithmImage, Job
 from grandchallenge.cases.models import RawImageUploadSession
-from grandchallenge.core.celery import (
-    acks_late_2xlarge_task,
-    acks_late_micro_short_task,
-)
+from grandchallenge.core.celery import acks_late_micro_short_task
 from grandchallenge.evaluation.models import Evaluation, Method
 from grandchallenge.workstations.models import Session
 
 
-@acks_late_2xlarge_task
+@acks_late_micro_short_task
 @transaction.atomic
 def cleanup_celery_backend():
     """Cleanup the Celery backend."""

--- a/app/grandchallenge/emails/tasks.py
+++ b/app/grandchallenge/emails/tasks.py
@@ -170,4 +170,4 @@ def cleanup_sent_raw_emails():
         sent_at__isnull=False,
         errored=False,
         created__lt=now() - timedelta(days=7),
-    ).defer("message").delete()
+    ).only("pk").delete()

--- a/app/grandchallenge/profiles/tasks.py
+++ b/app/grandchallenge/profiles/tasks.py
@@ -41,4 +41,6 @@ def delete_users_who_dont_login():
         date_joined__lt=(
             now() - timedelta(days=settings.USER_LOGIN_TIMEOUT_DAYS)
         ),
+    ).only(
+        "pk"
     ).delete()

--- a/app/grandchallenge/uploads/tasks.py
+++ b/app/grandchallenge/uploads/tasks.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from django.conf import settings
-from django.core.paginator import Paginator
+from django.db import transaction
 from django.utils.timezone import now
 
 from grandchallenge.core.celery import acks_late_micro_short_task
@@ -9,18 +9,8 @@ from grandchallenge.uploads.models import UserUpload
 
 
 @acks_late_micro_short_task
+@transaction.atomic
 def delete_old_user_uploads():
-    limit = now() - timedelta(days=settings.UPLOADS_TIMEOUT_DAYS)
-    queryset = UserUpload.objects.filter(created__lt=limit).order_by(
-        "-created"
-    )
-    paginator = Paginator(object_list=queryset, per_page=100)
-
-    # Reverse iteration over the queryset as we're deleting objects
-    for idx in range(paginator.num_pages, 0, -1):
-        page = paginator.get_page(idx)
-
-        # Another query as delete() cannot be used with LIMIT or OFFSET
-        UserUpload.objects.filter(
-            pk__in=page.object_list.values_list("pk", flat=True)
-        ).delete()
+    UserUpload.objects.filter(
+        created__lt=now() - timedelta(days=settings.UPLOADS_TIMEOUT_DAYS)
+    ).only("pk").delete()

--- a/app/grandchallenge/uploads/tasks.py
+++ b/app/grandchallenge/uploads/tasks.py
@@ -13,4 +13,4 @@ from grandchallenge.uploads.models import UserUpload
 def delete_old_user_uploads():
     UserUpload.objects.filter(
         created__lt=now() - timedelta(days=settings.UPLOADS_TIMEOUT_DAYS)
-    ).only("pk").delete()
+    ).only("pk", "status", "creator_id", "s3_upload_id").delete()


### PR DESCRIPTION
Puts the tasks on the short queue to run once an hour rather than once per day which should reduce memory usage by 24x, and also only fetch the minimum amount of information necessary to delete the objects.

See DIAGNijmegen/rse-grand-challenge-admin#339