### PR TITLE
Apply ordering of CIVs to API serializations

### DIFF
--- a/app/grandchallenge/components/serializers.py
+++ b/app/grandchallenge/components/serializers.py
@@ -14,6 +14,7 @@ from grandchallenge.components.models import (
     ComponentInterface,
     ComponentInterfaceValue,
 )
+from grandchallenge.components.templatetags.civ import sort_civs
 from grandchallenge.core.guardian import filter_by_permission
 from grandchallenge.uploads.models import UserUpload
 from grandchallenge.workstation_configs.serializers import (
@@ -162,6 +163,12 @@ class ComponentInterfaceValuePostSerializer(serializers.ModelSerializer):
         return attrs
 
 
+class SortedCIVSerializer(serializers.ListSerializer):
+    def to_representation(self, data):
+        sorted_data = sort_civs(data.all())
+        return super().to_representation(sorted_data)
+
+
 class ComponentInterfaceValueSerializer(serializers.ModelSerializer):
     # Serializes images in place rather than with hyperlinks for internal usage
     image = SimpleImageSerializer(required=False)
@@ -170,6 +177,7 @@ class ComponentInterfaceValueSerializer(serializers.ModelSerializer):
     class Meta:
         model = ComponentInterfaceValue
         fields = ["interface", "value", "file", "image", "pk"]
+        list_serializer_class = SortedCIVSerializer
 
 
 class HyperlinkedComponentInterfaceValueSerializer(

--- a/app/grandchallenge/components/serializers.py
+++ b/app/grandchallenge/components/serializers.py
@@ -165,7 +165,12 @@ class ComponentInterfaceValuePostSerializer(serializers.ModelSerializer):
 
 class SortedCIVSerializer(serializers.ListSerializer):
     def to_representation(self, data):
-        sorted_data = sort_civs(data.all())
+        iterable = (
+            data.all()
+            if isinstance(data, serializers.models.manager.BaseManager)
+            else data
+        )
+        sorted_data = sort_civs(iterable)
         return super().to_representation(sorted_data)
 
 

--- a/app/grandchallenge/components/templatetags/civ.py
+++ b/app/grandchallenge/components/templatetags/civ.py
@@ -25,12 +25,12 @@ def sort_civs(civs: Iterable[ComponentInterfaceValue]):
                 charts.append(v)
             else:
                 values.append(v)
-        elif v.file:
+        elif v.interface.is_file_kind:
             if v.interface.is_thumbnail_kind:
                 thumbnails.append(v)
             else:
                 files.append(v)
-        elif v.image:
+        elif v.interface.is_image_kind:
             images.append(v)
         else:
             residual.append(v)


### PR DESCRIPTION
Ensures the ordering of CIVs on the rendered views is now also applied to the API representations. This way, the order is the same when viewing them within a view and CIRRUS.