### PR TITLE
Make consistent html titles with breadcrumbs for workstation_configs app

### DIFF
--- a/app/grandchallenge/workstation_configs/templates/workstation_configs/workstationconfig_confirm_delete.html
+++ b/app/grandchallenge/workstation_configs/templates/workstation_configs/workstationconfig_confirm_delete.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+{% block title %}
+    Delete - {{ object.title }} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'workstation-configs:list' %}">Viewer Configurations</a></li>

--- a/app/grandchallenge/workstation_configs/templates/workstation_configs/workstationconfig_detail.html
+++ b/app/grandchallenge/workstation_configs/templates/workstation_configs/workstationconfig_detail.html
@@ -5,6 +5,9 @@
 {% load json %}
 {% load crispy_forms_tags %}
 
+{% block title %}
+    {{ object.title }} - Viewer Configurations - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/workstation_configs/templates/workstation_configs/workstationconfig_form.html
+++ b/app/grandchallenge/workstation_configs/templates/workstation_configs/workstationconfig_form.html
@@ -2,6 +2,10 @@
 {% load crispy_forms_tags %}
 {% load static %}
 
+{% block title %}
+    {{ object|yesno:"Update,Create" }} -{% if object %} {{ object.title }} -{% endif %} {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'workstation-configs:list' %}">Viewer Configurations</a></li>
@@ -12,10 +16,6 @@
         <li class="breadcrumb-item active"
             aria-current="page">{{ object|yesno:"Update,Create" }}</li>
     </ol>
-{% endblock %}
-
-{% block title %}
-    {{ object|yesno:"Update,Create" }} Viewer Configuration - {{ block.super }}
 {% endblock %}
 
 {% block content %}

--- a/app/grandchallenge/workstation_configs/templates/workstation_configs/workstationconfig_list.html
+++ b/app/grandchallenge/workstation_configs/templates/workstation_configs/workstationconfig_list.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
 {% load url %}
 
-{% block title %}Viewer Configurations - {{ block.super }}{% endblock %}
+{% block title %}
+    Viewer Configurations - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles match the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556