### PR TITLE
Use fullpage markdown widget for documentation pages

### DIFF
--- a/app/grandchallenge/documentation/forms.py
+++ b/app/grandchallenge/documentation/forms.py
@@ -2,7 +2,8 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
 from django import forms
 
-from grandchallenge.core.widgets import MarkdownEditorInlineWidget
+from grandchallenge.core.forms import SaveFormInitMixin
+from grandchallenge.core.widgets import MarkdownEditorFullPageWidget
 from grandchallenge.documentation.models import DocPage
 
 
@@ -14,13 +15,21 @@ class DocPageCreateForm(forms.ModelForm):
 
     class Meta:
         model = DocPage
-        fields = ("title", "content", "parent")
-        widgets = {"content": MarkdownEditorInlineWidget}
+        fields = ("title", "parent")
 
 
-class DocPageUpdateForm(DocPageCreateForm):
-    """Like the create form but you can also move the page."""
+class DocPageMetadataUpdateForm(DocPageCreateForm):
+    """Like the create form, but you can also move the page."""
 
     position = forms.IntegerField()
     position.label = "Move to index position"
     position.required = False
+
+
+class DocPageContentUpdateForm(SaveFormInitMixin, forms.ModelForm):
+    class Meta:
+        model = DocPage
+        fields = ("content",)
+        widgets = {
+            "content": MarkdownEditorFullPageWidget,
+        }

--- a/app/grandchallenge/documentation/templates/documentation/docpage_content_update.html
+++ b/app/grandchallenge/documentation/templates/documentation/docpage_content_update.html
@@ -1,0 +1,11 @@
+{% extends "documentation/docpage_form.html" %}
+{% load crispy from crispy_forms_tags %}
+
+{% block container %}container-fluid{% endblock %}
+
+{% block outer_content %}
+
+    <h2>Update Page</h2>
+
+    {% crispy form %}
+{% endblock %}

--- a/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
+++ b/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
@@ -122,9 +122,14 @@
         <div class="row mt-3">
             <div class="col-12 col-sm-6 col-md-7 d-inline-block text-left">
                 {% if 'documentation.change_docpage' in perms %}
-                    <a class="btn btn-md btn-outline-dark d-inline-flex" href="{% url 'documentation:list' %}">Page overview</a>
-                    <a class="btn btn-md btn-outline-dark d-inline-flex" href="{% url 'documentation:create' %}">Add</a>
-                    <a class="btn btn-md btn-outline-dark" href="{% url 'documentation:update' slug=currentdocpage.slug %}">Edit</a>
+                    <a class="btn btn-md btn-outline-dark" href="{% url 'documentation:list' %}">Page overview</a>
+                    <a class="btn btn-md btn-outline-dark" href="{% url 'documentation:create' %}">Add</a>
+                    <a class="btn btn-md btn-outline-dark" href="{% url 'documentation:content-update' slug=currentdocpage.slug %}" title="Edit page">
+                        <i class="fas fa-edit"></i>
+                    </a>
+                    <a class="btn btn-md btn-outline-dark" href="{% url 'documentation:metadata-update' slug=currentdocpage.slug %}" title="Edit metadata">
+                        <i class="fas fa-tools"></i>
+                    </a>
                 {% endif %}
             </div>
             <div class="col-12 col-sm-6 col-md-5 justify-content-start justify-content-sm-end form-inline">

--- a/app/grandchallenge/documentation/templates/documentation/docpage_list.html
+++ b/app/grandchallenge/documentation/templates/documentation/docpage_list.html
@@ -50,7 +50,8 @@
                     </td>
                     {% if 'documentation.change_docpage' in perms %}
                         <td>
