### PR TITLE
Add algorithm template forge JSON

### DIFF
--- a/app/grandchallenge/algorithms/admin.py
+++ b/app/grandchallenge/algorithms/admin.py
@@ -1,6 +1,9 @@
+import json
+
 from django.contrib import admin
 from django.db.models import Count
 from django.forms import ModelForm
+from django.utils.html import format_html
 from guardian.admin import GuardedModelAdmin
 
 from grandchallenge.algorithms.forms import AlgorithmIOValidationMixin
@@ -29,6 +32,9 @@ from grandchallenge.core.admin import (
     GroupObjectPermissionAdmin,
     UserObjectPermissionAdmin,
 )
+from grandchallenge.core.utils.grand_challenge_forge import (
+    get_forge_algorithm_template_context,
+)
 
 
 class AlgorithmAdminForm(AlgorithmIOValidationMixin, ModelForm):
@@ -39,6 +45,7 @@ class AlgorithmAdminForm(AlgorithmIOValidationMixin, ModelForm):
 
 @admin.register(Algorithm)
 class AlgorithmAdmin(GuardedModelAdmin):
+    readonly_fields = ("algorithm_forge_json",)
     list_display = (
         "title",
         "created",
@@ -53,6 +60,13 @@ class AlgorithmAdmin(GuardedModelAdmin):
 
     def container_count(self, obj):
         return obj.container_count
+
+    @staticmethod
+    def algorithm_forge_json(obj):
+        json_desc = get_forge_algorithm_template_context(algorithm=obj)
+        return format_html(
+            "<pre>{json_desc}</pre>", json_desc=json.dumps(json_desc, indent=2)
+        )
 
     def get_queryset(self, request):
         queryset = super().get_queryset(request)

--- a/app/grandchallenge/challenges/admin.py
+++ b/app/grandchallenge/challenges/admin.py
@@ -21,7 +21,7 @@ from grandchallenge.core.admin import (
 )
 from grandchallenge.core.templatetags.costs import millicents_to_euro
 from grandchallenge.core.utils.grand_challenge_forge import (
-    get_forge_json_description,
+    get_forge_challenge_pack_context,
 )
 from grandchallenge.subdomains.utils import reverse
 
@@ -61,7 +61,7 @@ class ChallengeAdmin(ModelAdmin):
 
     @staticmethod
     def challenge_forge_json(obj):
-        json_desc = get_forge_json_description(challenge=obj)
+        json_desc = get_forge_challenge_pack_context(challenge=obj)
         return format_html(
             "<pre>{json_desc}</pre>", json_desc=json.dumps(json_desc, indent=2)
         )

--- a/app/grandchallenge/core/utils/grand_challenge_forge.py
+++ b/app/grandchallenge/core/utils/grand_challenge_forge.py
@@ -66,6 +66,7 @@ def get_forge_algorithm_template_context(algorithm):
     return {
         "algorithm": {
             "title": algorithm.title,
+            "slug": algorithm.title,
             "url": algorithm.get_absolute_url(),
             "inputs": [
                 _process_component_interface(ci)

--- a/app/grandchallenge/core/utils/grand_challenge_forge.py
+++ b/app/grandchallenge/core/utils/grand_challenge_forge.py
@@ -1,8 +1,22 @@
 from grandchallenge.evaluation.utils import SubmissionKindChoices
-from grandchallenge.subdomains.utils import reverse
 
 
-def get_forge_json_description(challenge, phase_pks=None):
+def _process_component_interface(component_interface):
+    result = {
+        "slug": component_interface.slug,
+        "kind": component_interface.get_kind_display(),
+        "super_kind": component_interface.super_kind.label,
+        "relative_path": component_interface.relative_path,
+        "example_value": None,
+    }
+
+    if component_interface.is_json_kind:
+        result["example_value"] = component_interface.json_kind_example.value
+
+    return result
+
+
+def get_forge_challenge_pack_context(challenge, phase_pks=None):
     """
     Generates a JSON description of the challenge and phases suitable for
     grand-challenge-forge to generate a challenge pack.
@@ -21,15 +35,7 @@ def get_forge_json_description(challenge, phase_pks=None):
     def process_archive(archive):
         return {
             "slug": archive.slug,
-            "url": reverse("archives:detail", kwargs={"slug": archive.slug}),
-        }
-
-    def process_component_interface(component_interface):
-        return {
-            "slug": component_interface.slug,
-            "kind": component_interface.get_kind_display(),
-            "super_kind": component_interface.super_kind.label,
-            "relative_path": component_interface.relative_path,
+            "url": archive.get_absolute_url(),
         }
 
     def process_phase(phase):
@@ -37,11 +43,11 @@ def get_forge_json_description(challenge, phase_pks=None):
             "slug": phase.slug,
             "archive": process_archive(phase.archive),
             "algorithm_inputs": [
-                process_component_interface(ci)
+                _process_component_interface(ci)
                 for ci in phase.algorithm_inputs.all()
             ],
             "algorithm_outputs": [
-                process_component_interface(ci)
+                _process_component_interface(ci)
                 for ci in phase.algorithm_outputs.all()
             ],
         }
@@ -49,7 +55,25 @@ def get_forge_json_description(challenge, phase_pks=None):
     return {
         "challenge": {
             "slug": challenge.slug,
+            "url": challenge.get_absolute_url(),
             "phases": [process_phase(p) for p in phases],
             "archives": [process_archive(a) for a in archives],
+        }
+    }
+
+
+def get_forge_algorithm_template_context(algorithm):
+    return {
+        "algorithm": {
+            "title": algorithm.title,
+            "url": algorithm.get_absolute_url(),
+            "inputs": [
+                _process_component_interface(ci)
+                for ci in algorithm.inputs.all()
+            ],
+            "outputs": [
+                _process_component_interface(ci)
+                for ci in algorithm.outputs.all()
+            ],
         }
     }

--- a/app/grandchallenge/core/utils/grand_challenge_forge.py
+++ b/app/grandchallenge/core/utils/grand_challenge_forge.py
@@ -66,7 +66,7 @@ def get_forge_algorithm_template_context(algorithm):
     return {
         "algorithm": {
             "title": algorithm.title,
-            "slug": algorithm.title,
+            "slug": algorithm.slug,
             "url": algorithm.get_absolute_url(),
             "inputs": [
                 _process_component_interface(ci)

--- a/app/grandchallenge/evaluation/admin.py
+++ b/app/grandchallenge/evaluation/admin.py
@@ -17,7 +17,7 @@ from grandchallenge.core.admin import (
 )
 from grandchallenge.core.templatetags.remove_whitespace import oxford_comma
 from grandchallenge.core.utils.grand_challenge_forge import (
-    get_forge_json_description,
+    get_forge_challenge_pack_context,
 )
 from grandchallenge.evaluation.models import (
     CombinedLeaderboard,
@@ -109,7 +109,7 @@ class PhaseAdmin(admin.ModelAdmin):
 
     @staticmethod
     def challenge_forge_json(obj):
-        json_desc = get_forge_json_description(
+        json_desc = get_forge_challenge_pack_context(
             challenge=obj.challenge,
             phase_pks=[obj.pk],
         )

--- a/app/tests/core_tests/test_grand_challenge_forge.py
+++ b/app/tests/core_tests/test_grand_challenge_forge.py
@@ -136,7 +136,7 @@ def test_get_algorithm_template_context():
 
     context = get_forge_algorithm_template_context(algorithm=algorithm)
 
-    for key in ["title", "url", "inputs", "outputs"]:
+    for key in ["title", "slug", "url", "inputs", "outputs"]:
         assert key in context["algorithm"]
 
     for index, ci in enumerate(context["algorithm"]["inputs"]):


### PR DESCRIPTION
MVP for using future algorithm template forging in `grand-challenge-forge.`

Part of the pitch:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/338

It adds:
- An algorithm-template context generator for future forging
- A site admin readable field for `Algorithm` for debugging integration with forge
- Adds example values to the context of the challenge json for the forge