### PR TITLE
Parent object layer for flexible file

### DIFF
--- a/app/grandchallenge/components/form_fields.py
+++ b/app/grandchallenge/components/form_fields.py
@@ -183,8 +183,8 @@ class InterfaceFormField(forms.Field):
 
     @cached_property
     def civs_for_user_for_interface(self):
-        return get_component_interface_values_for_user(user=self.user).filter(
-            interface=self.instance
+        return get_component_interface_values_for_user(
+            user=self.user, interface=self.instance
         )
 
     @property

--- a/app/grandchallenge/components/templates/components/file_search_widget.html
+++ b/app/grandchallenge/components/templates/components/file_search_widget.html
@@ -5,21 +5,32 @@
 <div class="form-group mb-1"
      id="search-file-{{ widget.name }}"
      hx-get="{% url 'components:file-search' %}"
-     hx-trigger="load once, keyup[target.value.length > 1] delay:500ms from:#query-{{ widget.name }}, click[keyCode==8] delay:500ms from:#query-{{ widget.name }}"
+     hx-trigger="load once, keyup[target.value.length > 1] delay:500ms from:#query-{{ widget.name }},
+     click[keyCode==8] delay:500ms from:#query-{{ widget.name }}, change from:#selected-parent-object-type-{{ widget.name }}"
      hx-target="#selected-file-{{ widget.name }}"
      hx-swap="outerHTML"
      hx-include="[id='file-input-group-{{ widget.name }}']"
 >
     <div class="input-group" id="file-input-group-{{ widget.name }}">
-        <div class="input-group-prepend"><span class="input-group-text">Select a file</span></div>
-        <input class="form-control" type="search" name="query-{{ widget.name }}"
-               id="query-{{ widget.name }}"
-               placeholder="Search by pk or file name"
-        >
-        <select class="custom-select" name="file"
-                id="selected-file-{{ widget.name }}">
-            <option value="">No file selected</option>
-        </select>
+        <div class="input-group">
+            <div class="input-group-prepend"><span class="input-group-text">Select a file from</span></div>
+            <select class="custom-select" name="parent-object-type-{{ widget.name }}" id="selected-parent-object-type-{{ widget.name }}">
+                <option value="">No parent object selected</option>
+                <option value="{{ widget.parent_object_type_choices.JOB }}">Algorithm Jobs</option>
+                <option value="{{ widget.parent_object_type_choices.DISPLAY_SET }}">Reader study display sets</option>
+                <option value="{{ widget.parent_object_type_choices.ARCHIVE_ITEM }}">Archive items</option>
+            </select>
+        </div>
+        <div class="input-group">
+            <input class="form-control" type="search" name="query-{{ widget.name }}"
+                   id="query-{{ widget.name }}"
+                   placeholder="Search by pk or file name"
+            >
+            <select class="custom-select" name="file"
+                    id="selected-file-{{ widget.name }}">
+                <option value="">No file selected</option>
+            </select>
+        </div>
         <input type="hidden" name="prefixed-interface-slug" value="{{ widget.name }}">
     </div>
 

--- a/app/grandchallenge/components/widgets.py
+++ b/app/grandchallenge/components/widgets.py
@@ -14,6 +14,12 @@ class FileWidgetChoices(TextChoices):
     UNDEFINED = "UNDEFINED"
 
 
+class ParentObjectTypeChoices(TextChoices):
+    JOB = "JOB"
+    DISPLAY_SET = "DISPLAY_SET"
+    ARCHIVE_ITEM = "ARCHIVE_ITEM"
+
+
 class FileSearchWidget(ChoiceWidget, HiddenInput):
     template_name = "components/file_search_widget.html"
     input_type = None
@@ -28,6 +34,9 @@ class FileSearchWidget(ChoiceWidget, HiddenInput):
         context = super().get_context(*args, **kwargs)
         if self.name:
             context["widget"]["name"] = self.name
+        context["widget"]["parent_object_type_choices"] = {
+            choice.name: choice.value for choice in ParentObjectTypeChoices
+        }
         return context
 
 

--- a/app/grandchallenge/serving/models.py
+++ b/app/grandchallenge/serving/models.py
@@ -2,13 +2,22 @@ from django.conf import settings
 from django.db import models
 from django.db.models import Exists, OuterRef
 
-from grandchallenge.algorithms.models import AlgorithmImage, AlgorithmModel
+from grandchallenge.algorithms.models import (
+    AlgorithmImage,
+    AlgorithmModel,
+    Job,
+)
+from grandchallenge.archives.models import ArchiveItem
 from grandchallenge.cases.models import Image
 from grandchallenge.challenges.models import ChallengeRequest
 from grandchallenge.components.models import ComponentInterfaceValue
 from grandchallenge.components.widgets import ParentObjectTypeChoices
-from grandchallenge.core.guardian import get_objects_for_user
+from grandchallenge.core.guardian import (
+    filter_by_permission,
+    get_objects_for_user,
+)
 from grandchallenge.evaluation.models import Submission
+from grandchallenge.reader_studies.models import DisplaySet
 from grandchallenge.workstations.models import Feedback
 
 
@@ -48,29 +57,67 @@ class Download(models.Model):
     )
 
 
