### PR TITLE
Split off the Ground Truth page

### DIFF
--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -61,9 +61,8 @@
                    aria-selected="false"><i class="fas fa-question fa-fw"></i>&nbsp;Questions&nbsp;<span
                         class="badge badge-pill badge-secondary align-middle">{{ object.questions.all.count }}</span>
                 </a>
-                <a class="nav-link" id="v-pills-ground-truth-tab" data-toggle="pill"
-                   href="#ground-truth" role="tab"
-                   aria-controls="v-pills-ground-truth"
+                <a class="nav-link"
+                   href="{% url 'reader-studies:ground-truth' slug=object.slug %}"
                    aria-selected="false"><i class="fas fa-check fa-fw"></i>&nbsp;Ground
                     Truth
                 </a>
@@ -289,59 +288,6 @@
 
                 {% url 'reader-studies:readers-update' slug=object.slug as readers_update_url %}
                 {% include "groups/partials/user_list.html" with role_name="readers" edit_url=readers_update_url form=editor_remove_form users=readers display_direct_message_link=True %}
-            </div>
-
-            <div class="tab-pane fade"
-                 id="ground-truth"
-                 role="tabpanel"
-                 aria-labelledby="v-pills-ground-truth-tab">
-
-                <h2>Ground Truth</h2>
-
-                <p>
-                    If you wish to assess the performance of the readers you
-                    can upload the CSV file containing the ground truth for
-                    this reader study here.
-                </p>
-                <p>
-                    The first row of the CSV file must contain the headings
-                    <code>case</code>, followed by the question text for
-                    each of the questions in the reader study (excluding those
-                    of type <code>heading</code>).
-                </p>
-                <p>
-                    The consecutive lines contain the id per case.
-                    Then include the answer for the question
-                    corresponding to the question text defined in the header for that
-                    column. All answers must be enclosed in single quotes. Strings
-                    must be enclosed in both single and double quotes, i.e.
-                    <code>'"answer"'</code>. For choice type questions, the
-                    options text(s) must be provided as a string. For optional
-                    questions, use <code>null</code> if you do not widh to
-                    provide ground truth for that question.
-                </p>
-                <p>
-                    An example of the first two lines of the csv for this reader study is:
-                    <code>
-                        {{ example_ground_truth|linebreaks }}
-                    </code>
-                </p>
-                <div class="d-flex justify-content-between">
-                    <div>
-                        <a class="btn btn-primary"
-                           href="{% url 'reader-studies:add-ground-truth' slug=object.slug %}">
-                            <i class="fas fa-upload"></i> Upload Ground Truth
-                        </a>
-                        <a class="btn btn-secondary"
-                           href="{% url 'reader-studies:example-ground-truth' slug=object.slug %}">
-                            <i class="fas fa-download"></i> Download Example CSV
-                        </a>
-                    </div>
-                    <button class="btn btn-danger" hx-post="{% url 'reader-studies:ground-truth-remove' slug=object.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}" }'>
-                        <i class="fas fa-trash-alt"></i> Delete ground truth
-                    </button>
-                </div>
-
             </div>
 
             <div class="tab-pane fade"

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_ground_truth.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_ground_truth.html
@@ -20,7 +20,7 @@
 <h2>Ground Truth</h2>
 {% if not object.is_educational %}
 <div class="alert alert-warning" role="alert">
-        <i class="fa fa-info-triangle pr-1" aria-hidden="true"></i>
+        <i class="fa fa-exclamation-triangle pr-1" aria-hidden="true"></i>
         This reader study is currently not configured as educational: any ground truth is not utilized.
         Mark the reader study as educational via the <a href="{% url 'reader-studies:update' slug=object.slug %}">settings</a>.
     </div>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_ground_truth.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_ground_truth.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+{% load url %}
+{% load static %}
+
+{% block title %}
+    Ground Truth - {{ object }} - {{ block.super }}
+{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="{% url 'reader-studies:list' %}">Reader
+            Studies</a></li>
+        <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{{ object }}</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Ground Truth</li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+
+<h2>Ground Truth</h2>
+
+<p>
+    If you wish to assess the performance of the readers you
+    can upload the CSV file containing the ground truth for
+    this reader study here.
+</p>
+<p>
+    The first row of the CSV file must contain the headings
+    <code>case</code>, followed by the question text for
+    each of the questions in the reader study (excluding those
+    of type <code>heading</code>).
+</p>
+<p>
+    The consecutive lines contain the id per case.
+    Then include the answer for the question
+    corresponding to the question text defined in the header for that
+    column. All answers must be enclosed in single quotes. Strings
+    must be enclosed in both single and double quotes, i.e.
+    <code>'"answer"'</code>. For choice type questions, the
+    options text(s) must be provided as a string. For optional
+    questions, use <code>null</code> if you do not widh to
+    provide ground truth for that question.
+</p>
+<p>
+    An example of the first two lines of the csv for this reader study is:
+    <code>
+        {{ example_ground_truth|linebreaks }}
+    </code>
+</p>
+<div class="d-flex justify-content-between">
+    <div>
+        <a class="btn btn-primary"
+            href="{% url 'reader-studies:add-ground-truth' slug=object.slug %}">
+            <i class="fas fa-upload"></i> Upload Ground Truth
+        </a>
+        <a class="btn btn-secondary"
+            href="{% url 'reader-studies:example-ground-truth' slug=object.slug %}">
+            <i class="fas fa-download"></i> Download Example CSV
+        </a>
+    </div>
+    <button class="btn btn-danger" hx-post="{% url 'reader-studies:ground-truth-remove' slug=object.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}" }'>
+        <i class="fas fa-trash-alt"></i> Delete ground truth
+    </button>
+</div>
+
+{% endblock %}

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_ground_truth.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_ground_truth.html
@@ -18,6 +18,15 @@
 {% block content %}
 
 <h2>Ground Truth</h2>
