### PR TITLE
Add evaluation error message to evaluation details view

### DIFF
--- a/app/grandchallenge/algorithms/templates/algorithms/job_error_message.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_error_message.html
@@ -1,0 +1,5 @@
+{% if object.error_message %}
+    {{ object.error_message }}
+{% elif object.status == object.SUCCESS and object.stderr %},
+    {{ object.stderr }}
+{% endif %}

--- a/app/grandchallenge/algorithms/templates/algorithms/job_error_message.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_error_message.html
@@ -1,5 +1,0 @@
-{% if object.error_message %}
-    {{ object.error_message }}
-{% elif object.status == object.SUCCESS and object.stderr %},
-    {{ object.stderr }}
-{% endif %}

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -210,14 +210,14 @@
 
                 {% if not incomplete_jobs %}
 
-                    All prequisite jobs succeeded.
+                    All prerequisite jobs succeeded.
 
                     {% if object.error_message %}
                         Evaluation failed due to the following error: {{ object.error_message }}
                     {% endif %}
 
                 {% else %}
-                    Some jobs are incomplete. Check the status and error messages of the prequisite jobs above.
+                    Some jobs are incomplete. Check the status and error messages of the prerequisite jobs above.
                 {% endif %}
             </div>
 

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -56,6 +56,13 @@
             {% include 'evaluation/evaluation_status_detail.html' %}
         </dd>
 
+        {% if object.error_message %}
+            <dt>Error Message</dt>
+            <dd>
+                {{ object.error_message }}
+            </dd>
+        {% endif %}
+
         <dt>User</dt>
         <dd>
             {{ object.submission.creator|user_profile_link }}
@@ -204,21 +211,6 @@
             {% endif %}
 
             {% include "evaluation/evaluation_incomplete_jobs_detail.html" %}
-
-            {% if object.status != object.SUCCESS or incomplete_jobs %}
-                <div class="card-body">
-                    <h3 class="card-title">Error Message</h3>
-
-                    {% if not incomplete_jobs %}
-                        All prerequisite jobs succeeded.
-                        {% if object.error_message %}
-                            Evaluation failed due to the following error: {{ object.error_message }}
-                        {% endif %}
-                    {% else %}
-                        Some jobs are incomplete. Check the status and error messages of the prerequisite jobs above.
-                    {% endif %}
-                </div>
-            {% endif %}
 
             <div class="card-body">
                 <h3 class="card-title">Predictions</h3>

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -205,18 +205,20 @@
 
             {% include "evaluation/evaluation_incomplete_jobs_detail.html" %}
 
-            <div class="card-body">
-                <h3 class="card-title">Error Message</h3>
+            {% if object.status != object.SUCCESS or incomplete_jobs %}
+                <div class="card-body">
+                    <h3 class="card-title">Error Message</h3>
 
-                {% if not incomplete_jobs %}
-                    All prerequisite jobs succeeded.
-                    {% if object.error_message %}
-                        Evaluation failed due to the following error: {{ object.error_message }}
+                    {% if not incomplete_jobs %}
+                        All prerequisite jobs succeeded.
+                        {% if object.error_message %}
+                            Evaluation failed due to the following error: {{ object.error_message }}
+                        {% endif %}
+                    {% else %}
+                        Some jobs are incomplete. Check the status and error messages of the prerequisite jobs above.
                     {% endif %}
-                {% else %}
-                    Some jobs are incomplete. Check the status and error messages of the prerequisite jobs above.
-                {% endif %}
-            </div>
+                </div>
+            {% endif %}
 
             <div class="card-body">
                 <h3 class="card-title">Predictions</h3>

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -206,6 +206,22 @@
             {% include "evaluation/evaluation_incomplete_jobs_detail.html" %}
 
             <div class="card-body">
+                <h3 class="card-title">Error Message</h3>
+
+                {% if not incomplete_jobs %}
+
+                    All prequisite jobs succeeded.
+
+                    {% if object.error_message %}
+                        Evaluation failed due to the following error: {{ object.error_message }}
+                    {% endif %}
+
+                {% else %}
+                    Some jobs are incomplete. Check the status and error messages of the prequisite jobs above.
+                {% endif %}
+            </div>
+
+            <div class="card-body">
                 <h3 class="card-title">Predictions</h3>
 
                  {% if object.submission.predictions_file %}

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -209,13 +209,10 @@
                 <h3 class="card-title">Error Message</h3>
 
                 {% if not incomplete_jobs %}
-
                     All prerequisite jobs succeeded.
-
                     {% if object.error_message %}
                         Evaluation failed due to the following error: {{ object.error_message }}
                     {% endif %}
-
                 {% else %}
                     Some jobs are incomplete. Check the status and error messages of the prerequisite jobs above.
                 {% endif %}

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_incomplete_jobs_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_incomplete_jobs_detail.html
@@ -33,7 +33,7 @@
                             {% include "algorithms/job_status_detail.html" with object=job %}
                         </td>
                         <td>
-                            {% include "algorithms/job_error_message.html" with object=job %}
+                            {{ job.error_message }}
                         </td>
                     </tr>
                 {% endfor %}

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_incomplete_jobs_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_incomplete_jobs_detail.html
@@ -21,6 +21,7 @@
                 <th>ID</th>
                 <th>Created</th>
                 <th>Status</th>
+                <th>Error Message</th>
             </tr>
             </thead>
             <tbody>
@@ -30,6 +31,9 @@
                         <td>{{ job.created }}</td>
                         <td>
                             {% include "algorithms/job_status_detail.html" with object=job %}
+                        </td>
+                        <td>
+                            {% include "algorithms/job_error_message.html" with object=job %}
                         </td>
                     </tr>
                 {% endfor %}

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from factory.django import ImageField
 from guardian.shortcuts import assign_perm, remove_perm
 
