### PR TITLE
Reduce lock durations

### DIFF
--- a/app/grandchallenge/challenges/emails.py
+++ b/app/grandchallenge/challenges/emails.py
@@ -100,10 +100,24 @@ def send_email_percent_budget_consumed_alert(challenge, percent_threshold):
         challenge_name=challenge.short_name,
         percent_threshold=percent_threshold,
     )
-    message = format_html(
+    challenge_admins_message = format_html(
         "We would like to inform you that more than {percent_threshold}% of the "
+        "compute budget for the {challenge_name} challenge has been used.",
+        challenge_name=challenge.short_name,
+        percent_threshold=percent_threshold,
+    )
+    send_standard_email_batch(
+        site=Site.objects.get_current(),
+        subject=subject,
+        markdown_message=challenge_admins_message,
+        recipients=[*challenge.get_admins()],
+        subscription_type=EmailSubscriptionTypes.SYSTEM,
+    )
+
+    managers_message = format_html(
+        "More than {percent_threshold}% of the "
         "compute budget for the {challenge_name} challenge has been used. "
-        "You can find an overview of the costs [here]({statistics_url}).",
+        "See {statistics_url}.",
         challenge_name=challenge.short_name,
         percent_threshold=percent_threshold,
         statistics_url=reverse(
@@ -111,14 +125,7 @@ def send_email_percent_budget_consumed_alert(challenge, percent_threshold):
             kwargs={"challenge_short_name": challenge.short_name},
         ),
     )
-    send_standard_email_batch(
-        site=Site.objects.get_current(),
-        subject=subject,
-        markdown_message=message,
-        recipients=[*challenge.get_admins()],
-        subscription_type=EmailSubscriptionTypes.SYSTEM,
-    )
     mail_managers(
         subject=subject,
-        message=message,
+        message=managers_message,
     )

--- a/app/grandchallenge/challenges/tasks.py
+++ b/app/grandchallenge/challenges/tasks.py
@@ -61,9 +61,20 @@ def update_compute_costs_and_storage_size():
     for challenge in Challenge.objects.with_available_compute().iterator():
         with transaction.atomic():
             annotate_compute_costs_and_storage_size(challenge=challenge)
-            challenge.save()
+            challenge.save(
+                update_fields=(
+                    "size_in_storage",
+                    "size_in_registry",
+                    "compute_cost_euro_millicents",
+                )
+            )
 
     for phase in Phase.objects.iterator():
         with transaction.atomic():
             annotate_job_duration_and_compute_costs(phase=phase)
-            phase.save()
+            phase.save(
+                update_fields=(
+                    "average_algorithm_job_duration",
+                    "compute_cost_euro_millicents",
+                )
+            )

--- a/app/grandchallenge/challenges/tasks.py
+++ b/app/grandchallenge/challenges/tasks.py
@@ -6,9 +6,6 @@ from grandchallenge.challenges.costs import (
     annotate_compute_costs_and_storage_size,
     annotate_job_duration_and_compute_costs,
 )
-from grandchallenge.challenges.emails import (
-    send_email_percent_budget_consumed_alert,
-)
 from grandchallenge.challenges.models import Challenge
 from grandchallenge.core.celery import acks_late_2xlarge_task
 from grandchallenge.evaluation.models import Evaluation, Phase
@@ -59,56 +56,14 @@ def update_challenge_results_cache():
     )
 
 
-def send_alert_if_budget_consumed_warning_threshold_exceeded(challenge):
-    if challenge.has_changed("compute_cost_euro_millicents"):
-        for percent_threshold in sorted(
-            challenge.percent_budget_consumed_warning_thresholds, reverse=True
-        ):
-            previous_cost = challenge.initial_value(
-                "compute_cost_euro_millicents"
-            )
-            threshold = (
-                challenge.approved_compute_costs_euro_millicents
-                * percent_threshold
-                / 100
-            )
-            current_cost = challenge.compute_cost_euro_millicents
-            if previous_cost <= threshold < current_cost:
-                send_email_percent_budget_consumed_alert(
-                    challenge, percent_threshold
-                )
-                break
-
-
 @acks_late_2xlarge_task
-@transaction.atomic
 def update_compute_costs_and_storage_size():
-    challenges = Challenge.objects.all().with_available_compute()
+    for challenge in Challenge.objects.with_available_compute().iterator():
+        with transaction.atomic():
+            annotate_compute_costs_and_storage_size(challenge=challenge)
+            challenge.save()
 
-    for challenge in challenges:
-        annotate_compute_costs_and_storage_size(challenge=challenge)
-        send_alert_if_budget_consumed_warning_threshold_exceeded(
-            challenge=challenge
-        )
-
-    Challenge.objects.bulk_update(
-        challenges,
-        [
-            "size_in_storage",
-            "size_in_registry",
-            "compute_cost_euro_millicents",
-        ],
-    )
-
-    phases = Phase.objects.all()
-
-    for phase in phases:
-        annotate_job_duration_and_compute_costs(phase=phase)
-
-    Phase.objects.bulk_update(
-        phases,
-        [
-            "average_algorithm_job_duration",
-            "compute_cost_euro_millicents",
-        ],
-    )
+    for phase in Phase.objects.iterator():
+        with transaction.atomic():
+            annotate_job_duration_and_compute_costs(phase=phase)
+            phase.save()

--- a/app/tests/challenges_tests/test_tasks.py
+++ b/app/tests/challenges_tests/test_tasks.py
@@ -167,19 +167,23 @@ def test_challenge_budget_alert_email(settings):
 
     # Budget alert threshold exceeded
     assert len(mail.outbox) == 3
-    recipients = [r for m in mail.outbox for r in m.to]
-    assert recipients == [
+    recipients = {r for m in mail.outbox for r in m.to}
+    assert recipients == {
         challenge.creator.email,
         challenge_admin.email,
         staff_user.email,
+    }
+
+    challenge_admin_email = [
+        m for m in mail.outbox if challenge_admin.email in m.to
     ]
     assert (
-        mail.outbox[0].subject
+        challenge_admin_email[0].subject
         == "[testserver] [test] over 70% Budget Consumed Alert"
     )
     assert (
         "We would like to inform you that more than 70% of the compute budget for "
-        "the test challenge has been used." in mail.outbox[0].body
+        "the test challenge has been used." in challenge_admin_email[0].body
     )
 
     mail.outbox.clear()

--- a/app/tests/challenges_tests/test_tasks.py
+++ b/app/tests/challenges_tests/test_tasks.py
@@ -179,8 +179,7 @@ def test_challenge_budget_alert_email(settings):
     )
     assert (
         "We would like to inform you that more than 70% of the compute budget for "
-        "the test challenge has been used. You can find an overview of the costs "
-        "[here](https://test.testserver/statistics/)." in mail.outbox[0].body
+        "the test challenge has been used." in mail.outbox[0].body
     )
 
     mail.outbox.clear()

--- a/app/tests/evaluation_tests/test_models.py
+++ b/app/tests/evaluation_tests/test_models.py
@@ -463,7 +463,11 @@ def test_open_for_submission(
     open_for_submissions,
     expected_status,
 ):
-    phase = PhaseFactory()
+    PhaseFactory()
+
+    # Annotate the compute costs
+    phase = Phase.objects.get()
+
     phase.submissions_limit_per_user_per_period = (
         submissions_limit_per_user_per_period
     )


### PR DESCRIPTION
Moves updating each challenge to its own atomic block to avoid long lock contentions. Also changes the editors email as the fields are only visible to staff.

See https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/418