### PR TITLE
Make consistent html titles with breadcrumbs for profiles app

### DIFF
--- a/app/grandchallenge/profiles/templates/profiles/userprofile_detail.html
+++ b/app/grandchallenge/profiles/templates/profiles/userprofile_detail.html
@@ -7,9 +7,10 @@
 {% load humanize %}
 {% load profiles %}
 
-{% block title %}{% blocktrans with profile.user.username as username %}
-    {{ username }}'s profile
-{% endblocktrans %}{% endblock %}
+{% block title %}
+    {{ profile.user.username }} - Users - {{ block.super }}
+{% endblock %}
+
 {% block content_title %}
     <h2>{{ profile.user.username }} {% if profile.user.get_full_name %}(
         {{ profile.user.get_full_name }}

--- a/app/grandchallenge/profiles/templates/profiles/userprofile_form.html
+++ b/app/grandchallenge/profiles/templates/profiles/userprofile_form.html
@@ -2,7 +2,9 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}Edit Profile{% endblock %}
+{% block title %}
+    Edit Profile - {{ profile.user.username }} - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles matche the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556