### PR TITLE
Correct challenge request defaults

### DIFF
--- a/app/grandchallenge/challenges/migrations/0045_challengerequest_algorithm_maximum_settable_memory_gb_and_more.py
+++ b/app/grandchallenge/challenges/migrations/0045_challengerequest_algorithm_maximum_settable_memory_gb_and_more.py
@@ -88,7 +88,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="challengerequest",
             name="data_license",
-            field=models.BooleanField(default=True),
+            field=models.BooleanField(default=False),
         ),
         migrations.AlterField(
             model_name="challengerequest",

--- a/app/grandchallenge/challenges/migrations/0045_challengerequest_algorithm_maximum_settable_memory_gb_and_more.py
+++ b/app/grandchallenge/challenges/migrations/0045_challengerequest_algorithm_maximum_settable_memory_gb_and_more.py
@@ -104,7 +104,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="challengerequest",
             name="long_term_commitment",
-            field=models.BooleanField(default=True),
+            field=models.BooleanField(default=False),
         ),
         migrations.AlterField(
             model_name="challengerequest",

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -955,7 +955,7 @@ class ChallengeRequest(UUIDModel, ChallengeBase):
         help_text="What is your budget for hosting this challenge? Please be reminded of our <a href='/challenge-policy-and-pricing/'>challenge pricing policy</a>.",
     )
     long_term_commitment = models.BooleanField(
-        default=True,
+        default=False,
     )
     long_term_commitment_extra = models.CharField(
         max_length=2000,

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -962,7 +962,7 @@ class ChallengeRequest(UUIDModel, ChallengeBase):
         blank=True,
     )
     data_license = models.BooleanField(
-        default=True,
+        default=False,
     )
     data_license_extra = models.CharField(
         max_length=2000,


### PR DESCRIPTION
These had been [pre-checked on the form](https://github.com/comic/grand-challenge.org/pull/3731/files#diff-f578f140394fbfc242dcbbcb8e8af31bcd700285b32677b6e65f3543e01b0c0bL407-L408) so the correct default was used in #3731 in order to preserve behaviour, but I'm not sure they should be pre-checked.