### PR TITLE
Make consistent html titles with breadcrumbs for verifications app

### DIFF
--- a/app/grandchallenge/verifications/templates/verifications/confirm_email_form.html
+++ b/app/grandchallenge/verifications/templates/verifications/confirm_email_form.html
@@ -2,7 +2,9 @@
 {% load crispy_forms_tags %}
 {% load url %}
 
-{% block title %}Request Verification - {{ block.super }}{% endblock %}
+{% block title %}
+    Confirm Email - Verification - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/verifications/templates/verifications/verification_detail.html
+++ b/app/grandchallenge/verifications/templates/verifications/verification_detail.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags %}
 
-{% block title %}Verification - {{ block.super }}{% endblock %}
+{% block title %}
+    Verification - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/verifications/templates/verifications/verification_form.html
+++ b/app/grandchallenge/verifications/templates/verifications/verification_form.html
@@ -2,7 +2,9 @@
 {% load crispy_forms_tags %}
 {% load url %}
 
-{% block title %}Request Verification - {{ block.super }}{% endblock %}
+{% block title %}
+    Request Verification - Verification - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles match the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556