### PR TITLE
Ground Truth from Answers

### DIFF
--- a/app/grandchallenge/reader_studies/forms.py
+++ b/app/grandchallenge/reader_studies/forms.py
@@ -753,7 +753,7 @@ class AnswersFromGroundTruthForm(SaveFormInitMixin, Form):
         queryset=get_user_model().objects.none(),
         required=True,
         help_text=format_html(
-            "Select a user to whom the answers will assigned"
+            "Select a user to whom the answers will assigned. "
             "Only users that currently have <strong>no answers</strong> are valid options."
         ),
         widget=Select2Widget,
@@ -764,10 +764,14 @@ class AnswersFromGroundTruthForm(SaveFormInitMixin, Form):
 
         self._reader_study = reader_study
 
+        # self.fields["user"].queryset = (
+        #     get_user_model()
+        #     .objects.filter(answer__question__reader_study=reader_study)
+        #     .distinct()
+        # )
         self.fields["user"].queryset = (
-            get_user_model()
-            .objects.filter(answer__question__reader_study=reader_study)
-            .distinct()
+            self._reader_study.editors_group.user_set.all()
+            | self._reader_study.readers_group.user_set.all()
         )
 
     def clean_user(self):

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1938,17 +1938,17 @@ class Answer(UUIDModel):
     def assign_permissions(self):
         # Allow the editors and creator to view this answer
         assign_perm(
-            f"view_{self._meta.model_name}",
+            "view_answer",
             self.question.reader_study.editors_group,
             self,
         )
         assign_perm(
-            f"delete_{self._meta.model_name}",
+            "delete_answer",
             self.question.reader_study.editors_group,
             self,
         )
-        assign_perm(f"view_{self._meta.model_name}", self.creator, self)
-        assign_perm(f"change_{self._meta.model_name}", self.creator, self)
+        assign_perm("view_answer", self.creator, self)
+        assign_perm("change_answer", self.creator, self)
 
 
 class AnswerUserObjectPermission(UserObjectPermissionBase):

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1928,8 +1928,21 @@ class Answer(UUIDModel):
         self.score = self.question.calculate_score(self.answer, ground_truth)
         return self.score
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, calculate_score=True, **kwargs):
         adding = self._state.adding
+
+        if not self.is_ground_truth and calculate_score:
+            try:
+                ground_truth = Answer.objects.get(
+                    question=self.question,
+                    is_ground_truth=True,
+                    display_set=self.display_set,
+                )
+            except Answer.DoesNotExist:
+                pass  # Nothing to do here
+            else:
+                self.calculate_score(ground_truth=ground_truth.answer)
+
         super().save(*args, **kwargs)
 
         if adding:

--- a/app/grandchallenge/reader_studies/signals.py
+++ b/app/grandchallenge/reader_studies/signals.py
@@ -9,8 +9,7 @@ from django.db.transaction import on_commit
 from django.dispatch import receiver
 
 from grandchallenge.cases.models import Image
-from grandchallenge.reader_studies.models import Answer, DisplaySet
-from grandchallenge.reader_studies.tasks import add_scores_for_display_set
+from grandchallenge.reader_studies.models import DisplaySet
 
 
 @receiver(m2m_changed, sender=DisplaySet.values.through)
@@ -84,25 +83,3 @@ def set_display_set_order(sender, instance, **_):
     if instance.order:
         return
     instance.order = instance.reader_study.next_display_set_order
-
-
-@receiver(post_save, sender=Answer)
-def assign_score(sender, instance, created, update_fields=None, **kwargs):
-    if update_fields is not None and set(update_fields) == {"score"}:
-        return
-    if (
-        instance.is_ground_truth
-        or Answer.objects.filter(
-            question=instance.question,
-            is_ground_truth=True,
-            display_set=instance.display_set,
-        ).exists()
-    ):
-        on_commit(
-            lambda: add_scores_for_display_set.apply_async(
-                kwargs={
-                    "instance_pk": str(instance.pk),
-                    "ds_pk": str(instance.display_set.pk),
-                }
-            )
-        )

