### PR TITLE
Make consistent html titles with breadcrumbs for api_tokens app

### DIFF
--- a/app/grandchallenge/api_tokens/templates/knox/authtoken_confirm_delete.html
+++ b/app/grandchallenge/api_tokens/templates/knox/authtoken_confirm_delete.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
 {% load url %}
 
-{% block title %}Delete a Token - {{ block.super }}{% endblock %}
+{% block title %}
+    Delete - {{ object.token_key }} - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/api_tokens/templates/knox/authtoken_form.html
+++ b/app/grandchallenge/api_tokens/templates/knox/authtoken_form.html
@@ -2,7 +2,9 @@
 {% load url %}
 {% load crispy_forms_tags %}
 
-{% block title %}Create a Token - {{ block.super }}{% endblock %}
+{% block title %}
+    Create - API Tokens - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/api_tokens/templates/knox/authtoken_list.html
+++ b/app/grandchallenge/api_tokens/templates/knox/authtoken_list.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block title %}API Tokens - {{ block.super }}{% endblock %}
+{% block title %}
+    API Tokens - Settings - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles match the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556