### PR TITLE
Make consistent html titles with breadcrumbs for flatpages app

### DIFF
--- a/app/grandchallenge/flatpages/templates/flatpages/flatpage_form.html
+++ b/app/grandchallenge/flatpages/templates/flatpages/flatpage_form.html
@@ -4,7 +4,7 @@
 {% load static %}
 
 {% block title %}
-    {% if flatpage %}{{ flatpage.title }}{% else %}Flatpages{% endif %} - {{ block.super }}
+    {% if flatpage %}Update{% else %}Create Flatpage{% endif %} - {% if flatpage %}{{ flatpage.title }}{% else %}Flatpages{% endif %} - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles match the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556