--- a/app/grandchallenge/reader_studies/templates/reader_studies/answers_from_ground_truth_form.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/answers_from_ground_truth_form.html
@@ -1,0 +1,12 @@
+{% extends "reader_studies/ground_truth_csv_form.html" %}
+
+{% block form_heading %}
+    <h2> Add {{ type_to_add }} from Ground Truth to {{ object }} </h2>
+
+
+    <p>
+        The ground truth will be deleted and the selected user will get
+        new individual answers that are equal to the ground truth.
+    </p>
+
+{% endblock %}

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_ground_truth.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_ground_truth.html
@@ -43,7 +43,7 @@
                 or
                 <a class="btn btn-danger"
                         href="{% url 'reader-studies:add-answers-from-ground-truth' slug=object.slug %}">
-                    <i class="fas fa-recycle fa-fw pr-1"></i>Ground&nbsp;Truth to Answers
+                    <i class="fas fa-users fa-fw pr-1"></i>Ground&nbsp;Truth to User Answers
                 </a>
             </div>
         </div>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_ground_truth.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_ground_truth.html
@@ -35,11 +35,20 @@
             <p class="mb-0">
                 This reader study has ground truth
             </p>
-             <a class="btn btn-danger"
-                    href="{% url 'reader-studies:ground-truth-delete' slug=object.slug %}">
-                <i class="fas fa-trash-alt fa-fw pr-1"></i>Delete Ground&nbsp;Truth
-            </a>
+            <div>
+                <a class="btn btn-danger"
+                        href="{% url 'reader-studies:ground-truth-delete' slug=object.slug %}">
+                    <i class="fas fa-trash-alt fa-fw pr-1"></i>Delete Ground&nbsp;Truth
+                </a>
+                or
+                <a class="btn btn-danger"
+                        href="{% url 'reader-studies:add-answers-from-ground-truth' slug=object.slug %}">
+                    <i class="fas fa-recycle fa-fw pr-1"></i>Assign Ground Truth as Answers
+                </a>
+            </div>
         </div>
+
+
 
         <hr>
 

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_ground_truth.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_ground_truth.html
@@ -43,7 +43,7 @@
                 or
                 <a class="btn btn-danger"
                         href="{% url 'reader-studies:add-answers-from-ground-truth' slug=object.slug %}">
-                    <i class="fas fa-recycle fa-fw pr-1"></i>Assign Ground Truth as Answers
+                    <i class="fas fa-recycle fa-fw pr-1"></i>Ground&nbsp;Truth to Answers
                 </a>
             </div>
         </div>

