### PR TITLE
Make consistent html titles with breadcrumbs for admins app

### DIFF
--- a/app/grandchallenge/admins/templates/admins/admins_form.html
+++ b/app/grandchallenge/admins/templates/admins/admins_form.html
@@ -3,6 +3,10 @@
 {% load static %}
 {% load url %}
 
+{% block title %}
+    Add - Admins - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a

--- a/app/grandchallenge/admins/templates/admins/admins_list.html
+++ b/app/grandchallenge/admins/templates/admins/admins_list.html
@@ -1,6 +1,10 @@
 {% extends 'auth/user_list.html' %}
 {% load url %}
 
+{% block title %}
+    Admins - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles matche the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556