### PR TITLE
Move input/output annotation from manager to separate method

### DIFF
--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -69,6 +69,23 @@ logger = logging.getLogger(__name__)
 JINJA_ENGINE = sandbox.ImmutableSandboxedEnvironment()
 
 
+def annotate_input_output_counts(queryset, inputs=None, outputs=None):
+    return queryset.annotate(
+        input_count=Count("inputs", distinct=True),
+        output_count=Count("outputs", distinct=True),
+        relevant_input_count=Count(
+            "inputs",
+            filter=Q(inputs__in=inputs) if inputs is not None else Q(),
+            distinct=True,
+        ),
+        relevant_output_count=Count(
+            "outputs",
+            filter=Q(outputs__in=outputs) if outputs is not None else Q(),
+            distinct=True,
+        ),
+    )
+
+
 class AlgorithmInterfaceManager(models.Manager):
 
     def create(
@@ -95,22 +112,6 @@ class AlgorithmInterfaceManager(models.Manager):
 
     def delete(self):
         raise NotImplementedError("Bulk delete is not allowed.")
-
-    def with_input_output_counts(self, inputs=None, outputs=None):
-        return self.annotate(
-            input_count=Count("inputs", distinct=True),
-            output_count=Count("outputs", distinct=True),
-            relevant_input_count=Count(
-                "inputs",
-                filter=Q(inputs__in=inputs) if inputs is not None else Q(),
-                distinct=True,
-            ),
-            relevant_output_count=Count(
-                "outputs",
-                filter=Q(outputs__in=outputs) if outputs is not None else Q(),
-                distinct=True,
-            ),
-        )
 
 
 class AlgorithmInterface(UUIDModel):
@@ -144,10 +145,11 @@ class AlgorithmInterfaceOutput(models.Model):
 def get_existing_interface_for_inputs_and_outputs(
     *, inputs, outputs, model=AlgorithmInterface
 ):
+    annotated_qs = annotate_input_output_counts(
+        model.objects.all(), inputs=inputs, outputs=outputs
+    )
     try:
-        return model.objects.with_input_output_counts(
-            inputs=inputs, outputs=outputs
-        ).get(
+        return annotated_qs.get(
             relevant_input_count=len(inputs),
             relevant_output_count=len(outputs),
             input_count=len(inputs),
@@ -998,18 +1000,12 @@ class JobManager(ComponentJobManager):
         # the existing civs and filter on both counts so as to not include jobs
         # with partially overlapping inputs
         # or jobs with more inputs than the existing civs
-        existing_jobs = (
-            Job.objects.filter(**unique_kwargs)
-            .annotate(
-                input_count=Count("inputs", distinct=True),
-                input_match_count=Count(
-                    "inputs", filter=Q(inputs__in=existing_civs), distinct=True
-                ),
-            )
-            .filter(
-                input_count=input_interface_count,
-                input_match_count=input_interface_count,
-            )
+        annotated_qs = annotate_input_output_counts(
+            queryset=Job.objects.filter(**unique_kwargs), inputs=existing_civs
+        )
+        existing_jobs = annotated_qs.filter(
+            input_count=input_interface_count,
+            input_match_count=input_interface_count,
         )
 
         return existing_jobs

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -1005,7 +1005,7 @@ class JobManager(ComponentJobManager):
         )
         existing_jobs = annotated_qs.filter(
             input_count=input_interface_count,
-            input_match_count=input_interface_count,
+            relevant_input_count=input_interface_count,
         )
 
         return existing_jobs

--- a/app/grandchallenge/algorithms/serializers.py
+++ b/app/grandchallenge/algorithms/serializers.py
@@ -19,6 +19,7 @@ from grandchallenge.algorithms.models import (
     AlgorithmInterface,
     AlgorithmModel,
     Job,
+    annotate_input_output_counts,
 )
 from grandchallenge.components.backends.exceptions import (
     CIVNotEditableException,
@@ -288,10 +289,11 @@ class JobPostSerializer(JobSerializer):
         the algorithm and returns that AlgorithmInterface
         """
         provided_inputs = {i["interface"] for i in inputs}
+        annotated_qs = annotate_input_output_counts(
+            self._algorithm.interfaces, inputs=provided_inputs
+        )
         try:
-            interface = self._algorithm.interfaces.with_input_output_counts(
-                inputs=provided_inputs
-            ).get(
+            interface = annotated_qs.get(
                 relevant_input_count=len(provided_inputs),
                 input_count=len(provided_inputs),
             )


### PR DESCRIPTION
I added an input/output count annotation to the `AlgorithmInterfaceManager` in my last PR, but had not tested the migrations again. In my migration check for the phase interfaces, I realized that the migrations break with that addition since they don't have access to custom manager methods. So I'm moving the annotation to a separate function here. The upside of this is that I can now use it in 2 other places where we're making the same annotation. So I'm calling this a win. 

Note that this does not add or change functionality, it just moves the code. So I didn't spend time on adding a test for the new function - it is indirectly covered by tests of all the places where it is used. 