### PR TITLE
Add a pandoc view for testing markdown pages

### DIFF
--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -69,7 +69,13 @@
             </div>
         {% endif %}
 
-        <div id=pageContainer>{{ object.html|clean }}</div>
+        <div id=pageContainer>
+            {% if converted_to_markdown is True %}
+                {{ converted_markdown|md2html }}
+            {% else %}
+                {{ object.html|clean }}
+            {% endif %}
+        </div>
 
         {% if object.pk %}
             {% if "change_challenge" in challenge_perms %}

--- a/app/grandchallenge/pages/templates/pages/page_pandoc_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_pandoc_detail.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 
-<pre>{{ markdown }}</pre>
+<pre>{{ converted_markdown }}</pre>
 
 </body>
 </html>

--- a/app/grandchallenge/pages/templates/pages/page_pandoc_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_pandoc_detail.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Pandoc Detail</title>
+</head>
+<body>
+
+<pre>{{ markdown }}</pre>
+
+</body>
+</html>

--- a/app/grandchallenge/pages/urls.py
+++ b/app/grandchallenge/pages/urls.py
@@ -7,6 +7,7 @@ from grandchallenge.pages.views import (
     PageDelete,
     PageDetail,
     PageList,
+    PagePandoc,
     PageUpdate,
 )
 
@@ -20,4 +21,14 @@ urlpatterns = [
     path("<slug>/", PageDetail.as_view(), name="detail"),
     path("<slug>/update/", PageUpdate.as_view(), name="update"),
     path("<slug>/delete/", PageDelete.as_view(), name="delete"),
+    path(
+        "<slug>/pandoc/<str:format>/",
+        PagePandoc.as_view(raw=False),
+        name="detail-pandoc",
+    ),
+    path(
+        "<slug>/pandoc/<str:format>/raw/",
+        PagePandoc.as_view(raw=True),
+        name="detail-pandoc-raw",
+    ),
 ]

--- a/app/grandchallenge/pages/views.py
+++ b/app/grandchallenge/pages/views.py
@@ -20,7 +20,6 @@ from guardian.mixins import LoginRequiredMixin
 from grandchallenge.challenges.views import ActiveChallengeRequiredMixin
 from grandchallenge.charts.specs import stacked_bar, world_map
 from grandchallenge.core.guardian import ObjectPermissionRequiredMixin
-from grandchallenge.core.templatetags.bleach import md2html
 from grandchallenge.evaluation.models import Evaluation, Submission
 from grandchallenge.pages.forms import PageCreateForm, PageUpdateForm
 from grandchallenge.pages.models import Page
@@ -116,15 +115,17 @@ class PagePandoc(
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        markdown = pypandoc.convert_text(
-            source=context["object"].html,
-            format="html",
-            to=self.kwargs["format"],
-            sandbox=True,
+        context.update(
+            {
+                "converted_to_markdown": True,
+                "converted_markdown": pypandoc.convert_text(
+                    source=context["object"].html,
+                    format="html",
+                    to=self.kwargs["format"],
+                    sandbox=True,
+                ),
+            }
         )
-
-        context["object"].html = md2html(markdown=markdown)
-        context["markdown"] = markdown
 
         return context
 

--- a/app/tests/pages_tests/test_pages.py
+++ b/app/tests/pages_tests/test_pages.py
@@ -360,3 +360,28 @@ def test_should_show_verification_warning():
     del challenge.visible_phases
 
     assert challenge.should_show_verification_warning is False
+
+
+@pytest.mark.django_db
+def test_page_markdown_permissions(client):
+    page = PageFactory()
+    user = UserFactory(is_staff=True)
+
+    def get():
+        return get_view_for_user(
+            client=client,
+            viewname="pages:detail-pandoc",
+            reverse_kwargs={
+                "challenge_short_name": page.challenge.short_name,
+                "slug": page.slug,
+                "format": "markdown",
+            },
+            user=user,
+        )
+
+    assert get().status_code == 200
+
+    user.is_staff = False
+    user.save()
+
+    assert get().status_code == 403

--- a/poetry.lock
+++ b/poetry.lock
@@ -3243,6 +3243,22 @@ files = [
 numpy = "*"
 
 [[package]]
+name = "pypandoc-binary"
+version = "1.13"
+description = "Thin wrapper for pandoc."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pypandoc_binary-1.13-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:946666388eb79b307d7f497b3b33045ef807750f8e5ef3440e0ba3bbab698044"},
+    {file = "pypandoc_binary-1.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:21ef0345726d36fc45a50211320614daf2caede684b0d0963ce8738292809746"},
+    {file = "pypandoc_binary-1.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67c0c7af811bcf3cd4f3221be756a4975ec35b2d7df89d8de4313a8caa2cd54f"},
+    {file = "pypandoc_binary-1.13-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9455fdd9521cbf4b56d79a56b806afa94c8c22f3c8ef878536e58d941a70f6d6"},
+    {file = "pypandoc_binary-1.13-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:2915f52e4632bd2d0a8fcd2f7e7dfc2ea19b4e1a280fcbc2ddcd142713c4ff12"},
+    {file = "pypandoc_binary-1.13-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:11a2497320eb3dccb74de3c67b6df3e5d3f66cdc2a36a67e9a871708f7e48412"},
+    {file = "pypandoc_binary-1.13-py3-none-win_amd64.whl", hash = "sha256:3881aa7c84faec2007c0ae4466d3a1cfc93171206b8540f2defa8ea971bf6fd6"},
+]
+
+[[package]]
 name = "pypng"
 version = "0.20220715.0"
 description = "Pure Python library for saving and loading PNG images"
@@ -4976,4 +4992,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "03d3491fc0d36a16324bceb6566863a98ddae6ab474790014ff5ed4ff9354a9e"
+content-hash = "f4baaae344ef19ff3feff38b6b060a06fb27d4dc59dfdfb15b9dc6eb78aff840"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ psycopg = {version = ">3.1.8", extras = ["c"]}
 pycurl = "!=7.45.3" # Import issue with 7.45.3 (https://github.com/comic/grand-challenge.org/issues/3252)
 pyjwt = "*"
 beautifulsoup4 = "*"
+pypandoc-binary = "^1.13"
 
 [tool.poetry.group.dev.dependencies]
 pytest-django = "*"


### PR DESCRIPTION
This PR adds a view that uses `pandoc` to convert the existing html pages into markdown but only in the view. It allows staff users to test conversion to see if challenge pages can be easily migrated.

See #3294