### PR TITLE
Add html user completion for challenge admin users

### DIFF
--- a/app/grandchallenge/admins/forms.py
+++ b/app/grandchallenge/admins/forms.py
@@ -27,6 +27,7 @@ class AdminsForm(forms.Form):
                 "data-placeholder": "Search for a user ...",
                 "data-minimum-input-length": 3,
                 "data-theme": settings.CRISPY_TEMPLATE_PACK,
+                "data-html": True,
             },
         ),
     )

--- a/app/grandchallenge/admins/forms.py
+++ b/app/grandchallenge/admins/forms.py
@@ -3,4 +3,4 @@ from grandchallenge.groups.forms import UserGroupForm
 
 class AdminsForm(UserGroupForm):
     role = "admin"
-    url = "admins:users-autocomplete"
+    user_complete_url = "admins:users-autocomplete"

--- a/app/grandchallenge/admins/forms.py
+++ b/app/grandchallenge/admins/forms.py
@@ -1,50 +1,6 @@
-from dal import autocomplete
-from django import forms
-from django.conf import settings
-from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
-from guardian.utils import get_anonymous_user
-
-from grandchallenge.challenges.models import Challenge
+from grandchallenge.groups.forms import UserGroupForm
 
 
-class AdminsForm(forms.Form):
-    ADD = "ADD"
-    REMOVE = "REMOVE"
-    CHOICES = ((ADD, "Add admin"), (REMOVE, "Remove admin"))
-    user = forms.ModelChoiceField(
-        queryset=get_user_model().objects.all().order_by("username"),
-        help_text=(
-            "Select a user that will be added to the admins group for "
-            "this challenge. This user will have the ability to completely "
-            "manage this challenge, including updating the site, deleting "
-            "pages, etc."
-        ),
-        required=True,
-        widget=autocomplete.ModelSelect2(
-            url="/admins/update-autocomplete",
-            attrs={
-                "data-placeholder": "Search for a user ...",
-                "data-minimum-input-length": 3,
-                "data-theme": settings.CRISPY_TEMPLATE_PACK,
-                "data-html": True,
-            },
-        ),
-    )
-
-    action = forms.ChoiceField(
-        choices=CHOICES, required=True, widget=forms.HiddenInput(), initial=ADD
-    )
-
-    def clean_user(self):
-        user = self.cleaned_data["user"]
-        if user == get_anonymous_user():
-            raise ValidationError("You cannot add this user as an admin!")
-
-        return user
-
-    def add_or_remove_user(self, *, challenge: Challenge, site):
-        if self.cleaned_data["action"] == AdminsForm.ADD:
-            challenge.add_admin(self.cleaned_data["user"])
-        elif self.cleaned_data["action"] == AdminsForm.REMOVE:
-            challenge.remove_admin(self.cleaned_data["user"])
+class AdminsForm(UserGroupForm):
+    role = "admin"
+    url = "admins:users-autocomplete"

--- a/app/grandchallenge/admins/templates/admins/admins_form.html
+++ b/app/grandchallenge/admins/templates/admins/admins_form.html
@@ -21,14 +21,13 @@
 {% endblock %}
 
 {% block content %}
-
     <h2>Add another admin to {{ challenge.short_name }}</h2>
 
-    <form action="" method="post">
-        {% csrf_token %}
-        {{ form | crispy }}
-        <input type="submit" value="Save" class="btn btn-primary"/>
-    </form>
+    <p>
+        This user will have the ability to completely manage this challenge, including updating the site, deleting pages and other actions.
+    </p>
+
+    {% crispy form %}
 {% endblock %}
 
 {% block script %}

--- a/app/grandchallenge/admins/urls.py
+++ b/app/grandchallenge/admins/urls.py
@@ -1,10 +1,7 @@
 from django.urls import path
 
-from grandchallenge.admins.views import (
-    AdminsList,
-    AdminsUpdate,
-    AdminsUpdateAutocomplete,
-)
+from grandchallenge.admins.views import AdminsList, AdminsUpdate
+from grandchallenge.groups.views import UserAutocomplete
 
 app_name = "admins"
 
@@ -12,8 +9,8 @@ urlpatterns = [
     path("", AdminsList.as_view(), name="list"),
     path("update/", AdminsUpdate.as_view(), name="update"),
     path(
-        "update-autocomplete/",
-        AdminsUpdateAutocomplete.as_view(),
-        name="update-autocomplete",
+        "users-autocomplete/",
+        UserAutocomplete.as_view(),
+        name="users-autocomplete",
     ),
 ]

--- a/app/grandchallenge/admins/views.py
+++ b/app/grandchallenge/admins/views.py
@@ -4,7 +4,6 @@ from guardian.mixins import LoginRequiredMixin
 
 from grandchallenge.admins.forms import AdminsForm
 from grandchallenge.core.guardian import ObjectPermissionRequiredMixin
-from grandchallenge.groups.views import UserAutocomplete
 from grandchallenge.subdomains.utils import reverse, reverse_lazy
 
 
