### PR TITLE
Make consistent html titles with breadcrumbs for documentation app

### DIFF
--- a/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
+++ b/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
@@ -3,7 +3,11 @@
 {% load bleach %}
 
 {% block title %}
-    {{ currentdocpage.title }} - {{ block.super }}
+    {{ currentdocpage.title }} -
+    {% if currentdocpage.parent %}
+        {{ currentdocpage.parent.title }} -
+    {% endif %}
+    {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/grandchallenge/documentation/templates/documentation/docpage_form.html
+++ b/app/grandchallenge/documentation/templates/documentation/docpage_form.html
@@ -4,7 +4,11 @@
 {% load url %}
 
 {% block title %}
-    Documentation - {{ block.super }}
+    {% if object %}Update{% else %}Create Page{% endif %} -
+    {% if object %}
+        {{ object.title }} -
+    {% endif %}
+    {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/grandchallenge/documentation/templates/documentation/docpage_list.html
+++ b/app/grandchallenge/documentation/templates/documentation/docpage_list.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block title %}
-    Documentation - {{ block.super }}
+    Page Overview - Documentation - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles match the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556