### PR TITLE
Make consistent html titles with breadcrumbs for teams app

### DIFF
--- a/app/grandchallenge/teams/templates/teams/team_confirm_delete.html
+++ b/app/grandchallenge/teams/templates/teams/team_confirm_delete.html
@@ -2,6 +2,10 @@
 {% load get_obj_perms from guardian_tags %}
 {% load url %}
 
+{% block title %}
+    Delete - {{ object.name|title }} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a

--- a/app/grandchallenge/teams/templates/teams/team_detail.html
+++ b/app/grandchallenge/teams/templates/teams/team_detail.html
@@ -3,6 +3,10 @@
 {% load url %}
 {% load user_profile_link from profiles %}
 
+{% block title %}
+    {{ object.name|title }} - Teams - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a

--- a/app/grandchallenge/teams/templates/teams/team_form.html
+++ b/app/grandchallenge/teams/templates/teams/team_form.html
@@ -2,6 +2,10 @@
 {% load crispy_forms_tags %}
 {% load url %}
 
+{% block title %}
+    {% if object %}Update{% else %}Create{% endif %} -{% if object %} {{ object.name|title }} -{% endif %} {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a

--- a/app/grandchallenge/teams/templates/teams/team_list.html
+++ b/app/grandchallenge/teams/templates/teams/team_list.html
@@ -4,6 +4,11 @@
 {% load user_profile_link from profiles %}
 {% load static %}
 
+{% block title %}
+    Teams - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
+{% endblock %}
+
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a

--- a/app/grandchallenge/teams/templates/teams/teammember_confirm_delete.html
+++ b/app/grandchallenge/teams/templates/teams/teammember_confirm_delete.html
@@ -2,6 +2,10 @@
 {% load get_obj_perms from guardian_tags %}
 {% load url %}
 
+{% block title %}
+    Remove Member - {{ object.name|title }} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a

--- a/app/grandchallenge/teams/templates/teams/teammember_form.html
+++ b/app/grandchallenge/teams/templates/teams/teammember_form.html
@@ -2,6 +2,10 @@
 {% load crispy_forms_tags %}
 {% load url %}
 
+{% block title %}
+    Join - {{ object.name|title }} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles match the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556