### PR TITLE
Make consistent html titles with breadcrumbs for challenges app

### DIFF
--- a/app/grandchallenge/challenges/templates/challenges/challenge_costs_overview.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_costs_overview.html
@@ -4,6 +4,10 @@
 {% load static %}
 {% load costs %}
 
+{% block title %}
+    Cost Overview - Challenges - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a
@@ -12,10 +16,6 @@
         <li class="breadcrumb-item active"
             aria-current="page">Cost Overview</li>
     </ol>
-{% endblock %}
-
-{% block title %}
-    Challenge Cost Overview - {{ block.super }}
 {% endblock %}
 
 {% block content %}

--- a/app/grandchallenge/challenges/templates/challenges/challenge_form.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_form.html
@@ -3,7 +3,9 @@
 {% load crispy_forms_tags %}
 {% load static %}
 
-{% block title %}Create A Challenge{% endblock %}
+{% block title %}
+    Create - Challenges - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/challenges/templates/challenges/challenge_update.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_update.html
@@ -3,6 +3,10 @@
 {% load static %}
 {% load url %}
 
+{% block title %}
+    Update - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a
@@ -14,8 +18,6 @@
             aria-current="page">Update</li>
     </ol>
 {% endblock %}
-
-{% block title %}Update {{ challenge.short_name }}{% endblock %}
 
 {% block content %}
     <h2>Update {{ challenge.short_name }}</h2>

--- a/app/grandchallenge/challenges/templates/challenges/challenge_users_list.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_users_list.html
@@ -1,14 +1,16 @@
 {% extends 'datatables/list_base.html' %}
 {% load url %}
 
+{% block title %}
+    Your Challenges - Challenges - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'challenges:list' %}">Challenges</a></li>
         <li class="breadcrumb-item active" aria-current="page">Your Challenges</li>
     </ol>
 {% endblock %}
-
-{% block title %}Your Challenges - {{ block.super }}{% endblock %}
 
 {% block content %}
 

--- a/app/grandchallenge/challenges/templates/challenges/challengerequest_detail.html
+++ b/app/grandchallenge/challenges/templates/challenges/challengerequest_detail.html
@@ -7,7 +7,9 @@
 {% load naturaldelta %}
 {% load guardian_tags %}
 
-{% block title %}Challenge request: {{ object.title }}{% endblock %}
+{% block title %}
+    {{ object.title }} - {% if not perms.challenges.change_challengerequest %}Your{% endif %} Challenge Requests - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/challenges/templates/challenges/challengerequest_form.html
+++ b/app/grandchallenge/challenges/templates/challenges/challengerequest_form.html
@@ -3,7 +3,9 @@
 {% load crispy_forms_tags %}
 {% load static %}
 
-{% block title %}Request A Challenge{% endblock %}
+{% block title %}
+    Request - Challenges - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/challenges/templates/challenges/challengerequest_list.html
+++ b/app/grandchallenge/challenges/templates/challenges/challengerequest_list.html
@@ -5,7 +5,9 @@
 {% load naturaldelta %}
 {% load user_profile_link from profiles %}
 
-{% block title %}Challenge requests{% endblock %}
+{% block title %}
+    {% if not perms.challenges.change_challengerequest %}Your{% endif %} Challenge Requests - Challenges - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles matche the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556