### PR TITLE
Include hanging protocols check in view_content_example generation

### DIFF
--- a/app/grandchallenge/hanging_protocols/forms.py
+++ b/app/grandchallenge/hanging_protocols/forms.py
@@ -187,7 +187,9 @@ class ViewContentExampleMixin:
     def _get_viewports(self):
         if self.instance.hanging_protocol:
             return {
-                x["viewport_name"] for x in self.instance.hanging_protocol.json
+                x["viewport_name"]
+                for x in self.instance.hanging_protocol.json
+                if "viewport_name" in x
             }
         return ViewportNames.values
 

--- a/app/grandchallenge/hanging_protocols/forms.py
+++ b/app/grandchallenge/hanging_protocols/forms.py
@@ -206,12 +206,27 @@ class ViewContentExampleMixin:
     ):
         view_content_example = {}
 
-        if images and self.instance.hanging_protocol:
+        if self.instance.hanging_protocol:
             viewport_count = len(viewports)
-            images = (
-                images * (viewport_count // len(images))
-                + images[: (viewport_count % len(images))]
-            )
+
+            if mandatory_isolation_interfaces:
+                mandatory_isolation_interfaces = (
+                    mandatory_isolation_interfaces
+                    * (viewport_count // len(mandatory_isolation_interfaces))
+                    + mandatory_isolation_interfaces[
+                        : (
+                            viewport_count
+                            % len(mandatory_isolation_interfaces)
+                        )
+                    ]
+                )
+                viewport_count -= len(mandatory_isolation_interfaces)
+
+            if images:
+                images = (
+                    images * (viewport_count // len(images))
+                    + images[: (viewport_count % len(images))]
+                )
 
         overlays_per_image = len(overlays) // len(images) if images else 0
         remaining_overlays = len(overlays) % len(images) if images else 0

--- a/app/grandchallenge/hanging_protocols/forms.py
+++ b/app/grandchallenge/hanging_protocols/forms.py
@@ -1,5 +1,5 @@
 import json
-from collections import namedtuple
+from typing import NamedTuple
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import ButtonHolder, Div, Layout, Submit
@@ -132,6 +132,12 @@ class HangingProtocolForm(SaveFormInitMixin, forms.ModelForm):
             )
 
 
+class InterfaceLists(NamedTuple):
+    images: list[str]
+    mandatory_isolation_interfaces: list[str]
+    overlays: list[str]
+
+
 class ViewContentExampleMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -162,11 +168,6 @@ class ViewContentExampleMixin:
         )
 
     def _get_interface_lists(self):
-        interface_lists = namedtuple(
-            "interface_lists",
-            ["images", "mandatory_isolation_interfaces", "overlays"],
-        )
-
         images = [
             interface.slug
             for interface in self.instance.interfaces
@@ -188,8 +189,10 @@ class ViewContentExampleMixin:
                 InterfaceKindChoices.IMAGE,
             )
         ]
-        return interface_lists(
-            images, mandatory_isolation_interfaces, overlays
+        return InterfaceLists(
+            images=images,
+            mandatory_isolation_interfaces=mandatory_isolation_interfaces,
+            overlays=overlays,
         )
 
     def _get_viewports(self):

--- a/app/tests/hanging_protocols_tests/test_forms.py
+++ b/app/tests/hanging_protocols_tests/test_forms.py
@@ -728,6 +728,6 @@ def test_reader_study_forms_view_content_example_with_hanging_protocol(
     form = ReaderStudyUpdateForm(
         user=creator,
         instance=object.base_object,
-        data={**form_data, "hanging_protocl": hp.pk},
+        data={**form_data, "hanging_protocol": hp.pk},
     )
     assert form.is_valid()

--- a/app/tests/hanging_protocols_tests/test_forms.py
+++ b/app/tests/hanging_protocols_tests/test_forms.py
@@ -690,6 +690,16 @@ def test_generate_view_content_example(
             ],
             {"main", "secondary", "tertiary", "quaternary"},
         ),
+        (
+            [
+                {"viewport_name": "main"},
+                {"viewport_name": "secondary"},
+                {"viewport_name": "tertiary"},
+                {"viewport_name": "quaternary"},
+                {"viewport_name": "quinary"},
+            ],
+            {"main", "secondary", "tertiary", "quaternary", "quinary"},
+        ),
     ),
 )
 def test_reader_study_forms_view_content_example_with_hanging_protocol(

--- a/app/tests/hanging_protocols_tests/test_forms.py
+++ b/app/tests/hanging_protocols_tests/test_forms.py
@@ -702,13 +702,26 @@ def test_generate_view_content_example(
         ),
     ),
 )
+@pytest.mark.parametrize(
+    "num_of_images,num_of_isolated_interfaces",
+    (
+        (4, 0),
+        (1, 3),
+        (2, 2),
+        (3, 1),
+        (0, 4),
+    ),
+)
 def test_reader_study_forms_view_content_example_with_hanging_protocol(
-    hanging_protocol_json, view_content_example_json_expected_keys
+    hanging_protocol_json,
+    view_content_example_json_expected_keys,
+    num_of_images,
+    num_of_isolated_interfaces,
 ):
     ci_list = make_ci_list(
-        number_of_images=3,
+        number_of_images=num_of_images,
         number_of_overlays=2,
-        number_of_isolated_interfaces=1,
+        number_of_isolated_interfaces=num_of_isolated_interfaces,
         number_of_undisplayable_interfaces=1,
     )
     civ_list = [ComponentInterfaceValueFactory(interface=ci) for ci in ci_list]
@@ -748,9 +761,11 @@ def test_reader_study_forms_view_content_example_with_hanging_protocol(
     assert form.is_valid()
 
     view_content_example = form.generate_view_content_example()
-    view_content_example_json = (
-        json.loads(view_content_example) if view_content_example else None
+    view_content_example_keys = (
+        set(json.loads(view_content_example).keys())
+        if view_content_example
+        else None
     )
-    assert set(view_content_example_json.keys()) == set(
+    assert view_content_example_keys == set(
         view_content_example_json_expected_keys
     )


### PR DESCRIPTION
closes #3721 

Basically, example generation should create example with viewports equal to the viewports in the hanging protocol json (if the hanging protocol is defined). Otherwise, the viewports can be up to the number of values in ViewportNames