### PR TITLE
Use title instead of slug for label interface widgets

### DIFF
--- a/app/grandchallenge/components/form_fields.py
+++ b/app/grandchallenge/components/form_fields.py
@@ -71,7 +71,7 @@ class InterfaceFormField:
             "required": required,
             "disabled": disabled,
             "initial": self.get_initial_value(),
-            "label": instance.slug.title(),
+            "label": instance.title.title(),
         }
 
         if instance.is_image_kind:


### PR DESCRIPTION
There is a minor typo in a slug. Imho it should be the title anyhow here so this saves us some minor time on redoing the interface:

![Screenshot 2025-01-30 at 12 16 44](https://github.com/user-attachments/assets/f489a348-aa4b-4ea5-83b1-0de9c455ad0f)
