### PR TITLE
Add `inputs.json`

### DIFF
--- a/app/grandchallenge/components/backends/base.py
+++ b/app/grandchallenge/components/backends/base.py
@@ -74,9 +74,6 @@ class Executor(ABC):
             input_civs=input_civs, input_prefixes=input_prefixes
         )
         self._provision_auxilliary_data()
-        self._create_invocation_json(
-            input_civs=input_civs, input_prefixes=input_prefixes
-        )
 
     @abstractmethod
     def execute(self): ...
@@ -281,33 +278,11 @@ class Executor(ABC):
 
         return key, relative_path
 
-    def _get_invocation_json(self, *, input_civs, input_prefixes):
-        inputs = []
+    def _provision_inputs(self, *, input_civs, input_prefixes):
+        invocation_inputs = []
+
         for civ in input_civs:
             key, relative_path = self._get_key_and_relative_path(
-                civ=civ, input_prefixes=input_prefixes
-            )
-            inputs.append(
-                {
-                    "relative_path": relative_path,
-                    "bucket_name": settings.COMPONENTS_INPUT_BUCKET_NAME,
-                    "bucket_key": key,
-                    "decompress": civ.decompress,
-                }
-            )
-
-        return [
-            {
-                "pk": self._job_id,
-                "inputs": inputs,
-                "output_bucket_name": settings.COMPONENTS_OUTPUT_BUCKET_NAME,
-                "output_prefix": self._io_prefix,
-            }
-        ]
-
-    def _provision_inputs(self, *, input_civs, input_prefixes):
-        for civ in input_civs:
-            key, _ = self._get_key_and_relative_path(
                 civ=civ, input_prefixes=input_prefixes
             )
 
@@ -325,6 +300,34 @@ class Executor(ABC):
                         Key=key,
                     )
 
