### PR TITLE
Fix numberical slugs breaking collapsables

### DIFF
--- a/app/grandchallenge/evaluation/templates/evaluation/partials/combinedleaderboard_menu_sidebar.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/partials/combinedleaderboard_menu_sidebar.html
@@ -1,7 +1,7 @@
 <li class="nav-item">
     <a class="nav-link px-4 py-1 mb-1"
        data-toggle="collapse"
-       data-target="#{{ combined_leaderboard.slug }}-collapse"
+       data-target="#collapse-{{ combined_leaderboard.slug }}"
        aria-expanded={% if request.resolver_match.view_name in 'evaluation:combined-leaderboard-update,evaluation:combined-leaderboard-delete' and request.resolver_match.kwargs.slug == combined_leaderboard.slug %}"true"{% else %}"false"{% endif %}
       >
         <i class="fas fa-chevron-right fa-fw"></i>
@@ -9,7 +9,7 @@
         {{ combined_leaderboard.title }}
     </a>
     <div class="collapse {% if request.resolver_match.view_name in 'evaluation:combined-leaderboard-update,evaluation:combined-leaderboard-delete' and request.resolver_match.kwargs.slug == combined_leaderboard.slug %}show{% endif %}"
-         id="{{ combined_leaderboard.slug }}-collapse"
+         id="collapse-{{ combined_leaderboard.slug }}"
     >
         <ul class="nav nav-pills flex-column">
             <li class="nav-item pl-4">

--- a/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
+++ b/app/grandchallenge/pages/templates/pages/phase_menu_sidebar.html
@@ -3,7 +3,7 @@
 <li class="nav-item">
     <a class="nav-link px-4 py-1 mb-1"
        data-toggle="collapse"
-       data-target="#{{ phase.slug }}-collapse"
+       data-target="#collapse-{{ phase.slug }}"
        aria-expanded={% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail,evaluation:phase-archive-info,evaluation:interface-list, evaluation:interface-create, evaluation:interface-delete' and request.resolver_match.kwargs.slug == phase.slug %}"true"{% else %}"false"{% endif %}
     >
         <i class="fas fa-chevron-right fa-fw"></i>
@@ -12,7 +12,7 @@
         {{ phase.title }}
     </a>
     <div class="collapse {% if request.resolver_match.view_name in 'evaluation:phase-update,evaluation:method-list,evaluation:method-create,evaluation:evaluation-admin-list,evaluation:method-detail,evaluation:method-update,evaluation:ground-truth-list,evaluation:ground-truth-create,evaluation:ground-truth-update,evaluation:ground-truth-detail,evaluation:phase-archive-info,evaluation:interface-list, evaluation:interface-create, evaluation:interface-delete' and request.resolver_match.kwargs.slug == phase.slug %}show{% endif %}"
-         id="{{ phase.slug }}-collapse">
+         id="collapse-{{ phase.slug }}">
         <ul class="nav nav-pills flex-column">
             <li class="nav-item pl-4">
                 <a href="{% url 'evaluation:phase-update' slug=phase.slug %}"
@@ -54,7 +54,6 @@
                     <i class="fas fa-list fa-fw"></i> Submissions & Evaluations
                 </a>
             </li>
-
         </ul>
     </div>
 </li>


### PR DESCRIPTION
Seems like bootstrap does not like HTML element IDs that start with digits (e.g. `#64-collapse`). Simple fix.