### PR TITLE
Fix typo in rawimageuploadsession_detail.html

### DIFF
--- a/app/grandchallenge/cases/templates/cases/rawimageuploadsession_detail.html
+++ b/app/grandchallenge/cases/templates/cases/rawimageuploadsession_detail.html
@@ -6,7 +6,7 @@
 {% load static %}
 
 {% block title %}
-    {{ object.pk }} - Uplaods - {{ block.super }}
+    {{ object.pk }} - Uploads - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.