### PR TITLE
Fix Datatables initialization issues

### DIFF
--- a/app/grandchallenge/core/static/js/datatables.defaults.mjs
+++ b/app/grandchallenge/core/static/js/datatables.defaults.mjs
@@ -10,6 +10,13 @@ $.extend(true, DataTable.defaults, {
 });
 
 $(document).on("init.dt", () => {
-    // Set up floating scroll, note that the target class only shows up when scrollX is set to true
-    $(".dataTables_scrollBody").floatingScroll();
+    const element = $(".dt-scroll-body");
+
+    if (element.length === 0) {
+        console.warn(
+            "Warning: Element for floating-scroll attachment could not be located",
+        );
+    }
+
+    element.floatingScroll();
 });

--- a/app/grandchallenge/core/static/js/datatables.defaults.mjs
+++ b/app/grandchallenge/core/static/js/datatables.defaults.mjs
@@ -1,4 +1,4 @@
-$.extend(true, DataTable.defaults, {
+$.extend($.fn.dataTable.defaults, {
     scrollX: true,
     language: {
         paginate: {


### PR DESCRIPTION
It's possible there is some race condition in Datatables being registered in the global space and the default module being executed. This new call is the (new) documented method of settings defaults.


While I was at it I fixed floating scroll:
The update to Datatables v2 had the internals of the table scrambled. It's now actually a lot cleaner but the target for the floating scroll did change!