### PR TITLE
Use full page markdown editor for page editing view

### DIFF
--- a/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
@@ -76,7 +76,7 @@
                     </li>
                     {% if "change_challenge" in challenge_perms %}
                         <li class="nav-item">
-                            <a class="nav-link {% if request.resolver_match.view_name in 'challenge-update,pages:update,pages:delete,pages:create,update,pages:list,participants:list,participants:registration-list,evaluation:phase-create,evaluation:phase-update,evaluation:create,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:combined-leaderboard-update,evaluation:combined-leaderboard-create,evaluation:combined-leaderboard-delete' or request.resolver_match.app_name == 'admins' %}active{% endif %}"
+                            <a class="nav-link {% if request.resolver_match.view_name in 'challenge-update,pages:content-update,pages:delete,pages:create,update,pages:list,participants:list,participants:registration-list,evaluation:phase-create,evaluation:phase-update,evaluation:create,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:combined-leaderboard-update,evaluation:combined-leaderboard-create,evaluation:combined-leaderboard-delete' or request.resolver_match.app_name == 'admins' %}active{% endif %}"
                                href="{% url 'challenge-update' challenge_short_name=challenge.short_name %}">
                                 <i class="fas fa-cog fa-fw"></i>
                                     Admin

--- a/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
@@ -76,7 +76,7 @@
                     </li>
                     {% if "change_challenge" in challenge_perms %}
                         <li class="nav-item">
-                            <a class="nav-link {% if request.resolver_match.view_name in 'challenge-update,pages:content-update,pages:delete,pages:create,update,pages:list,participants:list,participants:registration-list,evaluation:phase-create,evaluation:phase-update,evaluation:create,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:combined-leaderboard-update,evaluation:combined-leaderboard-create,evaluation:combined-leaderboard-delete' or request.resolver_match.app_name == 'admins' %}active{% endif %}"
+                            <a class="nav-link {% if request.resolver_match.view_name in 'challenge-update,pages:content-update,pages:metadata-update,pages:delete,pages:create,update,pages:list,participants:list,participants:registration-list,evaluation:phase-create,evaluation:phase-update,evaluation:create,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:combined-leaderboard-update,evaluation:combined-leaderboard-create,evaluation:combined-leaderboard-delete' or request.resolver_match.app_name == 'admins' %}active{% endif %}"
                                href="{% url 'challenge-update' challenge_short_name=challenge.short_name %}">
                                 <i class="fas fa-cog fa-fw"></i>
                                     Admin

--- a/app/grandchallenge/core/templates/base.html
+++ b/app/grandchallenge/core/templates/base.html
@@ -72,7 +72,7 @@
             {% include "grandchallenge/partials/jumbotron.html" %}
         {% endblock %}
 
-        <div class="container pb-3 mt-3">
+        <div class="{% block container %}container{% endblock %} pb-3 mt-3">
 
             {% block messages %}
                 {% include 'challenges/challenge_banner.html' %}

--- a/app/grandchallenge/core/templates/markdownx/full_page_widget.html
+++ b/app/grandchallenge/core/templates/markdownx/full_page_widget.html
@@ -3,14 +3,14 @@
         {% include "markdownx/partials/notes.html" %}
     </div>
     {% include "markdownx/partials/toolbar.html" %}
-    <div class="row no-gutters">
+    <div class="row">
         <div class="col-md-6">
             <div id="editor-{{ widget.attrs.id }}" aria-labelledby="editor-panel-{{ widget.attrs.id }}">
                 {% include "markdownx/partials/textarea.html" %}
             </div>
         </div>
         <div class="col-md-6">
-            <div class="border" id="preview-{{ widget.attrs.id }}" aria-labelledby="preview-panel-{{ widget.attrs.id }}">
+            <div id="preview-{{ widget.attrs.id }}" aria-labelledby="preview-panel-{{ widget.attrs.id }}">
                 <div class="markdownx-preview overflow-auto"></div>
             </div>
         </div>

--- a/app/grandchallenge/core/widgets.py
+++ b/app/grandchallenge/core/widgets.py
@@ -102,7 +102,7 @@ class MarkdownEditorFullPageWidget(MarkdownEditorInlineWidget):
     template_name = "markdownx/full_page_widget.html"
 
     def __init__(self, attrs=None):
