### PR TITLE
Make consistent html titles with breadcrumbs for core app

### DIFF
--- a/app/grandchallenge/core/templates/about.html
+++ b/app/grandchallenge/core/templates/about.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
 {% load url %}
 
-{% block title %}About us - {{ block.super }}{% endblock %}
+{% block title %}
+    About - {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">

--- a/app/grandchallenge/core/templates/challenge_suspended.html
+++ b/app/grandchallenge/core/templates/challenge_suspended.html
@@ -6,6 +6,10 @@
     <meta name="robots" content="noindex">
 {% endblock %}
 
+{% block title %}
+    Challenge Suspended - Home - {{ block.super }}
+{% endblock %}
+
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>


### PR DESCRIPTION
This is part of Task 1 under issue https://github.com/comic/grand-challenge.org/issues/3556 aiming to fix inconsistent HTML titles in GC.

Each app will have a PR to make sure titles are there for all pages that have a breadcrumbs and that titles match the breadcrumbs as described in issue https://github.com/comic/grand-challenge.org/issues/3556