### PR TITLE
Allow filtering metrics on API views

### DIFF
--- a/app/grandchallenge/evaluation/migrations/0001_initial.py
+++ b/app/grandchallenge/evaluation/migrations/0001_initial.py
@@ -322,7 +322,7 @@ class Migration(migrations.Migration):
                     "display_all_metrics",
                     models.BooleanField(
                         default=True,
-                        help_text="Should all of the metrics be displayed on the Result detail page?",
+                        help_text="If True, the entire contents of metrics.json is available on the results detail page and over the API. If False, only the metrics used for ranking are available on the results detail page and over the API. Challenge administrators can always access the full metrics.json over the API.",
                     ),
                 ),
                 (

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1494,6 +1494,22 @@ class Evaluation(UUIDModel, ComponentJob):
                 return output.value
 
     @cached_property
+    def filtered_metrics_json(self):
+        output = {}
+
+        for metric in self.submission.phase.valid_metrics:
+            value = get_jsonpath(self.metrics_json_file, metric.path)
+
+            keys = str(metric.path).split(".")
+
+            for key in keys[:-1]:
+                output = output.setdefault(key, {})
+
+            output[keys[-1]] = value
+
+        return output
+
+    @cached_property
     def invalid_metrics(self):
         return {
             metric.path

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -442,7 +442,12 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
     display_all_metrics = models.BooleanField(
         default=True,
         help_text=(
-            "Should all of the metrics be displayed on the Result detail page?"
+            "If True, the entire contents of metrics.json is available "
+            "on the results detail page and over the API. "
+            "If False, only the metrics used for ranking are available "
+            "on the results detail page and over the API. "
+            "Challenge administrators can always access the full "
+            "metrics.json over the API."
         ),
     )
 

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1499,22 +1499,6 @@ class Evaluation(UUIDModel, ComponentJob):
                 return output.value
 
     @cached_property
-    def filtered_metrics_json(self):
-        output = {}
-
-        for metric in self.submission.phase.valid_metrics:
-            value = get_jsonpath(self.metrics_json_file, metric.path)
-
-            keys = str(metric.path).split(".")
-
-            for key in keys[:-1]:
-                output = output.setdefault(key, {})
-
-            output[keys[-1]] = value
-
-        return output
-
-    @cached_property
     def invalid_metrics(self):
         return {
             metric.path

--- a/app/grandchallenge/evaluation/serializers.py
+++ b/app/grandchallenge/evaluation/serializers.py
@@ -94,12 +94,19 @@ class FilteredMetricsJsonSerializer(ComponentInterfaceValueSerializer):
             for metric in self.valid_metrics:
                 value = get_jsonpath(obj.value, metric.path)
 
+                if not isinstance(value, (int, float)):
+                    continue
+
                 keys = str(metric.path).split(".")
 
-                for key in keys[:-1]:
-                    output = output.setdefault(key, {})
+                sub_output = output
 
-                output[keys[-1]] = value
+                for key in keys[:-1]:
+                    if key not in sub_output:
+                        sub_output[key] = {}
+                    sub_output = sub_output[key]
+
+                sub_output[keys[-1]] = value
 
             return output
         else:

--- a/app/tests/evaluation_tests/test_api.py
+++ b/app/tests/evaluation_tests/test_api.py
@@ -555,6 +555,12 @@ def test_metrics_json_filtering():
 
 @pytest.mark.django_db
 def test_evaluation_metrics_filtering(client):
+    user = UserFactory()
+
+    # Ensure object based filtering is used
+    other_challenge = ChallengeFactory()
+    other_challenge.add_admin(user=user)
+
     phase = PhaseFactory(
         challenge__hidden=False,
         display_all_metrics=False,
@@ -568,8 +574,6 @@ def test_evaluation_metrics_filtering(client):
         "l1d": {},
     }
     filtered_value = {"l1": {"l2a": 3}}
-
-    user = UserFactory()
 
     ci = ComponentInterface.objects.get(slug="metrics-json-file")
     civ = ComponentInterfaceValueFactory(

--- a/app/tests/evaluation_tests/test_api.py
+++ b/app/tests/evaluation_tests/test_api.py
@@ -576,10 +576,7 @@ def test_evaluation_metrics_filtering(client):
     filtered_value = {"l1": {"l2a": 3}}
 
     ci = ComponentInterface.objects.get(slug="metrics-json-file")
-    civ = ComponentInterfaceValueFactory(
-        interface=ci,
-        value=full_value
-    )
+    civ = ComponentInterfaceValueFactory(interface=ci, value=full_value)
     evaluation = EvaluationFactory(
         submission__phase=phase,
         time_limit=phase.evaluation_time_limit,

--- a/app/tests/evaluation_tests/test_api.py
+++ b/app/tests/evaluation_tests/test_api.py
@@ -578,11 +578,7 @@ def test_evaluation_metrics_filtering(client):
     ci = ComponentInterface.objects.get(slug="metrics-json-file")
     civ = ComponentInterfaceValueFactory(
         interface=ci,
-        value={
-            "l1": {"l2": {"l3a": 1, "l3b": 2}, "l2a": 3},
-            "l1v": "Sensitive",
-            "l1d": {},
-        },
+        value=full_value
     )
     evaluation = EvaluationFactory(
         submission__phase=phase,


### PR DESCRIPTION
We have an option "Display all metrics" that controlled whether to show all of the metrics in the evaluation detail view. This was just to keep things tidy, but a challenge organiser would like to generate metrics that only they can view, and not the participants. This extends the option to also count for the API view, where the metrics will be filtered based on whether the phase allows displaying all metrics, plus whether the user is an admin for that challenge.

Closes https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/348