### PR TITLE
Handle empty pages in datatables

### DIFF
--- a/app/grandchallenge/datatables/views.py
+++ b/app/grandchallenge/datatables/views.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from functools import reduce
 from operator import or_
 
+from django.core.paginator import EmptyPage
 from django.db.models import Q
 from django.http import JsonResponse
 from django.template.loader import render_to_string
@@ -54,7 +55,12 @@ class PaginatedTableListView(ListView):
         order_by = f"{'-' if order_dir == 'desc' else ''}{order_by}"
         data = self.filter_queryset(self.object_list, search, order_by)
         paginator = self.get_paginator(queryset=data, per_page=page_size)
-        objects = paginator.page(page)
+
+        try:
+            objects = paginator.page(page)
+        except EmptyPage:
+            # If the page is out of range, show the last page
+            objects = paginator.page(paginator.num_pages)
 
         return JsonResponse(
             {


### PR DESCRIPTION
A slight race condition can occur when searching for a term and requesting the next page on any datatable. 

See sentry issue: https://grand-challenge.sentry.io/issues/6016634627/?project=303639&query=%21logger%3Acsp%20is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=0

This fixes it by simply forcing the showing of the last page when that happens.
