### PR TITLE
Fix incorrectly defined table data when there are no evaluations

### DIFF
--- a/app/grandchallenge/evaluation/templates/evaluation/partials/evaluations_for_object_table.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/partials/evaluations_for_object_table.html
@@ -4,10 +4,10 @@
         <tr>
             <th>Created</th>
             <th>Updated</th>
-            <th>Evaluation</th>
-            <th>Submission</th>
+            <th class="nonSortable">Evaluation</th>
+            <th class="nonSortable">Submission</th>
             <th>Status</th>
-            <th>Result</th>
+            <th class="nonSortable">Result</th>
         </tr>
         </thead>
         <tbody>
@@ -29,8 +29,6 @@
                     {% endif %}
                 </td>
             </tr>
-        {% empty %}
-            <tr><td colspan="100%" class="text-center">No evaluations</td></tr>
         {% endfor %}
         </tbody>
     </table>


### PR DESCRIPTION
Closes #3770 

The `<td>` were missconstrued when the table had no data. The previous version of Datatables might have been reslient to this. The default is adequate:

![image](https://github.com/user-attachments/assets/75217159-20fe-411d-b232-edec471788dc)


Also applied some non-sortable classification to the relevant columns.