### PR TITLE
Remove headline from documentation search results

### DIFF
--- a/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
+++ b/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
@@ -139,7 +139,6 @@
                 {% for result in search_results %}
                     <div class="card rounded border-light my-1">
                         <a href="{% url 'documentation:detail' slug=result.slug %}"><h5 class="pl-3 pt-3">{{ result.title }}</h5></a>
-                        <div class="mb-3 pl-3">{{ result.headline|clean }}</div>
                     </div>
                 {% endfor %}
             {% else %}

--- a/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
+++ b/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
@@ -138,7 +138,7 @@
             {% if search_results %}
                 {% for result in search_results %}
                     <div class="card rounded border-light my-1">
-                        <a href="{% url 'documentation:detail' slug=result.slug %}"><h5 class="pl-3 pt-3">{{ result.title }}</h5></a>
+                        <a href="{% url 'documentation:detail' slug=result.slug %}"><h5 class="p-3 m-0">{{ result.title }}</h5></a>
                     </div>
                 {% endfor %}
             {% else %}

--- a/app/grandchallenge/documentation/views.py
+++ b/app/grandchallenge/documentation/views.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.postgres.search import (
-    SearchHeadline,
     SearchQuery,
     SearchRank,
     SearchVector,
@@ -44,10 +43,8 @@ class DocPageDetail(DetailView):
         if keywords:
             query = SearchQuery(keywords)
             vector = SearchVector("title", "content")
-            headline = SearchHeadline("content", query)
             qs = (
-                qs.annotate(headline=headline)
-                .annotate(rank=SearchRank(vector, query))
+                qs.annotate(rank=SearchRank(vector, query))
                 .annotate(
                     similarity=TrigramSimilarity("title", keywords)
                     + TrigramSimilarity("content", keywords)


### PR DESCRIPTION
closes #3575 

Example search results:

![Screenshot 2024-12-16 at 15 19 36](https://github.com/user-attachments/assets/3835d9a9-89d1-413d-bbd8-09c2541d69b9)