-        default_attrs = {"rows": "40"}
+        default_attrs = {"rows": "30"}
         if attrs:
             default_attrs.update(attrs)
         super().__init__(default_attrs)

--- a/app/grandchallenge/pages/forms.py
+++ b/app/grandchallenge/pages/forms.py
@@ -3,22 +3,18 @@ from django.core.exceptions import ValidationError
 from django.db.models import BLANK_CHOICE_DASH
 
 from grandchallenge.core.forms import SaveFormInitMixin
-from grandchallenge.core.widgets import MarkdownEditorInlineWidget
+from grandchallenge.core.widgets import MarkdownEditorFullPageWidget
 from grandchallenge.pages.models import Page
 
 
-class PageCreateForm(SaveFormInitMixin, forms.ModelForm):
+class PageMetadataForm(SaveFormInitMixin, forms.ModelForm):
     class Meta:
         model = Page
         fields = (
             "display_title",
             "permission_level",
             "hidden",
-            "content_markdown",
         )
-        widgets = {
-            "content_markdown": MarkdownEditorInlineWidget,
-        }
 
     def clean_display_title(self):
         display_title = self.cleaned_data["display_title"]
@@ -32,8 +28,12 @@ class PageCreateForm(SaveFormInitMixin, forms.ModelForm):
         return display_title
 
 
-class PageUpdateForm(PageCreateForm):
-    """Like the page update form but you can also move the page."""
+class PageUpdateForm(PageMetadataForm):
+    class Meta(PageMetadataForm.Meta):
+        fields = ("content_markdown",)
+        widgets = {
+            "content_markdown": MarkdownEditorFullPageWidget,
+        }
 
     move = forms.CharField(widget=forms.Select)
     move.required = False

--- a/app/grandchallenge/pages/forms.py
+++ b/app/grandchallenge/pages/forms.py
@@ -28,7 +28,7 @@ class PageCreateForm(SaveFormInitMixin, forms.ModelForm):
         return display_title
 
 
-class PageMetadataForm(PageCreateForm):
+class PageMetadataUpdateForm(PageCreateForm):
     """Like the page create form, but you can also move the page."""
 
     move = forms.CharField(widget=forms.Select)
@@ -42,8 +42,9 @@ class PageMetadataForm(PageCreateForm):
     )
 
 
