### PR TITLE
Fix flaky test due to existing browser sessions

### DIFF
--- a/app/tests/sessions_tests/test_models.py
+++ b/app/tests/sessions_tests/test_models.py
@@ -4,13 +4,9 @@ from grandchallenge.browser_sessions.models import BrowserSession
 from tests.factories import UserFactory
 
 
-@pytest.fixture(scope="module", autouse=True)
-def clear_sessions():
-    BrowserSession.objects.all().delete()
-
-
 @pytest.mark.django_db
 def test_no_user_is_assigned_to_session(client):
+    BrowserSession.objects.all().delete()
     response = client.get("/")
 
     assert response.status_code == 200
@@ -20,6 +16,7 @@ def test_no_user_is_assigned_to_session(client):
 
 @pytest.mark.django_db
 def test_user_is_assigned_to_session_after_login(client):
+    BrowserSession.objects.all().delete()
     user = UserFactory()
 
     client.force_login(user)

--- a/app/tests/sessions_tests/test_models.py
+++ b/app/tests/sessions_tests/test_models.py
@@ -6,22 +6,32 @@ from tests.factories import UserFactory
 
 @pytest.mark.django_db
 def test_no_user_is_assigned_to_session(client):
-    BrowserSession.objects.all().delete()
+    existing_browser_sessions = list(
+        BrowserSession.objects.values_list("pk", flat=True)
+    )
     response = client.get("/")
+    new_browser_sessions = BrowserSession.objects.exclude(
+        pk__in=existing_browser_sessions
+    )
 
     assert response.status_code == 200
-    assert BrowserSession.objects.count() == 1
-    assert BrowserSession.objects.get().user is None
+    assert new_browser_sessions.count() == 1
+    assert new_browser_sessions.get().user is None
 
 
 @pytest.mark.django_db
 def test_user_is_assigned_to_session_after_login(client):
-    BrowserSession.objects.all().delete()
+    existing_browser_sessions = list(
+        BrowserSession.objects.values_list("pk", flat=True)
+    )
     user = UserFactory()
 
     client.force_login(user)
     response = client.get("/")
+    new_browser_sessions = BrowserSession.objects.exclude(
+        pk__in=existing_browser_sessions
+    )
 
     assert response.status_code == 200
-    assert BrowserSession.objects.count() == 1
-    assert BrowserSession.objects.first().user == user
+    assert new_browser_sessions.count() == 1
+    assert new_browser_sessions.first().user == user

--- a/app/tests/sessions_tests/test_models.py
+++ b/app/tests/sessions_tests/test_models.py
@@ -4,6 +4,11 @@ from grandchallenge.browser_sessions.models import BrowserSession
 from tests.factories import UserFactory
 
 
+@pytest.fixture(scope="module", autouse=True)
+def clear_sessions():
+    BrowserSession.objects.all().delete()
+
+
 @pytest.mark.django_db
 def test_no_user_is_assigned_to_session(client):
     response = client.get("/")


### PR DESCRIPTION
Fix flaky test when orphan browser sessions exist. Flaky test failure:
```
>       assert BrowserSession.objects.count() == 1
E       assert 11 == 1
E        +  where 11 = count()
```