### PR TITLE
Rename interface to socket on user-facing views

### DIFF
--- a/app/grandchallenge/algorithms/migrations/0025_algorithm_hanging_protocol.py
+++ b/app/grandchallenge/algorithms/migrations/0025_algorithm_hanging_protocol.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             name="hanging_protocol",
             field=models.ForeignKey(
                 blank=True,
-                help_text='Indicate which Component Interfaces need to be displayed in which image port. E.g. {"main": ["interface1"]}. The first item in the list of interfaces will be the main image in the image port. The first overlay type interface thereafter will be rendered as an overlay. For now, any other items will be ignored by the viewer.',
+                help_text='Indicate which sockets need to be displayed in which image port. E.g. {"main": ["socket1"]}. The first item in the list of sockets will be the main image in the image port. The first overlay type socket thereafter will be rendered as an overlay. For now, any other items will be ignored by the viewer.',
                 null=True,
                 on_delete=django.db.models.deletion.SET_NULL,
                 to="hanging_protocols.hangingprotocol",

--- a/app/grandchallenge/archives/forms.py
+++ b/app/grandchallenge/archives/forms.py
@@ -206,14 +206,14 @@ class ArchiveItemsToReaderStudyForm(SaveFormInitMixin, Form):
 
 
 class AddCasesForm(UploadRawImagesForm):
-    interface = ModelChoiceField(
+    socket = ModelChoiceField(
         queryset=ComponentInterface.objects.filter(
             kind__in=InterfaceKind.interface_type_image()
         ).order_by("title"),
         widget=autocomplete.ModelSelect2(
             url="components:component-interface-autocomplete",
             attrs={
-                "data-placeholder": "Search for an interface ...",
+                "data-placeholder": "Search for a socket ...",
                 "data-minimum-input-length": 3,
                 "data-theme": settings.CRISPY_TEMPLATE_PACK,
                 "data-html": True,
@@ -223,18 +223,18 @@ class AddCasesForm(UploadRawImagesForm):
 
     def __init__(self, *args, interface_viewname, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["interface"].help_text = format_lazy(
+        self.fields["socket"].help_text = format_lazy(
             (
-                'See the <a href="{}">list of interfaces</a> for more '
-                "information about each interface. "
-                "Please contact support if your desired interface is missing."
+                'See the <a href="{}">list of sockets</a> for more '
+                "information about each socket. "
+                "Please contact support if your desired socket is missing."
             ),
             reverse_lazy(interface_viewname),
         )
 
     def save(self, *args, **kwargs):
         self._linked_task.kwargs.update(
-            {"interface_pk": self.cleaned_data["interface"].pk}
+            {"interface_pk": self.cleaned_data["socket"].pk}
         )
         return super().save(*args, **kwargs)
 

--- a/app/grandchallenge/archives/migrations/0011_archive_hanging_protocol.py
+++ b/app/grandchallenge/archives/migrations/0011_archive_hanging_protocol.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             name="hanging_protocol",
             field=models.ForeignKey(
                 blank=True,
-                help_text='Indicate which Component Interfaces need to be displayed in which image port. E.g. {"main": ["interface1"]}. The first item in the list of interfaces will be the main image in the image port. The first overlay type interface thereafter will be rendered as an overlay. For now, any other items will be ignored by the viewer.',
+                help_text='Indicate which sockets need to be displayed in which image port. E.g. {"main": ["socket1"]}. The first item in the list of sockets will be the main image in the image port. The first overlay type socket thereafter will be rendered as an overlay. For now, any other items will be ignored by the viewer.',
                 null=True,
                 on_delete=django.db.models.deletion.SET_NULL,
                 to="hanging_protocols.hangingprotocol",

--- a/app/grandchallenge/cases/models.py
+++ b/app/grandchallenge/cases/models.py
@@ -153,7 +153,7 @@ class RawImageUploadSession(UUIDModel):
         if detailed_error_message:
             notification_description = oxford_comma(
                 [
-                    f"Image validation for interface {key} failed with error: {val}. "
+                    f"Image validation for socket {key} failed with error: {val}. "
                     for key, val in detailed_error_message.items()
                 ]
             )

--- a/app/grandchallenge/components/forms.py
+++ b/app/grandchallenge/components/forms.py
@@ -279,7 +279,7 @@ class SingleCIVForm(Form):
             widget = autocomplete.ModelSelect2
             attrs.update(
                 {
-                    "data-placeholder": "Search for an interface ...",
+                    "data-placeholder": "Search for a socket ...",
                     "data-minimum-input-length": 3,
                     "data-theme": settings.CRISPY_TEMPLATE_PACK,
                     "data-html": True,
@@ -296,12 +296,12 @@ class SingleCIVForm(Form):
             initial=selected_interface,
             queryset=qs,
             widget=widget(**widget_kwargs),
-            label="Interface",
+            label="Socket",
             help_text=format_lazy(
                 (
-                    'See the <a href="{}">list of interfaces</a> for more '
-                    "information about each interface. "
-                    "Please contact support if your desired interface is missing."
+                    'See the <a href="{}">list of sockets</a> for more '
+                    "information about each socket. "
+                    "Please contact support if your desired socket is missing."
                 ),
                 reverse_lazy(base_obj.interface_viewname),
             ),

--- a/app/grandchallenge/components/templates/components/civ_set_form.html
+++ b/app/grandchallenge/components/templates/components/civ_set_form.html
@@ -54,7 +54,7 @@
       >
             <div class="d-none" hx-display-me>
               <span id="hx-add-interface-indicator" class="htmx-indicator spinner-border spinner-border-sm"></span>
-              Add value for new interface
+              Add value for new socket
             </div>
           <div hx-hide-me>
               <span class="spinner-border spinner-border-sm"></span>

--- a/app/grandchallenge/components/templates/components/componentinterface_io_switch.html
+++ b/app/grandchallenge/components/templates/components/componentinterface_io_switch.html
@@ -3,39 +3,40 @@
 {% load static %}
 
 {% block title %}
-    Interface Options - {{ block.super }}
+    Socket Options - {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
-        <li class="breadcrumb-item active" aria-current="page">Interface Options</li>
+        <li class="breadcrumb-item active" aria-current="page">Socket Options</li>
     </ol>
 {% endblock %}
 
 {% block content %}
-    <h2>Algorithm Interface Options</h2>
+    <h2>Algorithm Socket Options</h2>
 
     <p>
-        You will need to define the inputs to, and the outputs from, your algorithm.
-        The set of inputs and outputs that your algorithm uses is known as its interface.
-        You can build up your algorithm's interface by selecting from the current set of interface options.
-        Use the links below to see the options that are available for your algorithm's interface.
+        You will need to define the inputs and outputs for your algorithm.
+        A set of inputs and outputs that your algorithm uses is known as its interface.
+        The inputs and outputs that make up an algorithm interface are called sockets.
+        You can build up an algorithm interface by selecting from the current set of socket options.
+        Use the links below to see the socket options that are available.
     </p>
 
     <p>
         For example, lets say that you are developing an algorithm that predicts COVID-19 from a CT scan,
         which also produces a segmentation of COVID-19 lesions.
-        You would look in the list of interface options and select the ones to use.
-        You would then define an algorithm that has one input, a <code>ct-image</code>,
+        You would look in the list of socket options and select the ones to use.
+        You would then define an algorithm that has one interface with one input, a <code>ct-image</code>,
         and two outputs, <code>probability-covid-19</code> (a number)
         and <code>covid-19-lesion-segementation</code> (a segmentation of covid 19 lesions).
     </p>
 
-    <img src="{% static 'components/images/example-algorithm.drawio.svg' %}" class="mx-auto d-block" alt="Example algorithm with one input interface and two output interfaces">
+    <img src="{% static 'components/images/example-algorithm.drawio.svg' %}" class="mx-auto d-block" alt="Example algorithm with one interface consisting of one input and two output sockets">
 
     <p>
-        You can select as many inputs and outputs as your algorithm needs.
-        However, the same interface option cannot be used for both input to and output from your algorithm.
+        You can select as many inputs and outputs for a single interface as you need.
+        However, the same socket option cannot be used for both input to and output from your algorithm.
         All inputs and outputs are required to be set when your algorithm runs.
         The inputs will be set by the user running your algorithm.
         Your algorithm must write valid data to all the outputs you set.
@@ -57,7 +58,7 @@
 
     <p>
         If an option does not exist for your use case please contact support with the title, description, and
-        kind for your new interface option.
+        kind for your new socket option.
     </p>
 
 {% endblock %}

--- a/app/grandchallenge/components/templates/components/componentinterface_list.html
+++ b/app/grandchallenge/components/templates/components/componentinterface_list.html
@@ -6,19 +6,19 @@
 
 {% block title %}
     {% if object_type == object_type_options.ALGORITHM %}
-        {{ list_type|title }} - Interface Options - {{ block.super }}
+        {{ list_type|title }} - Socket Options - {{ block.super }}
     {% else %}
-        Interface Options - {{ block.super }}
+        Socket Options - {{ block.super }}
     {% endif %}
 {% endblock %}
 
 {% block breadcrumbs %}
     <ol class="breadcrumb">
         {% if object_type == object_type_options.ALGORITHM %}
-            <li class="breadcrumb-item"><a href="{% url 'components:component-interface-list-algorithms' %}">Interface Options</a></li>
+            <li class="breadcrumb-item"><a href="{% url 'components:component-interface-list-algorithms' %}">Socket Options</a></li>
             <li class="breadcrumb-item active" aria-current="page">{{ list_type|title }}</li>
         {% else %}
-            <li class="breadcrumb-item active" aria-current="page">Interface Options</li>
+            <li class="breadcrumb-item active" aria-current="page">Socket Options</li>
         {% endif %}
     </ol>
 {% endblock %}
@@ -39,7 +39,7 @@
             times within one {{ list_type|lower }}.
         {% endif %}
         If an option does not exist for your use case please contact support with the title, description, and kind
-        for your new interface option.
+        for your new socket option.
     </p>
 
     <div class="table-responsive">

--- a/app/grandchallenge/core/error_handlers.py
+++ b/app/grandchallenge/core/error_handlers.py
@@ -100,8 +100,8 @@ class UserUploadCIVErrorHandler(ErrorHandler):
     def handle_error(self, *, error_message, user, interface):
         Notification.send(
             kind=NotificationType.NotificationTypeChoices.FILE_COPY_STATUS,
-            message=f"Validation for interface {interface.title} failed.",
-            description=f"Validation for interface {interface.title} failed: {error_message}",
+            message=f"Validation for socket {interface.title} failed.",
+            description=f"Validation for socket {interface.title} failed: {error_message}",
             actor=user,
         )
 
@@ -118,8 +118,8 @@ class FallbackCIVValidationErrorHandler(ErrorHandler):
         if interface:
             Notification.send(
                 kind=NotificationType.NotificationTypeChoices.CIV_VALIDATION,
-                message=f"Validation for interface {interface.title} failed.",
-                description=f"Validation for interface {interface.title} failed: {error_message}",
+                message=f"Validation for socket {interface.title} failed.",
+                description=f"Validation for socket {interface.title} failed: {error_message}",
                 actor=user,
             )
         else:

--- a/app/grandchallenge/evaluation/migrations/0027_auto_20220707_0933.py
+++ b/app/grandchallenge/evaluation/migrations/0027_auto_20220707_0933.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
             name="hanging_protocol",
             field=models.ForeignKey(
                 blank=True,
-                help_text='Indicate which Component Interfaces need to be displayed in which image port. E.g. {"main": ["interface1"]}. The first item in the list of interfaces will be the main image in the image port. The first overlay type interface thereafter will be rendered as an overlay. For now, any other items will be ignored by the viewer.',
+                help_text='Indicate which sockets need to be displayed in which image port. E.g. {"main": ["socket1"]}. The first item in the list of sockets will be the main image in the image port. The first overlay type socket thereafter will be rendered as an overlay. For now, any other items will be ignored by the viewer.',
                 null=True,
                 on_delete=django.db.models.deletion.SET_NULL,
                 to="hanging_protocols.hangingprotocol",

--- a/app/grandchallenge/hanging_protocols/forms.py
+++ b/app/grandchallenge/hanging_protocols/forms.py
@@ -159,7 +159,7 @@ class ViewContentExampleMixin:
             if len(interface_slugs) > 0:
                 self.fields[
                     "view_content"
-                ].help_text += f"The following interfaces are used in your {self.instance._meta.verbose_name}: {oxford_comma(interface_slugs)}. "
+                ].help_text += f"The following sockets are used in your {self.instance._meta.verbose_name}: {oxford_comma(interface_slugs)}. "
 
             view_content_example = self.generate_view_content_example()
 
@@ -170,7 +170,7 @@ class ViewContentExampleMixin:
             else:
                 self.fields[
                     "view_content"
-                ].help_text += "No interfaces of type image, chart, pdf, mp4, thumbnail_jpg or thumbnail_png are used. At least one interface of those types is needed to configure the viewer. "
+                ].help_text += "No sockets of type image, chart, pdf, mp4, thumbnail_jpg or thumbnail_png are used. At least one socket of those types is needed to configure the viewer. "
 
         self.fields["view_content"].help_text += format_lazy(
             'Refer to the <a href="{}">documentation</a> for more information',

--- a/app/grandchallenge/hanging_protocols/models.py
+++ b/app/grandchallenge/hanging_protocols/models.py
@@ -316,10 +316,10 @@ class HangingProtocolMixin(models.Model):
         blank=True,
         on_delete=models.SET_NULL,
         help_text=(
-            "Indicate which Component Interfaces need to be displayed in "
-            'which image port. E.g. {"main": ["interface1"]}. The first '
-            "item in the list of interfaces will be the main image in "
-            "the image port. The first overlay type interface thereafter "
+            "Indicate which sockets need to be displayed in "
+            'which image port. E.g. {"main": ["socket1"]}. The first '
+            "item in the list of sockets will be the main image in "
+            "the image port. The first overlay type socket thereafter "
             "will be rendered as an overlay. For now, any other items "
             "will be ignored by the viewer."
         ),
@@ -356,7 +356,7 @@ class HangingProtocolMixin(models.Model):
 
             if set(slugs) != {i.slug for i in viewport_interfaces}:
                 raise ValidationError(
-                    f"Unknown interfaces in view content for viewport {viewport}: {', '.join(slugs)}"
+                    f"Unknown sockets in view content for viewport {viewport}: {', '.join(slugs)}"
                 )
 
             image_interfaces = [
@@ -367,7 +367,7 @@ class HangingProtocolMixin(models.Model):
 
             if len(image_interfaces) > 1:
                 raise ValidationError(
-                    "Maximum of one image interface is allowed per viewport, "
+                    "Maximum of one image socket is allowed per viewport, "
                     f"got {len(image_interfaces)} for viewport {viewport}: "
                     f"{', '.join(i.slug for i in image_interfaces)}"
                 )
@@ -383,7 +383,7 @@ class HangingProtocolMixin(models.Model):
                 and len(viewport_interfaces) > 1
             ):
                 raise ValidationError(
-                    "Some of the selected interfaces can only be displayed in isolation, "
+                    "Some of the selected sockets can only be displayed in isolation, "
                     f"found {len(mandatory_isolation_interfaces)} for viewport {viewport}: "
                     f"{', '.join(i.slug for i in mandatory_isolation_interfaces)}"
                 )
@@ -396,7 +396,7 @@ class HangingProtocolMixin(models.Model):
 
             if len(undisplayable_interfaces) > 0:
                 raise ValidationError(
-                    "Some of the selected interfaces cannot be displayed, "
+                    "Some of the selected sockets cannot be displayed, "
                     f"found {len(undisplayable_interfaces)} for viewport {viewport}: "
                     f"{', '.join(i.slug for i in undisplayable_interfaces)}"
                 )

--- a/app/grandchallenge/reader_studies/forms.py
+++ b/app/grandchallenge/reader_studies/forms.py
@@ -615,10 +615,11 @@ class QuestionForm(SaveFormInitMixin, DynamicFormMixin, ModelForm):
 
     interface = DynamicField(
         ModelChoiceField,
+        label="Socket",
         queryset=interface_choices,
         initial=None,
         required=False,
-        help_text="Select component interface to use as a default answer for this "
+        help_text="Select socket to use as a default answer for this "
         "question.",
     )
 

--- a/app/grandchallenge/reader_studies/migrations/0019_readerstudy_hanging_protocol.py
+++ b/app/grandchallenge/reader_studies/migrations/0019_readerstudy_hanging_protocol.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             name="hanging_protocol",
             field=models.ForeignKey(
                 blank=True,
-                help_text='Indicate which Component Interfaces need to be displayed in which image port. E.g. {"main": ["interface1"]}. The first item in the list of interfaces will be the main image in the image port. The first overlay type interface thereafter will be rendered as an overlay. For now, any other items will be ignored by the viewer.',
+                help_text='Indicate which sockets need to be displayed in which image port. E.g. {"main": ["socket1"]}. The first item in the list of sockets will be the main image in the image port. The first overlay type socket thereafter will be rendered as an overlay. For now, any other items will be ignored by the viewer.',
                 null=True,
                 on_delete=django.db.models.deletion.SET_NULL,
                 to="hanging_protocols.hangingprotocol",

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1513,7 +1513,7 @@ class Question(UUIDModel, OverlaySegmentsMixin):
             and self.interface not in self.allowed_component_interfaces
         ):
             raise ValidationError(
-                f"The interface {self.interface} is not allowed for this "
+                f"The socket {self.interface} is not allowed for this "
                 f"question type ({self.answer_type})"
             )
 

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_add_object.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_add_object.html
@@ -20,6 +20,6 @@
 {% block form_heading %}
     <h2>Add {{ type_to_add }} to {{ object }}</h2>
     {% if type_to_add == "images" %}
-        <p>This will create one new display set for each uploaded image using the interface you choose below.</p>
+        <p>This will create one new display set for each uploaded image using the socket you choose below.</p>
     {% endif %}
 {% endblock %}

--- a/app/tests/cases_tests/test_forms.py
+++ b/app/tests/cases_tests/test_forms.py
@@ -46,7 +46,7 @@ def test_upload_some_images(
         response = get_view_for_user(
             data={
                 "user_uploads": [user_upload.pk],
-                "interface": ComponentInterface.objects.first().pk,
+                "socket": ComponentInterface.objects.first().pk,
             },
             client=client,
             viewname="reader-studies:display-sets-create",

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -423,7 +423,7 @@ def test_add_image_to_object_updates_upload_session_on_validation_fail(
     us = RawImageUploadSessionFactory(status=RawImageUploadSession.SUCCESS)
     ci = ComponentInterfaceFactory(kind="IMG")
 
-    error_message = f"Image validation for interface {ci.title} failed with error: Image imports should result in a single image. "
+    error_message = f"Image validation for socket {ci.title} failed with error: Image imports should result in a single image. "
 
     linked_task = some_async_task.signature(
         kwargs={"foo": "bar"}, immutable=True
@@ -458,7 +458,7 @@ def test_add_image_to_object_marks_job_as_failed_on_validation_fail(
     us = RawImageUploadSessionFactory(status=RawImageUploadSession.SUCCESS)
     ci = ComponentInterfaceFactory(kind="IMG")
 
-    error_message = f"Image validation for interface {ci.title} failed with error: Image imports should result in a single image. "
+    error_message = f"Image validation for socket {ci.title} failed with error: Image imports should result in a single image. "
 
     linked_task = some_async_task.signature(
         kwargs={"foo": "bar"}, immutable=True
@@ -597,7 +597,7 @@ def test_add_file_to_object_sends_notification_on_validation_fail(
     us.refresh_from_db()
     assert Notification.objects.count() == 1
     assert (
-        f"Validation for interface {ci.title} failed."
+        f"Validation for socket {ci.title} failed."
         in Notification.objects.first().message
     )
     assert "some_async_task" not in str(callbacks)

--- a/app/tests/hanging_protocols_tests/test_forms.py
+++ b/app/tests/hanging_protocols_tests/test_forms.py
@@ -52,9 +52,7 @@ def test_view_content_mixin():
 
     assert not form.is_valid()
     assert form.errors == {
-        "__all__": [
-            "Unknown interfaces in view content for viewport main: test"
-        ]
+        "__all__": ["Unknown sockets in view content for viewport main: test"]
     }
 
     i = ComponentInterfaceFactory(
@@ -450,7 +448,7 @@ def make_ci_list(
             0,
             0,
             (
-                "No interfaces of type image, chart, pdf, mp4, thumbnail_jpg or thumbnail_png are used. At least one interface of those types is needed to configure the viewer. "
+                "No sockets of type image, chart, pdf, mp4, thumbnail_jpg or thumbnail_png are used. At least one socket of those types is needed to configure the viewer. "
                 'Refer to the <a href="https://testserver/documentation/viewer-content/">documentation</a> for more information'
             ),
         ),
@@ -460,8 +458,8 @@ def make_ci_list(
             0,
             1,
             (
-                "The following interfaces are used in your {}: test-ci-overlay-0 and test-ci-undisplayable-0. "
-                "No interfaces of type image, chart, pdf, mp4, thumbnail_jpg or thumbnail_png are used. At least one interface of those types is needed to configure the viewer. "
+                "The following sockets are used in your {}: test-ci-overlay-0 and test-ci-undisplayable-0. "
+                "No sockets of type image, chart, pdf, mp4, thumbnail_jpg or thumbnail_png are used. At least one socket of those types is needed to configure the viewer. "
                 'Refer to the <a href="https://testserver/documentation/viewer-content/">documentation</a> for more information'
             ),
         ),
@@ -471,7 +469,7 @@ def make_ci_list(
             1,
             1,
             (
-                "The following interfaces are used in your {}: test-ci-isolated-0, test-ci-image-0, test-ci-overlay-0, and test-ci-undisplayable-0. "
+                "The following sockets are used in your {}: test-ci-isolated-0, test-ci-image-0, test-ci-overlay-0, and test-ci-undisplayable-0. "
                 'Example usage: {{"main": ["test-ci-isolated-0"], "secondary": ["test-ci-image-0", "test-ci-overlay-0"]}}. '
                 'Refer to the <a href="https://testserver/documentation/viewer-content/">documentation</a> for more information'
             ),
@@ -522,7 +520,7 @@ def test_archive_and_reader_study_forms_view_content_help_text(
             0,
             0,
             (
-                "No interfaces of type image, chart, pdf, mp4, thumbnail_jpg or thumbnail_png are used. At least one interface of those types is needed to configure the viewer. "
+                "No sockets of type image, chart, pdf, mp4, thumbnail_jpg or thumbnail_png are used. At least one socket of those types is needed to configure the viewer. "
                 'Refer to the <a href="https://testserver/documentation/viewer-content/">documentation</a> for more information'
             ),
         ),
@@ -532,7 +530,7 @@ def test_archive_and_reader_study_forms_view_content_help_text(
             0,
             1,
             (
-                "No interfaces of type image, chart, pdf, mp4, thumbnail_jpg or thumbnail_png are used. At least one interface of those types is needed to configure the viewer. "
+                "No sockets of type image, chart, pdf, mp4, thumbnail_jpg or thumbnail_png are used. At least one socket of those types is needed to configure the viewer. "
                 'Refer to the <a href="https://testserver/documentation/viewer-content/">documentation</a> for more information'
             ),
         ),
@@ -586,7 +584,7 @@ def test_algorithm_form_view_content_help_text(
             0,
             0,
             (
-                "No interfaces of type image, chart, pdf, mp4, thumbnail_jpg or thumbnail_png are used. At least one interface of those types is needed to configure the viewer. "
+                "No sockets of type image, chart, pdf, mp4, thumbnail_jpg or thumbnail_png are used. At least one socket of those types is needed to configure the viewer. "
                 'Refer to the <a href="https://testserver/documentation/viewer-content/">documentation</a> for more information'
             ),
         ),
@@ -596,7 +594,7 @@ def test_algorithm_form_view_content_help_text(
             0,
             1,
             (
-                "No interfaces of type image, chart, pdf, mp4, thumbnail_jpg or thumbnail_png are used. At least one interface of those types is needed to configure the viewer. "
+                "No sockets of type image, chart, pdf, mp4, thumbnail_jpg or thumbnail_png are used. At least one socket of those types is needed to configure the viewer. "
                 'Refer to the <a href="https://testserver/documentation/viewer-content/">documentation</a> for more information'
             ),
         ),

--- a/app/tests/hanging_protocols_tests/test_models.py
+++ b/app/tests/hanging_protocols_tests/test_models.py
@@ -497,7 +497,7 @@ def test_view_content_validation():
     with pytest.raises(ValidationError) as err:
         hp.full_clean()
 
-    assert "Unknown interfaces in view content for viewport main: test" in str(
+    assert "Unknown sockets in view content for viewport main: test" in str(
         err.value
     )
 
@@ -553,7 +553,7 @@ def test_at_most_two_images():
         hp.full_clean()
 
     assert (
-        "Maximum of one image interface is allowed per viewport, got 2 for viewport main:"
+        "Maximum of one image socket is allowed per viewport, got 2 for viewport main:"
         in str(err.value)
     )
 
@@ -591,7 +591,7 @@ def test_interfaces_that_must_be_isolated(interface_kind):
         hp.full_clean()
 
     assert (
-        "Some of the selected interfaces can only be displayed in isolation, found 2 for viewport main"
+        "Some of the selected sockets can only be displayed in isolation, found 2 for viewport main"
         in str(err.value)
     )
 
@@ -603,7 +603,7 @@ def test_interfaces_that_must_be_isolated(interface_kind):
         hp.full_clean()
 
     assert (
-        "Some of the selected interfaces can only be displayed in isolation, found 1 for viewport main"
+        "Some of the selected sockets can only be displayed in isolation, found 1 for viewport main"
         in str(err.value)
     )
 
@@ -625,7 +625,7 @@ def test_interfaces_that_cannot_be_displayed(interface_kind):
         hp.full_clean()
 
     assert (
-        "Some of the selected interfaces cannot be displayed, found 1 for viewport main:"
+        "Some of the selected sockets cannot be displayed, found 1 for viewport main:"
         in str(err.value)
     )
 

--- a/app/tests/reader_studies_tests/test_models.py
+++ b/app/tests/reader_studies_tests/test_models.py
@@ -749,7 +749,7 @@ def test_question_interface():
         q.clean()
 
     assert e.value.message == (
-        f"The interface {ci_img} is not allowed for this "
+        f"The socket {ci_img} is not allowed for this "
         f"question type ({AnswerType.TEXT})"
     )
 


### PR DESCRIPTION
This renames `interface` to `socket` on user-facing views and forms. 
I did not change the urls that include the word `interface`. That seems less important to me for now. We will need to add permanent redirects when we do change them. 

I based this on the feature branch for optional inputs since a lot of the places that require changes are touched in this branch. The users can wait 1 week for the renaming I think. 

The only places where the user is still confronted with the word `interface` now (as far as I can tell) is the API. Updating that is more complex.