-                            <a href="{% url 'documentation:update' slug=page.slug %}"><i class="fa fa-cog text-primary" aria-hidden="true"></i></a>
+                            <a class="text-primary" title="Edit Page" href="{% url 'documentation:content-update' slug=page.slug %}"><i class="fa fa-edit"></i></a>
+                            <a class="text-primary" title="Edit Metadata" href="{% url 'documentation:metadata-update' slug=page.slug %}"><i class="fa fa-tools"></i></a>
                         </td>
                     {% endif %}
                 </tr>

--- a/app/grandchallenge/documentation/urls.py
+++ b/app/grandchallenge/documentation/urls.py
@@ -1,19 +1,30 @@
 from django.urls import path
 
 from grandchallenge.documentation.views import (
+    DocPageContentUpdate,
     DocPageCreate,
     DocPageDetail,
     DocPageList,
-    DocPageUpdate,
+    DocPageMetadataUpdate,
     DocumentationHome,
 )
 
 app_name = "documentation"
+
 
 urlpatterns = [
     path("", DocumentationHome.as_view(), name="home"),
     path("overview/", DocPageList.as_view(), name="list"),
     path("create/", DocPageCreate.as_view(), name="create"),
     path("<slug:slug>/", DocPageDetail.as_view(), name="detail"),
-    path("<slug:slug>/update/", DocPageUpdate.as_view(), name="update"),
+    path(
+        "<slug:slug>/content-update/",
+        DocPageContentUpdate.as_view(),
+        name="content-update",
+    ),
+    path(
+        "<slug:slug>/metadata-update/",
+        DocPageMetadataUpdate.as_view(),
+        name="metadata-update",
+    ),
 ]

--- a/app/grandchallenge/documentation/views.py
+++ b/app/grandchallenge/documentation/views.py
@@ -11,11 +11,12 @@ from django.views.generic import CreateView, DetailView, ListView, UpdateView
 from guardian.mixins import LoginRequiredMixin
 
 from grandchallenge.documentation.forms import (
+    DocPageContentUpdateForm,
     DocPageCreateForm,
-    DocPageUpdateForm,
+    DocPageMetadataUpdateForm,
 )
 from grandchallenge.documentation.models import DocPage
-from grandchallenge.subdomains.utils import reverse_lazy
+from grandchallenge.subdomains.utils import reverse, reverse_lazy
 
 
 class DocPageList(ListView):
@@ -72,9 +73,11 @@ class DocumentationHome(DocPageDetail):
         return get_object_or_404(DocPage, order=1)
 
 
-class DocPageUpdate(LoginRequiredMixin, PermissionRequiredMixin, UpdateView):
+class DocPageMetadataUpdate(
+    LoginRequiredMixin, PermissionRequiredMixin, UpdateView
+):
     model = DocPage
-    form_class = DocPageUpdateForm
+    form_class = DocPageMetadataUpdateForm
     permission_required = "documentation.change_docpage"
     raise_exception = True
     login_url = reverse_lazy("account_login")
@@ -85,9 +88,29 @@ class DocPageUpdate(LoginRequiredMixin, PermissionRequiredMixin, UpdateView):
         return response
 
 
+class DocPageContentUpdate(
+    LoginRequiredMixin, PermissionRequiredMixin, UpdateView
+):
+    model = DocPage
+    form_class = DocPageContentUpdateForm
+    template_name_suffix = "_content_update"
+    permission_required = "documentation.change_docpage"
+    raise_exception = True
+    login_url = reverse_lazy("account_login")
+
+
 class DocPageCreate(LoginRequiredMixin, PermissionRequiredMixin, CreateView):
     model = DocPage
     form_class = DocPageCreateForm
     permission_required = "documentation.add_docpage"
     raise_exception = True
     login_url = reverse_lazy("account_login")
+
+    def get_success_url(self):
+        """On successful creation, go to content update."""
+        return reverse(
+            "documentation:content-update",
+            kwargs={
+                "slug": self.object.slug,
+            },
+        )


### PR DESCRIPTION
Use the fullpage markdown editor for documentation pages. This splits up content and metadata editing. 

Related to https://github.com/comic/grand-challenge.org/issues/3682