### PR TITLE
Phase parenting warnings

### DIFF
--- a/app/grandchallenge/core/templatetags/negate.py
+++ b/app/grandchallenge/core/templatetags/negate.py
@@ -1,8 +1,0 @@
-from django import template
-
-register = template.Library()
-
-
-@register.filter
-def negate(value):
-    return not value

--- a/app/grandchallenge/core/templatetags/negate.py
+++ b/app/grandchallenge/core/templatetags/negate.py
@@ -1,0 +1,8 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def negate(value):
+    return not value

--- a/app/grandchallenge/evaluation/migrations/0052_phase_parent.py
+++ b/app/grandchallenge/evaluation/migrations/0052_phase_parent.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
             name="parent",
             field=models.ForeignKey(
                 blank=True,
-                help_text="Is this phase dependent on another phase? If selected, submissions to the current phase will only be possible after a successful submission has been made to the parent phase.<b>Bear in mind that if you require a successful submission to a sanity check phase in order to submit to a final test phase, it could prevent people from submitting to the test phase on deadline day if the sanity check submission takes a long time to execute. </b>",
+                help_text="Is this phase dependent on another phase? If selected, submissions to the current phase will only be possible after a successful submission has been made to the parent phase. <b>Bear in mind that if you require a successful submission to a sanity check phase in order to submit to a final test phase, it could prevent people from submitting to the test phase on deadline day if the sanity check submission takes a long time to execute. </b>",
                 null=True,
                 on_delete=django.db.models.deletion.PROTECT,
                 related_name="children",

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -624,7 +624,10 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
         super().clean()
         self._clean_algorithm_submission_settings()
         self._clean_submission_limits()
-        self._clean_parent_phase()
+        try:
+            self._clean_parent_phase()
+        except ValidationError as e:
+            raise ValidationError({"parent": e})
 
     def _clean_algorithm_submission_settings(self):
         if self.submission_kind == SubmissionKindChoices.ALGORITHM:

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -624,10 +624,7 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
         super().clean()
         self._clean_algorithm_submission_settings()
         self._clean_submission_limits()
-        try:
-            self._clean_parent_phase()
-        except ValidationError as e:
-            raise ValidationError({"parent": e})
+        self._clean_parent_phase()
 
     def _clean_algorithm_submission_settings(self):
         if self.submission_kind == SubmissionKindChoices.ALGORITHM:

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -559,7 +559,7 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
         help_text=(
             "Is this phase dependent on another phase? If selected, submissions "
             "to the current phase will only be possible after a successful "
-            "submission has been made to the parent phase."
+            "submission has been made to the parent phase. "
             "<b>Bear in mind that if you require a successful submission to a "
             "sanity check phase in order to submit to a final test phase, "
             "it could prevent people from submitting to the test phase on deadline "

--- a/app/grandchallenge/evaluation/templates/evaluation/partials/phase_admin_warnings.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/partials/phase_admin_warnings.html
@@ -22,9 +22,9 @@
     </div>
 {% endif %}
 
-{% if phase.parent %}
-    <div class="alert alert-danger" role="alert">
-        <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+{% if phase.parent and not hide_phase_parent_info %}
+    <div class="alert alert-info" role="alert">
+        <i class="fa fa-info-circle" aria-hidden="true"></i>
         This phase is dependent on another phase.
         Submissions to this phase are only possible for algorithm images that have successfully been submitted to the parent phase "{{ phase.parent }}".
         You can update this setting in the
@@ -34,8 +34,8 @@
 
 {% with phase.children.count as child_count %}
     {% if child_count != 0 %}
-        <div class="alert alert-danger" role="alert">
-            <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+        <div class="alert alert-info" role="alert">
+            <i class="fa fa-info-circle" aria-hidden="true"></i>
             This phase serves as parent phase for {{ child_count }} phase{{ child_count|pluralize }}. Submissions to the child phase{{ child_count|pluralize }} are only possible for algorithm images that have been succesfully submitted to this phase.
             You can update this setting in the
             <a href="{% url 'evaluation:phase-update' challenge_short_name=challenge.short_name slug=phase.slug %}">Phase Settings</a>.

--- a/app/grandchallenge/evaluation/templates/evaluation/partials/phase_admin_warnings.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/partials/phase_admin_warnings.html
@@ -22,7 +22,7 @@
     </div>
 {% endif %}
 
-{% if phase.parent and not hide_phase_parent_info %}
+{% if phase.parent and show_phase_parent_info|default_if_none:True %}
     <div class="alert alert-info" role="alert">
         <i class="fa fa-info-circle" aria-hidden="true"></i>
         This phase is dependent on another phase.

--- a/app/grandchallenge/evaluation/templates/evaluation/phase_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/phase_form.html
@@ -1,7 +1,6 @@
 {% extends "pages/challenge_settings_base.html" %}
 {% load crispy from crispy_forms_tags %}
 {% load url %}
-{% load negate %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
@@ -28,7 +27,7 @@
             For instance, you could have a training and test phase, or have a phase for each task.
         </p>
     {% else %}
-    {% include "evaluation/partials/phase_admin_warnings.html" with phase=object hide_phase_parent_info=form.initial.parent|negate %}
+    {% include "evaluation/partials/phase_admin_warnings.html" with phase=object show_phase_parent_info=form.initial.parent|default_if_none:False %}
     {% endif %}
 
     {% crispy form %}

--- a/app/grandchallenge/evaluation/templates/evaluation/phase_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/phase_form.html
@@ -1,6 +1,7 @@
 {% extends "pages/challenge_settings_base.html" %}
 {% load crispy from crispy_forms_tags %}
 {% load url %}
+{% load negate %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
@@ -27,7 +28,7 @@
             For instance, you could have a training and test phase, or have a phase for each task.
         </p>
     {% else %}
-        {% include "evaluation/partials/phase_admin_warnings.html" with phase=object %}
+    {% include "evaluation/partials/phase_admin_warnings.html" with phase=object hide_phase_parent_info=form.initial.parent|negate %}
     {% endif %}
 
     {% crispy form %}


### PR DESCRIPTION
Closes: #3537 

This PR makes the phase parenting warnings a bit less intrusive and the related errors easier to see.

### Before
![image](https://github.com/user-attachments/assets/4c95b234-0021-4796-9bce-6fbbfd4569ba)

### Updated

- No longer shows the info blob when validation fails for the parent field, incorrectly giving the suggestion it succeded in updating
- Shows the parent-enabled information as info, instead of error (danger!)
- ~Binds the `parent` errors to the field!~

![phase_parent_info](https://github.com/user-attachments/assets/808fe6f1-8085-4cb3-888b-214ef21a93c4)
