### PR TITLE
Add option to skip calculating ranks

### DIFF
--- a/app/grandchallenge/challenges/tasks.py
+++ b/app/grandchallenge/challenges/tasks.py
@@ -108,10 +108,11 @@ def update_compute_costs_and_storage_size():
             @retry_with_backoff((LockNotAvailable,))
             def save_phase():
                 phase.save(
+                    skip_calculate_ranks=True,
                     update_fields=(
                         "average_algorithm_job_duration",
                         "compute_cost_euro_millicents",
-                    )
+                    ),
                 )
 
             save_phase()

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -658,7 +658,7 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
     def __str__(self):
         return f"{self.title} Evaluation for {self.challenge.short_name}"
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, skip_calculate_ranks=False, **kwargs):
         adding = self._state.adding
 
         super().save(*args, **kwargs)
@@ -694,9 +694,12 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
         ):
             self.send_give_algorithm_editors_job_view_permissions_changed_email()
 
-        on_commit(
-            lambda: calculate_ranks.apply_async(kwargs={"phase_pk": self.pk})
-        )
+        if not skip_calculate_ranks:
+            on_commit(
+                lambda: calculate_ranks.apply_async(
+                    kwargs={"phase_pk": self.pk}
+                )
+            )
 
     def clean(self):
         super().clean()


### PR DESCRIPTION
Prevents many celery tasks being unnecessarily created