@@ -31,18 +30,6 @@ class AdminsList(LoginRequiredMixin, ObjectPermissionRequiredMixin, ListView):
         return challenge.get_admins().select_related(
             "user_profile", "verification"
         )
-
-
-class AdminsUpdateAutocomplete(
-    ObjectPermissionRequiredMixin,
-    UserAutocomplete,
-):
-    permission_required = "change_challenge"
-    raise_exception = True
-    login_url = reverse_lazy("account_login")
-
-    def get_permission_object(self):
-        return self.request.challenge
 
 
 class AdminsUpdate(

--- a/app/grandchallenge/admins/views.py
+++ b/app/grandchallenge/admins/views.py
@@ -56,5 +56,5 @@ class AdminsUpdate(
 
     def form_valid(self, form):
         challenge = self.request.challenge
-        form.add_or_remove_user(challenge=challenge, site=self.request.site)
+        form.add_or_remove_user(obj=challenge)
         return super().form_valid(form)

--- a/app/grandchallenge/admins/views.py
+++ b/app/grandchallenge/admins/views.py
@@ -1,11 +1,10 @@
-from dal import autocomplete
-from django.contrib.auth import get_user_model
 from django.contrib.messages.views import SuccessMessageMixin
 from django.views.generic import FormView, ListView
 from guardian.mixins import LoginRequiredMixin
 
 from grandchallenge.admins.forms import AdminsForm
 from grandchallenge.core.guardian import ObjectPermissionRequiredMixin
+from grandchallenge.groups.views import UserAutocomplete
 from grandchallenge.subdomains.utils import reverse, reverse_lazy
 
 
@@ -35,9 +34,8 @@ class AdminsList(LoginRequiredMixin, ObjectPermissionRequiredMixin, ListView):
 
 
 class AdminsUpdateAutocomplete(
-    LoginRequiredMixin,
     ObjectPermissionRequiredMixin,
-    autocomplete.Select2QuerySetView,
+    UserAutocomplete,
 ):
     permission_required = "change_challenge"
     raise_exception = True
@@ -45,14 +43,6 @@ class AdminsUpdateAutocomplete(
 
     def get_permission_object(self):
         return self.request.challenge
-
-    def get_queryset(self):
-        qs = get_user_model().objects.all().order_by("username")
-
-        if self.q:
-            qs = qs.filter(username__istartswith=self.q)
-
-        return qs
 
 
 class AdminsUpdate(

--- a/app/grandchallenge/groups/forms.py
+++ b/app/grandchallenge/groups/forms.py
@@ -10,7 +10,7 @@ from grandchallenge.core.forms import SaveFormInitMixin
 
 class UserGroupForm(SaveFormInitMixin, Form):
     role = None
-    url = "users-autocomplete"
+    user_complete_url = "users-autocomplete"
 
     ADD = "ADD"
     REMOVE = "REMOVE"
@@ -39,7 +39,7 @@ class UserGroupForm(SaveFormInitMixin, Form):
         user_field.help_text = (
             f"Select a user that will be added as {self.role}"
         )
-        user_field.widget.url = self.url
+        user_field.widget.url = self.user_complete_url
 
     def clean_user(self):
         user = self.cleaned_data["user"]

--- a/app/grandchallenge/groups/forms.py
+++ b/app/grandchallenge/groups/forms.py
@@ -9,15 +9,17 @@ from grandchallenge.core.forms import SaveFormInitMixin
 
 
 class UserGroupForm(SaveFormInitMixin, Form):
+    role = None
+    url = "users-autocomplete"
+
     ADD = "ADD"
     REMOVE = "REMOVE"
     CHOICES = ((ADD, "Add"), (REMOVE, "Remove"))
+
     user = ModelChoiceField(
         queryset=get_user_model().objects.all().order_by("username"),
-        help_text="Select a user that will be added to the group",
         required=True,
         widget=autocomplete.ModelSelect2(
-            url="users-autocomplete",
             attrs={
                 "data-placeholder": "Search for a user ...",
                 "data-minimum-input-length": 3,
@@ -26,9 +28,18 @@ class UserGroupForm(SaveFormInitMixin, Form):
             },
         ),
     )
+
     action = ChoiceField(
         choices=CHOICES, required=True, widget=HiddenInput(), initial=ADD
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        user_field = self.fields["user"]
+        user_field.help_text = (
+            f"Select a user that will be added as {self.role}"
+        )
+        user_field.widget.url = self.url
 
     def clean_user(self):
         user = self.cleaned_data["user"]


### PR DESCRIPTION
Was annoying not to be able to check if I had the correct user in the workshop challenge add admin page.


## Before

![image](https://github.com/user-attachments/assets/578ab95f-97f0-4a40-9b4f-b3beaf1ac8fc)

## After

![image](https://github.com/user-attachments/assets/47292fe8-fa2c-446d-bfea-d78b8174591c)
