### PR TITLE
Create auto-refreshing incomplete jobs table

### DIFF
--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -203,43 +203,7 @@
                 </div>
             {% endif %}
 
-            {% if object.status != object.SUCCESS and incomplete_jobs %}
-                <div class="card-body">
-                    <h3 class="card-title">Prerequisite Jobs</h3>
-
-                    <p>
-                        The successful completion of the algorithm jobs listed below is a prerequisite for executing
-                        the evaluation method on the predictions.
-                        Any algorithm jobs mentioned here that have not encountered failures or been cancelled are
-                        presently undergoing execution within the platform.
-                        Your patience is appreciated during this process.
-                        If any of these algorithm jobs have unfortunately failed, it is typically necessary to get in
-                        touch with the participant to address any issues within their algorithm container.
-                        A job is only marked as cancelled if another job within this set has experienced a failure.
-                    </p>
-
-                    <table class="table table-borderless table-hover table-sm">
-                        <thead class="thead-light">
-                        <tr>
-                            <th>ID</th>
-                            <th>Created</th>
-                            <th>Status</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {% for job in incomplete_jobs %}
-                            <tr>
-                                <td><a href="{{ job.get_absolute_url }}">{{ job.pk }}</a></td>
-                                <td>{{ job.created }}</td>
-                                <td>
-                                    {% include "algorithms/job_status_badge_detail.html" with object=job %}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-            {% endif %}
+            {% include "evaluation/evaluation_incomplete_jobs_detail.html" %}
 
             <div class="card-body">
                 <h3 class="card-title">Predictions</h3>

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_incomplete_jobs_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_incomplete_jobs_detail.html
@@ -1,0 +1,39 @@
+{% load url %}
+
+{% if object.status != object.SUCCESS and incomplete_jobs %}
+    <div class="card-body" {% if incomplete_jobs %}hx-get="{% url 'evaluation:evaluation-incomplete-jobs-detail' challenge_short_name=challenge.short_name pk=object.pk %}" hx-trigger="load delay:180s" hx-swap="outerHTML"{% endif %}>
+        <h3 class="card-title">Prerequisite Jobs</h3>
+
+        <p>
+            The successful completion of the algorithm jobs listed below is a prerequisite for executing
+            the evaluation method on the predictions.
+            Any algorithm jobs mentioned here that have not encountered failures or been cancelled are
+            presently undergoing execution within the platform.
+            Your patience is appreciated during this process.
+            If any of these algorithm jobs have unfortunately failed, it is typically necessary to get in
+            touch with the participant to address any issues within their algorithm container.
+            A job is only marked as cancelled if another job within this set has experienced a failure.
+        </p>
+
+        <table class="table table-borderless table-hover table-sm">
+            <thead class="thead-light">
+            <tr>
+                <th>ID</th>
+                <th>Created</th>
+                <th>Status</th>
+            </tr>
+            </thead>
+            <tbody>
+                {% for job in incomplete_jobs %}
+                    <tr>
+                        <td><a href="{{ job.get_absolute_url }}">{{ job.pk }}</a></td>
+                        <td>{{ job.created }}</td>
+                        <td>
+                            {% include "algorithms/job_status_badge_detail.html" with object=job %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endif %}

