### PR TITLE
Onboarding tasks emails

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1232,7 +1232,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "send_onboarding_task_reminder_emails": {
         "task": "grandchallenge.challenges.tasks.send_onboarding_task_reminder_emails",
-        "schedule": crontab(hour=6, minute=0),
+        "schedule": crontab(day_of_week="mon", hour=6, minute=0),
     },
     "delete_users_who_dont_login": {
         "task": "grandchallenge.profiles.tasks.delete_users_who_dont_login",

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1231,7 +1231,7 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(hour=5, minute=30),
     },
     "send_onboarding_task_reminder_emails": {
-        "task": "grandchallenge.challenge.tasks.send_onboarding_task_reminder_emails",
+        "task": "grandchallenge.challenges.tasks.send_onboarding_task_reminder_emails",
         "schedule": crontab(hour=6, minute=0),
     },
     "delete_users_who_dont_login": {

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1127,7 +1127,7 @@ READER_STUDY_CREATORS_GROUP_NAME = "reader_study_creators"
 ###############################################################################
 
 CHALLENGES_DEFAULT_ACTIVE_MONTHS = 12
-CHALLENGE_ONBOARDING_TASKS_OVERDUE_SOON_CUTOFF = timedelta(hours=72)
+CHALLENGE_ONBOARDING_TASKS_OVERDUE_SOON_CUTOFF = timedelta(days=7)
 
 ###############################################################################
 #

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1230,6 +1230,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "grandchallenge.statistics.tasks.update_site_statistics_cache",
         "schedule": crontab(hour=5, minute=30),
     },
