### PR TITLE
Fix container builds

### DIFF
--- a/dockerfiles/web-base/Dockerfile
+++ b/dockerfiles/web-base/Dockerfile
@@ -28,9 +28,8 @@ RUN apt-get update \
         libopenslide-dev \
         libvips-dev \
         gcc \
-        # ruby3.1 and rugged for licensee
-        ruby3.1 \
-        ruby3.1-dev \
+        # ruby3.4 and rugged for licensee
+        ruby3.4 \
         ruby-rugged \
         # git for CodeBuild integration
         git \

--- a/dockerfiles/web-base/Dockerfile
+++ b/dockerfiles/web-base/Dockerfile
@@ -28,9 +28,10 @@ RUN apt-get update \
         libopenslide-dev \
         libvips-dev \
         gcc \
-        # ruby3.4 and rugged for licensee
-        ruby3.4 \
+        # ruby3.1, rugged and nokogiri for licensee
+        ruby3.1 \
         ruby-rugged \
+        ruby-nokogiri \
         # git for CodeBuild integration
         git \
         # for dbshell \

--- a/dockerfiles/web-base/Dockerfile
+++ b/dockerfiles/web-base/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
         gcc \
         # ruby3.1 and rugged for licensee
         ruby3.1 \
+        ruby3.1-dev \
         ruby-rugged \
         # git for CodeBuild integration
         git \


### PR DESCRIPTION
`nokogiri` now requires building native extensions on the ruby that is bundled with debian stable.