### PR TITLE
Clear existing phase inputs

### DIFF
--- a/app/grandchallenge/evaluation/migrations/0075_alter_phase_inputs_alter_phase_outputs.py
+++ b/app/grandchallenge/evaluation/migrations/0075_alter_phase_inputs_alter_phase_outputs.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+
+
+def remove_phase_inputs_and_outputs(apps, _schema_editor):
+    Phase = apps.get_model("evaluation", "Phase")  # noqa: N806
+
+    for phase in Phase.objects.all():
+        phase.inputs.clear()
+        phase.outputs.clear()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("components", "0024_alter_componentinterface_kind_and_more"),
+        ("evaluation", "0074_alter_phase_algorithm_inputs_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="phase",
+            name="inputs",
+            field=models.ManyToManyField(
+                blank=True,
+                related_name="evaluation_inputs",
+                to="components.componentinterface",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="phase",
+            name="outputs",
+            field=models.ManyToManyField(
+                blank=True,
+                related_name="evaluation_outputs",
+                to="components.componentinterface",
+            ),
+        ),
+        migrations.RunPython(remove_phase_inputs_and_outputs, elidable=True),
+    ]

--- a/app/grandchallenge/evaluation/migrations/0075_alter_phase_inputs_alter_phase_outputs.py
+++ b/app/grandchallenge/evaluation/migrations/0075_alter_phase_inputs_alter_phase_outputs.py
@@ -1,12 +1,11 @@
 from django.db import migrations, models
 
 
-def remove_phase_inputs_and_outputs(apps, _schema_editor):
+def remove_phase_inputs(apps, _schema_editor):
     Phase = apps.get_model("evaluation", "Phase")  # noqa: N806
 
     for phase in Phase.objects.all():
         phase.inputs.clear()
-        phase.outputs.clear()
 
 
 class Migration(migrations.Migration):
@@ -25,14 +24,5 @@ class Migration(migrations.Migration):
                 to="components.componentinterface",
             ),
         ),
-        migrations.AlterField(
-            model_name="phase",
-            name="outputs",
-            field=models.ManyToManyField(
-                blank=True,
-                related_name="evaluation_outputs",
-                to="components.componentinterface",
-            ),
-        ),
-        migrations.RunPython(remove_phase_inputs_and_outputs, elidable=True),
+        migrations.RunPython(remove_phase_inputs, elidable=True),
     ]

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -541,10 +541,14 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
         help_text="The interfaces that an algorithm for this phase must implement.",
     )
     inputs = models.ManyToManyField(
-        to=ComponentInterface, related_name="evaluation_inputs"
+        to=ComponentInterface,
+        related_name="evaluation_inputs",
+        blank=True,
     )
     outputs = models.ManyToManyField(
-        to=ComponentInterface, related_name="evaluation_outputs"
+        to=ComponentInterface,
+        related_name="evaluation_outputs",
+        blank=True,
     )
     algorithm_inputs = deprecate_field(
         models.ManyToManyField(
@@ -747,7 +751,6 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
         super().save(*args, **kwargs)
 
         if adding:
-            self.set_default_interfaces()
             self.assign_permissions()
             for admin in self.challenge.get_admins():
                 if not is_following(admin, self):
@@ -948,14 +951,6 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
                 and self.submissions_open_at < self.parent.submissions_open_at
             ):
                 raise ValidationError(SUBMISSION_WINDOW_PARENT_VALIDATION_TEXT)
-
-    def set_default_interfaces(self):
-        self.inputs.set(
-            [ComponentInterface.objects.get(slug="predictions-csv-file")]
-        )
-        self.outputs.set(
-            [ComponentInterface.objects.get(slug="metrics-json-file")]
-        )
 
     @cached_property
     def linked_component_interfaces(self):

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -548,7 +548,6 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
     outputs = models.ManyToManyField(
         to=ComponentInterface,
         related_name="evaluation_outputs",
-        blank=True,
     )
     algorithm_inputs = deprecate_field(
         models.ManyToManyField(

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -750,6 +750,7 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
         super().save(*args, **kwargs)
 
         if adding:
+            self.set_default_interfaces()
             self.assign_permissions()
             for admin in self.challenge.get_admins():
                 if not is_following(admin, self):
@@ -950,6 +951,11 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
                 and self.submissions_open_at < self.parent.submissions_open_at
             ):
                 raise ValidationError(SUBMISSION_WINDOW_PARENT_VALIDATION_TEXT)
+
+    def set_default_interfaces(self):
+        self.outputs.set(
+            [ComponentInterface.objects.get(slug="metrics-json-file")]
+        )
 
     @cached_property
     def linked_component_interfaces(self):

--- a/app/tests/evaluation_tests/test_config.py
+++ b/app/tests/evaluation_tests/test_config.py
@@ -3,10 +3,9 @@ import pytest
 from grandchallenge.components.models import (
     ComponentInterface,
     ComponentInterfaceValue,
-    InterfaceKind,
 )
 from grandchallenge.evaluation.models import Evaluation
-from tests.evaluation_tests.factories import EvaluationFactory, PhaseFactory
+from tests.evaluation_tests.factories import EvaluationFactory
 from tests.utils import get_view_for_user
 
 
@@ -98,15 +97,3 @@ def test_setting_display_all_metrics(client, challenge_set):
     assert str(metrics["public"]) in response.rendered_content
     assert str(metrics["extra"]) in response.rendered_content
     assert str(metrics["secret"]) not in response.rendered_content
-
-
-@pytest.mark.django_db
-def test_default_interfaces_created():
-    p = PhaseFactory()
-
-    assert {i.kind for i in p.inputs.all()} == {
-        InterfaceKind.InterfaceKindChoices.CSV
-    }
-    assert {o.kind for o in p.outputs.all()} == {
-        InterfaceKind.InterfaceKindChoices.ANY
-    }

--- a/app/tests/evaluation_tests/test_config.py
+++ b/app/tests/evaluation_tests/test_config.py
@@ -3,9 +3,10 @@ import pytest
 from grandchallenge.components.models import (
     ComponentInterface,
     ComponentInterfaceValue,
+    InterfaceKind,
 )
 from grandchallenge.evaluation.models import Evaluation
-from tests.evaluation_tests.factories import EvaluationFactory
+from tests.evaluation_tests.factories import EvaluationFactory, PhaseFactory
 from tests.utils import get_view_for_user
 
 
@@ -97,3 +98,12 @@ def test_setting_display_all_metrics(client, challenge_set):
     assert str(metrics["public"]) in response.rendered_content
     assert str(metrics["extra"]) in response.rendered_content
     assert str(metrics["secret"]) not in response.rendered_content
+
+
+@pytest.mark.django_db
+def test_default_interfaces_created():
+    p = PhaseFactory()
+
+    assert {o.kind for o in p.outputs.all()} == {
+        InterfaceKind.InterfaceKindChoices.ANY
+    }


### PR DESCRIPTION
All phases have default input interfaces defined at the moment, but the current workflow ignores them. We now want to make it possible to add inputs that should not be ignored. For that, it makes sense to remove those default inputs and to only set inputs in the future when those should actually be shown as additional inputs for users when creating a submission. 

Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/357