+    "send_onboarding_task_reminder_emails": {
+        "task": "grandchallenge.challenge.tasks.send_onboarding_task_reminder_emails",
+        "schedule": crontab(hour=6, minute=0),
+    },
     "delete_users_who_dont_login": {
         "task": "grandchallenge.profiles.tasks.delete_users_who_dont_login",
         "schedule": timedelta(hours=1),

--- a/app/grandchallenge/challenges/emails.py
+++ b/app/grandchallenge/challenges/emails.py
@@ -224,7 +224,7 @@ def send_onboarding_task_due_reminder(challenge, num_is_overdue_soon):
 
     message = format_html(
         "Your challenge {short_name} has {num} onboarding task{plural_num} that {plural_verb} "
-        "are soon due. To view and complete onboarding tasks, go [here]({list_url}).",
+        "soon due. To view and complete onboarding tasks, go [here]({list_url}).",
         short_name=challenge.short_name,
         num=num_is_overdue_soon,
         plural_num=plural_num,

--- a/app/grandchallenge/challenges/emails.py
+++ b/app/grandchallenge/challenges/emails.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.mail import mail_managers
+from django.template.defaultfilters import pluralize
 from django.template.loader import render_to_string
 from django.utils.html import format_html
 
@@ -128,4 +129,113 @@ def send_email_percent_budget_consumed_alert(challenge, percent_threshold):
     mail_managers(
         subject=subject,
         message=managers_message,
+    )
+
+
+def send_onboarding_task_overdue_alert(challenge, num_is_overdue):
+    plural_num = pluralize(num_is_overdue)
+    plural_verb = "are" if num_is_overdue > 1 else "is"
+
+    challenge_admins_subject = format_html(
+        "[{short_name}] Action Required: {num} Onboarding Task{plural_num} Overdue",
+        short_name=challenge.short_name,
+        num=num_is_overdue,
+        plural_num=plural_num,
+    )
+
+    challenge_admins_message = format_html(
+        "Your challenge {short_name} has {num} onboarding task{plural_num} that {plural_verb} "
+        "overdue. To view and complete onboarding tasks go [here]({list_url}).",
+        short_name=challenge.short_name,
+        num=num_is_overdue,
+        plural_num=plural_num,
+        plural_verb=plural_verb,
+        list_url=reverse(
+            viewname="challenge-onboarding-task-list",
+            kwargs={"challenge_short_name": challenge.short_name},
+        ),
+    )
+
+    send_standard_email_batch(
+        site=Site.objects.get_current(),
+        subject=challenge_admins_subject,
+        markdown_message=challenge_admins_message,
+        recipients=[*challenge.get_admins()],
+        subscription_type=EmailSubscriptionTypes.SYSTEM,
+    )
+
+    manager_subject = format_html(
+        "[{short_name}] {num} Organizer Onboarding Task{plural_num} Overdue",
+        short_name=challenge.short_name,
+        num=num_is_overdue,
+        plural_num=plural_num,
+    )
+
+    managers_message = format_html(
+        "The organizers of challenge {short_name} have {num} onboarding task{plural_num} that {plural_verb} "
+        "overdue: the organizers have been alerted.",
+        short_name=challenge.short_name,
+        num=num_is_overdue,
+        plural_num=plural_num,
+        plural_verb=plural_verb,
+    )
+
+    mail_managers(
+        subject=manager_subject,
+        message=managers_message,
+    )
+
+
+def send_onboarding_task_support_overdue_alert(challenge, num_is_overdue):
+    plural_num = pluralize(num_is_overdue)
+    manager_subject = format_html(
+        "[{short_name}] Action required: {num} Support Onboarding Task{plural_num} Overdue",
+        short_name=challenge.short_name,
+        num=num_is_overdue,
+        plural_num=plural_num,
+    )
+
+    managers_message = format_html(
+        "For the challenge {short_name}, the support staff are late on completing {num} onboarding task{plural_num}.",
+        short_name=challenge.short_name,
+        num=num_is_overdue,
+        plural_num=plural_num,
+    )
+
+    mail_managers(
+        subject=manager_subject,
+        message=managers_message,
+    )
+
+
+def send_onboarding_task_due_reminder(challenge, num_is_overdue_soon):
+    plural_num = pluralize(num_is_overdue_soon)
+    list_url = reverse(
+        viewname="challenge-onboarding-task-list",
+        kwargs={"challenge_short_name": challenge.short_name},
+    )
+
+    subject = format_html(
+        "[{short_name}] Reminder: {num} Onboarding Task{plural_num} Soon Due",
+        short_name=challenge.short_name,
+        num=num_is_overdue_soon,
+        plural_num=plural_num,
+    )
+
+    message = format_html(
+        "Your challenge {short_name} has {num} onboarding task{plural_num} that {plural_verb} "
+        "are soon due. To view and complete onboarding tasks, go [here]({list_url}).",
+        short_name=challenge.short_name,
+        num=num_is_overdue_soon,
+        plural_num=plural_num,
+        plural_verb="are" if num_is_overdue_soon > 1 else "is",
+        list_url=list_url,
+    )
+
+    send_standard_email_batch(
+        site=Site.objects.get_current(),
+        subject=subject,
+        markdown_message=message,
+        recipients=[*challenge.get_admins()],
+        subscription_type=EmailSubscriptionTypes.SYSTEM,
     )

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -1424,15 +1424,9 @@ class TaskResponsiblePartyChoices(models.TextChoices):
 
 
 class OnboardingTaskQuerySet(models.QuerySet):
-    def with_overdue_status(self, soon_delta=None):
+    def with_overdue_status(self):
 
         _now = now()
-        soon_delta = (
-            settings.CHALLENGE_ONBOARDING_TASKS_OVERDUE_SOON_CUTOFF
-            if soon_delta is None
-            else soon_delta
-        )
-
         return self.annotate(
             is_overdue=Case(
                 When(complete=False, deadline__lt=_now, then=Value(True)),
@@ -1443,7 +1437,8 @@ class OnboardingTaskQuerySet(models.QuerySet):
                 When(
                     complete=False,
                     is_overdue=False,
-                    deadline__lt=_now + soon_delta,
+                    deadline__lt=_now
+                    + settings.CHALLENGE_ONBOARDING_TASKS_OVERDUE_SOON_CUTOFF,
                     then=Value(True),
                 ),
                 default=Value(False),

--- a/app/grandchallenge/challenges/tasks.py
+++ b/app/grandchallenge/challenges/tasks.py
@@ -160,7 +160,13 @@ def send_onboarding_task_reminder_emails():
                     responsible_party=OnboardingTask.ResponsiblePartyChoices.CHALLENGE_ORGANIZERS,
                 ),
             ),
-            min_deadline=Min("deadline"),
+            min_deadline=Min(
+                "deadline",
+                filter=Q(
+                    is_overdue=True,
+                    responsible_party=OnboardingTask.ResponsiblePartyChoices.CHALLENGE_ORGANIZERS,
+                ),
+            ),
             num_support_is_overdue=Count(
                 "pk",
                 filter=Q(

--- a/app/grandchallenge/challenges/tasks.py
+++ b/app/grandchallenge/challenges/tasks.py
@@ -124,7 +124,7 @@ def update_compute_costs_and_storage_size():
 
 
 @acks_late_2xlarge_task
-def sent_onboarding_task_reminders():
+def send_onboarding_task_reminder_emails():
     onboarding_task_info = (
         OnboardingTask.objects.with_overdue_status()
         .values("challenge")

--- a/app/grandchallenge/challenges/tasks.py
+++ b/app/grandchallenge/challenges/tasks.py
@@ -126,8 +126,8 @@ def update_compute_costs_and_storage_size():
             save_phase()
 
 
-@transaction.atomic
 @acks_late_micro_short_task
+@transaction.atomic
 def send_onboarding_task_reminder_emails():
     onboarding_task_info = (
         OnboardingTask.objects.with_overdue_status()

--- a/app/grandchallenge/challenges/tasks.py
+++ b/app/grandchallenge/challenges/tasks.py
@@ -21,6 +21,7 @@ from grandchallenge.core.celery import (
     acks_late_2xlarge_task,
     acks_late_micro_short_task,
 )
+from grandchallenge.core.exceptions import LockNotAcquiredException
 from grandchallenge.evaluation.models import Evaluation, Phase
 
 
@@ -126,7 +127,7 @@ def update_compute_costs_and_storage_size():
             save_phase()
 
 
-@acks_late_micro_short_task
+@acks_late_micro_short_task(retry_on=(LockNotAcquiredException,))
 @transaction.atomic
 def send_onboarding_task_reminder_emails():
     onboarding_task_info = (

--- a/app/grandchallenge/challenges/tasks.py
+++ b/app/grandchallenge/challenges/tasks.py
@@ -21,7 +21,6 @@ from grandchallenge.core.celery import (
     acks_late_2xlarge_task,
     acks_late_micro_short_task,
 )
-from grandchallenge.core.exceptions import LockNotAcquiredException
 from grandchallenge.evaluation.models import Evaluation, Phase
 
 
@@ -127,7 +126,7 @@ def update_compute_costs_and_storage_size():
             save_phase()
 
 
-@acks_late_micro_short_task(retry_on=(LockNotAcquiredException,))
+@acks_late_micro_short_task
 @transaction.atomic
 def send_onboarding_task_reminder_emails():
     onboarding_task_info = (

--- a/app/grandchallenge/challenges/tasks.py
+++ b/app/grandchallenge/challenges/tasks.py
@@ -6,7 +6,7 @@ from typing import NamedTuple
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.db.models import Count, Max, Min, Q
-from django.utils.timezone import datetime, timedelta
+from django.utils.timezone import datetime
 from psycopg.errors import LockNotAvailable
 
 from grandchallenge.challenges.costs import (
@@ -141,9 +141,7 @@ class OnboardingTaskInfo(NamedTuple):
 @transaction.atomic
 def send_onboarding_task_reminder_emails():
     onboarding_task_info = (
-        OnboardingTask.objects.with_overdue_status(
-            soon_delta=timedelta(days=7)
-        )
+        OnboardingTask.objects.with_overdue_status()
         .values("challenge")
         .annotate(
             num_is_overdue=Count(

--- a/app/grandchallenge/challenges/templates/challenges/partials/challenge_onboarding_task_alert_email.md
+++ b/app/grandchallenge/challenges/templates/challenges/partials/challenge_onboarding_task_alert_email.md
@@ -1,7 +1,4 @@
-{% spaceless %}
-    {% load humanize %}
-    {% load url %}
-{% endspaceless %}
+{% load humanize url %}
 Your challenge {{ challenge.short_name }} has {{ num_is_overdue }} onboarding task{{ num_is_overdue|pluralize }} that {{ num_is_overdue|pluralize:"is,are" }} overdue.
 
 Please complete them as soon as possible: the due date was {{ min_deadline|naturaltime }}.

--- a/app/grandchallenge/challenges/templates/challenges/partials/challenge_onboarding_task_alert_email.md
+++ b/app/grandchallenge/challenges/templates/challenges/partials/challenge_onboarding_task_alert_email.md
@@ -1,0 +1,11 @@
+{% spaceless %}
+    {% load humanize %}
+    {% load url %}
+{% endspaceless %}
+Your challenge {{ challenge.short_name }} has {{ num_is_overdue }} onboarding task{{ num_is_overdue|pluralize }} that {{ num_is_overdue|pluralize:"is,are" }} overdue.
+
+Please complete them as soon as possible: the due date was {{ min_deadline|naturaltime }}.
+
+To view and complete onboarding tasks go [here]({% url "challenge-onboarding-task-list" challenge_short_name=challenge.short_name %}).
+
+Feel free to ask us for any assistance.

--- a/app/grandchallenge/challenges/templates/challenges/partials/challenge_onboarding_task_reminder_email.md
+++ b/app/grandchallenge/challenges/templates/challenges/partials/challenge_onboarding_task_reminder_email.md
@@ -1,0 +1,9 @@
+{% spaceless %}
+    {% load humanize %}
+    {% load url %}
+{% endspaceless %}
+Your challenge {{ challenge.short_name }} has {{ num_is_overdue_soon }} onboarding task{{ num_is_overdue_soon|pluralize }} that {{ num_is_overdue_soon|pluralize:"is,are" }} due sometime in the next week.
+
+To view and complete onboarding tasks go [here]({% url "challenge-onboarding-task-list" challenge_short_name=challenge.short_name %}).
+
+Feel free to ask us for any assistance.

--- a/app/grandchallenge/challenges/templates/challenges/partials/challenge_onboarding_task_reminder_email.md
+++ b/app/grandchallenge/challenges/templates/challenges/partials/challenge_onboarding_task_reminder_email.md
@@ -1,7 +1,4 @@
-{% spaceless %}
-    {% load humanize %}
-    {% load url %}
-{% endspaceless %}
+{% load humanize url %}
 Your challenge {{ challenge.short_name }} has {{ num_is_overdue_soon }} onboarding task{{ num_is_overdue_soon|pluralize }} that {{ num_is_overdue_soon|pluralize:"is,are" }} due sometime in the next week.
 
 To view and complete onboarding tasks go [here]({% url "challenge-onboarding-task-list" challenge_short_name=challenge.short_name %}).

--- a/app/tests/challenges_tests/test_models.py
+++ b/app/tests/challenges_tests/test_models.py
@@ -1,6 +1,6 @@
 import random
-from datetime import datetime, timedelta
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 import pytest
 from actstream.actions import is_following
@@ -9,7 +9,7 @@ from dateutil.relativedelta import relativedelta
 from dateutil.utils import today
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import ProtectedError
-from django.utils.timezone import now
+from django.utils.timezone import datetime, now, timedelta
 from machina.apps.forum_conversation.models import Topic
 
 from grandchallenge.challenges.models import Challenge, OnboardingTask
@@ -197,31 +197,28 @@ def test_onboarding_tasks_registering_completion_time():
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "deadline, mock_now, expected_is_overdue, expected_is_overdue_soon, expected_due_timedelta",
+    "deadline, mock_now, expected_is_overdue, expected_is_overdue_soon",
     [
         # Test case 1: Task deadline is far away, so it's neither overdue nor almost overdue
         (
-            datetime(2025, 1, 30, 11, 0, 0),
-            datetime(2025, 1, 29, 11, 0, 0),
+            datetime(2025, 1, 30, 11, 0, 0, tzinfo=ZoneInfo("UTC")),
+            datetime(2025, 1, 29, 11, 0, 0, tzinfo=ZoneInfo("UTC")),
             False,
             False,
-            timedelta(days=1),
         ),
         # Test case 2: Task is almost overdue (within the 1-hour cutoff)
         (
-            datetime(2025, 1, 29, 12, 0, 0),
-            datetime(2025, 1, 29, 11, 30, 0),
+            datetime(2025, 1, 29, 12, 0, 0, tzinfo=ZoneInfo("UTC")),
+            datetime(2025, 1, 29, 11, 30, 0, tzinfo=ZoneInfo("UTC")),
             False,
             True,
-            timedelta(minutes=30),
         ),
         # Test case 3: Task is overdue
         (
-            datetime(2025, 1, 29, 11, 0, 0),
-            datetime(2025, 1, 29, 12, 0, 0),
+            datetime(2025, 1, 29, 11, 0, 0, tzinfo=ZoneInfo("UTC")),
+            datetime(2025, 1, 29, 12, 0, 0, tzinfo=ZoneInfo("UTC")),
             True,
             False,
-            timedelta(hours=-1),
         ),
     ],
 )
@@ -234,14 +231,13 @@ def test_onboarding_tasks_overdue_status_annotations(
     mock_now,
     expected_is_overdue,
     expected_is_overdue_soon,
-    expected_due_timedelta,
     mocker,
 ):
+
     OnboardingTaskFactory(deadline=deadline)
-    with mocker.patch(
-        "grandchallenge.challenges.models.now", return_value=mock_now
-    ):
-        task = OnboardingTask.objects.with_overdue_status().get()
-        assert task.due_timedelta == expected_due_timedelta
-        assert task.is_overdue == expected_is_overdue
-        assert task.is_overdue_soon == expected_is_overdue_soon
+
+    mocker.patch("grandchallenge.challenges.models.now", return_value=mock_now)
+
+    task = OnboardingTask.objects.with_overdue_status().get()
+    assert task.is_overdue == expected_is_overdue
+    assert task.is_overdue_soon == expected_is_overdue_soon

--- a/app/tests/challenges_tests/test_tasks.py
+++ b/app/tests/challenges_tests/test_tasks.py
@@ -378,7 +378,3 @@ def test_challenge_onboarding_task_due_emails(
         assert expected_subject in organizer_mail.subject
     else:
         assert not any(challenge_admin.email in m.to for m in mail.outbox)
-
-    for m in mail.outbox:
-        print("Subject: ", m.subject)
-        print(m.body)

--- a/app/tests/challenges_tests/test_tasks.py
+++ b/app/tests/challenges_tests/test_tasks.py
@@ -9,7 +9,7 @@ from grandchallenge.challenges.models import (
     OnboardingTask,
 )
 from grandchallenge.challenges.tasks import (
-    sent_onboarding_task_reminders,
+    send_onboarding_task_reminder_emails,
     update_challenge_results_cache,
     update_compute_costs_and_storage_size,
 )
@@ -357,7 +357,7 @@ def test_challenge_onboarding_task_due_emails(
     with mocker.patch(
         "grandchallenge.challenges.models.now", return_value=_mock_now
     ):
-        sent_onboarding_task_reminders()
+        send_onboarding_task_reminder_emails()
 
     if staff_email_subject:
         staff_email = next(m for m in mail.outbox if staff_user.email in m.to)


### PR DESCRIPTION
Part of the pitch:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/339

This PR adds the email reminders for onboarding tasks.

# Showcase

## Challenge Organizers

### Reminder: gentle
> Subject:  [testserver] [test-challenge-0] Reminder: 1 Onboarding Task Soon Due
> 
> Dear test_user_0000,
> 
> Your challenge test-challenge-0 has 1 onboarding task that is are soon due. To view and complete onboarding tasks, go [here](https://test-challenge-0.testserver/onboarding-tasks/).
> 
> Regards,
> The Testserver:8000 Team


### Alert: call for action
> Subject:  [testserver] [test-challenge-0] Action Required: 1 Onboarding Task Overdue
> 
> Dear test_user_0000,
> 
> Your challenge test-challenge-0 has 1 onboarding task that is overdue. To view and complete onboarding tasks go [here](https://test-challenge-0.testserver/onboarding-tasks/).
> 
> Regards,
> The Testserver:8000 Team
> 

## Support

### Note: challenge organizers are late

> Subject:  [Django] [test-challenge-0] 1 Organizer Onboarding Task Overdue
> The organizers of challenge test-challenge-0 have 1 onboarding task that is overdue: the organizers have been alerted.

### Alert: support is late

> Subject:  [Django] [test-challenge-0] Action required: 1 Support Onboarding Task Overdue
> For the challenge test-challenge-0, the support staff are late on completing 1 onboarding task.