### PR TITLE
Make consistent html titles with breadcrumbs for participants app

### DIFF
--- a/app/grandchallenge/participants/templates/participants/participants_list.html
+++ b/app/grandchallenge/participants/templates/participants/participants_list.html
@@ -1,6 +1,10 @@
 {% extends 'auth/user_list.html' %}
 {% load url %}
 
+{% block title %}
+    Participants - {% firstof challenge.title challenge.short_name %} - {{ request.site.name }}
+{% endblock %}
+
 {% block content_title %}
     <h2>Participants for {{ challenge.short_name }}</h2>
 {% endblock %}

--- a/app/grandchallenge/participants/templates/participants/registrationquestion_confirm_delete.html
+++ b/app/grandchallenge/participants/templates/participants/registrationquestion_confirm_delete.html
@@ -1,6 +1,10 @@
 {% extends "pages/challenge_settings_base.html" %}
 {% load url %}
 
+{% block title %}
+    Delete Registration Question - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a

--- a/app/grandchallenge/participants/templates/participants/registrationquestion_form.html
+++ b/app/grandchallenge/participants/templates/participants/registrationquestion_form.html
@@ -4,6 +4,10 @@
 {% load static %}
 {% load meta_attr %}
 
+{% block title %}
+    {{ object|yesno:"Update,Add" }} Registration Question - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a

--- a/app/grandchallenge/participants/templates/participants/registrationquestion_list.html
+++ b/app/grandchallenge/participants/templates/participants/registrationquestion_list.html
@@ -4,6 +4,10 @@
 {% load static %}
 {% load meta_attr %}
 
+{% block title %}
+    Registration Questions - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a

--- a/app/grandchallenge/participants/templates/participants/registrationrequest_form.html
+++ b/app/grandchallenge/participants/templates/participants/registrationrequest_form.html
@@ -3,6 +3,10 @@
 {% load bleach %}
 {% load url %}
 
+{% block title %}
+    Join - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a

--- a/app/grandchallenge/participants/templates/participants/registrationrequest_list.html
+++ b/app/grandchallenge/participants/templates/participants/registrationrequest_list.html
@@ -4,6 +4,10 @@
 {% load static %}
 {% load dict_lookup %}
 
+{% block title %}
+    Participation Requests - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles match the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556