-class PageUpdateForm(PageMetadataForm):
-    class Meta(PageMetadataForm.Meta):
+class PageContentUpdateForm(SaveFormInitMixin, forms.ModelForm):
+    class Meta:
+        model = Page
         fields = ("content_markdown",)
         widgets = {
             "content_markdown": MarkdownEditorFullPageWidget,

--- a/app/grandchallenge/pages/forms.py
+++ b/app/grandchallenge/pages/forms.py
@@ -7,7 +7,7 @@ from grandchallenge.core.widgets import MarkdownEditorFullPageWidget
 from grandchallenge.pages.models import Page
 
 
-class PageMetadataForm(SaveFormInitMixin, forms.ModelForm):
+class PageCreateForm(SaveFormInitMixin, forms.ModelForm):
     class Meta:
         model = Page
         fields = (
@@ -28,12 +28,8 @@ class PageMetadataForm(SaveFormInitMixin, forms.ModelForm):
         return display_title
 
 
-class PageUpdateForm(PageMetadataForm):
-    class Meta(PageMetadataForm.Meta):
-        fields = ("content_markdown",)
-        widgets = {
-            "content_markdown": MarkdownEditorFullPageWidget,
-        }
+class PageMetadataForm(PageCreateForm):
+    """Like the page create form, but you can also move the page."""
 
     move = forms.CharField(widget=forms.Select)
     move.required = False
@@ -44,3 +40,11 @@ class PageUpdateForm(PageMetadataForm):
         (Page.DOWN, "Down"),
         (Page.LAST, "Last"),
     )
+
+
+class PageUpdateForm(PageMetadataForm):
+    class Meta(PageMetadataForm.Meta):
+        fields = ("content_markdown",)
+        widgets = {
+            "content_markdown": MarkdownEditorFullPageWidget,
+        }

--- a/app/grandchallenge/pages/templates/pages/challenge_settings_base.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_settings_base.html
@@ -37,7 +37,7 @@
                     <i class="fas fa-question-circle fa-fw"></i> Registration Questions </a>
               </li>
               <li class="nav-item">
-                  <a class="nav-link px-4 py-1 mb-1 {% if request.resolver_match.view_name == 'pages:list' or request.resolver_match.view_name == 'pages:create' or request.resolver_match.view_name == 'pages:content-update' or request.resolver_match.view_name == 'pages:delete' %}active{% endif %}"
+                  <a class="nav-link px-4 py-1 mb-1 {% if request.resolver_match.view_name in 'pages:list,pages:create,pages:content-update,pages:metadata-update,pages:delete' %}active{% endif %}"
                     href="{% url 'pages:list' challenge_short_name=challenge.short_name %}">
                       <i class="far fa-file fa-fw"></i> Pages</a>
               </li>

--- a/app/grandchallenge/pages/templates/pages/challenge_settings_base.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_settings_base.html
@@ -37,7 +37,7 @@
                     <i class="fas fa-question-circle fa-fw"></i> Registration Questions </a>
               </li>
               <li class="nav-item">
-                  <a class="nav-link px-4 py-1 mb-1 {% if request.resolver_match.view_name == 'pages:list' or request.resolver_match.view_name == 'pages:create' or request.resolver_match.view_name == 'pages:update' or request.resolver_match.view_name == 'pages:delete' %}active{% endif %}"
+                  <a class="nav-link px-4 py-1 mb-1 {% if request.resolver_match.view_name == 'pages:list' or request.resolver_match.view_name == 'pages:create' or request.resolver_match.view_name == 'pages:content-update' or request.resolver_match.view_name == 'pages:delete' %}active{% endif %}"
                     href="{% url 'pages:list' challenge_short_name=challenge.short_name %}">
                       <i class="far fa-file fa-fw"></i> Pages</a>
               </li>

--- a/app/grandchallenge/pages/templates/pages/page_content_update.html
+++ b/app/grandchallenge/pages/templates/pages/page_content_update.html
@@ -1,4 +1,4 @@
-{% extends "pages/challenge_settings_base.html" %}
+{% extends "base.html" %}
 {% load crispy from crispy_forms_tags %}
 {% load static %}
 {% load url %}
@@ -28,7 +28,9 @@
     </ol>
 {% endblock %}
 
-{% block content %}
+{% block container %}container-fluid{% endblock %}
+
+{% block outer_content %}
 
     <h2>{% if object %}Update{% else %}Create{% endif %} Page</h2>
 

--- a/app/grandchallenge/pages/templates/pages/page_content_update.html
+++ b/app/grandchallenge/pages/templates/pages/page_content_update.html
@@ -4,7 +4,7 @@
 {% load url %}
 
 {% block title %}
-    {% if object %}Update{% else %}Create{% endif %} -{% if object %} {{ object|title }} -{% endif %} {{ block.super }}
+    Update -{% if object %} {{ object|title }} -{% endif %} {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}
@@ -23,7 +23,7 @@
             </a></li>
         {% endif %}
         <li class="breadcrumb-item active"
-            aria-current="page">{% if object %}Update{% else %}Create{% endif %}
+            aria-current="page">Update
         </li>
     </ol>
 {% endblock %}
@@ -32,7 +32,7 @@
 
 {% block outer_content %}
 
-    <h2>{% if object %}Update{% else %}Create{% endif %} Page</h2>
+    <h2>Update Page</h2>
 
     {% crispy form %}
 {% endblock %}

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -88,6 +88,12 @@
                 >
                     <i class="fas fa-edit"></i>
                 </a>
+                <a class="btn btn-primary"
+                   href="{% url 'pages:metadata' challenge_short_name=object.challenge.short_name slug=object.slug %}"
+                   title="Edit metadata of this page"
+                >
+                    <i class="fas fa-tools"></i>
+                </a>
             {% endif %}
         {% endif %}
     </div>

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -83,13 +83,13 @@
             {% if "change_challenge" in challenge_perms %}
                 <br>
                 <a class="btn btn-primary"
-                   href="{% url 'pages:update' challenge_short_name=object.challenge.short_name slug=object.slug %}"
+                   href="{% url 'pages:content-update' challenge_short_name=object.challenge.short_name slug=object.slug %}"
                    title="Edit this page"
                 >
                     <i class="fas fa-edit"></i>
                 </a>
                 <a class="btn btn-primary"
-                   href="{% url 'pages:metadata' challenge_short_name=object.challenge.short_name slug=object.slug %}"
+                   href="{% url 'pages:metadata-update' challenge_short_name=object.challenge.short_name slug=object.slug %}"
                    title="Edit metadata of this page"
                 >
                     <i class="fas fa-tools"></i>

--- a/app/grandchallenge/pages/templates/pages/page_form.html
+++ b/app/grandchallenge/pages/templates/pages/page_form.html
@@ -1,4 +1,4 @@
-{% extends "pages/challenge_settings_base.html" %}
+{% extends "base.html" %}
 {% load crispy from crispy_forms_tags %}
 {% load static %}
 {% load url %}
@@ -28,7 +28,9 @@
     </ol>
 {% endblock %}
 
-{% block content %}
+{% block container %}container-fluid{% endblock %}
+
+{% block outer_content %}
 
     <h2>{% if object %}Update{% else %}Create{% endif %} Page</h2>
 

--- a/app/grandchallenge/pages/templates/pages/page_list.html
+++ b/app/grandchallenge/pages/templates/pages/page_list.html
@@ -71,10 +71,10 @@
                         {% endif %}
                     </td>
                     <td>
-                        <a href="{% url 'pages:update' challenge_short_name=challenge.short_name slug=page.slug %}">
+                        <a href="{% url 'pages:content-update' challenge_short_name=challenge.short_name slug=page.slug %}">
                             <i class="fa fa-edit" title="Edit Page"></i>
                         </a>
-                        <a href="{% url 'pages:metadata' challenge_short_name=challenge.short_name slug=page.slug %}">
+                        <a href="{% url 'pages:metadata-update' challenge_short_name=challenge.short_name slug=page.slug %}">
                             <i class="fa fa-tools" title="Edit Metadata"></i>
                         </a>
                     </td>

--- a/app/grandchallenge/pages/templates/pages/page_list.html
+++ b/app/grandchallenge/pages/templates/pages/page_list.html
@@ -74,6 +74,9 @@
                         <a href="{% url 'pages:update' challenge_short_name=challenge.short_name slug=page.slug %}">
                             <i class="fa fa-edit" title="Edit Page"></i>
                         </a>
+                        <a href="{% url 'pages:metadata' challenge_short_name=challenge.short_name slug=page.slug %}">
+                            <i class="fa fa-tools" title="Edit Metadata"></i>
+                        </a>
                     </td>
                     <td>
                         <a href="{% url 'pages:delete' challenge_short_name=challenge.short_name slug=page.slug %}">

--- a/app/grandchallenge/pages/urls.py
+++ b/app/grandchallenge/pages/urls.py
@@ -3,12 +3,12 @@ from django.urls import path
 from grandchallenge.pages.views import (
     ChallengeHome,
     ChallengeStatistics,
+    PageContentUpdate,
     PageCreate,
     PageDelete,
     PageDetail,
     PageList,
-    PageMetadata,
-    PageUpdate,
+    PageMetadataUpdate,
 )
 
 app_name = "pages"
@@ -19,7 +19,15 @@ urlpatterns = [
     path("statistics/", ChallengeStatistics.as_view(), name="statistics"),
     path("", ChallengeHome.as_view(), name="home"),
     path("<slug>/", PageDetail.as_view(), name="detail"),
-    path("<slug>/update/", PageUpdate.as_view(), name="update"),
-    path("<slug>/metadata/", PageMetadata.as_view(), name="metadata"),
+    path(
+        "<slug>/content-update/",
+        PageContentUpdate.as_view(),
+        name="content-update",
+    ),
+    path(
+        "<slug>/metadata-update/",
+        PageMetadataUpdate.as_view(),
+        name="metadata-update",
+    ),
     path("<slug>/delete/", PageDelete.as_view(), name="delete"),
 ]

--- a/app/grandchallenge/pages/urls.py
+++ b/app/grandchallenge/pages/urls.py
@@ -7,6 +7,7 @@ from grandchallenge.pages.views import (
     PageDelete,
     PageDetail,
     PageList,
+    PageMetadata,
     PageUpdate,
 )
 
@@ -19,5 +20,6 @@ urlpatterns = [
     path("", ChallengeHome.as_view(), name="home"),
     path("<slug>/", PageDetail.as_view(), name="detail"),
     path("<slug>/update/", PageUpdate.as_view(), name="update"),
+    path("<slug>/metadata/", PageMetadata.as_view(), name="metadata"),
     path("<slug>/delete/", PageDelete.as_view(), name="delete"),
 ]

--- a/app/grandchallenge/pages/views.py
+++ b/app/grandchallenge/pages/views.py
@@ -19,7 +19,11 @@ from grandchallenge.challenges.views import ActiveChallengeRequiredMixin
 from grandchallenge.charts.specs import stacked_bar, world_map
 from grandchallenge.core.guardian import ObjectPermissionRequiredMixin
 from grandchallenge.evaluation.models import Evaluation, Submission
-from grandchallenge.pages.forms import PageMetadataForm, PageUpdateForm
+from grandchallenge.pages.forms import (
+    PageCreateForm,
+    PageMetadataForm,
+    PageUpdateForm,
+)
 from grandchallenge.pages.models import Page
 from grandchallenge.subdomains.utils import reverse, reverse_lazy
 
@@ -44,7 +48,7 @@ class PageCreate(
     CreateView,
 ):
     model = Page
-    form_class = PageMetadataForm
+    form_class = PageCreateForm
     permission_required = "change_challenge"
     raise_exception = True
     login_url = reverse_lazy("account_login")
@@ -104,14 +108,14 @@ class ChallengeHome(PageDetail):
         return page
 
 
-class PageUpdate(
+class PageMetadata(
     LoginRequiredMixin,
     ObjectPermissionRequiredMixin,
     ChallengeFilteredQuerysetMixin,
     UpdateView,
 ):
     model = Page
-    form_class = PageUpdateForm
+    form_class = PageMetadataForm
     permission_required = "change_challenge"
     raise_exception = True
     login_url = reverse_lazy("account_login")
@@ -125,8 +129,8 @@ class PageUpdate(
         return response
 
 
-class PageMetadata(PageUpdate):
-    form_class = PageMetadataForm
+class PageUpdate(PageMetadata):
+    form_class = PageUpdateForm
 
 
 class PageDelete(

--- a/app/grandchallenge/pages/views.py
+++ b/app/grandchallenge/pages/views.py
@@ -56,6 +56,15 @@ class PageCreate(
         form.instance.challenge = self.request.challenge
         return super().form_valid(form)
 
+    def get_success_url(self):
+        return reverse(
+            "pages:update",
+            kwargs={
+                "challenge_short_name": self.object.challenge.short_name,
+                "slug": self.object.slug,
+            },
+        )
+
 
 class PageList(
     LoginRequiredMixin,

--- a/app/grandchallenge/pages/views.py
+++ b/app/grandchallenge/pages/views.py
@@ -19,7 +19,7 @@ from grandchallenge.challenges.views import ActiveChallengeRequiredMixin
 from grandchallenge.charts.specs import stacked_bar, world_map
 from grandchallenge.core.guardian import ObjectPermissionRequiredMixin
 from grandchallenge.evaluation.models import Evaluation, Submission
-from grandchallenge.pages.forms import PageCreateForm, PageUpdateForm
+from grandchallenge.pages.forms import PageMetadataForm, PageUpdateForm
 from grandchallenge.pages.models import Page
 from grandchallenge.subdomains.utils import reverse, reverse_lazy
 
@@ -44,7 +44,7 @@ class PageCreate(
     CreateView,
 ):
     model = Page
-    form_class = PageCreateForm
+    form_class = PageMetadataForm
     permission_required = "change_challenge"
     raise_exception = True
     login_url = reverse_lazy("account_login")
@@ -114,6 +114,10 @@ class PageUpdate(
         response = super().form_valid(form)
         self.object.move(form.cleaned_data["move"])
         return response
+
+
+class PageMetadata(PageUpdate):
+    form_class = PageMetadataForm
 
 
 class PageDelete(

--- a/app/grandchallenge/pages/views.py
+++ b/app/grandchallenge/pages/views.py
@@ -20,9 +20,9 @@ from grandchallenge.charts.specs import stacked_bar, world_map
 from grandchallenge.core.guardian import ObjectPermissionRequiredMixin
 from grandchallenge.evaluation.models import Evaluation, Submission
 from grandchallenge.pages.forms import (
+    PageContentUpdateForm,
     PageCreateForm,
-    PageMetadataForm,
-    PageUpdateForm,
+    PageMetadataUpdateForm,
 )
 from grandchallenge.pages.models import Page
 from grandchallenge.subdomains.utils import reverse, reverse_lazy
@@ -62,7 +62,7 @@ class PageCreate(
 
     def get_success_url(self):
         return reverse(
-            "pages:update",
+            "pages:content-update",
             kwargs={
                 "challenge_short_name": self.object.challenge.short_name,
                 "slug": self.object.slug,
@@ -108,14 +108,14 @@ class ChallengeHome(PageDetail):
         return page
 
 
-class PageMetadata(
+class PageMetadataUpdate(
     LoginRequiredMixin,
     ObjectPermissionRequiredMixin,
     ChallengeFilteredQuerysetMixin,
     UpdateView,
 ):
     model = Page
-    form_class = PageMetadataForm
+    form_class = PageMetadataUpdateForm
     permission_required = "change_challenge"
     raise_exception = True
     login_url = reverse_lazy("account_login")
@@ -129,8 +129,20 @@ class PageMetadata(
         return response
 
 
-class PageUpdate(PageMetadata):
-    form_class = PageUpdateForm
+class PageContentUpdate(
+    LoginRequiredMixin,
+    ObjectPermissionRequiredMixin,
+    ChallengeFilteredQuerysetMixin,
+    UpdateView,
+):
+    model = Page
+    form_class = PageContentUpdateForm
+    permission_required = "change_challenge"
+    raise_exception = True
+    login_url = reverse_lazy("account_login")
+
+    def get_permission_object(self):
+        return self.request.challenge
 
 
 class PageDelete(

--- a/app/grandchallenge/pages/views.py
+++ b/app/grandchallenge/pages/views.py
@@ -137,6 +137,7 @@ class PageContentUpdate(
 ):
     model = Page
     form_class = PageContentUpdateForm
+    template_name_suffix = "_content_update"
     permission_required = "change_challenge"
     raise_exception = True
     login_url = reverse_lazy("account_login")

--- a/app/grandchallenge/pages/views.py
+++ b/app/grandchallenge/pages/views.py
@@ -61,6 +61,7 @@ class PageCreate(
         return super().form_valid(form)
 
     def get_success_url(self):
+        """On successful creation, go to content update."""
         return reverse(
             "pages:content-update",
             kwargs={

--- a/app/grandchallenge/pages/views.py
+++ b/app/grandchallenge/pages/views.py
@@ -122,7 +122,7 @@ class PageMetadataUpdate(
     login_url = reverse_lazy("account_login")
 
     def get_permission_object(self):
-        return self.request.challenge
+        return self.get_object().challenge
 
     def form_valid(self, form):
         response = super().form_valid(form)
@@ -144,7 +144,7 @@ class PageContentUpdate(
     login_url = reverse_lazy("account_login")
 
     def get_permission_object(self):
-        return self.request.challenge
+        return self.get_object().challenge
 
 
 class PageDelete(
@@ -161,7 +161,7 @@ class PageDelete(
     login_url = reverse_lazy("account_login")
 
     def get_permission_object(self):
-        return self.request.challenge
+        return self.get_object().challenge
 
     def get_success_url(self):
         return reverse(

--- a/app/tests/pages_tests/test_pages.py
+++ b/app/tests/pages_tests/test_pages.py
@@ -39,7 +39,7 @@ def test_page_update_permissions(client, two_challenge_sets):
         display_title="challenge1page1permissiontest",
     )
     validate_admin_only_view(
-        viewname="pages:update",
+        viewname="pages:content-update",
         two_challenge_set=two_challenge_sets,
         client=client,
         reverse_kwargs={"slug": p1.slug},
@@ -91,7 +91,7 @@ def test_page_create(client, two_challenge_sets):
         },
     )
     assert response.status_code == 302
-    assert response.url.endswith(f"{page_title}/update/")
+    assert response.url.endswith(f"{page_title}/content-update/")
     response = get_view_for_user(
         url=response.url,
         client=client,
@@ -127,20 +127,20 @@ def test_page_create(client, two_challenge_sets):
 
 
 @pytest.mark.django_db
-def test_page_metadata(client, two_challenge_sets):
+def test_page_metadata_update(client, two_challenge_sets):
     p1 = PageFactory(
         challenge=two_challenge_sets.challenge_set_1.challenge,
         display_title="page1metadatatest",
-        content_markdown="oldhtml",
+        content_markdown="",
     )
     # page with the same name in another challenge to check selection
     PageFactory(
         challenge=two_challenge_sets.challenge_set_2.challenge,
         display_title="page1metadatatest",
-        content_markdown="oldhtml",
+        content_markdown="",
     )
     response = get_view_for_user(
-        viewname="pages:metadata",
+        viewname="pages:metadata-update",
         client=client,
         challenge=two_challenge_sets.challenge_set_1.challenge,
         user=two_challenge_sets.admin12,
@@ -149,7 +149,7 @@ def test_page_metadata(client, two_challenge_sets):
     assert response.status_code == 200
     assert 'value="page1metadatatest"' in str(response.content)
     response = get_view_for_user(
-        viewname="pages:metadata",
+        viewname="pages:metadata-update",
         client=client,
         method=client.post,
         challenge=two_challenge_sets.challenge_set_1.challenge,
@@ -164,7 +164,7 @@ def test_page_metadata(client, two_challenge_sets):
 
     # The slug shouldn't change
     response = get_view_for_user(
-        viewname="pages:metadata",
+        viewname="pages:metadata-update",
         client=client,
         challenge=two_challenge_sets.challenge_set_1.challenge,
         user=two_challenge_sets.admin12,
@@ -175,7 +175,7 @@ def test_page_metadata(client, two_challenge_sets):
 
     # check that the other page is unaffected
     response = get_view_for_user(
-        viewname="pages:metadata",
+        viewname="pages:metadata-update",
         client=client,
         challenge=two_challenge_sets.challenge_set_2.challenge,
         user=two_challenge_sets.admin12,
@@ -186,7 +186,7 @@ def test_page_metadata(client, two_challenge_sets):
 
 
 @pytest.mark.django_db
-def test_page_update(client, two_challenge_sets):
+def test_page_content_update(client, two_challenge_sets):
     p1 = PageFactory(
         challenge=two_challenge_sets.challenge_set_1.challenge,
         display_title="page1updatetest",
@@ -199,7 +199,7 @@ def test_page_update(client, two_challenge_sets):
         content_markdown="oldhtml",
     )
     response = get_view_for_user(
-        viewname="pages:update",
+        viewname="pages:detail",
         client=client,
         challenge=two_challenge_sets.challenge_set_1.challenge,
         user=two_challenge_sets.admin12,
@@ -208,7 +208,7 @@ def test_page_update(client, two_challenge_sets):
     assert response.status_code == 200
     assert "oldhtml" in str(response.content)
     response = get_view_for_user(
-        viewname="pages:update",
+        viewname="pages:content-update",
         client=client,
         method=client.post,
         challenge=two_challenge_sets.challenge_set_1.challenge,
@@ -305,7 +305,7 @@ def test_page_move(
     assert [p.order for p in c2_pages] == [1, 2, 3, 4]
 
     response = get_view_for_user(
-        viewname="pages:update",
+        viewname="pages:metadata-update",
         client=client,
         method=client.post,
         challenge=two_challenge_sets.challenge_set_1.challenge,


### PR DESCRIPTION
This PR adds the usage of the full page markdown editor for page editing and thereby splits up the page editing into a metadata edit and a page content edit. 

related to https://github.com/DIAGNijmegen/rse-roadmap/issues/351