### PR TITLE
Make consistent html titles with breadcrumbs for archives app

### DIFF
--- a/app/grandchallenge/archives/templates/archives/archive_cases_list.html
+++ b/app/grandchallenge/archives/templates/archives/archive_cases_list.html
@@ -2,6 +2,10 @@
 {% load guardian_tags %}
 {% load static %}
 
+{% block title %}
+    Images - {{ archive.title }} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'archives:list' %}">Archives</a></li>

--- a/app/grandchallenge/archives/templates/archives/archive_cases_to_reader_study_form.html
+++ b/app/grandchallenge/archives/templates/archives/archive_cases_to_reader_study_form.html
@@ -3,6 +3,10 @@
 {% load static %}
 {% load url %}
 
+{% block title %}
+    Add Items to Reader Study - Items - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'archives:list' %}">Archives</a>

--- a/app/grandchallenge/archives/templates/archives/archive_detail.html
+++ b/app/grandchallenge/archives/templates/archives/archive_detail.html
@@ -8,7 +8,7 @@
 {% load static %}
 
 {% block title %}
-    {{ object.title }} - {{ block.super }}
+    {{ object.title }} - Archives - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/grandchallenge/archives/templates/archives/archive_form.html
+++ b/app/grandchallenge/archives/templates/archives/archive_form.html
@@ -3,7 +3,7 @@
 {% load url %}
 
 {% block title %}
-    {% if object %}Update{% else %}New{% endif %} Archive - {{ block.super }}
+    {% if object %}Update{% else %}New{% endif %} Archive -{% if object %} {{ object.title }} -{% endif %} {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/grandchallenge/archives/templates/archives/archive_item_job_list.html
+++ b/app/grandchallenge/archives/templates/archives/archive_item_job_list.html
@@ -2,7 +2,7 @@
 {% load meta_attr %}
 
 {% block title %}
-    Algorithm Results - {{ block.super }}
+    Jobs - {{ object.pk }} - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/grandchallenge/archives/templates/archives/archive_upload_session_create.html
+++ b/app/grandchallenge/archives/templates/archives/archive_upload_session_create.html
@@ -5,7 +5,7 @@
 {% load static %}
 
 {% block title %}
-    Add Items to Archive - {{ block.super }}
+    Add Items - {{ archive.title }} - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/grandchallenge/archives/templates/archives/archive_user_groups_form.html
+++ b/app/grandchallenge/archives/templates/archives/archive_user_groups_form.html
@@ -1,6 +1,10 @@
 {% extends "groups/groups_form_base.html" %}
 {% load url %}
 
+{% block title %}
+    Add user - {{ object.title }} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'archives:list' %}">Archives</a></li>

--- a/app/grandchallenge/archives/templates/archives/archivepermissionrequest_form.html
+++ b/app/grandchallenge/archives/templates/archives/archivepermissionrequest_form.html
@@ -3,6 +3,9 @@
 {% load clean from bleach %}
 {% load guardian_tags %}
 
+{% block title %}
+    {% if "change_archive" in archive_perms %}Review access request{% else %}Request access{% endif %} - {{ archive.title }} - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     {% get_obj_perms request.user for archive as "archive_perms" %}

--- a/app/grandchallenge/archives/templates/archives/archivepermissionrequest_form.html
+++ b/app/grandchallenge/archives/templates/archives/archivepermissionrequest_form.html
@@ -4,6 +4,7 @@
 {% load guardian_tags %}
 
 {% block title %}
+    {% get_obj_perms request.user for archive as "archive_perms" %}
     {% if "change_archive" in archive_perms %}Review access request{% else %}Request access{% endif %} - {{ archive.title }} - {{ block.super }}
 {% endblock %}
 

--- a/app/grandchallenge/archives/templates/archives/archivepermissionrequest_list.html
+++ b/app/grandchallenge/archives/templates/archives/archivepermissionrequest_list.html
@@ -5,7 +5,7 @@
 {% load static %}
 
 {% block title %}
-    Permission Requests - {{ block.super }}
+    Permission Requests - {{ archive.title }} - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles matche the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556