### PR TITLE
Auto refresh status badge cleanup

### DIFF
--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -1024,6 +1024,16 @@ class Job(CIVForObjectMixin, ComponentJob):
         )
 
     @property
+    def status_url(self) -> str:
+        return reverse(
+            "algorithms:job-status-detail",
+            kwargs={
+                "slug": self.algorithm_image.algorithm.slug,
+                "pk": self.pk,
+            },
+        )
+
+    @property
     def api_url(self) -> str:
         return reverse("api:algorithms-job-detail", kwargs={"pk": self.pk})
 

--- a/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
@@ -114,7 +114,7 @@
 
                 <dt class="col-sm-3">Status</dt>
                 <dd class="col-sm-9">
-                    {% include "algorithms/job_status_badge_detail.html" %}
+                    {% include "algorithms/job_status_detail.html" %}
                 </dd>
 
                 {% if object.error_message %}

--- a/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_list_row.html
@@ -27,7 +27,7 @@
 
 <split></split>
 
-{% include "algorithms/job_status_badge_detail.html" %}
+{% include "algorithms/job_status_detail.html" %}
 <split></split>
 
 {% if object.public %}

--- a/app/grandchallenge/algorithms/templates/algorithms/job_status_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_status_detail.html
@@ -1,6 +1,4 @@
-{% load url %}
-
-<span class="badge badge-{{ object.status_context }}" {% if not object.finished %}hx-get="{% url 'algorithms:job-status-detail' slug=object.algorithm_image.algorithm.slug pk=object.pk %}" hx-trigger="load delay:30s" hx-swap="outerHTML"{% endif %}>
+<span class="badge badge-{{ object.status_context }}" {% if not object.finished %}hx-get="{{ object.status_url }}" hx-trigger="load delay:30s" hx-swap="outerHTML"{% endif %}>
     {% if object.animate %}
         <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
     {% endif %}

--- a/app/grandchallenge/algorithms/templates/algorithms/job_status_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_status_detail.html
@@ -1,6 +1,6 @@
 {% load url %}
 
-<span class="badge badge-{{ object.status_context }}" {% if not object.finished %}hx-get="{% url 'algorithms:job-status-badge-detail' slug=object.algorithm_image.algorithm.slug pk=object.pk %}" hx-trigger="load delay:30s" hx-swap="outerHTML"{% endif %}>
+<span class="badge badge-{{ object.status_context }}" {% if not object.finished %}hx-get="{% url 'algorithms:job-status-detail' slug=object.algorithm_image.algorithm.slug pk=object.pk %}" hx-trigger="load delay:30s" hx-swap="outerHTML"{% endif %}>
     {% if object.animate %}
         <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
     {% endif %}

