### PR TITLE
Fix auto accepting pending requests upon verification

### DIFF
--- a/app/grandchallenge/verifications/admin.py
+++ b/app/grandchallenge/verifications/admin.py
@@ -17,7 +17,9 @@ from grandchallenge.verifications.models import (
     permissions=("change",),
 )
 def mark_verified(modeladmin, request, queryset):
-    for verification in queryset:
+    verifications = queryset.filter(email_is_verified=True)
+
+    for verification in verifications:
         verification.is_verified = True
         verification.verified_at = now()
         verification.save()

--- a/app/grandchallenge/verifications/admin.py
+++ b/app/grandchallenge/verifications/admin.py
@@ -17,9 +17,7 @@ from grandchallenge.verifications.models import (
     permissions=("change",),
 )
 def mark_verified(modeladmin, request, queryset):
-    verifications = queryset.filter(email_is_verified=True)
-
-    for verification in verifications:
+    for verification in queryset.filter(email_is_verified=True):
         verification.is_verified = True
         verification.verified_at = now()
         verification.save()

--- a/app/grandchallenge/verifications/admin.py
+++ b/app/grandchallenge/verifications/admin.py
@@ -17,9 +17,10 @@ from grandchallenge.verifications.models import (
     permissions=("change",),
 )
 def mark_verified(modeladmin, request, queryset):
-    queryset.filter(email_is_verified=True).update(
-        is_verified=True, verified_at=now()
-    )
+    for verfication_request in queryset:
+        verfication_request.is_verified = True
+        verfication_request.verified_at = now()
+        verfication_request.save()
 
 
 @admin.action(

--- a/app/grandchallenge/verifications/admin.py
+++ b/app/grandchallenge/verifications/admin.py
@@ -17,10 +17,10 @@ from grandchallenge.verifications.models import (
     permissions=("change",),
 )
 def mark_verified(modeladmin, request, queryset):
-    for verfication in queryset:
-        verfication.is_verified = True
-        verfication.verified_at = now()
-        verfication.save()
+    for verification in queryset:
+        verification.is_verified = True
+        verification.verified_at = now()
+        verification.save()
 
 
 @admin.action(

--- a/app/grandchallenge/verifications/admin.py
+++ b/app/grandchallenge/verifications/admin.py
@@ -17,10 +17,10 @@ from grandchallenge.verifications.models import (
     permissions=("change",),
 )
 def mark_verified(modeladmin, request, queryset):
-    for verfication_request in queryset:
-        verfication_request.is_verified = True
-        verfication_request.verified_at = now()
-        verfication_request.save()
+    for verfication in queryset:
+        verfication.is_verified = True
+        verfication.verified_at = now()
+        verfication.save()
 
 
 @admin.action(

--- a/app/grandchallenge/verifications/models.py
+++ b/app/grandchallenge/verifications/models.py
@@ -167,13 +167,15 @@ class Verification(FieldChangeMixin, models.Model):
             object_name,
             request_class,
         ) in permission_request_classes.items():
-            request_class.objects.filter(
+            for request_object in request_class.objects.filter(
                 **{
                     "user": self.user,
                     "status": request_class.PENDING,
                     f"{object_name}__access_request_handling": AccessRequestHandlingOptions.ACCEPT_VERIFIED_USERS,
                 }
-            ).update(status=request_class.ACCEPTED)
+            ):
+                request_object.status = request_class.ACCEPTED
+                request_object.save()
 
 
 def create_verification(email_address, *_, **__):

--- a/app/tests/verification_tests/test_admin.py
+++ b/app/tests/verification_tests/test_admin.py
@@ -115,8 +115,6 @@ def test_deactivate_users(django_capture_on_commit_callbacks, settings):
     ],
 )
 def test_verify_users_and_accept_pending_requests(
-    django_capture_on_commit_callbacks,
-    settings,
     perm_request_factory,
     perm_request_entity_attr,
     entity_factory,
@@ -124,9 +122,6 @@ def test_verify_users_and_accept_pending_requests(
     expected_request_status_without_verification,
     expected_request_status_with_verification,
 ):
-    settings.task_eager_propagates = (True,)
-    settings.task_always_eager = (True,)
-
     usr = UserFactory()
 
     t = entity_factory(access_request_handling=access_request_handling)
@@ -136,12 +131,11 @@ def test_verify_users_and_accept_pending_requests(
 
     assert pr.status == expected_request_status_without_verification
 
-    with django_capture_on_commit_callbacks(execute=True):
-        mark_verified(
-            None,
-            None,
-            Verification.objects.filter(user_id=usr.pk),
-        )
+    mark_verified(
+        None,
+        None,
+        Verification.objects.filter(user_id=usr.pk),
+    )
 
     pr.refresh_from_db()
 


### PR DESCRIPTION
This fix relates to issue #2461 and PR #3514. The issue is that the logic of auto accepting pending requests upon verification was implemented in the save() method of the model. However, in Admin, the actions are performed as an update on the queryset which does not trigger the save() method, and similar behaviour affected the proper handling of permissions since the queryset update did not trigger the pre_save signals.