### PR TITLE
Adds algorithm create redirect view

### DIFF
--- a/app/grandchallenge/algorithms/forms.py
+++ b/app/grandchallenge/algorithms/forms.py
@@ -252,7 +252,7 @@ class AlgorithmIOValidationMixin:
 
 class PhaseSelectForm(Form):
     phase = ModelChoiceField(
-        label="Please select the phase for which you are creating an algorithm for",
+        label="Please select the phase for which you are creating an algorithm",
         queryset=Phase.objects.none(),
         required=True,
         widget=Select2Widget,

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_create_redirect.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_create_redirect.html
@@ -31,7 +31,7 @@
         <h2>Create a Custom Algorithm</h2>
 
         <p>
-            If you're algorithm is not for a specific challenge then you can follow the link below to create
+            If your algorithm is not for a specific challenge then you can follow the link below to create
             an algorithm with completely custom interfaces.
         </p>
 

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_create_redirect.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_create_redirect.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% load url %}
+{% load crispy_forms_tags %}
+
+{% block title %}
+    Create Algorithm - Algorithms - {{ block.super }}
+{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% url 'algorithms:list' %}">Algorithms</a></li>
+        <li class="breadcrumb-item active"
+            aria-current="page">Create Algorithm</li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <h2>Create an Algorithm for a Challenge</h2>
+
+    {% if form.fields.phase.queryset %}
+        {% crispy form %}
+    {% else %}
+        <p>
+            You are not currently participating in any challenges with active algorithm submission phases.
+            Please <a href="{% url "challenges:list" %}">find and join one</a>
+            or come back later when the submissions have opened.
+        </p>
+    {% endif %}
+
+    {% if perms.algorithms.add_algorithm %}
+        <h2>Create a Custom Algorithm</h2>
+
+        <p>
+            If you're algorithm is not for a specific challenge then you can follow the link below to create
+            an algorithm with completely custom interfaces.
+        </p>
+
+        <p>
+            <a href="{% url "algorithms:custom-create" %}"
+               class="btn btn-primary">
+                <i class="fa fa-plus"></i> Add a Custom Algorithm
+            </a>
+        </p>
+    {% endif %}
+{% endblock %}

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_list.html
@@ -10,14 +10,12 @@
 {% endblock %}
 
 {% block content %}
-    {% if perms.algorithms.add_algorithm %}
-        <p>
-            <a href="{% url "algorithms:create" %}"
-               class="btn btn-primary">
-                <i class="fa fa-plus"></i> Add a new algorithm
-            </a>
-        </p>
-    {% endif %}
+    <p>
+        <a href="{% url "algorithms:create-redirect" %}"
+           class="btn btn-primary">
+            <i class="fa fa-plus"></i> Add a new algorithm
+        </a>
+    </p>
 
     {% include "grandchallenge/partials/filters.html" with filter=filter filters_applied=filters_applied %}
 

