### PR TITLE
Add easy to find information of linked phase archive

### DIFF
--- a/app/grandchallenge/evaluation/templates/evaluation/phase-archive-info.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/phase-archive-info.html
@@ -1,0 +1,53 @@
+{% extends "pages/challenge_settings_base.html" %}
+{% load url %}
+
+{% block title %}
+    Linked archive for {{ phase.title }} - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
+{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a
+                href="{% url 'challenges:list' %}">Challenges</a>
+        </li>
+        <li class="breadcrumb-item"><a
+                href="{{ challenge.get_absolute_url }}">{% firstof challenge.title challenge.short_name %}</a></li>
+        <li class="breadcrumb-item active"
+            aria-current="page">Linked archive for {{ phase.title }}</li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+
+    <h2 class="mb-3">Linked archive for {{ phase.title }}</h2>
+
+    <p>The (hidden) input data for this phase needs to be uploaded to an archive on Grand Challenge.</p>
+
+    {% if phase.archive and phase.submission_kind == phase.SubmissionKindChoices.ALGORITHM and not phase.external_evaluation %}
+        <p>This phase is linked to archive <a href="{{ phase.archive.get_absolute_url }}">{{ phase.archive }}</a>.</p>
+
+        {% if phase.algorithm_inputs.all %}
+            <p> Each item in the archive needs to contain data for the following interfaces, which are defined as algorithm inputs:</p>
+            <ul>
+                {% for input in phase.algorithm_inputs.all %}
+                    <li>{{ input }}</li>
+                {% endfor %}
+            </ul>
+            <p>
+                For each submission, {{ phase.count_valid_archive_items }}
+                algorithm job{{ phase.count_valid_archive_items|pluralize }} will be created
+                from the {{ phase.count_valid_archive_items }} valid item{{ phase.count_valid_archive_items|pluralize }}.
+            </p>
+            <a class="btn btn-primary" href="{% url 'archives:items-list' slug=phase.archive.slug %}"> <i class="fa fa-upload mr-1"></i> Upload data to {{ phase.archive }}</a>
+        {% else %}
+            <p> Before you can upload data to your archive, <b>you need to define the algorithm inputs and outputs</b>. Contact <a href="mailto:support@grand-challenge.org"> Grand Challenge Support</a> for help with getting this set up.</p>
+        {% endif %}
+
+    {% elif phase.submission_kind == phase.SubmissionKindChoices.ALGORITHM and not phase.external_evaluation and not phase.archive %}
+        <p>This phase <b>does not have an archive</b> linked to it yet.</p>
+        <p>Contact <a href="mailto:support@grand-challenge.org"> Grand Challenge Support</a> for help with getting this set up.</p>
+    {% else %}
+        <p>This phase does not require a linked archive.</p>
+    {% endif %}
+
+{% endblock %}

--- a/app/grandchallenge/evaluation/templates/evaluation/phase_archive_info.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/phase_archive_info.html
@@ -2,7 +2,7 @@
 {% load url %}
 
 {% block title %}
-    Linked archive for {{ phase.title }} - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
+    Linked archive for {{ object.title }} - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}
@@ -13,37 +13,37 @@
         <li class="breadcrumb-item"><a
                 href="{{ challenge.get_absolute_url }}">{% firstof challenge.title challenge.short_name %}</a></li>
         <li class="breadcrumb-item active"
-            aria-current="page">Linked archive for {{ phase.title }}</li>
+            aria-current="page">Linked archive for {{ object.title }}</li>
     </ol>
 {% endblock %}
 
 {% block content %}
 
-    <h2 class="mb-3">Linked archive for {{ phase.title }}</h2>
+    <h2 class="mb-3">Linked archive for {{ object.title }}</h2>
 
     <p>The (hidden) input data for this phase needs to be uploaded to an archive on Grand Challenge.</p>
 
-    {% if phase.archive and phase.submission_kind == phase.SubmissionKindChoices.ALGORITHM and not phase.external_evaluation %}
-        <p>This phase is linked to archive <a href="{{ phase.archive.get_absolute_url }}">{{ phase.archive }}</a>.</p>
+    {% if object.archive and object.submission_kind == object.SubmissionKindChoices.ALGORITHM and not object.external_evaluation %}
+        <p>This phase is linked to archive <a href="{{ object.archive.get_absolute_url }}">{{ object.archive }}</a>.</p>
 
-        {% if phase.algorithm_inputs.all %}
+        {% if object.algorithm_inputs.all %}
             <p> Each item in the archive needs to contain data for the following interfaces, which are defined as algorithm inputs:</p>
             <ul>
-                {% for input in phase.algorithm_inputs.all %}
+                {% for input in object.algorithm_inputs.all %}
                     <li>{{ input }}</li>
                 {% endfor %}
             </ul>
             <p>
-                For each submission, {{ phase.count_valid_archive_items }}
-                algorithm job{{ phase.count_valid_archive_items|pluralize }} will be created
-                from the {{ phase.count_valid_archive_items }} valid item{{ phase.count_valid_archive_items|pluralize }}.
+                For each submission, {{ object.count_valid_archive_items }}
+                algorithm job{{ object.count_valid_archive_items|pluralize }} will be created
+                from the {{ object.count_valid_archive_items }} valid item{{ object.count_valid_archive_items|pluralize }}.
             </p>
