### PR TITLE
Make consistent html titles with breadcrumbs for emails app

### DIFF
--- a/app/grandchallenge/emails/templates/emails/email_detail.html
+++ b/app/grandchallenge/emails/templates/emails/email_detail.html
@@ -2,7 +2,9 @@
 {% load url %}
 {% load bleach %}
 
-{% block title %}{{ object.subject }} - Emails - {{ block.super }}{% endblock %}
+{% block title %}
+    {{ object.subject }} - Emails - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/emails/templates/emails/email_form.html
+++ b/app/grandchallenge/emails/templates/emails/email_form.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags %}
 
-{% block title %}{% if object %}Update{% else %}Create{% endif %} Email - {{ block.super }}{% endblock %}
+{% block title %}
+    {% if object %}Update{% else %}Create{% endif %} -{% if object %} {{ object }} -{% endif %} {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/emails/templates/emails/email_list.html
+++ b/app/grandchallenge/emails/templates/emails/email_list.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
 {% load url %}
 
-{% block title %}Emails - {{ block.super }}{% endblock %}
+{% block title %}
+    Emails - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles match the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556