### PR TITLE
Rename interfaces property to avoid clash with AlgorithmInterface

### DIFF
--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -444,7 +444,7 @@ class Algorithm(UUIDModel, TitleSlugDescriptionModel, HangingProtocolMixin):
         return user.groups.remove(self.users_group)
 
     @cached_property
-    def interfaces(self):
+    def linked_component_interfaces(self):
         return (self.inputs.all() | self.outputs.all()).distinct()
 
     @cached_property

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -2626,7 +2626,7 @@ class ValuesForInterfacesMixin:
         return values_for_interfaces
 
     @cached_property
-    def interfaces(self):
+    def linked_component_interfaces(self):
         return ComponentInterface.objects.filter(
             pk__in=self.civ_sets_related_manager.exclude(
                 values__isnull=True

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -876,7 +876,7 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
         )
 
     @cached_property
-    def interfaces(self):
+    def linked_component_interfaces(self):
         return (
             self.algorithm_inputs.all() | self.algorithm_outputs.all()
         ).distinct()

--- a/app/grandchallenge/hanging_protocols/forms.py
+++ b/app/grandchallenge/hanging_protocols/forms.py
@@ -144,7 +144,8 @@ class ViewContentExampleMixin:
         super().__init__(*args, **kwargs)
         if self.instance:
             interface_slugs = [
-                interface.slug for interface in self.instance.interfaces
+                interface.slug
+                for interface in self.instance.linked_component_interfaces
             ]
 
             if len(interface_slugs) > 0:
@@ -176,18 +177,18 @@ class ViewContentExampleMixin:
     def _get_interface_lists(self):
         images = [
             interface.slug
-            for interface in self.instance.interfaces
+            for interface in self.instance.linked_component_interfaces
             if interface.kind == InterfaceKindChoices.IMAGE
         ]
         mandatory_isolation_interfaces = [
             interface.slug
-            for interface in self.instance.interfaces
+            for interface in self.instance.linked_component_interfaces
             if interface.kind
             in InterfaceKind.interface_type_mandatory_isolation()
         ]
         overlays = [
             interface.slug
-            for interface in self.instance.interfaces
+            for interface in self.instance.linked_component_interfaces
             if interface.kind
             not in (
                 *InterfaceKind.interface_type_undisplayable(),


### PR DESCRIPTION
I realized when trying to merge main into the optional inputs feature branch, that the cached property that was added to multiple models in this [PR ](https://github.com/comic/grand-challenge.org/pull/3697) clashes with the newly added `interfaces` field on the Algorithm model. So this is renaming the cached properties to avoid such a clash. 

When we move to a different naming for component_interfaces, these properties will probably be renamed again, but for now `linked_component_interfaces` was the best I could think of. 