### PR TITLE
Prevent duplicate notifications for failed image imports

### DIFF
--- a/app/grandchallenge/cases/models.py
+++ b/app/grandchallenge/cases/models.py
@@ -171,7 +171,7 @@ class RawImageUploadSession(UUIDModel):
             Notification.send(
                 kind=NotificationType.NotificationTypeChoices.IMAGE_IMPORT_STATUS,
                 message=error_message,
-                description=notification_description,
+                description=self.error_message,
                 action_object=self,
             )
         from grandchallenge.algorithms.models import Job

--- a/app/grandchallenge/cases/tasks.py
+++ b/app/grandchallenge/cases/tasks.py
@@ -180,7 +180,7 @@ def build_images(  # noqa:C901
                 upload_session=upload_session,
             )
 
-        if len(upload_session.import_result["consumed_files"]) == 0:
+        if upload_session.image_set.count() == 0:
             error_handler.handle_error(
                 interface=ci,
                 error_message=upload_session.default_error_message,

--- a/app/grandchallenge/cases/tasks.py
+++ b/app/grandchallenge/cases/tasks.py
@@ -179,6 +179,14 @@ def build_images(  # noqa:C901
                 base_directory=tmp_dir,
                 upload_session=upload_session,
             )
+
+        if len(upload_session.import_result["consumed_files"]) == 0:
+            error_handler.handle_error(
+                interface=ci,
+                error_message=upload_session.default_error_message,
+            )
+        else:
+            upload_session.update_status(status=RawImageUploadSession.SUCCESS)
     except RuntimeError as error:
         if "std::bad_alloc" in str(error):
             error_handler.handle_error(
@@ -215,18 +223,6 @@ def build_images(  # noqa:C901
         logger.error("An unexpected error occurred", exc_info=True)
     finally:
         upload_session.user_uploads.all().delete()
-
-    if (
-        len(upload_session.import_result["file_errors"]) != 0
-        and len(upload_session.import_result["consumed_files"]) == 0
-    ):
-        # if no files were imported successfully, mark the session as failed
-        error_handler.handle_error(
-            interface=ci,
-            error_message=upload_session.default_error_message,
-        )
-    else:
-        upload_session.update_status(status=RawImageUploadSession.SUCCESS)
 
 
 @dataclass

--- a/app/grandchallenge/cases/tasks.py
+++ b/app/grandchallenge/cases/tasks.py
@@ -175,7 +175,17 @@ def build_images(  # noqa:C901
                 upload_session=upload_session,
             )
 
-        upload_session.update_status(status=RawImageUploadSession.SUCCESS)
+        if (
+            len(upload_session.import_result["file_errors"]) != 0
+            and len(upload_session.import_result["consumed_files"]) == 0
+        ):
+            # if no files were imported successfully, mark the session as failed
+            error_handler.handle_error(
+                interface=ci,
+                error_message=upload_session.default_error_message,
+            )
+        else:
+            upload_session.update_status(status=RawImageUploadSession.SUCCESS)
 
     except RuntimeError as error:
         _delete_session_files(upload_session=upload_session)

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1192,8 +1192,8 @@ def add_image_to_object(  # noqa: C901
     )
     error_handler = object.get_error_handler(linked_object=upload_session)
 
-    if upload_session.status == upload_session.FAILURE:
-        logger.info("Nothing to do: upload session failed.")
+    if upload_session.status != upload_session.SUCCESS:
+        logger.info("Nothing to do: upload session was not successful.")
         return
 
     try:

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1192,6 +1192,10 @@ def add_image_to_object(  # noqa: C901
     )
     error_handler = object.get_error_handler(linked_object=upload_session)
 
+    if upload_session.status == upload_session.FAILURE:
+        logger.info("Nothing to do: upload session failed.")
+        return
+
     try:
         image = Image.objects.get(origin_id=upload_session_pk)
     except (Image.DoesNotExist, Image.MultipleObjectsReturned):

--- a/app/tests/algorithms_tests/test_api.py
+++ b/app/tests/algorithms_tests/test_api.py
@@ -472,7 +472,7 @@ class TestJobCreationThroughAPI:
         assert (
             "One or more of the inputs failed validation." == job.error_message
         )
-        assert "Image imports should result in a single image" in str(
+        assert "1 file could not be imported" in str(
             job.detailed_error_message
         )
         # and no CIVs should have been created

--- a/app/tests/algorithms_tests/test_serializers.py
+++ b/app/tests/algorithms_tests/test_serializers.py
@@ -7,6 +7,7 @@ from grandchallenge.algorithms.serializers import (
     HyperlinkedJobSerializer,
     JobPostSerializer,
 )
+from grandchallenge.cases.models import RawImageUploadSession
 from grandchallenge.components.models import ComponentInterface
 from tests.algorithms_tests.factories import (
     AlgorithmFactory,
@@ -192,7 +193,9 @@ def test_algorithm_job_post_serializer_create(
 
     # setup
     user = UserFactory()
-    upload = RawImageUploadSessionFactory(creator=user)
+    upload = RawImageUploadSessionFactory(
+        creator=user, status=RawImageUploadSession.SUCCESS
+    )
     image1, image2 = ImageFactory.create_batch(2)
     upload.image_set.set([image1])
     for im in [image1, image2]:

--- a/app/tests/algorithms_tests/test_serializers.py
+++ b/app/tests/algorithms_tests/test_serializers.py
@@ -193,9 +193,7 @@ def test_algorithm_job_post_serializer_create(
 
     # setup
     user = UserFactory()
-    upload = RawImageUploadSessionFactory(
-        creator=user, status=RawImageUploadSession.SUCCESS
-    )
+    upload = RawImageUploadSessionFactory(creator=user)
     image1, image2 = ImageFactory.create_batch(2)
     upload.image_set.set([image1])
     for im in [image1, image2]:
@@ -230,6 +228,10 @@ def test_algorithm_job_post_serializer_create(
 
     # verify
     assert serializer.is_valid()
+    # fake successful upload
+    upload.status = RawImageUploadSession.SUCCESS
+    upload.save()
+
     with django_capture_on_commit_callbacks(execute=True):
         serializer.create(serializer.validated_data)
     assert len(Job.objects.all()) == 1

--- a/app/tests/algorithms_tests/test_views.py
+++ b/app/tests/algorithms_tests/test_views.py
@@ -1443,7 +1443,7 @@ class TestJobCreateView:
         assert (
             "One or more of the inputs failed validation." == job.error_message
         )
-        assert "Image imports should result in a single image" in str(
+        assert "1 file could not be imported" in str(
             job.detailed_error_message
         )
         # and no CIVs should have been created

--- a/app/tests/cases_tests/test_background_tasks.py
+++ b/app/tests/cases_tests/test_background_tasks.py
@@ -293,7 +293,7 @@ def test_build_zip_file(settings, django_capture_on_commit_callbacks):
 
 @pytest.mark.django_db
 @mock.patch(
-    "grandchallenge.cases.tasks._handle_raw_image_files",
+    "grandchallenge.cases.tasks._handle_raw_files",
     side_effect=SoftTimeLimitExceeded(),
 )
 def test_soft_time_limit(_):

--- a/app/tests/cases_tests/test_background_tasks.py
+++ b/app/tests/cases_tests/test_background_tasks.py
@@ -138,7 +138,7 @@ def test_no_convertible_file(settings, django_capture_on_commit_callbacks):
     )
 
     session.refresh_from_db()
-    assert session.status == session.SUCCESS
+    assert session.status == session.FAILURE
     assert f"{len(images)} file" in session.error_message
 
     assert session.import_result["consumed_files"] == []

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -379,7 +379,7 @@ def test_add_image_to_object(
     settings.task_always_eager = (True,)
 
     obj = object_type(**extra_object_kwargs)
-    us = RawImageUploadSessionFactory()
+    us = RawImageUploadSessionFactory(status=RawImageUploadSession.SUCCESS)
     ci = ComponentInterfaceFactory(kind="IMG")
     ImageFactory(origin=us)
 
@@ -415,7 +415,7 @@ def test_add_image_to_object_updates_upload_session_on_validation_fail(
     settings.task_always_eager = (True,)
 
     obj = object_type()
-    us = RawImageUploadSessionFactory()
+    us = RawImageUploadSessionFactory(status=RawImageUploadSession.SUCCESS)
     ci = ComponentInterfaceFactory(kind="IMG")
 
     error_message = f"Image validation for interface {ci.title} failed with error: Image imports should result in a single image. "
@@ -450,7 +450,7 @@ def test_add_image_to_object_marks_job_as_failed_on_validation_fail(
     settings.task_always_eager = (True,)
 
     obj = AlgorithmJobFactory(time_limit=10)
-    us = RawImageUploadSessionFactory()
+    us = RawImageUploadSessionFactory(status=RawImageUploadSession.SUCCESS)
     ci = ComponentInterfaceFactory(kind="IMG")
 
     error_message = f"Image validation for interface {ci.title} failed with error: Image imports should result in a single image. "

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -12,6 +12,7 @@ from django.contrib.sites.models import Site
 from guardian.shortcuts import assign_perm
 from requests import put
 
+from grandchallenge.cases.models import RawImageUploadSession
 from grandchallenge.cases.widgets import WidgetChoices
 from grandchallenge.components.backends import docker_client
 from grandchallenge.components.form_fields import INTERFACE_FORM_FIELD_PREFIX
@@ -557,7 +558,9 @@ def algorithm_with_multiple_inputs():
     )
 
     # Create inputs
-    im_upload_through_api = RawImageUploadSessionFactory(creator=user)
+    im_upload_through_api = RawImageUploadSessionFactory(
+        creator=user, status=RawImageUploadSession.SUCCESS
+    )
     image_1, image_2 = ImageFactory.create_batch(2)
     mhd1, mhd2 = ImageFileFactoryWithMHDFile.create_batch(2)
     image_1.files.set([mhd1])

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -12,7 +12,6 @@ from django.contrib.sites.models import Site
 from guardian.shortcuts import assign_perm
 from requests import put
 
-from grandchallenge.cases.models import RawImageUploadSession
 from grandchallenge.cases.widgets import WidgetChoices
 from grandchallenge.components.backends import docker_client
 from grandchallenge.components.form_fields import INTERFACE_FORM_FIELD_PREFIX
@@ -558,9 +557,7 @@ def algorithm_with_multiple_inputs():
     )
 
     # Create inputs
-    im_upload_through_api = RawImageUploadSessionFactory(
-        creator=user, status=RawImageUploadSession.SUCCESS
-    )
+    im_upload_through_api = RawImageUploadSessionFactory(creator=user)
     image_1, image_2 = ImageFactory.create_batch(2)
     mhd1, mhd2 = ImageFileFactoryWithMHDFile.create_batch(2)
     image_1.files.set([mhd1])


### PR DESCRIPTION
I noticed while doing some more local testing for the workshop that failed image uploads (uploading an image that none of our importers can read) results in 2 notifications being sent to users, one from `build_images` and one in `add_image_to_object`. 

This PR adds a check on the upload session status at the beginning of `add_image_to_object`, making sure that we exit this task if the upload session failed. We also check in this task that there is an image for the upload session and we could in theory exit the task there (rather than sending a notification, like we do now), but that seems too indirect of a check to me, since there might be other reasons that the image does not exist (anymore), independent of the upload session status. 

While working on this, I noticed that we mark uploads as successful even if 0 images could be imported. That doesn't really make sense. I checked in the codebase for dependencies on that assumption, but didn't find any, so I'm proposing to mark those as failed. 