--- a/app/grandchallenge/reader_studies/urls.py
+++ b/app/grandchallenge/reader_studies/urls.py
@@ -17,6 +17,7 @@ from grandchallenge.reader_studies.views import (
     QuestionInterfacesView,
     QuestionUpdate,
     QuestionWidgetsView,
+    ReaderStudyAnswersFromGroundTruth,
     ReaderStudyCopy,
     ReaderStudyCreate,
     ReaderStudyDelete,
@@ -90,6 +91,11 @@ urlpatterns = [
         "<slug:slug>/ground-truth/answers/create/",
         ReaderStudyGroundTruthFromAnswers.as_view(),
         name="add-ground-truth-answers",
+    ),
+    path(
+        "<slug:slug>/answers/ground-truth/create/",
+        ReaderStudyAnswersFromGroundTruth.as_view(),
+        name="add-answers-from-ground-truth",
     ),
     path(
         "<slug:slug>/display-sets/create/",

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -478,11 +478,12 @@ class BaseAddObjectToReaderStudyMixin(
 
 
 class AddGroundTruthViaCSVToReaderStudy(
-    BaseAddObjectToReaderStudyMixin, FormView
+    SuccessMessageMixin, BaseAddObjectToReaderStudyMixin, FormView
 ):
     form_class = GroundTruthCSVForm
     template_name = "reader_studies/ground_truth_csv_form.html"
     type_to_add = "Ground Truth"
+    success_message = "Ground Truth has been added succesfully. Updating the scores is done asynchronously."
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -514,12 +515,14 @@ class AddGroundTruthViaCSVToReaderStudy(
 
 
 class ReaderStudyGroundTruthFromAnswers(
+    SuccessMessageMixin,
     BaseAddObjectToReaderStudyMixin,
     FormView,
 ):
     form_class = GroundTruthFromAnswersForm
     template_name = "reader_studies/ground_truth_from_answers_form.html"
     type_to_add = "Ground Truth"
+    success_message = "Answers have been succesfully converted to Ground Truth. Updating the scores is done asynchronously."
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -536,12 +536,16 @@ class ReaderStudyGroundTruthFromAnswers(
 
 
 class ReaderStudyAnswersFromGroundTruth(
+    SuccessMessageMixin,
     BaseAddObjectToReaderStudyMixin,
     FormView,
 ):
     form_class = AnswersFromGroundTruthForm
     template_name = "reader_studies/answers_from_ground_truth_form.html"
     type_to_add = "Answers"
+    success_message = (
+        "Conversion of Ground Truth to Answers will be done asynchronously."
+    )
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -84,6 +84,7 @@ from grandchallenge.reader_studies.filters import (
     ReaderStudyFilter,
 )
 from grandchallenge.reader_studies.forms import (
+    AnswersFromGroundTruthForm,
     DisplaySetCreateForm,
     DisplaySetUpdateForm,
     GroundTruthCSVForm,
@@ -528,6 +529,28 @@ class ReaderStudyGroundTruthFromAnswers(
     def form_valid(self, form):
         response = super().form_valid(form)
         form.create_ground_truth()
+        return response
+
+    def get_success_url(self):
+        return self.reader_study.get_absolute_url()
+
+
+class ReaderStudyAnswersFromGroundTruth(
+    BaseAddObjectToReaderStudyMixin,
+    FormView,
+):
+    form_class = AnswersFromGroundTruthForm
+    template_name = "reader_studies/answers_from_ground_truth_form.html"
+    type_to_add = "Answers"
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs.update({"reader_study": self.reader_study})
+        return kwargs
+
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        form.convert_answers()
         return response
 
     def get_success_url(self):

--- a/app/tests/reader_studies_tests/test_forms.py
+++ b/app/tests/reader_studies_tests/test_forms.py
@@ -2016,7 +2016,7 @@ def test_answers_from_ground_truth_form():
 
 @pytest.mark.django_db
 @override_settings(task_eager_propagates=True, task_always_eager=True)
-def test_ground_truth_from_answers_form():
+def test_ground_truth_from_answers_form(django_capture_on_commit_callbacks):
     rs = ReaderStudyFactory()
 
     reader, editor = UserFactory.create_batch(2)
@@ -2078,7 +2078,8 @@ def test_ground_truth_from_answers_form():
     )
     assert form.is_valid(), "With both answers the user is a valid source"
 
-    form.create_ground_truth()
+    with django_capture_on_commit_callbacks(execute=True):
+        form.create_ground_truth()
 
     assert not Answer.objects.filter(
         question__answer_type=Question.AnswerType.BOUNDING_BOX_2D,

--- a/app/tests/reader_studies_tests/test_models.py
+++ b/app/tests/reader_studies_tests/test_models.py
@@ -1232,4 +1232,4 @@ def test_answer_score_calculation():
     answer.save()
 
     answer.refresh_from_db()  # Sanity
-    assert answer.score == 0.0, "Udpate an answer re-calculates a score"
+    assert answer.score == 0.0, "Updating an answer re-calculates a score"

--- a/app/tests/reader_studies_tests/test_tasks.py
+++ b/app/tests/reader_studies_tests/test_tasks.py
@@ -2,10 +2,16 @@ import pytest
 
 from grandchallenge.components.models import ComponentInterface
 from grandchallenge.reader_studies.tasks import (
+    answers_from_ground_truth,
     create_display_sets_for_upload_session,
 )
-from tests.factories import ImageFactory
-from tests.reader_studies_tests.factories import ReaderStudyFactory
+from tests.factories import ImageFactory, UserFactory
+from tests.reader_studies_tests.factories import (
+    AnswerFactory,
+    DisplaySetFactory,
+    QuestionFactory,
+    ReaderStudyFactory,
+)
 
 
 @pytest.mark.django_db
@@ -33,3 +39,25 @@ def test_create_display_sets_for_upload_session():
 
     assert rs.display_sets.count() == 1
     assert rs.display_sets.first().values.first().image == image
+
+
+@pytest.mark.django_db
+def test_answers_from_ground_truth_with_existing_answers():
+    rs = ReaderStudyFactory()
+    ds = DisplaySetFactory(reader_study=rs)
+    q = QuestionFactory(reader_study=rs)
+
+    user = UserFactory()
+    rs.add_editor(user)
+
+    answers_from_ground_truth(
+        reader_study_pk=rs.pk, target_user_pk=user.pk
+    )  # NOOP
+
+    AnswerFactory(creator=user, question=q, display_set=ds)
+
+    with pytest.raises(ValueError) as error:
+        answers_from_ground_truth(
+            reader_study_pk=rs.pk, target_user_pk=user.pk
+        )
+    assert "User already has answers" in str(error)

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -933,7 +933,16 @@ def test_display_set_upload_corrupt_image(
 
 
 @pytest.mark.django_db
-def test_ground_truth_view(client):
+@pytest.mark.parametrize(
+    "viewname",
+    [
+        "reader-studies:ground-truth",
+        "reader-studies:add-ground-truth-csv",
+        "reader-studies:add-ground-truth-answers",
+        "reader-studies:add-answers-from-ground-truth",
+    ],
+)
+def test_ground_truth_views(client, viewname):
     rs = ReaderStudyFactory()
 
     editor, reader, a_user = UserFactory.create_batch(3)
@@ -943,20 +952,20 @@ def test_ground_truth_view(client):
     for usr in [reader, a_user]:
         response = get_view_for_user(
             client=client,
-            viewname="reader-studies:ground-truth",
+            viewname=viewname,
             reverse_kwargs={"slug": rs.slug},
             user=usr,
         )
-        assert response.status_code == 403
+        assert response.status_code == 403, "Non editor cannot get view"
 
     response = get_view_for_user(
         client=client,
-        viewname="reader-studies:ground-truth",
+        viewname=viewname,
         reverse_kwargs={"slug": rs.slug},
         user=editor,
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 200, "Editors can get view"
 
 
 @pytest.mark.django_db

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -76,16 +76,6 @@ def test_example_ground_truth(client, tmpdir):
         method=client.get,
         reverse_kwargs={"slug": rs.slug},
         follow=True,
-        user=reader,
-    )
-    assert response.status_code == 403
-
-    response = get_view_for_user(
-        viewname="reader-studies:example-ground-truth-csv",
-        client=client,
-        method=client.get,
-        reverse_kwargs={"slug": rs.slug},
-        follow=True,
         user=editor,
     )
     assert response.status_code == 200


### PR DESCRIPTION
This PR is the final part on:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/385

It adds a form that allows the ground truth to be transformed into answers for a selected user. The selected user should not have any existing answers.

To simplify the permissions I've opted to fully create new answers in an asyncronous task. However, because of wish to have the whole conversion in a single transaction I ran into problems with signals.

As a consequence I've also opted to boot the signal on the post_save of an `Answer` and pull the logic there into the `Answer.save()`. It used to be the case that an async task got spawned for each new `Answer` added. That is now done synchronously: the ground truth was being retrieved anyway. When added ground truth, which is done in bulk anyway, the re-calculation is now batched in a single task. Should be a bit more performant than a typical 1000 tasks spawned instantly.

Not sure about the current flag-based calculation of scores approach to `Answer.save()`: perhaps there is a better ay? It fixes an N+1 run off on creating answers from ground truth.

## Showcase

Showing the loop: answers to ground truth to answers to ground truth




https://github.com/user-attachments/assets/bd4f2915-6eb5-4a79-9a0b-ac888b3d519a