+{% if not object.is_educational %}
+<div class="alert alert-warning" role="alert">
+        <i class="fa fa-info-triangle pr-1" aria-hidden="true"></i>
+        This reader study is currently not configured as educational: any ground truth is not utilized.
+        Mark the reader study as educational via the <a href="{% url 'reader-studies:update' slug=object.slug %}">settings</a>.
+    </div>
+
+{% endif %}
+
 
 <p>
     If you wish to assess the performance of the readers you

--- a/app/grandchallenge/reader_studies/urls.py
+++ b/app/grandchallenge/reader_studies/urls.py
@@ -24,6 +24,7 @@ from grandchallenge.reader_studies.views import (
     ReaderStudyDetail,
     ReaderStudyDisplaySetList,
     ReaderStudyExampleGroundTruth,
+    ReaderStudyGroundTruth,
     ReaderStudyLeaderBoard,
     ReaderStudyList,
     ReaderStudyPermissionRequestCreate,
@@ -63,6 +64,11 @@ urlpatterns = [
         "<slug>/remove-answers/<username>/",
         AnswersRemoveForUser.as_view(),
         name="answers-remove",
+    ),
+    path(
+        "<slug>/ground-truth/",
+        ReaderStudyGroundTruth.as_view(),
+        name="ground-truth",
     ),
     path(
         "<slug>/remove-ground-truth/",

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -175,6 +175,28 @@ class ReaderStudyCreate(
         return response
 
 
+class ReaderStudyGroundTruth(
+    LoginRequiredMixin, ObjectPermissionRequiredMixin, DetailView
+):
+    model = ReaderStudy
+    permission_required = (
+        f"{ReaderStudy._meta.app_label}.change_{ReaderStudy._meta.model_name}"
+    )
+    raise_exception = True
+    template_name = "reader_studies/readerstudy_ground_truth.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "example_ground_truth": self.object.get_example_ground_truth_csv_text(
+                    limit=2
+                )
+            }
+        )
+        return context
+
+
 class ReaderStudyExampleGroundTruth(
     LoginRequiredMixin, ObjectPermissionRequiredMixin, DetailView
 ):
@@ -262,9 +284,6 @@ class ReaderStudyDetail(ObjectPermissionRequiredMixin, DetailView):
                     "num_readers": self.object.readers_group.user_set.count(),
                     "reader_remove_form": reader_remove_form,
                     "editor_remove_form": editor_remove_form,
-                    "example_ground_truth": self.object.get_example_ground_truth_csv_text(
-                        limit=2
-                    ),
                     "pending_permission_requests": pending_permission_requests,
                 }
             )

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -931,3 +931,34 @@ def test_display_set_upload_corrupt_image(
     notification = Notification.objects.get()
     assert notification.user == editor
     assert "1 file could not be imported" in notification.description
+
+
+@pytest.mark.django_db
+def test_ground_truth_view(client):
+    rs = ReaderStudyFactory()
+
+    editor, reader, a_user = UserFactory.create_batch(3)
+    rs.add_editor(editor)
+    rs.add_reader(reader)
+
+    for usr in [reader, a_user]:
+        response = get_view_for_user(
+            client=client,
+            viewname="reader-studies:ground_truth",
+            reverse_kwargs={"slug": rs.slug},
+            user=usr,
+        )
+        assert response.status_code == 404
+
+    response = get_view_for_user(
+        client=client,
+        viewname="reader-studies:ground_truth",
+        reverse_kwargs={"slug": rs.slug},
+        user=editor,
+    )
+
+    assert response.status_code == 200
+    assert (
+        "Reader study is currently not configured as editorial and ground truths are not used"
+        in response.content
+    )


### PR DESCRIPTION
Part of the pitch:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/385

A quick pre-lude:
- split the ground truth from being a tab in the the reader study detail to its own view
- add a warning when the reader study is not configured for educational purposes

Other than above, I did not change the content of the page.

Considered to refactor all reader study views to have the configuration side-panel, much like the algorithms. But have put that out of scope (for now).



## Showcase
![afbeelding](https://github.com/user-attachments/assets/f88398bc-e5b5-4f7f-99be-6edc538ac9ae)
