### PR TITLE
Make consistent html titles with breadcrumbs for hanging_protocols app

### DIFF
--- a/app/grandchallenge/hanging_protocols/templates/hanging_protocols/hangingprotocol_detail.html
+++ b/app/grandchallenge/hanging_protocols/templates/hanging_protocols/hangingprotocol_detail.html
@@ -6,15 +6,15 @@
 {% load profiles %}
 {% load guardian_tags %}
 
+{% block title %}
+    {{ object.title }} - Hanging Protocols - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'hanging-protocols:list' %}">Hanging Protocols</a></li>
         <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{{ object.title }}</a></li>
     </ol>
-{% endblock %}
-
-{% block title %}
-    Hanging Protocol - {{ object.title }} - {{ block.super }}
 {% endblock %}
 
 {% block content %}

--- a/app/grandchallenge/hanging_protocols/templates/hanging_protocols/hangingprotocol_form.html
+++ b/app/grandchallenge/hanging_protocols/templates/hanging_protocols/hangingprotocol_form.html
@@ -3,6 +3,10 @@
 {% load crispy_forms_tags %}
 {% load static %}
 
+{% block title %}
+    {{ object|yesno:"Update,Create" }} -{% if object %} {{ object.title }} -{% endif %} {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'hanging-protocols:list' %}">Hanging Protocols</a></li>
@@ -13,10 +17,6 @@
         <li class="breadcrumb-item active"
             aria-current="page">{{ object|yesno:"Update,Create" }}</li>
     </ol>
-{% endblock %}
-
-{% block title %}
-    Hanging Protocol {{ object|yesno:"Update,Create" }} - {{ block.super }}
 {% endblock %}
 
 {% block content %}

--- a/app/grandchallenge/hanging_protocols/templates/hanging_protocols/hangingprotocol_list.html
+++ b/app/grandchallenge/hanging_protocols/templates/hanging_protocols/hangingprotocol_list.html
@@ -3,15 +3,14 @@
 {% load static %}
 {% load json %}
 
+{% block title %}
+    Hanging Protocols - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item active">Hanging Protocols</li>
     </ol>
-{% endblock %}
-
-{% block title %}
-    Hanging Protocols - {{ block.super }}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles match the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556