### PR TITLE
Fix algorithm template generation

### DIFF
--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -1054,13 +1054,19 @@ class AlgorithmImageTemplate(ObjectPermissionRequiredMixin, DetailView):
         forge_context = get_forge_algorithm_template_context(algorithm)
 
         with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir)
+
             generate_algorithm_template(
                 context=forge_context,
-                output_path=Path(temp_dir),
+                output_path=output_path,
+            )
+
+            buffer = zip_memory_buffer(
+                source=output_path / f"{algorithm.slug}-template"
             )
 
             return FileResponse(
-                streaming_content=zip_memory_buffer(source=temp_dir),
+                streaming_content=buffer,
                 as_attachment=True,
                 filename=f"{algorithm.slug}-template.zip",
                 content_type="application/zip",

--- a/app/tests/algorithms_tests/test_views.py
+++ b/app/tests/algorithms_tests/test_views.py
@@ -1,7 +1,6 @@
 import datetime
 import io
 import json
-import os
 import tempfile
 import zipfile
 from pathlib import Path
@@ -2133,7 +2132,6 @@ def test_algorithm_template_download(client):
     # Spot check for expected files in the zip
     expected_files = ["README.md", "Dockerfile", "inference.py"]
     for file_name in expected_files:
-        relative_file_path = os.path.join(f"{alg.slug}-template", file_name)
         assert (
-            relative_file_path in zip_file.namelist()
-        ), f"{relative_file_path} is in the ZIP file"
+            file_name in zip_file.namelist()
+        ), f"{file_name} is in the ZIP file"


### PR DESCRIPTION
This makes the generation work on systems where the temporary directory is a link, removes top level directory in the zip file, and uses the pathlib API.

See https://github.com/DIAGNijmegen/rse-roadmap/issues/338