-            <a class="btn btn-primary" href="{% url 'archives:items-list' slug=phase.archive.slug %}"> <i class="fa fa-upload mr-1"></i> Upload data to {{ phase.archive }}</a>
+            <a class="btn btn-primary" href="{% url 'archives:items-list' slug=object.archive.slug %}"> <i class="fa fa-upload mr-1"></i> Upload data to {{ object.archive }}</a>
         {% else %}
             <p> Before you can upload data to your archive, <b>you need to define the algorithm inputs and outputs</b>. Contact <a href="mailto:support@grand-challenge.org"> Grand Challenge Support</a> for help with getting this set up.</p>
         {% endif %}
 
-    {% elif phase.submission_kind == phase.SubmissionKindChoices.ALGORITHM and not phase.external_evaluation and not phase.archive %}
+    {% elif object.submission_kind == object.SubmissionKindChoices.ALGORITHM and not object.external_evaluation and not object.archive %}
         <p>This phase <b>does not have an archive</b> linked to it yet.</p>
         <p>Contact <a href="mailto:support@grand-challenge.org"> Grand Challenge Support</a> for help with getting this set up.</p>
     {% else %}

--- a/app/grandchallenge/evaluation/urls.py
+++ b/app/grandchallenge/evaluation/urls.py
@@ -23,6 +23,7 @@ from grandchallenge.evaluation.views import (
     MethodList,
     MethodUpdate,
     PhaseAlgorithmCreate,
+    PhaseArchiveInfo,
     PhaseCreate,
     PhaseUpdate,
     SubmissionCreate,
@@ -73,6 +74,11 @@ urlpatterns = [
         "<slug>/algorithms/create/",
         PhaseAlgorithmCreate.as_view(),
         name="phase-algorithm-create",
+    ),
+    path(
+        "<slug>/linked-archive/",
+        PhaseArchiveInfo.as_view(),
+        name="phase-archive-info",
     ),
     path(
         "<slug>/ground-truths/",

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import (
-    AccessMixin,
     PermissionRequiredMixin,
     UserPassesTestMixin,
 )
@@ -24,7 +23,6 @@ from django.views.generic import (
     FormView,
     ListView,
     RedirectView,
-    TemplateView,
     UpdateView,
 )
 from guardian.mixins import LoginRequiredMixin
@@ -1178,12 +1176,16 @@ class EvaluationGroundTruthVersionManagement(
 
 
 class PhaseArchiveInfo(
-    LoginRequiredMixin, CachedPhaseMixin, AccessMixin, TemplateView
+    LoginRequiredMixin, ObjectPermissionRequiredMixin, DetailView
 ):
-    template_name = "evaluation/phase-archive-info.html"
+    model = Phase
+    permission_required = "evaluation.change_phase"
+    raise_exception = True
+    template_name = "evaluation/phase_archive_info.html"
 
-    def dispatch(self, request, *args, **kwargs):
-        if request.user.has_perm("evaluation.change_phase", self.phase):
-            return super().dispatch(request, *args, **kwargs)
-        else:
-            return self.handle_no_permission()
+    def get_object(self, queryset=None):
+        return get_object_or_404(
+            Phase,
+            challenge=self.request.challenge,
+            slug=self.kwargs["slug"],
+        )

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import (
+    AccessMixin,
     PermissionRequiredMixin,
     UserPassesTestMixin,
 )
@@ -23,6 +24,7 @@ from django.views.generic import (
     FormView,
     ListView,
     RedirectView,
+    TemplateView,
     UpdateView,
 )
 from guardian.mixins import LoginRequiredMixin
@@ -1173,3 +1175,15 @@ class EvaluationGroundTruthVersionManagement(
                 "slug": self.phase.slug,
             },
         )
+
+
+class PhaseArchiveInfo(
+    LoginRequiredMixin, CachedPhaseMixin, AccessMixin, TemplateView
+):
+    template_name = "evaluation/phase-archive-info.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.has_perm("evaluation.change_phase", self.phase):
+            return super().dispatch(request, *args, **kwargs)
+        else:
+            return self.handle_no_permission()

--- a/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
+++ b/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
@@ -2,14 +2,14 @@
     <a class="nav-link px-4 py-1 mb-1"
        data-toggle="collapse"
        data-target="#{{ phase.slug }}-collapse"
-       aria-expanded={% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}"true"{% else %}"false"{% endif %}
+       aria-expanded={% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail,evaluation:phase-archive-info' and request.resolver_match.kwargs.slug == phase.slug %}"true"{% else %}"false"{% endif %}
     >
         <i class="fas fa-chevron-right fa-fw"></i>
         <i class="fas fa-chevron-down fa-fw"></i>
         {% if not phase.public %}<i class="fas fa-lock" title="Phase is private"></i>{% endif %}
         {{ phase.title }}
     </a>
-    <div class="collapse {% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail' and request.resolver_match.kwargs.slug == phase.slug %}show{% endif %}"
+    <div class="collapse {% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail,evaluation:phase-archive-info' and request.resolver_match.kwargs.slug == phase.slug %}show{% endif %}"
          id="{{ phase.slug }}-collapse">
         <ul class="nav nav-pills flex-column">
             <li class="nav-item pl-4">
@@ -30,12 +30,21 @@
                     <i class="fas fa-cube fa-fw"></i> Ground Truths
                 </a>
             </li>
+            {% if phase.submission_kind == phase.SubmissionKindChoices.ALGORITHM and not phase.external_evaluation %}
+                <li class="nav-item pl-4">
+                    <a href="{% url "evaluation:phase-archive-info" slug=phase.slug %}"
+                       class="nav-link py-1 pl-3 {% if request.resolver_match.view_name == 'evaluation:phase-archive-info' and request.resolver_match.kwargs.slug == phase.slug %} active {% endif %}">
+                        <i class="fas fa-database fa-fw"></i> Linked archive
+                    </a>
+                </li>
+            {% endif %}
             <li class="nav-item pl-4">
                 <a href="{% url "evaluation:evaluation-admin-list" slug=phase.slug %}"
                    class="nav-link py-1 pl-3 {% if request.resolver_match.view_name == 'evaluation:evaluation-admin-list' and request.resolver_match.kwargs.slug == phase.slug %} active {% endif %}">
                     <i class="fas fa-list fa-fw"></i> Submissions & Evaluations
                 </a>
             </li>
+
         </ul>
     </div>
 </li>

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -1668,3 +1668,32 @@ def test_submission_create_sets_limits_correctly_with_predictions(client):
 
     assert submission.algorithm_requires_gpu_type == ""
     assert submission.algorithm_requires_memory_gb == 0
+
+
+@pytest.mark.django_db
+def test_phase_archive_info_permissions(client):
+    phase = PhaseFactory()
+    editor, user = UserFactory.create_batch(2)
+    phase.challenge.add_admin(editor)
+
+    response = get_view_for_user(
+        client=client,
+        viewname="evaluation:phase-archive-info",
+        reverse_kwargs={
+            "slug": phase.slug,
+            "challenge_short_name": phase.challenge.short_name,
+        },
+        user=user,
+    )
+    assert response.status_code == 403
+
+    response = get_view_for_user(
+        client=client,
+        viewname="evaluation:phase-archive-info",
+        reverse_kwargs={
+            "slug": phase.slug,
+            "challenge_short_name": phase.challenge.short_name,
+        },
+        user=editor,
+    )
+    assert response.status_code == 200

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -1672,16 +1672,16 @@ def test_submission_create_sets_limits_correctly_with_predictions(client):
 
 @pytest.mark.django_db
 def test_phase_archive_info_permissions(client):
-    phase = PhaseFactory()
+    phase1, phase2 = PhaseFactory.create_batch(2, title="Test")
     editor, user = UserFactory.create_batch(2)
-    phase.challenge.add_admin(editor)
+    phase1.challenge.add_admin(editor)
 
     response = get_view_for_user(
         client=client,
         viewname="evaluation:phase-archive-info",
         reverse_kwargs={
-            "slug": phase.slug,
-            "challenge_short_name": phase.challenge.short_name,
+            "slug": phase2.slug,
+            "challenge_short_name": phase2.challenge.short_name,
         },
         user=user,
     )
@@ -1691,8 +1691,30 @@ def test_phase_archive_info_permissions(client):
         client=client,
         viewname="evaluation:phase-archive-info",
         reverse_kwargs={
-            "slug": phase.slug,
-            "challenge_short_name": phase.challenge.short_name,
+            "slug": phase2.slug,
+            "challenge_short_name": phase2.challenge.short_name,
+        },
+        user=editor,
+    )
+    assert response.status_code == 403
+
+    response = get_view_for_user(
+        client=client,
+        viewname="evaluation:phase-archive-info",
+        reverse_kwargs={
+            "slug": phase1.slug,
+            "challenge_short_name": phase1.challenge.short_name,
+        },
+        user=user,
+    )
+    assert response.status_code == 403
+
+    response = get_view_for_user(
+        client=client,
+        viewname="evaluation:phase-archive-info",
+        reverse_kwargs={
+            "slug": phase1.slug,
+            "challenge_short_name": phase1.challenge.short_name,
         },
         user=editor,
     )


### PR DESCRIPTION
Addresses https://github.com/comic/grand-challenge.org/issues/3531

This adds a tab to the Challenge admin for each algorithm phase which lists relevant information about the linked archive: 
![image](https://github.com/user-attachments/assets/505a9346-f625-455b-9777-8c60fd933125)

The page then tells the challenge admin which archive is linked to it, which interfaces the archive items need to contain and how many jobs will be scheduled per submission based on the current content of the archive: 

![image](https://github.com/user-attachments/assets/fb5148b1-e97e-4be3-9879-fde378390fd8)

Alternatively, it says: 
![image](https://github.com/user-attachments/assets/39e84195-7c88-4040-b951-a5e4e1c2997b)