-from grandchallenge.algorithms.models import Algorithm, Job
+from grandchallenge.algorithms.models import Algorithm
 from grandchallenge.components.models import (
     ComponentInterface,
     ImportStatusChoices,
@@ -23,10 +23,7 @@ from grandchallenge.evaluation.models import (
     Evaluation,
     Submission,
 )
-from grandchallenge.evaluation.tasks import (
-    create_algorithm_jobs_for_evaluation,
-    update_combined_leaderboard,
-)
+from grandchallenge.evaluation.tasks import update_combined_leaderboard
 from grandchallenge.evaluation.utils import SubmissionKindChoices
 from grandchallenge.invoices.models import PaymentStatusChoices
 from grandchallenge.workstations.models import Workstation
@@ -51,8 +48,6 @@ from tests.factories import (
     ChallengeFactory,
     ChallengeRequestFactory,
     GroupFactory,
-    ImageFactory,
-    UploadSessionFactory,
     UserFactory,
     WorkstationConfigFactory,
     WorkstationFactory,
@@ -1765,33 +1760,11 @@ def test_phase_archive_info_permissions(client):
 
 @pytest.mark.django_db
 def test_evaluation_details_error_message(client):
-    s = UploadSessionFactory()
-    im = ImageFactory()
-    s.image_set.set([im])
+    evaluation_error_message = "Test evaluation error message"
 
-    input_interface = ComponentInterface.objects.get(
-        slug="generic-medical-image"
-    )
-    civ = ComponentInterfaceValueFactory(image=im, interface=input_interface)
+    evaluation = EvaluationFactory(time_limit=60)
 
-    ai = AlgorithmImageFactory()
-    ai.algorithm.inputs.set([input_interface])
-
-    archive = ArchiveFactory()
-    archive.algorithms.set([ai.algorithm])
-
-    archive_item = ArchiveItemFactory(archive=archive)
-    archive_item.values.set([civ])
-
-    evaluation = EvaluationFactory(
-        submission__phase__archive=archive,
-        submission__algorithm_image=ai,
-        time_limit=ai.algorithm.time_limit,
-    )
-
-    create_algorithm_jobs_for_evaluation(evaluation_pk=evaluation.pk)
-
-    response1 = get_view_for_user(
+    response = get_view_for_user(
         viewname="evaluation:detail",
         client=client,
         method=client.get,
@@ -1802,36 +1775,13 @@ def test_evaluation_details_error_message(client):
         challenge=evaluation.submission.phase.challenge,
     )
 
-    assert response1.status_code == 200
-    assert "Some jobs are incomplete" in response1.rendered_content
+    assert response.status_code == 200
+    assert evaluation_error_message not in response.rendered_content
 
-    job = Job.objects.get()
-    job.status = Job.SUCCESS
-    job.save()
-
-    response2 = get_view_for_user(
-        viewname="evaluation:detail",
-        client=client,
-        method=client.get,
-        reverse_kwargs={
-            "pk": evaluation.pk,
-        },
-        user=evaluation.submission.phase.challenge.creator,
-        challenge=evaluation.submission.phase.challenge,
-    )
-
-    assert response2.status_code == 200
-    assert "All prerequisite jobs succeeded" in response2.rendered_content
-    assert (
-        "Evaluation failed due to the following error"
-        not in response2.rendered_content
-    )
-
-    evaluation.status = Evaluation.FAILURE
     evaluation.error_message = "Test evaluation error message"
     evaluation.save()
 
-    response3 = get_view_for_user(
+    response = get_view_for_user(
         viewname="evaluation:detail",
         client=client,
         method=client.get,
@@ -1842,28 +1792,5 @@ def test_evaluation_details_error_message(client):
         challenge=evaluation.submission.phase.challenge,
     )
 
-    assert response3.status_code == 200
-    assert "All prerequisite jobs succeeded" in response3.rendered_content
-    assert (
-        "Evaluation failed due to the following error"
-        in response3.rendered_content
-    )
-    assert "Test evaluation error message" in response3.rendered_content
-
-    evaluation.status = Evaluation.SUCCESS
-    evaluation.error_message = ""
-    evaluation.save()
-
-    response4 = get_view_for_user(
-        viewname="evaluation:detail",
-        client=client,
-        method=client.get,
-        reverse_kwargs={
-            "pk": evaluation.pk,
-        },
-        user=evaluation.submission.phase.challenge.creator,
-        challenge=evaluation.submission.phase.challenge,
-    )
-
-    assert response4.status_code == 200
-    assert "Error Message" not in response4.rendered_content
+    assert response.status_code == 200
+    assert evaluation_error_message in response.rendered_content

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -1849,3 +1849,21 @@ def test_evaluation_details_error_message(client):
         in response3.rendered_content
     )
     assert "Test evaluation error message" in response3.rendered_content
+
+    evaluation.status = Evaluation.SUCCESS
+    evaluation.error_message = ""
+    evaluation.save()
+
+    response4 = get_view_for_user(
+        viewname="evaluation:detail",
+        client=client,
+        method=client.get,
+        reverse_kwargs={
+            "pk": evaluation.pk,
+        },
+        user=evaluation.submission.phase.challenge.creator,
+        challenge=evaluation.submission.phase.challenge,
+    )
+
+    assert response4.status_code == 200
+    assert "Error Message" not in response4.rendered_content


### PR DESCRIPTION
closes #3467 

This PR adds a message section to the evaluation details view (admin section) to better communicate with the user the reason for evaluation failure.

I also adds an error message column to the prerequisite jobs table to show the error of failed jobs.