+            invocation_inputs.append(
+                {
+                    "relative_path": relative_path,
+                    "bucket_name": settings.COMPONENTS_INPUT_BUCKET_NAME,
+                    "bucket_key": key,
+                    "decompress": civ.decompress,
+                }
+            )
+
+        self._create_invocation_json(inputs=invocation_inputs)
+
+    def _create_invocation_json(self, *, inputs):
+        f = io.BytesIO(
+            json.dumps(
+                [
+                    {
+                        "pk": self._job_id,
+                        "inputs": inputs,
+                        "output_bucket_name": settings.COMPONENTS_OUTPUT_BUCKET_NAME,
+                        "output_prefix": self._io_prefix,
+                    }
+                ]
+            ).encode("utf-8")
+        )
+        self._s3_client.upload_fileobj(
+            f, settings.COMPONENTS_INPUT_BUCKET_NAME, self._invocation_key
+        )
+
     def _provision_auxilliary_data(self):
         if self._algorithm_model:
             self._copy_input_file(
@@ -334,18 +337,6 @@ class Executor(ABC):
             self._copy_input_file(
                 src=self._ground_truth, dest_key=self._ground_truth_key
             )
-
-    def _create_invocation_json(self, *, input_civs, input_prefixes):
-        f = io.BytesIO(
-            json.dumps(
-                self._get_invocation_json(
-                    input_civs=input_civs, input_prefixes=input_prefixes
-                )
-            ).encode("utf-8")
-        )
-        self._s3_client.upload_fileobj(
-            f, settings.COMPONENTS_INPUT_BUCKET_NAME, self._invocation_key
-        )
 
     def _copy_input_file(self, *, src, dest_key):
         self._s3_client.copy(

--- a/app/grandchallenge/components/migrations/0001_initial.py
+++ b/app/grandchallenge/components/migrations/0001_initial.py
@@ -98,6 +98,7 @@ class Migration(migrations.Migration):
                         validators=[
                             grandchallenge.components.validators.validate_safe_path,
                             grandchallenge.components.validators.validate_no_slash_at_ends,
+                            grandchallenge.components.validators.validate_relative_path_not_reserved,
                             django.core.validators.RegexValidator(
                                 flags=re.RegexFlag["IGNORECASE"],
                                 inverse_match=True,

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -59,6 +59,7 @@ from grandchallenge.components.validators import (
     validate_biom_format,
     validate_newick_tree_format,
     validate_no_slash_at_ends,
+    validate_relative_path_not_reserved,
     validate_safe_path,
 )
 from grandchallenge.core.celery import acks_late_2xlarge_task
@@ -438,6 +439,7 @@ class ComponentInterface(OverlaySegmentsMixin):
         validators=[
             validate_safe_path,
             validate_no_slash_at_ends,
+            validate_relative_path_not_reserved,
             # No uuids in path
             RegexValidator(
                 regex=r".*[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}.*",

--- a/app/grandchallenge/components/validators.py
+++ b/app/grandchallenge/components/validators.py
@@ -30,6 +30,11 @@ def validate_no_slash_at_ends(value):
         raise ValidationError("Path must not begin or end with '/'")
 
 
+def validate_relative_path_not_reserved(value):
+    if value.casefold() == "inputs.json".casefold():
+        raise ValidationError("This relative path is reserved")
+
+
 def _newick_parser(tree):
     return NewickIO.Parser.from_string(tree)
 

--- a/app/tests/components_tests/test_amazon_sagemaker_training_backend.py
+++ b/app/tests/components_tests/test_amazon_sagemaker_training_backend.py
@@ -213,7 +213,14 @@ def test_invocation_json(settings):
 
     assert result == [
         {
-            "inputs": [],
+            "inputs": [
+                {
+                    "bucket_key": f"/io/algorithms/job/{pk}/inputs.json",
+                    "bucket_name": "grand-challenge-components-inputs",
+                    "decompress": False,
+                    "relative_path": "inputs.json",
+                },
+            ],
             "output_bucket_name": "grand-challenge-components-outputs",
             "output_prefix": f"/io/algorithms/job/{pk}",
             "pk": f"algorithms-job-{pk}",

--- a/app/tests/components_tests/test_backends.py
+++ b/app/tests/components_tests/test_backends.py
@@ -5,7 +5,6 @@ from zipfile import ZipInfo
 
 import pytest
 from django.template.defaultfilters import title
-from django.utils._os import safe_join
 
 from grandchallenge.components.backends.docker_client import _get_cpuset_cpus
 from grandchallenge.components.backends.utils import (
@@ -154,7 +153,7 @@ def test_inputs_json(settings):
         executor._s3_client.download_fileobj(
             Fileobj=fileobj,
             Bucket=settings.COMPONENTS_INPUT_BUCKET_NAME,
-            Key=safe_join(executor._io_prefix, "inputs.json"),
+            Key="/io/test/test/test/inputs.json",
         )
         fileobj.seek(0)
         result = json.loads(fileobj.read().decode("utf-8"))

--- a/app/tests/components_tests/test_backends.py
+++ b/app/tests/components_tests/test_backends.py
@@ -1,7 +1,11 @@
+import io
+import json
 import os
 from zipfile import ZipInfo
 
 import pytest
+from django.template.defaultfilters import title
+from django.utils._os import safe_join
 
 from grandchallenge.components.backends.docker_client import _get_cpuset_cpus
 from grandchallenge.components.backends.utils import (
@@ -9,6 +13,7 @@ from grandchallenge.components.backends.utils import (
     user_error,
 )
 from grandchallenge.components.schemas import GPUTypeChoices
+from tests.components_tests.factories import ComponentInterfaceValueFactory
 from tests.components_tests.resources.backends import InsecureDockerExecutor
 
 
@@ -129,3 +134,69 @@ def test_internal_logs_filtered():
         executor.stdout
         == "2022-05-31T09:48:03.205773000Z Greetings from stdout"
     )
+
+
+@pytest.mark.django_db
+def test_inputs_json(settings):
+    executor = InsecureDockerExecutor(
+        job_id="test-test-test",
+        exec_image_repo_tag="test",
+        memory_limit=4,
+        time_limit=100,
+        requires_gpu_type=GPUTypeChoices.NO_GPU,
+    )
+
+    civ1, civ2 = ComponentInterfaceValueFactory.create_batch(2)
+
+    executor.provision(input_civs=[civ1, civ2], input_prefixes={})
+
+    with io.BytesIO() as fileobj:
+        executor._s3_client.download_fileobj(
+            Fileobj=fileobj,
+            Bucket=settings.COMPONENTS_INPUT_BUCKET_NAME,
+            Key=safe_join(executor._io_prefix, "inputs.json"),
+        )
+        fileobj.seek(0)
+        result = json.loads(fileobj.read().decode("utf-8"))
+
+    expected = [
+        {
+            "interface": {
+                "title": civ1.interface.title,
+                "description": civ1.interface.description,
+                "slug": civ1.interface.slug,
+                "kind": civ1.interface.get_kind_display(),
+                "pk": civ1.interface.pk,
+                "default_value": civ1.interface.default_value,
+                "super_kind": title(civ1.interface.super_kind.name),
+                "relative_path": civ1.interface.relative_path,
+                "overlay_segments": civ1.interface.overlay_segments,
+                "look_up_table": civ1.interface.look_up_table,
+            },
+            "value": civ1.value,
+            "file": None,
+            "image": civ1.image,
+            "pk": civ1.pk,
+        },
+        {
+            "interface": {
+                "title": civ2.interface.title,
+                "description": civ2.interface.description,
+                "slug": civ2.interface.slug,
+                "kind": civ2.interface.get_kind_display(),
+                "pk": civ2.interface.pk,
+                "default_value": civ2.interface.default_value,
+                "super_kind": title(civ2.interface.super_kind.name),
+                "relative_path": civ2.interface.relative_path,
+                "overlay_segments": civ2.interface.overlay_segments,
+                "look_up_table": civ2.interface.look_up_table,
+            },
+            "value": civ2.value,
+            "file": None,
+            "image": civ2.image,
+            "pk": civ2.pk,
+        },
+    ]
+
+    for e in expected:
+        assert e in result

--- a/app/tests/components_tests/test_models.py
+++ b/app/tests/components_tests/test_models.py
@@ -1750,3 +1750,14 @@ def test_component_interface_custom_queue(kind, expected_kwargs, mocker):
     del mock_task.signature.call_args.kwargs["kwargs"]
 
     assert mock_task.signature.call_args.kwargs == expected_kwargs
+
+
+def test_inputs_json_reserved():
+    ci = ComponentInterface(relative_path="inputs.json")
+
+    with pytest.raises(ValidationError) as error:
+        ci.full_clean()
+
+    assert "'relative_path': ['This relative path is reserved']" in str(
+        error.value
+    )


### PR DESCRIPTION
This PR adds metadata about the jobs inputs through `inputs.json`. The structure is the same as the inputs section of `predictions.json`.

Closes https://github.com/DIAGNijmegen/rse-roadmap/issues/397