### PR TITLE
Fix superusers not being able to see challenge registration-questions responses

### DIFF
--- a/app/grandchallenge/participants/views.py
+++ b/app/grandchallenge/participants/views.py
@@ -111,7 +111,7 @@ class RegistrationRequestList(
 
     def _get_registration_questions(self):
         return filter_by_permission(
-            queryset=self.request.challenge.registration_questions,
+            queryset=self.request.challenge.registration_questions.all(),
             user=self.request.user,
             codename="view_registrationquestion",
             accept_user_perms=False,


### PR DESCRIPTION
Unintentionally passed a Manager to the filter, whereas it should have been a queryset. Not a problem for regular users because the argument is generally passed through `.filter()`. 

However, for superusers it is short-circuited so does not work.