### PR TITLE
Make consistent html titles with breadcrumbs for statistics app

### DIFF
--- a/app/grandchallenge/statistics/templates/statistics/statistics_detail.html
+++ b/app/grandchallenge/statistics/templates/statistics/statistics_detail.html
@@ -4,7 +4,7 @@
 {% load static %}
 
 {% block title %}
-    Statistics
+    Statistics - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/app/grandchallenge/statistics/templates/statistics/statistics_detail.html
+++ b/app/grandchallenge/statistics/templates/statistics/statistics_detail.html
@@ -3,7 +3,9 @@
 {% load url %}
 {% load static %}
 
-{% block title %}Statistics{% endblock %}
+{% block title %}
+    Statistics
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles match the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556