### PR TITLE
Make consistent html titles with breadcrumbs for workstations app

### DIFF
--- a/app/grandchallenge/workstations/templates/workstations/session_debug_form.html
+++ b/app/grandchallenge/workstations/templates/workstations/session_debug_form.html
@@ -2,7 +2,9 @@
 {% load crispy_forms_tags %}
 {% load static %}
 
-{% block title %}Create Debug Session - {{ block.super }}{% endblock %}
+{% block title %}
+    Create Debug Session - {{ object }} - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/workstations/templates/workstations/session_detail.html
+++ b/app/grandchallenge/workstations/templates/workstations/session_detail.html
@@ -2,8 +2,9 @@
 {% load url %}
 {% load static %}
 
-{% block title %}{{ object.workstation.slug }} Session -
-    {{ block.super }}{% endblock %}
+{% block title %}
+    {{ object }} - {{ object.workstation.slug }} - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/workstations/templates/workstations/session_form.html
+++ b/app/grandchallenge/workstations/templates/workstations/session_form.html
@@ -2,7 +2,9 @@
 {% load crispy_forms_tags %}
 {% load static %}
 
-{% block title %}Create Session - {{ block.super }}{% endblock %}
+{% block title %}
+    Create Session - {{ object }} - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/workstations/templates/workstations/workstation_detail.html
+++ b/app/grandchallenge/workstations/templates/workstations/workstation_detail.html
@@ -3,7 +3,9 @@
 {% load user_profile_link from profiles %}
 {% load guardian_tags %}
 
-{% block title %}{{ object.slug }} - {{ block.super }}{% endblock %}
+{% block title %}
+    {{ object.title }} - Viewers - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/workstations/templates/workstations/workstation_form.html
+++ b/app/grandchallenge/workstations/templates/workstations/workstation_form.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags %}
 
-{% block title %}Viewer {{ object|yesno:"Update,Create" }} -
-    {{ block.super }}{% endblock %}
+{% block title %}
+    {{ object|yesno:"Update,Create" }} -{% if object %} {{ object.title }} -{% endif %} {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/workstations/templates/workstations/workstation_user_groups_form.html
+++ b/app/grandchallenge/workstations/templates/workstations/workstation_user_groups_form.html
@@ -1,6 +1,10 @@
 {% extends "groups/groups_form_base.html" %}
 {% load url %}
 
+{% block title %}
+    Add user - {{ object.title }} - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'workstations:list' %}">Viewers</a></li>

--- a/app/grandchallenge/workstations/templates/workstations/workstationimage_detail.html
+++ b/app/grandchallenge/workstations/templates/workstations/workstationimage_detail.html
@@ -4,7 +4,9 @@
 {% load naturaldelta %}
 {% load guardian_tags %}
 
-{% block title %}Viewer Container Image - {{ block.super }}{% endblock %}
+{% block title %}
+    {{ object }} - {{ object.workstation.title }} - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/workstations/templates/workstations/workstationimage_form.html
+++ b/app/grandchallenge/workstations/templates/workstations/workstationimage_form.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags %}
 
-{% block title %}New Viewer Image - {{ block.super }}{% endblock %}
+{% block title %}
+    {% firstof object.title "New Workstation Image" %} - {{ workstation.title }} - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/workstations/templates/workstations/workstationimage_move.html
+++ b/app/grandchallenge/workstations/templates/workstations/workstationimage_move.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags %}
 
-{% block title %}Move Viewer Image -
-    {{ block.super }}{% endblock %}
+{% block title %}
+    Move - {{ form.fields.workstation_image.initial }} - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/workstations/templates/workstations/workstationimage_update.html
+++ b/app/grandchallenge/workstations/templates/workstations/workstationimage_update.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags %}
 
-{% block title %}Update The Viewer Image Settings -
-    {{ block.super }}{% endblock %}
+{% block title %}
+    Update - {{ object }} - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles match the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556