### PR TITLE
Make consistent html titles with breadcrumbs for components app

### DIFF
--- a/app/grandchallenge/components/templates/components/civ_set_delete_confirm.html
+++ b/app/grandchallenge/components/templates/components/civ_set_delete_confirm.html
@@ -2,6 +2,10 @@
 {% load crispy_forms_tags %}
 {% load meta_attr %}
 
+{% block title %}
+    {{ base_object.civ_set_model|verbose_name_plural|title }} - {{ base_object }} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{{ base_object.list_url }}">{{ base_object|verbose_name_plural|title }}</a></li>

--- a/app/grandchallenge/components/templates/components/civ_set_detail.html
+++ b/app/grandchallenge/components/templates/components/civ_set_detail.html
@@ -5,9 +5,8 @@
 {% load civ %}
 {% load guardian_tags %}
 
-
 {% block title %}
-    {{ object.title }} - {{ block.super }}
+    {{ object.pk }} - {{ object.base_object.civ_set_model|verbose_name_plural|title }} - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/grandchallenge/components/templates/components/civ_set_form.html
+++ b/app/grandchallenge/components/templates/components/civ_set_form.html
@@ -6,11 +6,12 @@
 
 {% block title %}
     {% if object %}
-        Update {{ base_object.civ_set_model|verbose_name|title }}
+        Update
     {% else %}
-        Add {{ base_object.civ_set_model|verbose_name|title }} to {{ base_object }}
+        Add
     {% endif %}
-    - {{ block.super }}
+    {{ base_object.civ_set_model|verbose_name|title }}
+    - {{ base_object.civ_set_model|verbose_name_plural|title }} - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/grandchallenge/components/templates/components/civ_set_list.html
+++ b/app/grandchallenge/components/templates/components/civ_set_list.html
@@ -3,6 +3,10 @@
 {% load url %}
 {% load meta_attr %}
 
+{% block title %}
+    {{ base_object.civ_set_model|verbose_name_plural|title }} - {{ base_object }} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{{ base_object.list_url }}">{{ base_object|verbose_name_plural|title }}</a></li>

--- a/app/grandchallenge/components/templates/components/civset_confirm_delete.html
+++ b/app/grandchallenge/components/templates/components/civset_confirm_delete.html
@@ -3,7 +3,7 @@
 {% load meta_attr %}
 
 {% block title %}
-    Delete {{ object|verbose_name|title }} - {{ block.super }}
+    Delete {{ object.pk }} - {{ object|verbose_name_plural|title }} - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/grandchallenge/components/templates/components/componentinterface_list.html
+++ b/app/grandchallenge/components/templates/components/componentinterface_list.html
@@ -5,7 +5,11 @@
 {% load bleach %}
 
 {% block title %}
-    {{ object_type|title }} {{ list_type|title }} Options - {{ block.super }}
+    {% if object_type == object_type_options.ALGORITHM %}
+        {{ list_type|title }} - Interface Options - {{ block.super }}
+    {% else %}
+        Interface Options - {{ block.super }}
+    {% endif %}
 {% endblock %}
 
 {% block breadcrumbs %}


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles matche the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556