### PR TITLE
Make consistent html titles with breadcrumbs for cases app

### DIFF
--- a/app/grandchallenge/cases/templates/cases/rawimageuploadsession_detail.html
+++ b/app/grandchallenge/cases/templates/cases/rawimageuploadsession_detail.html
@@ -5,7 +5,9 @@
 {% load pathlib %}
 {% load static %}
 
-{% block title %}Upload Session {{ object.pk }} - {{ block.super }}{% endblock %}
+{% block title %}
+    {{ object.pk }} - Uplaods - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/cases/templates/cases/rawimageuploadsession_list.html
+++ b/app/grandchallenge/cases/templates/cases/rawimageuploadsession_list.html
@@ -1,7 +1,9 @@
 {% extends "datatables/list_base.html" %}
 {% load humanize %}
 
-{% block title %}Upload Sessions - {{ block.super }}{% endblock %}
+{% block title %}
+    Uploads - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles matche the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556