### PR TITLE
Retain current selection of gpu type choice and allow challenge admins to update gpu types

### DIFF
--- a/app/grandchallenge/algorithms/forms.py
+++ b/app/grandchallenge/algorithms/forms.py
@@ -441,6 +441,7 @@ class AlgorithmForm(
     @property
     def selectable_gpu_type_choices(self):
         choices_set = {
+            self.instance.job_requires_gpu_type,
             *get_default_gpu_type_choices(),
             *chain.from_iterable(
                 self.job_requirement_properties_from_phases["gpu_type_choices"]


### PR DESCRIPTION
When the options for choices is changed (in the relevant phases or organization or because the user has changed) the current selection can easily be lost if it's not included in the options.

Related to https://github.com/DIAGNijmegen/rse-roadmap/issues/346