--- a/app/grandchallenge/evaluation/urls.py
+++ b/app/grandchallenge/evaluation/urls.py
@@ -14,6 +14,7 @@ from grandchallenge.evaluation.views import (
     EvaluationGroundTruthList,
     EvaluationGroundTruthUpdate,
     EvaluationGroundTruthVersionManagement,
+    EvaluationIncompleteJobsDetail,
     EvaluationList,
     EvaluationStatusBadgeDetail,
     EvaluationUpdate,
@@ -40,6 +41,11 @@ urlpatterns = [
         "<uuid:pk>/status-badge/",
         EvaluationStatusBadgeDetail.as_view(),
         name="evaluation-status-badge-detail",
+    ),
+    path(
+        "<uuid:pk>/incomplete-jobs/",
+        EvaluationIncompleteJobsDetail.as_view(),
+        name="evaluation-incomplete-jobs-detail",
     ),
     # UUID should be matched before slugs
     path("<uuid:pk>/update/", EvaluationUpdate.as_view(), name="update"),

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -610,7 +610,7 @@ class EvaluationStatusBadgeDetail(ObjectPermissionRequiredMixin, DetailView):
 class EvaluationIncompleteJobsDetail(
     ObjectPermissionRequiredMixin, DetailView
 ):
-    permission_required = "view_evaluation"
+    permission_required = "change_evaluation"
     template_name_suffix = "_incomplete_jobs_detail"
     model = Evaluation
     raise_exception = True

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -535,7 +535,36 @@ class EvaluationAdminList(
         return context
 
 
-class EvaluationDetail(ObjectPermissionRequiredMixin, DetailView):
+class EvaluationIncompleteJobsMixin(ObjectPermissionRequiredMixin, DetailView):
+    model = Evaluation
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        incomplete_jobs = filter_by_permission(
+            queryset=Job.objects.exclude(status=Job.SUCCESS)
+            .filter(
+                algorithm_image=self.object.submission.algorithm_image,
+                inputs__archive_items__archive=self.object.submission.phase.archive,
+            )
+            .distinct()
+            .order_by("status"),
+            user=self.request.user,
+            codename="view_job",
+        )
+
+        context.update(
+            {
+                "incomplete_jobs": incomplete_jobs,
+            }
+        )
+
+        return context
+
+
+class EvaluationDetail(
+    EvaluationIncompleteJobsMixin, ObjectPermissionRequiredMixin, DetailView
+):
     model = Evaluation
     permission_required = "view_evaluation"
     raise_exception = True
@@ -576,23 +605,10 @@ class EvaluationDetail(ObjectPermissionRequiredMixin, DetailView):
         except ObjectDoesNotExist:
             predictions = None
 
-        incomplete_jobs = filter_by_permission(
-            queryset=Job.objects.exclude(status=Job.SUCCESS)
-            .filter(
-                algorithm_image=self.object.submission.algorithm_image,
-                inputs__archive_items__archive=self.object.submission.phase.archive,
-            )
-            .distinct()
-            .order_by("status"),
-            user=self.request.user,
-            codename="view_job",
-        )
-
         context.update(
             {
                 "metrics": metrics,
                 "predictions": predictions,
-                "incomplete_jobs": incomplete_jobs,
                 "conversation_form": self.get_conversation_form(),
             }
         )
@@ -608,35 +624,12 @@ class EvaluationStatusBadgeDetail(ObjectPermissionRequiredMixin, DetailView):
 
 
 class EvaluationIncompleteJobsDetail(
-    ObjectPermissionRequiredMixin, DetailView
+    EvaluationIncompleteJobsMixin, ObjectPermissionRequiredMixin, DetailView
 ):
     permission_required = "change_evaluation"
     template_name_suffix = "_incomplete_jobs_detail"
     model = Evaluation
     raise_exception = True
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-
-        incomplete_jobs = filter_by_permission(
-            queryset=Job.objects.exclude(status=Job.SUCCESS)
-            .filter(
-                algorithm_image=self.object.submission.algorithm_image,
-                inputs__archive_items__archive=self.object.submission.phase.archive,
-            )
-            .distinct()
-            .order_by("status"),
-            user=self.request.user,
-            codename="view_job",
-        )
-
-        context.update(
-            {
-                "incomplete_jobs": incomplete_jobs,
-            }
-        )
-
-        return context
 
 
 class LeaderboardRedirect(RedirectView):

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -535,8 +535,7 @@ class EvaluationAdminList(
         return context
 
 
-class EvaluationIncompleteJobsMixin(ObjectPermissionRequiredMixin, DetailView):
-    model = Evaluation
+class EvaluationIncompleteJobsMixin:
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -224,7 +224,7 @@ class TestObjectPermissionRequiredViews:
             (
                 "evaluation-incomplete-jobs-detail",
                 {"pk": e.pk},
-                "view_evaluation",
+                "change_evaluation",
                 e,
             ),
         ]:

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -221,6 +221,12 @@ class TestObjectPermissionRequiredViews:
                 "view_evaluation",
                 e,
             ),
+            (
+                "evaluation-incomplete-jobs-detail",
+                {"pk": e.pk},
+                "view_evaluation",
+                e,
+            ),
         ]:
             response = get_view_for_user(
                 client=client,


### PR DESCRIPTION
Create auto-refreshing incomplete jobs table for pre-requisite jobs during evaluations. 

The table will refresh after 3 minutes if there are incomplete jobs when it loads. It will show the latest list of incomplete jobs when it refreshes or it will vanish if there are no incomplete jobs left. 

part of https://github.com/comic/grand-challenge.org/issues/3639