### PR TITLE
Add border to user profile image

### DIFF
--- a/app/grandchallenge/profiles/templatetags/profiles.py
+++ b/app/grandchallenge/profiles/templatetags/profiles.py
@@ -22,7 +22,7 @@ def user_profile_link(user: AbstractUser | None) -> str:
         )
         mugshot = format_html(
             (
-                '<img class="rounded-circle align-middle" loading="lazy" '
+                '<img class="rounded-circle border align-middle" loading="lazy" '
                 'src="{0}" alt="User Mugshot" '
                 # Match the "fa-lg" class style
                 'style="height: 1.33em;"/>'


### PR DESCRIPTION
closes #3863 

Adding the border helps in cases where the user profile image is as the same background of the site which makes it looks like broken.

Not it looks like this:

<img width="196" alt="Screenshot 2025-03-11 at 10 08 35" src="https://github.com/user-attachments/assets/42f34ad4-2925-46af-b7b8-4ffb8ebcbec4" />
