### PR TITLE
Add phase interface configuration links to challenge admin

### DIFF
--- a/app/grandchallenge/challenges/admin.py
+++ b/app/grandchallenge/challenges/admin.py
@@ -28,6 +28,7 @@ from grandchallenge.core.templatetags.costs import millicents_to_euro
 from grandchallenge.core.utils.grand_challenge_forge import (
     get_forge_challenge_pack_context,
 )
+from grandchallenge.evaluation.utils import SubmissionKindChoices
 from grandchallenge.subdomains.utils import reverse
 
 
@@ -38,6 +39,7 @@ class ChallengeAdmin(ModelAdmin):
         "creator",
         "challenge_forge_json",
         "algorithm_phase_configuration_link",
+        "algorithm_interface_configuration_links",
     )
     autocomplete_fields = ("publications",)
     ordering = ("-created",)
@@ -80,6 +82,26 @@ class ChallengeAdmin(ModelAdmin):
                 kwargs={"challenge_short_name": obj.short_name},
             ),
         )
+
+    @staticmethod
+    def algorithm_interface_configuration_links(obj):
+        phases = []
+        for phase in obj.phase_set.filter(
+            submission_kind=SubmissionKindChoices.ALGORITHM
+        ).all():
+            phases.append(
+                format_html(
+                    '<a href="{link}">{link}</a>',
+                    link=reverse(
+                        "evaluation:interface-list",
+                        kwargs={
+                            "challenge_short_name": obj.short_name,
+                            "slug": phase.slug,
+                        },
+                    ),
+                )
+            )
+        return format_html("<br>".join(phases)) if phases else "-"
 
 
 @admin.register(ChallengeRequest)


### PR DESCRIPTION
Accessing the pages to set up the algorithm interfaces for phases is difficult for non-superusers since those are hidden within the challenge admin panel. This adds the urls to the relevant pages to the challenge admin, just underneath the configure-algorithm-phase link. 