### PR TITLE
Add get_first_or_create method for CIVs

### DIFF
--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -666,12 +666,10 @@ class JobManager(ComponentJobManager):
                 continue
             elif civ.image:
                 try:
-                    civ, _ = (
-                        ComponentInterfaceValue.objects.get_first_or_create(
-                            interface__slug=civ.interface_slug, image=civ.image
-                        ).get()
-                    )
-                    existing_civs.append(civ)
+                    civs = ComponentInterfaceValue.objects.filter(
+                        interface__slug=civ.interface_slug, image=civ.image
+                    ).all()
+                    existing_civs.append(civs)
                 except ObjectDoesNotExist:
                     continue
             elif civ.file_civ:
@@ -679,12 +677,10 @@ class JobManager(ComponentJobManager):
             else:
                 # values can be of different types, including None and False
                 try:
-                    civ, _ = (
-                        ComponentInterfaceValue.objects.get_first_or_create(
-                            interface__slug=civ.interface_slug, value=civ.value
-                        ).get()
-                    )
-                    existing_civs.append(civ)
+                    civs = ComponentInterfaceValue.objects.filter(
+                        interface__slug=civ.interface_slug, value=civ.value
+                    ).all()
+                    existing_civs.append(civs)
                 except ObjectDoesNotExist:
                     continue
 

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -666,9 +666,11 @@ class JobManager(ComponentJobManager):
                 continue
             elif civ.image:
                 try:
-                    civ = ComponentInterfaceValue.objects.filter(
-                        interface__slug=civ.interface_slug, image=civ.image
-                    ).get()
+                    civ, _ = (
+                        ComponentInterfaceValue.objects.get_first_or_create(
+                            interface__slug=civ.interface_slug, image=civ.image
+                        ).get()
+                    )
                     existing_civs.append(civ)
                 except ObjectDoesNotExist:
                     continue
@@ -677,9 +679,11 @@ class JobManager(ComponentJobManager):
             else:
                 # values can be of different types, including None and False
                 try:
-                    civ = ComponentInterfaceValue.objects.filter(
-                        interface__slug=civ.interface_slug, value=civ.value
-                    ).get()
+                    civ, _ = (
+                        ComponentInterfaceValue.objects.get_first_or_create(
+                            interface__slug=civ.interface_slug, value=civ.value
+                        ).get()
+                    )
                     existing_civs.append(civ)
                 except ObjectDoesNotExist:
                     continue

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -669,7 +669,7 @@ class JobManager(ComponentJobManager):
                     civs = ComponentInterfaceValue.objects.filter(
                         interface__slug=civ.interface_slug, image=civ.image
                     ).all()
-                    existing_civs.append(civs)
+                    existing_civs.extend(civs)
                 except ObjectDoesNotExist:
                     continue
             elif civ.file_civ:
@@ -680,7 +680,7 @@ class JobManager(ComponentJobManager):
                     civs = ComponentInterfaceValue.objects.filter(
                         interface__slug=civ.interface_slug, value=civ.value
                     ).all()
-                    existing_civs.append(civs)
+                    existing_civs.extend(civs)
                 except ObjectDoesNotExist:
                     continue
 

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -1171,6 +1171,15 @@ def component_interface_value_path(instance, filename):
     )
 
 
+class ComponentInterfaceValueManager(models.Manager):
+
+    def get_first_or_create(self, **kwargs):
+        try:
+            return self.get_or_create(**kwargs)
+        except MultipleObjectsReturned:
+            return self.filter(**kwargs).first(), False
+
+
 class ComponentInterfaceValue(models.Model):
     """Encapsulates the value of an interface at a certain point in the graph."""
 
@@ -1237,6 +1246,8 @@ class ComponentInterfaceValue(models.Model):
     )
 
     _user_upload_validated = False
+
+    objects = ComponentInterfaceValueManager()
 
     @property
     def title(self):
@@ -2249,7 +2260,7 @@ class CIVForObjectMixin:
     ):
         current_value = current_civ.value if current_civ else None
 
-        civ, created = ComponentInterfaceValue.objects.get_or_create(
+        civ, created = ComponentInterfaceValue.objects.get_first_or_create(
             interface=ci, value=new_value
         )
 
@@ -2290,9 +2301,10 @@ class CIVForObjectMixin:
     ):
         current_image = current_civ.image if current_civ else None
         if image and current_image != image:
-            civ, created = ComponentInterfaceValue.objects.get_or_create(
+            civ, created = ComponentInterfaceValue.objects.get_first_or_create(
                 interface=ci, image=image
             )
+
             if created:
                 try:
                     civ.full_clean()

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1203,7 +1203,7 @@ def add_image_to_object(
         interface=interface, upload_session=upload_session
     )
 
-    civ, created = ComponentInterfaceValue.objects.get_or_create(
+    civ, created = ComponentInterfaceValue.objects.get_first_or_create(
         interface=interface, image=image
     )
 


### PR DESCRIPTION
There can be multiple CIVs with the same interface and value/image/file in the DB. Retrieve the first of those if that's the case rather than throwing an error. 

Closes #3594 