### PR TITLE
Tweak image upload help text

### DIFF
--- a/app/grandchallenge/cases/forms.py
+++ b/app/grandchallenge/cases/forms.py
@@ -8,20 +8,26 @@ from grandchallenge.core.guardian import get_objects_for_user
 from grandchallenge.uploads.models import UserUpload
 from grandchallenge.uploads.widgets import UserUploadMultipleWidget
 
-IMAGE_UPLOAD_HELP_TEXT = (
-    "The total size of all files uploaded in a single session "
-    "cannot exceed 10 GB. "
-    "A maximum of 100 files can be uploaded per session. "
-    "Please only upload one volume per session. "
-    "If your volume consists of more than this then please compress the "
-    "directory and upload a single .zip file.<br>"
-    "The following file formats are supported and will be converted to MHA: "
-    ".mha, .mhd, .raw, .zraw, .dcm, .nii, .nii.gz, .nrrd, "
-    ".fda, .fds, .tiff, .png, .jpeg and .jpg.<br>"
-    "The following file formats can be uploaded and will be converted to "
-    "TIFF: Aperio (.svs), Hamamatsu (.vms, .vmu, .ndpi), Leica (.scn), "
-    "MIRAX (.mrxs), Ventana (.bif) and DICOM-WSI (.dcm)."
-)
+IMAGE_UPLOAD_HELP_TEXT = """
+<p>
+    The total size of all files uploaded in a single session cannot exceed 10 GB.
+    A maximum of 100 files can be uploaded per session.
+</p>
+<p>
+    Please only upload one volume per session. If your volume is made up of multiple
+    individual slices (e.g. DICOM files), please compress the entire directory into
+    a single .zip file and upload that file.
+</p>
+<p>
+   The following file formats are supported and will be converted to MHA format:
+    .mha, .mhd, .raw, .zraw, .dcm, .nii, .nii.gz, .nrrd, .fda, .fds, .png, .jpeg, and .jpg.
+</p>
+<p>
+    The following file formats can be uploaded and will be converted to TIF format:
+    .tiff, Aperio (.svs), Hamamatsu (.vms, .vmu, .ndpi), Leica (.scn), MIRAX (.mrxs),
+    Ventana (.bif), and DICOM-WSI (.dcm)."
+</p>
+"""
 
 
 class UploadRawImagesForm(SaveFormInitMixin, forms.ModelForm):

--- a/app/grandchallenge/cases/forms.py
+++ b/app/grandchallenge/cases/forms.py
@@ -9,24 +9,18 @@ from grandchallenge.uploads.models import UserUpload
 from grandchallenge.uploads.widgets import UserUploadMultipleWidget
 
 IMAGE_UPLOAD_HELP_TEXT = """
-<p>
-    The total size of all files uploaded in a single session cannot exceed 10 GB.
-    A maximum of 100 files can be uploaded per session.
-</p>
-<p>
-    Please only upload one volume per session. If your volume is made up of multiple
-    individual slices (e.g. DICOM files), please compress the entire directory into
-    a single .zip file and upload that file.
-</p>
-<p>
-   The following file formats are supported and will be converted to MHA format:
-    .mha, .mhd, .raw, .zraw, .dcm, .nii, .nii.gz, .nrrd, .fda, .fds, .png, .jpeg, and .jpg.
-</p>
-<p>
-    The following file formats can be uploaded and will be converted to TIF format:
-    .tiff, Aperio (.svs), Hamamatsu (.vms, .vmu, .ndpi), Leica (.scn), MIRAX (.mrxs),
-    Ventana (.bif), and DICOM-WSI (.dcm)."
-</p>
+The total size of all files uploaded in a single session cannot exceed 10 GB.
+A maximum of 100 files can be uploaded per session. Please only upload one volume per session.
+<br>
+If your volume is made up of multiple individual slices (e.g. DICOM files), please
+compress the entire directory into a single .zip file and upload that file.
+<br>
+The following file formats are supported and will be converted to MHA format:
+.mha, .mhd, .raw, .zraw, .dcm, .nii, .nii.gz, .nrrd, .fda, .fds, .png, .jpeg, and .jpg.
+<br>
+The following file formats can be uploaded and will be converted to TIF format:
+.tiff, Aperio (.svs), Hamamatsu (.vms, .vmu, .ndpi), Leica (.scn), MIRAX (.mrxs),
+Ventana (.bif), and DICOM-WSI (.dcm).
 """
 
 


### PR DESCRIPTION
A user mentioned some confusion by clinicians trying to upload dicoms. Imho the user had a valid point. The help text also had the suggestion that .tiff was converted to MHA. That is incorrect. I opted to sacrifice some horizontal space for clarity.

## Before

![image](https://github.com/user-attachments/assets/8dfde665-f2da-493f-8bd4-ff39b6fde567)

## After

![image](https://github.com/user-attachments/assets/3c2ef64a-d1ff-44a5-bf84-5db5ca8057e2)

Note: text is used in a widget, no need for a migration.