### PR TITLE
Make consistent html titles with breadcrumbs for organizations app

### DIFF
--- a/app/grandchallenge/organizations/templates/organizations/organization_detail.html
+++ b/app/grandchallenge/organizations/templates/organizations/organization_detail.html
@@ -7,7 +7,7 @@
 {% load user_profile_link from profiles %}
 
 {% block title %}
-    {{ object.title }} - {{ block.super }}
+    {{ object.title }} - Organizations - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/grandchallenge/organizations/templates/organizations/organization_form.html
+++ b/app/grandchallenge/organizations/templates/organizations/organization_form.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 
 {% block title %}
-    {{ object|yesno:"Update,Create" }} Organization - {{ block.super }}
+    {{ object|yesno:"Update,Create" }} -{% if object %} {{ object.title }} -{% endif %} {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/grandchallenge/organizations/templates/organizations/user_groups_form.html
+++ b/app/grandchallenge/organizations/templates/organizations/user_groups_form.html
@@ -1,6 +1,10 @@
 {% extends "groups/groups_form_base.html" %}
 {% load url %}
 
+{% block title %}
+    Add user - {% firstof object.title object %} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'organizations:list' %}">Organizations</a></li>


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles match the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556