--- a/app/grandchallenge/algorithms/urls.py
+++ b/app/grandchallenge/algorithms/urls.py
@@ -27,7 +27,7 @@ from grandchallenge.algorithms.views import (
     JobDetail,
     JobProgressDetail,
     JobsList,
-    JobStatusBadgeDetail,
+    JobStatusDetail,
     JobUpdate,
     JobViewersUpdate,
     UsersUpdate,
@@ -106,9 +106,9 @@ urlpatterns = [
     path("<slug>/jobs/create/", JobCreate.as_view(), name="job-create"),
     path("<slug>/jobs/<uuid:pk>/", JobDetail.as_view(), name="job-detail"),
     path(
-        "<slug>/jobs/<uuid:pk>/status-badge/",
-        JobStatusBadgeDetail.as_view(),
-        name="job-status-badge-detail",
+        "<slug>/jobs/<uuid:pk>/status/",
+        JobStatusDetail.as_view(),
+        name="job-status-detail",
     ),
     path(
         "<slug>/jobs/<uuid:pk>/update/", JobUpdate.as_view(), name="job-update"

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -683,6 +683,7 @@ class JobStatusBadgeDetail(ObjectPermissionRequiredMixin, DetailView):
     permission_required = "algorithms.view_job"
     template_name_suffix = "_status_badge_detail"
     model = Job
+    raise_exception = True
 
 
 class DisplaySetFromJobCreate(

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -679,9 +679,9 @@ class JobUpdate(LoginRequiredMixin, ObjectPermissionRequiredMixin, UpdateView):
     raise_exception = True
 
 
-class JobStatusBadgeDetail(ObjectPermissionRequiredMixin, DetailView):
+class JobStatusDetail(ObjectPermissionRequiredMixin, DetailView):
     permission_required = "algorithms.view_job"
-    template_name_suffix = "_status_badge_detail"
+    template_name_suffix = "_status_detail"
     model = Job
     raise_exception = True
 

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -1581,6 +1581,10 @@ class ComponentJob(FieldChangeMixin, UUIDModel):
 
     objects = ComponentJobManager.as_manager()
 
+    @property
+    def status_url(self) -> str:
+        raise NotImplementedError
+
     def save(self, *args, **kwargs):
         adding = self._state.adding
 

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1653,6 +1653,16 @@ class Evaluation(ComponentJob):
             },
         )
 
+    @property
+    def status_url(self) -> str:
+        return reverse(
+            "evaluation:status-detail",
+            kwargs={
+                "pk": self.pk,
+                "challenge_short_name": self.submission.phase.challenge.short_name,
+            },
+        )
+
 
 class EvaluationUserObjectPermission(UserObjectPermissionBase):
     content_object = models.ForeignKey(Evaluation, on_delete=models.CASCADE)

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -53,7 +53,7 @@
 
         <dt>Status</dt>
         <dd>
-            {% include 'evaluation/evaluation_status_badge_detail.html' %}
+            {% include 'evaluation/evaluation_status_detail.html' %}
         </dd>
 
         <dt>User</dt>
@@ -232,7 +232,7 @@
                                 <td><a href="{{ job.get_absolute_url }}">{{ job.pk }}</a></td>
                                 <td>{{ job.created }}</td>
                                 <td>
-                                    {% include "algorithms/job_status_badge_detail.html" with object=job %}
+                                    {% include "algorithms/job_status_detail.html" with object=job %}
                                 </td>
                             </tr>
                         {% endfor %}

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_incomplete_jobs_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_incomplete_jobs_detail.html
@@ -29,7 +29,7 @@
                         <td><a href="{{ job.get_absolute_url }}">{{ job.pk }}</a></td>
                         <td>{{ job.created }}</td>
                         <td>
-                            {% include "algorithms/job_status_badge_detail.html" with object=job %}
+                            {% include "algorithms/job_status_detail.html" with object=job %}
                         </td>
                     </tr>
                 {% endfor %}

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_list.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_list.html
@@ -71,7 +71,7 @@
                         </td>
                     {% endif %}
                     <td>
-                        {% include 'evaluation/evaluation_status_badge_detail.html' with object=evaluation %}
+                        {% include 'evaluation/evaluation_status_detail.html' with object=evaluation %}
                     </td>
 
                     {% if "change_challenge" in challenge_perms %}

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_status_badge_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_status_badge_detail.html
@@ -1,8 +1,0 @@
-{% load url %}
-
-<span class="badge badge-{{ object.status_context }}" {% if not object.finished %}hx-get="{% url 'evaluation:evaluation-status-badge-detail' challenge_short_name=challenge.short_name pk=object.pk %}" hx-trigger="load delay:30s" hx-swap="outerHTML"{% endif %}>
-    {% if object.animate %}
-        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-    {% endif %}
-    {{ object.get_status_display }}
-</span>

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_status_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_status_detail.html
@@ -1,0 +1,8 @@
+{% load url %}
+
+<span class="badge badge-{{ object.status_context }}" {% if not object.finished %}hx-get="{% url 'evaluation:status-detail' challenge_short_name=challenge.short_name pk=object.pk %}" hx-trigger="load delay:30s" hx-swap="outerHTML"{% endif %}>
+    {% if object.animate %}
+        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+    {% endif %}
+    {{ object.get_status_display }}
+</span>

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_status_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_status_detail.html
@@ -1,6 +1,4 @@
-{% load url %}
-
-<span class="badge badge-{{ object.status_context }}" {% if not object.finished %}hx-get="{% url 'evaluation:status-detail' challenge_short_name=challenge.short_name pk=object.pk %}" hx-trigger="load delay:30s" hx-swap="outerHTML"{% endif %}>
+<span class="badge badge-{{ object.status_context }}" {% if not object.finished %}hx-get="{{ object.status_url }}" hx-trigger="load delay:30s" hx-swap="outerHTML"{% endif %}>
     {% if object.animate %}
         <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
     {% endif %}

--- a/app/grandchallenge/evaluation/templates/evaluation/partials/evaluations_for_object_table.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/partials/evaluations_for_object_table.html
@@ -21,7 +21,7 @@
                     <a href="{{ evaluation.submission.get_absolute_url }}">{{ evaluation.submission.id }}</a>
                 </td>
                 <td>
-                    {% include 'evaluation/evaluation_status_badge_detail.html' with object=evaluation %}
+                    {% include 'evaluation/evaluation_status_detail.html' with object=evaluation %}
                 </td>
                 <td>
                     {% if evaluation.status == evaluation.SUCCESS %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_detail.html
@@ -89,7 +89,7 @@
                         <a href="{{ evaluation.method.get_absolute_url }}">{{ evaluation.method.id }}</a>
                     </td>
                     <td>
-                        {% include 'evaluation/evaluation_status_badge_detail.html' with object=evaluation %}
+                        {% include 'evaluation/evaluation_status_detail.html' with object=evaluation %}
                     </td>
                     <td>
                         {% if evaluation.status == evaluation.SUCCESS %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_list.html
@@ -56,7 +56,7 @@
                         <ul class="list-unstyled">
                             {% for evaluation in submission.evaluation_set.all %}
                                 <li>
-                                    {% include 'evaluation/evaluation_status_badge_detail.html' with object=evaluation %}
+                                    {% include 'evaluation/evaluation_status_detail.html' with object=evaluation %}
                                     {% if evaluation.status == evaluation.SUCCESS %}
                                         {% if evaluation.published %}
                                             <a href="{{ evaluation.get_absolute_url }}">Result</a>

--- a/app/grandchallenge/evaluation/urls.py
+++ b/app/grandchallenge/evaluation/urls.py
@@ -15,7 +15,7 @@ from grandchallenge.evaluation.views import (
     EvaluationGroundTruthUpdate,
     EvaluationGroundTruthVersionManagement,
     EvaluationList,
-    EvaluationStatusBadgeDetail,
+    EvaluationStatusDetail,
     EvaluationUpdate,
     LeaderboardDetail,
     LeaderboardRedirect,
@@ -37,9 +37,9 @@ app_name = "evaluation"
 urlpatterns = [
     path("<uuid:pk>/", EvaluationDetail.as_view(), name="detail"),
     path(
-        "<uuid:pk>/status-badge/",
-        EvaluationStatusBadgeDetail.as_view(),
-        name="evaluation-status-badge-detail",
+        "<uuid:pk>/status/",
+        EvaluationStatusDetail.as_view(),
+        name="status-detail",
     ),
     # UUID should be matched before slugs
     path("<uuid:pk>/update/", EvaluationUpdate.as_view(), name="update"),

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -600,9 +600,9 @@ class EvaluationDetail(ObjectPermissionRequiredMixin, DetailView):
         return context
 
 
-class EvaluationStatusBadgeDetail(ObjectPermissionRequiredMixin, DetailView):
+class EvaluationStatusDetail(ObjectPermissionRequiredMixin, DetailView):
     permission_required = "view_evaluation"
-    template_name_suffix = "_status_badge_detail"
+    template_name_suffix = "_status_detail"
     model = Evaluation
     raise_exception = True
 

--- a/app/tests/algorithms_tests/test_views.py
+++ b/app/tests/algorithms_tests/test_views.py
@@ -420,7 +420,7 @@ class TestObjectPermissionRequiredViews:
                 None,
             ),
             (
-                "job-status-badge-detail",
+                "job-status-detail",
                 {"slug": ai.algorithm.slug, "pk": j.pk},
                 "view_job",
                 j,

--- a/app/tests/algorithms_tests/test_views.py
+++ b/app/tests/algorithms_tests/test_views.py
@@ -420,6 +420,13 @@ class TestObjectPermissionRequiredViews:
                 None,
             ),
             (
+                "job-status-badge-detail",
+                {"slug": ai.algorithm.slug, "pk": j.pk},
+                "view_job",
+                j,
+                None,
+            ),
+            (
                 "job-update",
                 {"slug": ai.algorithm.slug, "pk": j.pk},
                 "change_job",
@@ -583,32 +590,6 @@ class TestJobDetailView:
             assert content in response.rendered_content
 
             remove_perm(permission, u, permission_object)
-
-
-@pytest.mark.django_db
-class TestJobStatusBadgeDetail:
-    def test_guarded_content_visibility(self, client):
-        j = AlgorithmJobFactory(time_limit=60)
-        u = UserFactory()
-
-        view_kwargs = {
-            "client": client,
-            "viewname": "algorithms:job-status-badge-detail",
-            "reverse_kwargs": {
-                "slug": j.algorithm_image.algorithm.slug,
-                "pk": j.pk,
-            },
-            "user": u,
-        }
-        response = get_view_for_user(**view_kwargs)
-
-        assert response.status_code == 302
-
-        assign_perm("view_job", u, j)
-
-        response = get_view_for_user(**view_kwargs)
-
-        assert response.status_code == 200
 
 
 @pytest.mark.django_db

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -216,7 +216,7 @@ class TestObjectPermissionRequiredViews:
             ("update", {"pk": e.pk}, "change_evaluation", e),
             ("detail", {"pk": e.pk}, "view_evaluation", e),
             (
-                "evaluation-status-badge-detail",
+                "status-detail",
                 {"pk": e.pk},
                 "view_evaluation",
                 e,


### PR DESCRIPTION
Cleanup of work related to auto refresh badges

- Rename of status badge to status
- `JobStatusDetail` now has `raise_exception = True`
- the url to the status view is now provided by the models (`Evaluation` and `Job`)

part of https://github.com/comic/grand-challenge.org/issues/3639
