### PR TITLE
Make sure algorithm sockets don't overlap with evaluation sockets

### DIFF
--- a/app/grandchallenge/algorithms/forms.py
+++ b/app/grandchallenge/algorithms/forms.py
@@ -194,8 +194,8 @@ class JobCreateForm(AdditionalInputsMixin, Form):
         return cleaned_data
 
 
-# Exclude interfaces that are not aimed at algorithms from user selection
-NON_ALGORITHM_INTERFACES = [
+# Exclude sockets that are not aimed at algorithms or evaluations from user selection
+RESERVED_SOCKET_SLUGS = [
     "predictions-csv-file",
     "predictions-json-file",
     "predictions-zip-file",
@@ -1359,13 +1359,13 @@ class AlgorithmModelVersionControlForm(Form):
 class AlgorithmInterfaceForm(SaveFormInitMixin, ModelForm):
     inputs = ModelMultipleChoiceField(
         queryset=ComponentInterface.objects.exclude(
-            slug__in=NON_ALGORITHM_INTERFACES
+            slug__in=RESERVED_SOCKET_SLUGS
         ),
         widget=Select2MultipleWidget,
     )
     outputs = ModelMultipleChoiceField(
         queryset=ComponentInterface.objects.exclude(
-            slug__in=NON_ALGORITHM_INTERFACES
+            slug__in=RESERVED_SOCKET_SLUGS
         ),
         widget=Select2MultipleWidget,
     )
@@ -1450,7 +1450,7 @@ class AlgorithmInterfaceForm(SaveFormInitMixin, ModelForm):
                 str(obj) for obj in overlapping_sockets
             )
             raise ValidationError(
-                "The following sockets are already configured as sockets on"
+                "The following sockets are already configured as additional inputs or outputs on"
                 f" {self._base_obj}: {overlapping_names}"
             )
 

--- a/app/grandchallenge/algorithms/forms.py
+++ b/app/grandchallenge/algorithms/forms.py
@@ -1387,7 +1387,10 @@ class AlgorithmInterfaceForm(SaveFormInitMixin, ModelForm):
         if not inputs:
             raise ValidationError("You must provide at least 1 input.")
 
-        if self._base_obj.additional_inputs_field:
+        if (
+            self._base_obj.additional_inputs_field
+            or self._base_obj.additional_outputs_field
+        ):
             self.check_for_overlapping_sockets(
                 sockets=inputs,
             )
@@ -1417,7 +1420,10 @@ class AlgorithmInterfaceForm(SaveFormInitMixin, ModelForm):
         if not outputs:
             raise ValidationError("You must provide at least 1 output.")
 
-        if self._base_obj.additional_outputs_field:
+        if (
+            self._base_obj.additional_inputs_field
+            or self._base_obj.additional_outputs_field
+        ):
             self.check_for_overlapping_sockets(
                 sockets=outputs,
             )

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -521,6 +521,14 @@ class Algorithm(UUIDModel, TitleSlugDescriptionModel, HangingProtocolMixin):
         return AlgorithmAlgorithmInterface.objects.filter(algorithm=self)
 
     @property
+    def additional_inputs_field(self):
+        return None
+
+    @property
+    def additional_outputs_field(self):
+        return None
+
+    @property
     def algorithm_interface_create_url(self):
         return reverse(
             "algorithms:interface-create", kwargs={"slug": self.slug}

--- a/app/grandchallenge/components/views.py
+++ b/app/grandchallenge/components/views.py
@@ -24,7 +24,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from guardian.mixins import LoginRequiredMixin
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
-from grandchallenge.algorithms.forms import NON_ALGORITHM_INTERFACES
+from grandchallenge.algorithms.forms import RESERVED_SOCKET_SLUGS
 from grandchallenge.api.permissions import IsAuthenticated
 from grandchallenge.archives.models import Archive
 from grandchallenge.components.form_fields import (
@@ -90,7 +90,7 @@ class ComponentInterfaceList(LoginRequiredMixin, ListView):
     model = ComponentInterface
     queryset = ComponentInterface.objects.select_related(
         "example_value"
-    ).exclude(slug__in=NON_ALGORITHM_INTERFACES)
+    ).exclude(slug__in=RESERVED_SOCKET_SLUGS)
     list_type = None
     object_type = None
 

--- a/app/grandchallenge/evaluation/admin.py
+++ b/app/grandchallenge/evaluation/admin.py
@@ -136,7 +136,7 @@ class PhaseAdmin(admin.ModelAdmin):
         "challenge__short_name",
     )
     autocomplete_fields = (
-        "additional_evaluation_inputs",
+        "inputs",
         "outputs",
         "archive",
     )

--- a/app/grandchallenge/evaluation/admin.py
+++ b/app/grandchallenge/evaluation/admin.py
@@ -107,7 +107,7 @@ class PhaseAdminForm(ModelForm):
             if overlapping_slugs:
                 conflicting_slugs = ", ".join(overlapping_slugs)
                 raise ValidationError(
-                    f"The following sockets cannot be defined as evaluation"
+                    f"The following sockets cannot be defined as evaluation "
                     f"inputs or outputs because they are already defined as "
                     f"algorithm inputs or outputs for this phase: {conflicting_slugs}"
                 )

--- a/app/grandchallenge/evaluation/admin.py
+++ b/app/grandchallenge/evaluation/admin.py
@@ -6,6 +6,7 @@ from django.forms import ModelForm
 from django.utils.html import format_html
 from guardian.admin import GuardedModelAdmin
 
+from grandchallenge.algorithms.forms import RESERVED_SOCKET_SLUGS
 from grandchallenge.components.admin import (
     ComponentImageAdmin,
     cancel_jobs,
@@ -38,14 +39,6 @@ from grandchallenge.evaluation.models import (
 )
 from grandchallenge.evaluation.utils import SubmissionKindChoices
 
-NON_EVALUATION_SOCKET_SLUGS = [
-    "predictions-csv-file",
-    "predictions-json-file",
-    "predictions-zip-file",
-    "metrics-json-file",
-    "results-json-file",
-]
-
 
 class PhaseAdminForm(ModelForm):
     class Meta:
@@ -65,11 +58,11 @@ class PhaseAdminForm(ModelForm):
         inputs = self.cleaned_data["inputs"]
 
         if any(
-            elem in NON_EVALUATION_SOCKET_SLUGS
+            elem in RESERVED_SOCKET_SLUGS
             for elem in inputs.values_list("slug", flat=True)
         ):
             raise ValidationError(
-                f'Evaluation inputs cannot be of the following types: {", ".join(NON_EVALUATION_SOCKET_SLUGS)}'
+                f'Evaluation inputs cannot be of the following types: {", ".join(RESERVED_SOCKET_SLUGS)}'
             )
 
         return inputs
@@ -143,7 +136,7 @@ class PhaseAdmin(admin.ModelAdmin):
         "challenge__short_name",
     )
     autocomplete_fields = (
-        "inputs",
+        "additional_evaluation_inputs",
         "outputs",
         "archive",
     )

--- a/app/grandchallenge/evaluation/admin.py
+++ b/app/grandchallenge/evaluation/admin.py
@@ -79,12 +79,12 @@ class PhaseAdminForm(ModelForm):
 
         if self.instance.submission_kind == SubmissionKindChoices.ALGORITHM:
             input_slugs = (
-                set(cleaned_data.get("inputs").values_list("slug", flat=True))
+                set(cleaned_data["inputs"].values_list("slug", flat=True))
                 if "inputs" in cleaned_data
                 else set()
             )
             output_slugs = (
-                set(cleaned_data.get("outputs").values_list("slug", flat=True))
+                set(cleaned_data["outputs"].values_list("slug", flat=True))
                 if "outputs" in cleaned_data
                 else set()
             )

--- a/app/grandchallenge/evaluation/admin.py
+++ b/app/grandchallenge/evaluation/admin.py
@@ -38,7 +38,7 @@ from grandchallenge.evaluation.models import (
 )
 from grandchallenge.evaluation.utils import SubmissionKindChoices
 
-NON_EVALUATION_INTERFACES = [
+NON_EVALUATION_SOCKET_SLUGS = [
     "predictions-csv-file",
     "predictions-json-file",
     "predictions-zip-file",
@@ -65,11 +65,11 @@ class PhaseAdminForm(ModelForm):
         inputs = self.cleaned_data["inputs"]
 
         if any(
-            elem in NON_EVALUATION_INTERFACES
+            elem in NON_EVALUATION_SOCKET_SLUGS
             for elem in inputs.values_list("slug", flat=True)
         ):
             raise ValidationError(
-                f'Evaluation inputs cannot be of the following types: {", ".join(NON_EVALUATION_INTERFACES)}'
+                f'Evaluation inputs cannot be of the following types: {", ".join(NON_EVALUATION_SOCKET_SLUGS)}'
             )
 
         return inputs
@@ -79,20 +79,12 @@ class PhaseAdminForm(ModelForm):
 
         if self.instance.submission_kind == SubmissionKindChoices.ALGORITHM:
             input_slugs = (
-                set(
-                    cleaned_data.get("inputs", []).values_list(
-                        "slug", flat=True
-                    )
-                )
+                set(cleaned_data.get("inputs").values_list("slug", flat=True))
                 if "inputs" in cleaned_data
                 else set()
             )
             output_slugs = (
-                set(
-                    cleaned_data.get("outputs", []).values_list(
-                        "slug", flat=True
-                    )
-                )
+                set(cleaned_data.get("outputs").values_list("slug", flat=True))
                 if "outputs" in cleaned_data
                 else set()
             )

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1299,6 +1299,14 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
         return PhaseAlgorithmInterface.objects.filter(phase=self)
 
     @property
+    def additional_inputs_field(self):
+        return self.inputs
+
+    @property
+    def additional_outputs_field(self):
+        return self.outputs
+
+    @property
     def algorithm_interface_create_url(self):
         return reverse(
             "evaluation:interface-create",

--- a/app/tests/evaluation_tests/test_admin.py
+++ b/app/tests/evaluation_tests/test_admin.py
@@ -5,6 +5,7 @@ from django.contrib.sessions.middleware import SessionMiddleware
 
 from grandchallenge.components.models import ComponentInterface
 from grandchallenge.evaluation.admin import (
+    NON_EVALUATION_SOCKET_SLUGS,
     PhaseAdmin,
     PhaseAdminForm,
     SubmissionAdmin,
@@ -147,9 +148,10 @@ def test_disjoint_inputs_and_algorithm_sockets():
     assert ci4.slug not in str(form.errors)
 
 
+@pytest.mark.parametrize("slug", NON_EVALUATION_SOCKET_SLUGS)
 @pytest.mark.django_db
-def test_non_evaluation_interfaces():
-    ci = ComponentInterface.objects.get(slug="predictions-json-file")
+def test_non_evaluation_socket_slugs(slug):
+    ci, _ = ComponentInterface.objects.get_or_create(slug=slug)
 
     form = PhaseAdminForm(instance=PhaseFactory(), data={"inputs": [ci.pk]})
     assert not form.is_valid()

--- a/app/tests/evaluation_tests/test_admin.py
+++ b/app/tests/evaluation_tests/test_admin.py
@@ -3,9 +3,9 @@ from django.contrib.admin import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.middleware import SessionMiddleware
 
+from grandchallenge.algorithms.forms import RESERVED_SOCKET_SLUGS
 from grandchallenge.components.models import ComponentInterface
 from grandchallenge.evaluation.admin import (
-    NON_EVALUATION_SOCKET_SLUGS,
     PhaseAdmin,
     PhaseAdminForm,
     SubmissionAdmin,
@@ -148,7 +148,7 @@ def test_disjoint_inputs_and_algorithm_sockets():
     assert ci4.slug not in str(form.errors)
 
 
-@pytest.mark.parametrize("slug", NON_EVALUATION_SOCKET_SLUGS)
+@pytest.mark.parametrize("slug", RESERVED_SOCKET_SLUGS)
 @pytest.mark.django_db
 def test_non_evaluation_socket_slugs(slug):
     ci, _ = ComponentInterface.objects.get_or_create(slug=slug)

--- a/app/tests/evaluation_tests/test_admin.py
+++ b/app/tests/evaluation_tests/test_admin.py
@@ -136,10 +136,11 @@ def test_disjoint_inputs_and_algorithm_sockets():
 
     assert not form.is_valid()
     assert (
-        "The following sockets are already defined as algorithm inputs or outputs for this phase:"
-        in str(form.errors["inputs"])
+        "The following sockets cannot be defined as evaluation inputs or "
+        "outputs because they are already defined as algorithm inputs or "
+        "outputs for this phase" in str(form.errors)
     )
-    assert ci1.slug in str(form.errors["inputs"])
-    assert ci2.slug in str(form.errors["inputs"])
-    assert ci3.slug not in str(form.errors["inputs"])
-    assert ci4.slug not in str(form.errors["inputs"])
+    assert ci1.slug in str(form.errors)
+    assert ci2.slug in str(form.errors)
+    assert ci3.slug not in str(form.errors)
+    assert ci4.slug not in str(form.errors)

--- a/app/tests/evaluation_tests/test_admin.py
+++ b/app/tests/evaluation_tests/test_admin.py
@@ -3,6 +3,7 @@ from django.contrib.admin import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.middleware import SessionMiddleware
 
+from grandchallenge.components.models import ComponentInterface
 from grandchallenge.evaluation.admin import (
     PhaseAdmin,
     PhaseAdminForm,
@@ -144,3 +145,15 @@ def test_disjoint_inputs_and_algorithm_sockets():
     assert ci2.slug in str(form.errors)
     assert ci3.slug not in str(form.errors)
     assert ci4.slug not in str(form.errors)
+
+
+@pytest.mark.django_db
+def test_non_evaluation_interfaces():
+    ci = ComponentInterface.objects.get(slug="predictions-json-file")
+
+    form = PhaseAdminForm(instance=PhaseFactory(), data={"inputs": [ci.pk]})
+    assert not form.is_valid()
+    assert (
+        form.errors["inputs"][0]
+        == "Evaluation inputs cannot be of the following types: predictions-csv-file, predictions-json-file, predictions-zip-file, metrics-json-file, results-json-file"
+    )

--- a/app/tests/evaluation_tests/test_forms.py
+++ b/app/tests/evaluation_tests/test_forms.py
@@ -5,7 +5,10 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.forms import CharField
 from factory.django import ImageField
 
-from grandchallenge.algorithms.forms import AlgorithmForPhaseForm
+from grandchallenge.algorithms.forms import (
+    AlgorithmForPhaseForm,
+    AlgorithmInterfaceForm,
+)
 from grandchallenge.algorithms.models import Job
 from grandchallenge.cases.widgets import FlexibleImageField
 from grandchallenge.components.form_fields import (
@@ -1304,4 +1307,24 @@ def test_additional_inputs_on_submission_form():
     )
     assert isinstance(
         form.fields[f"{INTERFACE_FORM_FIELD_PREFIX}{ci_str.slug}"], CharField
+    )
+
+
+@pytest.mark.django_db
+def test_disjoint_algorithm_interface_sockets_and_evaluation_inputs():
+    ci1, ci2, ci3, ci4 = ComponentInterfaceFactory.create_batch(4)
+    phase = PhaseFactory(submission_kind=SubmissionKindChoices.ALGORITHM)
+    phase.inputs.set([ci1, ci2])
+
+    form = AlgorithmInterfaceForm(
+        base_obj=phase, data={"inputs": [ci1, ci3], "outputs": [ci2, ci4]}
+    )
+    assert not form.is_valid()
+    assert (
+        f"The following sockets are already configured as sockets on "
+        f"{phase}: {ci1}" in str(form.errors["inputs"])
+    )
+    assert (
+        f"The following sockets are already configured as sockets on "
+        f"{phase}: {ci2}" in str(form.errors["outputs"])
     )

--- a/app/tests/evaluation_tests/test_forms.py
+++ b/app/tests/evaluation_tests/test_forms.py
@@ -1321,10 +1321,10 @@ def test_disjoint_algorithm_interface_sockets_and_evaluation_inputs():
     )
     assert not form.is_valid()
     assert (
-        f"The following sockets are already configured as sockets on "
+        f"The following sockets are already configured as additional inputs or outputs on "
         f"{phase}: {ci1}" in str(form.errors["inputs"])
     )
     assert (
-        f"The following sockets are already configured as sockets on "
+        f"The following sockets are already configured as additional inputs or outputs on "
         f"{phase}: {ci2}" in str(form.errors["outputs"])
     )


### PR DESCRIPTION
This adds validation to the forms to make sure that evaluation inputs and outputs (as defined on the phase) do not overlap with the algorithm inputs and outputs of the phase. 

Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/357 

