### PR TITLE
Always invoke component jobs using the invocations file

### DIFF
--- a/app/grandchallenge/components/backends/amazon_sagemaker_training.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_training.py
@@ -106,14 +106,3 @@ class AmazonSageMakerTrainingExecutor(AmazonSageMakerBaseExecutor):
             raise TaskCancelled
         else:
             raise RuntimeError(f"Unknown status {secondary_status!r}")
-
-    def _get_invocation_json(self, *args, **kwargs):
-        # SageMaker Training Jobs expect a list
-        invocation_json = super()._get_invocation_json(*args, **kwargs)
-
-        if not isinstance(invocation_json, dict):
-            raise RuntimeError(
-                "Expected to receive a single invocation JSON object"
-            )
-
-        return [invocation_json]

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -727,12 +727,7 @@ def execute_job(  # noqa: C901
 
     try:
         # This call is potentially very long
-        executor.execute(
-            input_civs=job.inputs.prefetch_related(
-                "interface", "image__files"
-            ).all(),
-            input_prefixes=job.input_prefixes,
-        )
+        executor.execute()
     except RetryStep:
         job.update_status(status=job.PROVISIONED)
         raise

--- a/app/tests/components_tests/resources/backends.py
+++ b/app/tests/components_tests/resources/backends.py
@@ -1,7 +1,5 @@
-import json
 import sys
 from json import JSONDecodeError
-from subprocess import CalledProcessError
 
 from dateutil.parser import isoparse
 from django.conf import settings
@@ -13,12 +11,10 @@ from grandchallenge.components.backends.docker import (
     DockerConnectionMixin,
     logger,
 )
-from grandchallenge.components.backends.exceptions import ComponentException
 from grandchallenge.components.backends.utils import (
     LOGLINES,
     SourceChoices,
     parse_structured_log,
-    user_error,
 )
 
 
@@ -39,11 +35,9 @@ class InsecureDockerExecutor(DockerConnectionMixin, Executor):
 
         super().__init__(*args, **kwargs)
 
-    def execute(self, *, input_civs, input_prefixes):
+    def execute(self):
         self._pull_image()
-        self._execute_container(
-            input_civs=input_civs, input_prefixes=input_prefixes
-        )
+        self._execute_container()
 
     def handle_event(self, *, event):
         raise RuntimeError("This backend is not event-driven")
@@ -82,7 +76,7 @@ class InsecureDockerExecutor(DockerConnectionMixin, Executor):
         logger.warning("Runtime metrics are not implemented for this backend")
         return
 
-    def _execute_container(self, *, input_civs, input_prefixes) -> None:
+    def _execute_container(self) -> None:
         environment = {
             **self.invocation_environment,
             "NVIDIA_VISIBLE_DEVICES": settings.COMPONENTS_NVIDIA_VISIBLE_DEVICES,
@@ -101,120 +95,22 @@ class InsecureDockerExecutor(DockerConnectionMixin, Executor):
             docker_client.run_container(
                 repo_tag=self._exec_image_repo_tag,
                 name=self.container_name,
-                command=["serve"],
+                command=[
+                    "invoke",
+                    "--file",
+                    f"s3://{settings.COMPONENTS_INPUT_BUCKET_NAME}/{self._invocation_key}",
+                ],
                 labels=self._labels,
                 environment=environment,
                 network=settings.COMPONENTS_DOCKER_NETWORK_NAME,
                 mem_limit=self._memory_limit,
-            )
-            self._await_container_ready()
-            response = self._invoke_inference(
-                input_civs=input_civs, input_prefixes=input_prefixes
+                detach=False,
             )
         finally:
             docker_client.stop_container(name=self.container_name)
             self._set_task_logs()
 
-        exit_code = int(response["return_code"])
-
-        if exit_code == 137:
-            raise ComponentException(
-                "The container was killed as it exceeded the memory limit "
-                f"of {self._memory_limit}g"
-            )
-        elif exit_code != 0:
-            raise ComponentException(user_error(self.stderr))
-
-    def _await_container_ready(self):
-        attempts = 0
-        while True:
-            attempts += 1
-
-            if attempts > 10:
-                raise ComponentException("Container did not start in time")
-
-            try:
-                response = self._curl_container(
-                    url=f"http://{self.container_name}:8080/ping",
-                    timeout=2,
-                    extra_args=[
-                        "--silent",
-                        "--head",
-                        "--output",
-                        "/dev/null",
-                        "--write-out",
-                        "%{http_code}",
-                    ],
-                )
-            except CalledProcessError as err:
-                if err.returncode == 7:
-                    # Container is not ready, try again
-                    continue
-                else:
-                    raise
-
-            if response[-1].split()[1] == "200":
-                return
-
-    def _invoke_inference(self, *, input_civs, input_prefixes):
-        try:
-            response = self._curl_container(
-                url=f"http://{self.container_name}:8080/invocations",
-                timeout=self._time_limit,
-                request="POST",
-                extra_args=[
-                    "--silent",
-                    "--json",
-                    json.dumps(
-                        self._get_invocation_json(
-                            input_civs=input_civs,
-                            input_prefixes=input_prefixes,
-                        )
-                    ),
-                ],
-            )
-        except CalledProcessError as err:
-            if err.returncode == 28:
-                raise ComponentException("Time limit exceeded")
-            else:
-                raise
-
-        return json.loads(response[-1].split()[1])
-
-    def _curl_container(self, *, url, timeout, request="GET", extra_args=None):
-        """
-        Make a CURL request to a container on an internal network
-
-        We cannot make the request directly as the container is running on
-        another network, and potentially on another machine. So here we run a
-        container that can directly make a curl request to the other one.
-        """
-        container_name = f"{self.container_name}-curl"
-
-        command = ["--request", request, "--max-time", str(timeout)]
-
-        if extra_args is not None:
-            command.extend(extra_args)
-
-        command.append(url)
-
-        try:
-            docker_client.run_container(
-                repo_tag="quay.io/curl/curl",
-                name=container_name,
-                command=command,
-                labels=self._labels,
-                network=settings.COMPONENTS_DOCKER_NETWORK_NAME,
-                environment={},
-                mem_limit=1,
-                detach=False,
-            )
-            loglines = docker_client.get_logs(name=container_name)
-        finally:
-            docker_client.stop_container(name=container_name)
-            docker_client.remove_container(name=container_name)
-
-        return loglines
+        self._handle_completed_job()
 
     def _set_task_logs(self):
         try:

--- a/app/tests/components_tests/test_amazon_sagemaker_training_backend.py
+++ b/app/tests/components_tests/test_amazon_sagemaker_training_backend.py
@@ -142,7 +142,7 @@ def test_transform_job_name(model, container, container_model, key):
     assert job_params.attempt == 0
 
 
-def test_execute(settings):
+def test_invocation_json(settings):
     settings.COMPONENTS_AMAZON_ECR_REGION = "us-east-1"
     settings.COMPONENTS_AMAZON_SAGEMAKER_EXECUTION_ROLE_ARN = (
         "arn:aws:iam::123456789012:role/service-role/ExecutionRole"
@@ -200,7 +200,7 @@ def test_execute(settings):
                 "RemoteDebugConfig": {"EnableRemoteDebug": False},
             },
         )
-        executor.execute(input_civs=[], input_prefixes={})
+        executor.provision(input_civs=[], input_prefixes={})
 
     with io.BytesIO() as fileobj:
         executor._s3_client.download_fileobj(


### PR DESCRIPTION
Small refactoring to prepare for inputs.json. This unifies the API, removes the double setting of the input civs and prefixes and creates the invocation json only once.

See https://github.com/DIAGNijmegen/rse-roadmap/issues/397