### PR TITLE
Removes oninput for challenge request form

### DIFF
--- a/app/grandchallenge/challenges/forms.py
+++ b/app/grandchallenge/challenges/forms.py
@@ -193,33 +193,6 @@ class ChallengeRequestForm(forms.ModelForm):
         widgets = {
             "start_date": forms.TextInput(attrs={"type": "date"}),
             "end_date": forms.TextInput(attrs={"type": "date"}),
-            "expected_number_of_teams": forms.NumberInput(
-                attrs={"oninput": "validity.valid||(value='');"}
-            ),
-            "number_of_tasks": forms.NumberInput(
-                attrs={"oninput": "validity.valid||(value='');"}
-            ),
-            "average_size_of_test_image_in_mb": forms.NumberInput(
-                attrs={"oninput": "validity.valid||(value='');"}
-            ),
-            "inference_time_limit_in_minutes": forms.NumberInput(
-                attrs={"oninput": "validity.valid||(value='');"}
-            ),
-            "phase_1_number_of_submissions_per_team": forms.NumberInput(
-                attrs={"oninput": "validity.valid||(value='');"}
-            ),
-            "phase_2_number_of_submissions_per_team": forms.NumberInput(
-                attrs={"oninput": "validity.valid||(value='');"}
-            ),
-            "phase_1_number_of_test_images": forms.NumberInput(
-                attrs={"oninput": "validity.valid||(value='');"}
-            ),
-            "phase_2_number_of_test_images": forms.NumberInput(
-                attrs={"oninput": "validity.valid||(value='');"}
-            ),
-            "budget_for_hosting_challenge": forms.NumberInput(
-                attrs={"oninput": "validity.valid||(value='');"}
-            ),
         }
         labels = {
             "short_name": "Acronym",

--- a/app/grandchallenge/challenges/migrations/0045_challengerequest_algorithm_maximum_settable_memory_gb_and_more.py
+++ b/app/grandchallenge/challenges/migrations/0045_challengerequest_algorithm_maximum_settable_memory_gb_and_more.py
@@ -81,7 +81,6 @@ class Migration(migrations.Migration):
             model_name="challengerequest",
             name="budget_for_hosting_challenge",
             field=models.PositiveIntegerField(
-                default=0,
                 help_text="What is your budget for hosting this challenge? Please be reminded of our <a href='/challenge-policy-and-pricing/'>challenge pricing policy</a>.",
             ),
         ),

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -951,7 +951,6 @@ class ChallengeRequest(UUIDModel, ChallengeBase):
         validators=[MinValueValidator(limit_value=1)],
     )
     budget_for_hosting_challenge = models.PositiveIntegerField(
-        default=0,
         help_text="What is your budget for hosting this challenge? Please be reminded of our <a href='/challenge-policy-and-pricing/'>challenge pricing policy</a>.",
     )
     long_term_commitment = models.BooleanField(

--- a/app/tests/factories.py
+++ b/app/tests/factories.py
@@ -115,6 +115,7 @@ class ChallengeRequestFactory(factory.django.DjangoModelFactory):
     phase_1_number_of_test_images = 100
     phase_2_number_of_test_images = 0
     number_of_tasks = 1
+    budget_for_hosting_challenge = 0
     structured_challenge_submission_doi = "10.5281/zenodo.6362337"
 
 


### PR DESCRIPTION
The old functionality was to drop invalid values, this does not seem user friendly. Now, we use the default behaviour of the browser forcing the user to fill in a valid value when they try to submit the form instead.

This also removes the budget default of zero which prevents the requester overlooking the field.

Closes #3748