--- a/app/grandchallenge/algorithms/urls.py
+++ b/app/grandchallenge/algorithms/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from grandchallenge.algorithms.views import (
     AlgorithmCreate,
+    AlgorithmCreateRedirect,
     AlgorithmDescriptionUpdate,
     AlgorithmDetail,
     AlgorithmImageActivate,
@@ -41,7 +42,8 @@ app_name = "algorithms"
 
 urlpatterns = [
     path("", AlgorithmList.as_view(), name="list"),
-    path("create/", AlgorithmCreate.as_view(), name="create"),
+    path("create/", AlgorithmCreateRedirect.as_view(), name="create-redirect"),
+    path("custom-create/", AlgorithmCreate.as_view(), name="custom-create"),
     path("import/", AlgorithmImportView.as_view(), name="import"),
     path("<slug>/", AlgorithmDetail.as_view(), name="detail"),
     path(

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -57,6 +57,7 @@ from grandchallenge.algorithms.forms import (
     ImageActivateForm,
     JobCreateForm,
     JobForm,
+    PhaseSelectForm,
     UsersForm,
     ViewersForm,
 )
@@ -100,6 +101,31 @@ from grandchallenge.subdomains.utils import reverse, reverse_lazy
 from grandchallenge.verifications.views import VerificationRequiredMixin
 
 logger = logging.getLogger(__name__)
+
+
+class AlgorithmCreateRedirect(
+    LoginRequiredMixin,
+    VerificationRequiredMixin,
+    FormView,
+):
+    form_class = PhaseSelectForm
+    template_name = "algorithms/algorithm_create_redirect.html"
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["user"] = self.request.user
+        return kwargs
+
+    def form_valid(self, form):
+        phase = form.cleaned_data["phase"]
+        self.success_url = reverse(
+            "evaluation:phase-algorithm-create",
+            kwargs={
+                "challenge_short_name": phase.challenge.short_name,
+                "slug": phase.slug,
+            },
+        )
+        return super().form_valid(form=form)
 
 
 class AlgorithmCreate(

--- a/app/tests/algorithms_tests/test_forms.py
+++ b/app/tests/algorithms_tests/test_forms.py
@@ -161,7 +161,7 @@ def test_algorithm_create(client, uploaded_image):
 
     def try_create_algorithm():
         return get_view_for_user(
-            viewname="algorithms:create",
+            viewname="algorithms:custom-create",
             client=client,
             method=client.post,
             data={

--- a/app/tests/algorithms_tests/test_views.py
+++ b/app/tests/algorithms_tests/test_views.py
@@ -25,6 +25,8 @@ from grandchallenge.components.models import (
     InterfaceKindChoices,
 )
 from grandchallenge.components.schemas import GPUTypeChoices
+from grandchallenge.evaluation.utils import SubmissionKindChoices
+from grandchallenge.invoices.models import PaymentStatusChoices
 from grandchallenge.profiles.templatetags.profiles import user_profile_link
 from grandchallenge.subdomains.utils import reverse
 from grandchallenge.uploads.models import UserUpload
@@ -43,6 +45,7 @@ from tests.components_tests.factories import (
 from tests.conftest import get_interface_form_data
 from tests.evaluation_tests.factories import EvaluationFactory, PhaseFactory
 from tests.factories import ImageFactory, UserFactory
+from tests.invoices_tests.factories import InvoiceFactory
 from tests.reader_studies_tests.factories import ReaderStudyFactory
 from tests.uploads_tests.factories import (
     UserUploadFactory,
@@ -2242,3 +2245,76 @@ def test_algorithm_statistics_view(client):
     assert f"<dd>{len(failed_jobs)}</dd>" in response2.rendered_content
     assert top_user_profile in response2.rendered_content
     assert f"{total_jobs} jobs" in response2.rendered_content
+
+
+@pytest.mark.django_db
+def test_algorithm_create_redirect(client):
+    user = UserFactory()
+    VerificationFactory(user=user, is_verified=True)
+
+    open_phase, closed_phase, non_public_phase, non_participant_phase = (
+        PhaseFactory.create_batch(
+            4,
+            submission_kind=SubmissionKindChoices.ALGORITHM,
+            submissions_limit_per_user_per_period=1,
+        )
+    )
+
+    open_phase.challenge.add_participant(user=user)
+    closed_phase.challenge.add_participant(user=user)
+
+    non_public_phase.challenge.add_participant(user=user)
+    non_public_phase.public = False
+    non_public_phase.save()
+
+    InvoiceFactory(
+        challenge=open_phase.challenge,
+        support_costs_euros=0,
+        compute_costs_euros=10,
+        storage_costs_euros=0,
+        payment_status=PaymentStatusChoices.PAID,
+    )
+
+    response = get_view_for_user(
+        viewname="algorithms:create-redirect",
+        client=client,
+        user=user,
+    )
+
+    assert response.status_code == 200
+    assert {*response.context["form"].fields["phase"].queryset} == {
+        open_phase,
+        closed_phase,
+    }
+
+    response = get_view_for_user(
+        viewname="algorithms:create-redirect",
+        client=client,
+        user=user,
+        method=client.post,
+        data={"phase": open_phase.pk},
+    )
+
+    assert response.status_code == 302
+    assert response.url == reverse(
+        "evaluation:phase-algorithm-create",
+        kwargs={
+            "challenge_short_name": open_phase.challenge.short_name,
+            "slug": open_phase.slug,
+        },
+    )
+
+    response = get_view_for_user(
+        viewname="algorithms:create-redirect",
+        client=client,
+        user=user,
+        method=client.post,
+        data={"phase": closed_phase.pk},
+    )
+
+    assert response.status_code == 200
+    assert response.context["form"].errors == {
+        "phase": [
+            "This phase is not currently open for submissions, please try again later."
+        ]
+    }

--- a/app/tests/algorithms_tests/test_views.py
+++ b/app/tests/algorithms_tests/test_views.py
@@ -56,18 +56,20 @@ from tests.verification_tests.factories import VerificationFactory
 def test_create_link_view(client, settings):
     user = UserFactory()
 
+    VerificationFactory(user=user, is_verified=True)
+
     response = get_view_for_user(
-        viewname="algorithms:list", client=client, user=user
+        viewname="algorithms:create-redirect", client=client, user=user
     )
-    assert reverse("algorithms:create") not in response.rendered_content
+    assert reverse("algorithms:custom-create") not in response.rendered_content
 
     g = Group.objects.get(name=settings.ALGORITHMS_CREATORS_GROUP_NAME)
     g.user_set.add(user)
 
     response = get_view_for_user(
-        viewname="algorithms:list", client=client, user=user
+        viewname="algorithms:create-redirect", client=client, user=user
     )
-    assert reverse("algorithms:create") in response.rendered_content
+    assert reverse("algorithms:custom-create") in response.rendered_content
 
 
 @pytest.mark.django_db
@@ -354,7 +356,7 @@ class TestObjectPermissionRequiredViews:
         VerificationFactory(user=u, is_verified=True)
 
         for view_name, kwargs, permission, obj, redirect in [
-            ("create", {}, "algorithms.add_algorithm", None, None),
+            ("custom-create", {}, "algorithms.add_algorithm", None, None),
             (
                 "detail",
                 {"slug": ai.algorithm.slug},


### PR DESCRIPTION
Users are presented with the phases that they have the `"create_phase_submission"` which is currently public phases for the participants group, or all phases for the admins group. 

<img width="1169" alt="Screenshot 2025-02-19 at 17 11 18" src="https://github.com/user-attachments/assets/577cd1e6-6c02-45aa-9087-c0bbf19873ae" />

The check on whether the phase is open is very complex and in a mixin that cannot really be re-used here, so we just clean the phase to see if it is open for non-admins. The full check is then done on the redirect but the errors are not as nice.

<img width="1164" alt="Screenshot 2025-02-19 at 17 11 25" src="https://github.com/user-attachments/assets/94ea5fbd-cf7c-4309-9814-462ab464a0ce" />

If the phase is open then the user will end up on the usual page.

<img width="1148" alt="Screenshot 2025-02-19 at 17 11 33" src="https://github.com/user-attachments/assets/52461f4d-91bb-479f-9bec-c1a4603dfff1" />

Those with custom algorithm permissions will see the extra link.

<img width="1176" alt="Screenshot 2025-02-19 at 17 15 39" src="https://github.com/user-attachments/assets/43b2048f-dd6b-46bb-a033-8b7feb8f499e" />

Closes #3671 