### PR TITLE
Export of registration requests

### DIFF
--- a/app/grandchallenge/participants/templates/participants/registrationrequest_list.html
+++ b/app/grandchallenge/participants/templates/participants/registrationrequest_list.html
@@ -20,6 +20,14 @@
 
     <h2>Participation Requests for {{ challenge.short_name }}</h2>
 
+    {% if viewable_registration_questions %}
+        <a class="btn btn-primary mb-4"
+            href="{% url 'participants:registration-question-answer-list-export' challenge_short_name=challenge.short_name %}"
+        >
+            <i class="fas fa-download pr-1"></i> Answers to questions
+        </a>
+    {% endif %}
+
     <div class="table-responsive">
         <table class="table table-hover table-borderless table-sm" id="participantsTable">
             <thead class="thead-light">

--- a/app/grandchallenge/participants/templates/participants/registrationrequest_list.html
+++ b/app/grandchallenge/participants/templates/participants/registrationrequest_list.html
@@ -20,13 +20,11 @@
 
     <h2>Participation Requests for {{ challenge.short_name }}</h2>
 
-    {% if viewable_registration_questions %}
-        <a class="btn btn-primary mb-4"
-            href="{% url 'participants:registration-question-answer-list-export' challenge_short_name=challenge.short_name %}"
-        >
-            <i class="fas fa-download pr-1"></i> Answers to questions
-        </a>
-    {% endif %}
+    <a class="btn btn-primary mb-4"
+        href="{% url 'participants:registration-list-export' challenge_short_name=challenge.short_name %}"
+    >
+        <i class="fas fa-file-csv pr-1"></i> Export participation requests
+    </a>
 
     <div class="table-responsive">
         <table class="table table-hover table-borderless table-sm" id="participantsTable">

--- a/app/grandchallenge/participants/urls.py
+++ b/app/grandchallenge/participants/urls.py
@@ -2,13 +2,13 @@ from django.urls import path
 
 from grandchallenge.participants.views import (
     ParticipantsList,
-    RegistrationQuestionAnswerListExport,
     RegistrationQuestionCreate,
     RegistrationQuestionDelete,
     RegistrationQuestionList,
     RegistrationQuestionUpdate,
     RegistrationRequestCreate,
     RegistrationRequestList,
+    RegistrationRequestListExport,
     RegistrationRequestUpdate,
 )
 
@@ -20,6 +20,11 @@ urlpatterns = [
         "registration/",
         RegistrationRequestList.as_view(),
         name="registration-list",
+    ),
+    path(
+        "registration/export/",
+        RegistrationRequestListExport.as_view(),
+        name="registration-list-export",
     ),
     path(
         "registration/create/",
@@ -50,10 +55,5 @@ urlpatterns = [
         "registration/questions/<uuid:pk>/delete/",
         RegistrationQuestionDelete.as_view(),
         name="registration-question-delete",
-    ),
-    path(
-        "registration/questions/answers/export/",
-        RegistrationQuestionAnswerListExport.as_view(),
-        name="registration-question-answer-list-export",
     ),
 ]

--- a/app/grandchallenge/participants/urls.py
+++ b/app/grandchallenge/participants/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from grandchallenge.participants.views import (
     ParticipantsList,
+    RegistrationQuestionAnswerListExport,
     RegistrationQuestionCreate,
     RegistrationQuestionDelete,
     RegistrationQuestionList,
@@ -49,5 +50,10 @@ urlpatterns = [
         "registration/questions/<uuid:pk>/delete/",
         RegistrationQuestionDelete.as_view(),
         name="registration-question-delete",
+    ),
+    path(
+        "registration/questions/answers/export/",
+        RegistrationQuestionAnswerListExport.as_view(),
+        name="registration-question-answer-list-export",
     ),
 ]


### PR DESCRIPTION
With the addition of registration questions, I noticed that aggregating the answers can sometimes be hard.

To allow for maximum flexibility, this PR adds an export button:

<img src="https://github.com/user-attachments/assets/675245e7-7ebd-486c-8410-1032602fb6f7">