-def get_component_interface_values_for_user(*, user):
-    job_inputs_query = get_objects_for_user(
-        user=user, perms="algorithms.view_job"
-    ).filter(inputs__pk__in=OuterRef("pk"))
+def get_component_interface_values_for_user(
+    *, user, civ_pk=None, interface=None
+):
+    extra_filter_kwargs = {}
+    if interface:
+        extra_filter_kwargs["interface"] = interface
+    if civ_pk:
+        extra_filter_kwargs["pk"] = civ_pk
 
-    job_outputs_query = get_objects_for_user(
-        user=user, perms="algorithms.view_job"
-    ).filter(outputs__pk__in=OuterRef("pk"))
+    civs = ComponentInterfaceValue.objects.filter(**extra_filter_kwargs)
 
-    display_set_query = get_objects_for_user(
-        user=user, perms="reader_studies.view_displayset"
-    ).filter(values__pk__in=OuterRef("pk"))
+    job_query = filter_by_permission(
+        queryset=Job.objects.all(),
+        user=user,
+        codename="view_job",
+        accept_user_perms=False,
+    )
 
-    archive_item_query = get_objects_for_user(
-        user=user, perms="archives.view_archiveitem"
-    ).filter(values__pk__in=OuterRef("pk"))
+    job_inputs = (
+        job_query.filter(inputs__in=civs)
+        .distinct()
+        .values_list("inputs__pk", flat=True)
+    )
+    job_outputs = (
+        job_query.filter(outputs__in=civs)
+        .distinct()
+        .values_list("outputs__pk", flat=True)
+    )
 
-    return ComponentInterfaceValue.objects.annotate(
-        user_has_view_permission=Exists(job_inputs_query)
-        | Exists(job_outputs_query)
-        | Exists(display_set_query)
-        | Exists(archive_item_query)
-    ).filter(user_has_view_permission=True)
+    display_set_query = (
+        filter_by_permission(
+            queryset=DisplaySet.objects.all(),
+            user=user,
+            codename="view_displayset",
+            accept_user_perms=False,
+        )
+        .filter(values__in=civs)
+        .distinct()
+        .values_list("values__pk", flat=True)
+    )
+
+    archive_item_query = (
+        filter_by_permission(
+            queryset=ArchiveItem.objects.all(),
+            user=user,
+            codename="view_archiveitem",
+            accept_user_perms=False,
+        )
+        .filter(values__in=civs)
+        .distinct()
+        .values_list("values__pk", flat=True)
+    )
+
+    return civs.filter(
+        pk__in=[
+            *job_inputs,
+            *job_outputs,
+            *display_set_query,
+            *archive_item_query,
+        ]
+    )
 
 
 def get_component_interface_values_for_user_for_parent_object_type(

--- a/app/grandchallenge/serving/views.py
+++ b/app/grandchallenge/serving/views.py
@@ -139,11 +139,9 @@ def serve_component_interface_value(
     except (MultipleObjectsReturned, ComponentInterfaceValue.DoesNotExist):
         raise Http404("No ComponentInterfaceValue found.")
 
-    if (
-        get_component_interface_values_for_user(user=user)
-        .filter(pk=civ.pk)
-        .exists()
-    ):
+    if get_component_interface_values_for_user(
+        user=user, civ_pk=civ.pk
+    ).exists():
         return protected_storage_redirect(
             name=civ.file.name, creator=user, component_interface_value=civ
         )

--- a/app/tests/components_tests/test_form_fields.py
+++ b/app/tests/components_tests/test_form_fields.py
@@ -30,8 +30,9 @@ def test_flexible_file_field_validation_empty_data_and_missing_values():
     )
     field = FlexibleFileField(
         file_search_queryset=get_component_interface_values_for_user(
-            user=user
-        ).filter(interface=ci),
+            user=user,
+            interface=ci,
+        ),
         upload_queryset=UserUpload.objects.filter(creator=user).all(),
     )
 
