### PR TITLE
Process Newick files on `acks-late-2xlarge`

### DIFF
--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -2487,7 +2487,6 @@ class CIVForObjectMixin:
             custom_queue = INTERFACE_KIND_TO_CUSTOM_QUEUE.get(ci.kind, False)
             task_queue_kwarg = {}
             if custom_queue:
-                # Providing None would have Celery use the Celery-scope default
                 task_queue_kwarg["queue"] = custom_queue
 
             transaction.on_commit(

--- a/app/tests/components_tests/test_models.py
+++ b/app/tests/components_tests/test_models.py
@@ -15,6 +15,7 @@ from grandchallenge.algorithms.models import AlgorithmImage, Job
 from grandchallenge.cases.models import Image
 from grandchallenge.components.models import (
     INTERFACE_TYPE_JSON_EXAMPLES,
+    CIVData,
     ComponentInterface,
     ComponentInterfaceExampleValue,
     ComponentInterfaceValue,
@@ -45,12 +46,13 @@ from tests.components_tests.factories import (
     ComponentInterfaceValueFactory,
 )
 from tests.evaluation_tests.factories import EvaluationFactory, MethodFactory
-from tests.factories import ImageFactory, WorkstationImageFactory
+from tests.factories import ImageFactory, UserFactory, WorkstationImageFactory
 from tests.reader_studies_tests.factories import (
     DisplaySetFactory,
     QuestionFactory,
     ReaderStudyFactory,
 )
+from tests.uploads_tests.factories import UserUploadFactory
 from tests.utils import create_raw_upload_image_session
 
 
@@ -1634,3 +1636,47 @@ def test_component_interface_value_manager():
 
     assert civ == civ1
     assert not created
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "kind,expected_queue",
+    (
+        (InterfaceKindChoices.STRING, False),
+        (InterfaceKindChoices.NEWICK, "acks-late-2xlarge"),
+    ),
+)
+def test_component_interface_custom_queue(kind, expected_queue, mocker):
+
+    ci = ComponentInterfaceFactory(
+        kind=kind,
+        store_in_database=False,
+    )
+    user = UserFactory()
+
+    # Need an existing CIVSet, use archive here since it is slightly easier setup
+    archive = ArchiveFactory()
+    archive.add_editor(user)
+    ai = ArchiveItemFactory.build(archive=None)
+
+    mock_task_signature = mocker.patch(
+        "grandchallenge.components.tasks.add_file_to_object.signature"
+    )
+    ai.validate_values_and_execute_linked_task(
+        values=[
+            CIVData(
+                interface_slug=ci.slug,
+                value=UserUploadFactory(creator=user),
+            )
+        ],
+        user=user,
+    )
+    assert mock_task_signature.called_once()
+
+    kwargs = mock_task_signature.call_args.kwargs
+    if not expected_queue:
+        # Ensure it's not passed since setting to None would
+        # have Celery use the Celery-scope default ("celerly")
+        assert "queue" not in kwargs
+    else:
+        assert kwargs["queue"] == expected_queue


### PR DESCRIPTION
This tiny PR introduces an (optional) custom upload processing queue per component interface. Not sure if we should also add this to the processing of images. I suggest we tackle that when we want to define a custom queue for super_kind images.

# TODO
- [x] re-define tests so this is actual tested.