### PR TITLE
Make consistent html titles with breadcrumbs for notifications app

### DIFF
--- a/app/grandchallenge/notifications/templates/notifications/notification_list.html
+++ b/app/grandchallenge/notifications/templates/notifications/notification_list.html
@@ -6,8 +6,9 @@
 {% load url %}
 {% load notification_extras %}
 
-
-{% block title %}Notifications - {{ block.super }}{% endblock %}
+{% block title %}
+    Notifications - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles match the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556