@@ -55,8 +56,9 @@ def test_flexible_file_field_validation_user_uploads():
     )
     field = FlexibleFileField(
         file_search_queryset=get_component_interface_values_for_user(
-            user=user
-        ).filter(interface=ci),
+            user=user,
+            interface=ci,
+        ),
         upload_queryset=UserUpload.objects.filter(creator=user).all(),
     )
     upload1 = UserUploadFactory(creator=user)
@@ -98,17 +100,18 @@ def test_flexible_file_field_validation_with_algorithm_job_inputs():
     ci = ComponentInterfaceFactory(
         kind=FuzzyChoice(InterfaceKind.interface_type_file())
     )
-    field = FlexibleFileField(
-        file_search_queryset=get_component_interface_values_for_user(
-            user=user
-        ).filter(interface=ci),
-        upload_queryset=UserUpload.objects.filter(creator=user).all(),
-    )
     civ1, civ2 = ComponentInterfaceValueFactory.create_batch(2, interface=ci)
     job_with_perm = AlgorithmJobFactory(creator=user, time_limit=60)
     job_without_perm = AlgorithmJobFactory(time_limit=60)
     job_with_perm.inputs.set([civ1])
     job_without_perm.inputs.set([civ2])
+    field = FlexibleFileField(
+        file_search_queryset=get_component_interface_values_for_user(
+            user=user,
+            interface=ci,
+        ),
+        upload_queryset=UserUpload.objects.filter(creator=user).all(),
+    )
 
     parsed_value_for_file_with_permission = field.widget.value_from_datadict(
         data={ci.slug: civ1.pk}, name=ci.slug, files={}
@@ -149,17 +152,18 @@ def test_flexible_file_field_validation_with_algorithm_job_outputs():
     ci = ComponentInterfaceFactory(
         kind=FuzzyChoice(InterfaceKind.interface_type_file())
     )
-    field = FlexibleFileField(
-        file_search_queryset=get_component_interface_values_for_user(
-            user=user
-        ).filter(interface=ci),
-        upload_queryset=UserUpload.objects.filter(creator=user).all(),
-    )
     civ1, civ2 = ComponentInterfaceValueFactory.create_batch(2, interface=ci)
     job_with_perm = AlgorithmJobFactory(creator=user, time_limit=60)
     job_without_perm = AlgorithmJobFactory(time_limit=60)
     job_with_perm.outputs.set([civ1])
     job_without_perm.outputs.set([civ2])
+    field = FlexibleFileField(
+        file_search_queryset=get_component_interface_values_for_user(
+            user=user,
+            interface=ci,
+        ),
+        upload_queryset=UserUpload.objects.filter(creator=user).all(),
+    )
 
     parsed_value_for_file_with_permission = field.widget.value_from_datadict(
         data={ci.slug: civ1.pk}, name=ci.slug, files={}
@@ -200,13 +204,6 @@ def test_flexible_file_field_validation_with_display_sets():
     ci = ComponentInterfaceFactory(
         kind=FuzzyChoice(InterfaceKind.interface_type_file())
     )
-    field = FlexibleFileField(
-        file_search_queryset=get_component_interface_values_for_user(
-            user=user
-        ).filter(interface=ci),
-        upload_queryset=UserUpload.objects.filter(creator=user).all(),
-    )
-
     civ1, civ2 = ComponentInterfaceValueFactory.create_batch(2, interface=ci)
     rs1, rs2 = ReaderStudyFactory.create_batch(2)
     rs1.add_editor(user)
@@ -214,6 +211,13 @@ def test_flexible_file_field_validation_with_display_sets():
     display_set_without_perm = DisplaySetFactory(reader_study=rs2)
     display_set_with_perm.values.add(civ1)
     display_set_without_perm.values.add(civ2)
+    field = FlexibleFileField(
+        file_search_queryset=get_component_interface_values_for_user(
+            user=user,
+            interface=ci,
+        ),
+        upload_queryset=UserUpload.objects.filter(creator=user).all(),
+    )
 
     parsed_value_for_file_with_permission = field.widget.value_from_datadict(
         data={ci.slug: civ1.pk}, name=ci.slug, files={}
@@ -254,13 +258,6 @@ def test_flexible_file_field_validation_with_archive_items():
     ci = ComponentInterfaceFactory(
         kind=FuzzyChoice(InterfaceKind.interface_type_file())
     )
-    field = FlexibleFileField(
-        file_search_queryset=get_component_interface_values_for_user(
-            user=user
-        ).filter(interface=ci),
-        upload_queryset=UserUpload.objects.filter(creator=user).all(),
-    )
-
     civ1, civ2 = ComponentInterfaceValueFactory.create_batch(2, interface=ci)
     a1, a2 = ArchiveFactory.create_batch(2)
     a1.add_editor(user)
@@ -268,6 +265,13 @@ def test_flexible_file_field_validation_with_archive_items():
     archive_item_without_perm = ArchiveItemFactory(archive=a2)
     archive_item_with_perm.values.set([civ1])
     archive_item_without_perm.values.set([civ2])
+    field = FlexibleFileField(
+        file_search_queryset=get_component_interface_values_for_user(
+            user=user,
+            interface=ci,
+        ),
+        upload_queryset=UserUpload.objects.filter(creator=user).all(),
+    )
 
     parsed_value_for_file_with_permission = field.widget.value_from_datadict(
         data={ci.slug: civ1.pk}, name=ci.slug, files={}

--- a/app/tests/serving_tests/test_models.py
+++ b/app/tests/serving_tests/test_models.py
@@ -1,5 +1,6 @@
 import pytest
 
+from grandchallenge.components.widgets import ParentObjectTypeChoices
 from grandchallenge.serving.models import (
     get_component_interface_values_for_user,
 )
@@ -84,3 +85,22 @@ def test_get_component_interface_values_for_user():
         set(get_component_interface_values_for_user(user=user, civ_pk=civ2.pk))
         == set()
     )
+
+    # subset by parent object type choice
+    assert set(
+        get_component_interface_values_for_user(
+            user=user, parent_object_type_choice=ParentObjectTypeChoices.JOB
+        )
+    ) == {civ1, civ3, civ9, civ11}
+    assert set(
+        get_component_interface_values_for_user(
+            user=user,
+            parent_object_type_choice=ParentObjectTypeChoices.DISPLAY_SET,
+        )
+    ) == {civ5, civ13}
+    assert set(
+        get_component_interface_values_for_user(
+            user=user,
+            parent_object_type_choice=ParentObjectTypeChoices.ARCHIVE_ITEM,
+        )
+    ) == {civ7, civ15}

--- a/app/tests/serving_tests/test_models.py
+++ b/app/tests/serving_tests/test_models.py
@@ -19,43 +19,68 @@ from tests.reader_studies_tests.factories import (
 @pytest.mark.django_db
 def test_get_component_interface_values_for_user():
     user = UserFactory()
-    assert list(get_component_interface_values_for_user(user=user)) == []
+    assert set(get_component_interface_values_for_user(user=user)) == set()
 
-    ci = ComponentInterfaceFactory()
+    ci1, ci2 = ComponentInterfaceFactory.create_batch(2)
 
     civ1, civ2, civ3, civ4, civ5, civ6, civ7, civ8 = (
-        ComponentInterfaceValueFactory.create_batch(8, interface=ci)
+        ComponentInterfaceValueFactory.create_batch(8, interface=ci1)
+    )
+    civ9, civ10, civ11, civ12, civ13, civ14, civ15, civ16 = (
+        ComponentInterfaceValueFactory.create_batch(8, interface=ci2)
     )
 
     job_with_perm = AlgorithmJobFactory(creator=user, time_limit=60)
     job_without_perm = AlgorithmJobFactory(time_limit=60)
 
-    job_with_perm.inputs.set([civ1])
-    job_without_perm.inputs.set([civ2])
-    job_with_perm.outputs.set([civ3])
-    job_without_perm.outputs.set([civ4])
+    job_with_perm.inputs.set([civ1, civ9])
+    job_without_perm.inputs.set([civ2, civ10])
+    job_with_perm.outputs.set([civ3, civ11])
+    job_without_perm.outputs.set([civ4, civ12])
 
     rs = ReaderStudyFactory()
     rs.add_editor(user)
     ds_with_perm = DisplaySetFactory(reader_study=rs)
     ds_without_perm = DisplaySetFactory()
 
-    ds_with_perm.values.set([civ5])
-    ds_without_perm.values.set([civ6])
+    ds_with_perm.values.set([civ5, civ13])
+    ds_without_perm.values.set([civ6, civ14])
 
     archive = ArchiveFactory()
     archive.add_editor(user)
     ai_with_perm = ArchiveItemFactory(archive=archive)
     ai_without_perm = ArchiveItemFactory()
 
-    ai_with_perm.values.set([civ7])
-    ai_without_perm.values.set([civ8])
+    ai_with_perm.values.set([civ7, civ15])
+    ai_without_perm.values.set([civ8, civ16])
 
-    assert civ1 in get_component_interface_values_for_user(user=user)
-    assert civ3 in get_component_interface_values_for_user(user=user)
-    assert civ5 in get_component_interface_values_for_user(user=user)
-    assert civ7 in get_component_interface_values_for_user(user=user)
-    assert civ2 not in get_component_interface_values_for_user(user=user)
-    assert civ4 not in get_component_interface_values_for_user(user=user)
-    assert civ6 not in get_component_interface_values_for_user(user=user)
-    assert civ8 not in get_component_interface_values_for_user(user=user)
+    assert set(get_component_interface_values_for_user(user=user)) == {
+        civ1,
+        civ3,
+        civ5,
+        civ7,
+        civ9,
+        civ11,
+        civ13,
+        civ15,
+    }
+
+    # subset by interface
+    assert set(
+        get_component_interface_values_for_user(user=user, interface=ci1)
+    ) == {civ1, civ3, civ5, civ7}
+    assert set(
+        get_component_interface_values_for_user(user=user, interface=ci2)
+    ) == {civ9, civ11, civ13, civ15}
+
+    # subset by civ pk
+    assert set(
+        get_component_interface_values_for_user(user=user, civ_pk=civ1.pk)
+    ) == {civ1}
+    assert set(
+        get_component_interface_values_for_user(user=user, civ_pk=civ9.pk)
+    ) == {civ9}
+    assert (
+        set(get_component_interface_values_for_user(user=user, civ_pk=civ2.pk))
+        == set()
+    )


### PR DESCRIPTION
Add a layer for selecting the parent object type (algorithm job, display set or archive item) to the flexible file widget. 

The parent object is used to make the query more specific and smaller. 

related to https://github.com/DIAGNijmegen/rse-roadmap/issues/363