### PR TITLE
Make consistent html titles with breadcrumbs for pages app

### DIFF
--- a/app/grandchallenge/pages/templates/pages/challenge_settings_base.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_settings_base.html
@@ -5,8 +5,7 @@
 {% load static %}
 
 {% block title %}
-        Admin
-    - {{ block.super }}
+    Challenge Admin - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/grandchallenge/pages/templates/pages/challenge_statistics.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_statistics.html
@@ -7,7 +7,7 @@
 {% load divide_by %}
 
 {% block title %}
-    Statistics - {{ block.super }}
+    Statistics - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/grandchallenge/pages/templates/pages/page_confirm_delete.html
+++ b/app/grandchallenge/pages/templates/pages/page_confirm_delete.html
@@ -1,6 +1,10 @@
 {% extends "pages/challenge_settings_base.html" %}
 {% load url %}
 
+{% block title %}
+    Delete - {{ object|title }} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -6,7 +6,7 @@
 {% load random_encode %}
 
 {% block title %}
-    {{ object|title }} - {{ block.super }}
+    {{ object|title }} - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/grandchallenge/pages/templates/pages/page_form.html
+++ b/app/grandchallenge/pages/templates/pages/page_form.html
@@ -3,6 +3,10 @@
 {% load static %}
 {% load url %}
 
+{% block title %}
+    {% if object %}Update{% else %}Create{% endif %} -{% if object %} {{ object|title }} -{% endif %} {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a

--- a/app/grandchallenge/pages/templates/pages/page_list.html
+++ b/app/grandchallenge/pages/templates/pages/page_list.html
@@ -2,6 +2,10 @@
 {% load url %}
 {% load static %}
 
+{% block title %}
+    Pages - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles match the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556