### PR TITLE
Fix cleaning of documentation pages

### DIFF
--- a/app/grandchallenge/documentation/models.py
+++ b/app/grandchallenge/documentation/models.py
@@ -6,7 +6,6 @@ from django.dispatch import receiver
 from django_extensions.db.fields import AutoSlugField
 from simple_history.models import HistoricalRecords
 
-from grandchallenge.core.templatetags.bleach import clean
 from grandchallenge.subdomains.utils import reverse
 
 
@@ -73,7 +72,6 @@ class DocPage(models.Model):
                     + 1
                 )
 
-        self.content = clean(self.content)
         super().save(*args, **kwargs)
 
     def position(self, position):


### PR DESCRIPTION
The content of a documentation page is markdown. Cleaning the markdown will escape characters such as `>`, which means they then fail to render correctly in code blocks. This step is anyway unnecessary: we save the raw markdown and then convert it on the fly in the template which calls `md2html`. At no point do we assume that `content` is safe, so it is okay to remove this step.