### PR TITLE
Make consistent html titles with breadcrumbs for publications app

### DIFF
--- a/app/grandchallenge/publications/templates/publications/publication_form.html
+++ b/app/grandchallenge/publications/templates/publications/publication_form.html
@@ -2,7 +2,9 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
-{% block title %}Add Publication{% endblock %}
+{% block title %}
+    Add Publication - Publications - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/publications/templates/publications/publication_list.html
+++ b/app/grandchallenge/publications/templates/publications/publication_list.html
@@ -5,8 +5,9 @@
 {% load url %}
 {% load bleach %}
 
-
-{% block title %}Publications - {{ block.super }}{% endblock %}
+{% block title %}
+    Publications - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles matche the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556