### PR TITLE
Image processing and assignment: account for object not existing

### DIFF
--- a/app/grandchallenge/cases/models.py
+++ b/app/grandchallenge/cases/models.py
@@ -128,7 +128,9 @@ class RawImageUploadSession(UUIDModel):
 
     @property
     def default_error_message(self):
-        n_errors = len(self.import_result["file_errors"])
+        n_errors = self.import_result and len(
+            self.import_result["file_errors"]
+        )
         if n_errors:
             return (
                 f"{n_errors} file{pluralize(n_errors)} could not be imported"

--- a/app/grandchallenge/cases/tasks.py
+++ b/app/grandchallenge/cases/tasks.py
@@ -138,10 +138,6 @@ def build_images(  # noqa:C901
         app_label=RawImageUploadSession._meta.app_label,
         model_name=RawImageUploadSession._meta.model_name,
     )
-    if linked_interface_slug:
-        ci = ComponentInterface.objects.get(slug=linked_interface_slug)
-    else:
-        ci = None
 
     if linked_object_pk:
         try:
@@ -156,11 +152,22 @@ def build_images(  # noqa:C901
                 DisplaySet._meta.model_name,
             ]:
                 # users can delete archive items and display sets before this task runs
+                logger.info(
+                    f"Nothing to do here: {linked_model_name} no longer exists."
+                )
+                upload_session.update_status(
+                    status=RawImageUploadSession.CANCELLED
+                )
                 return
             else:
                 raise e
     else:
         linked_object = None
+
+    if linked_interface_slug:
+        ci = ComponentInterface.objects.get(slug=linked_interface_slug)
+    else:
+        ci = None
 
     error_handler = upload_session.get_error_handler(
         linked_object=linked_object

--- a/app/grandchallenge/cases/tasks.py
+++ b/app/grandchallenge/cases/tasks.py
@@ -156,7 +156,9 @@ def build_images(  # noqa:C901
                     f"Nothing to do here: {linked_model_name} no longer exists."
                 )
                 upload_session.update_status(
-                    status=RawImageUploadSession.CANCELLED
+                    status=RawImageUploadSession.CANCELLED,
+                    error_message="Image processing canceled. "
+                    f"The associated {linked_model_name} not longer exists.",
                 )
                 return
             else:

--- a/app/grandchallenge/cases/tasks.py
+++ b/app/grandchallenge/cases/tasks.py
@@ -8,7 +8,7 @@ from tempfile import TemporaryDirectory
 
 from billiard.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
 from django.conf import settings
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.db import transaction
 from django.db.transaction import on_commit
@@ -146,23 +146,17 @@ def build_images(  # noqa:C901
                 model_name=linked_model_name,
                 pk=linked_object_pk,
             )
-        except ObjectDoesNotExist as e:
-            if linked_model_name in [
-                ArchiveItem._meta.model_name,
-                DisplaySet._meta.model_name,
-            ]:
-                # users can delete archive items and display sets before this task runs
-                logger.info(
-                    f"Nothing to do here: {linked_model_name} no longer exists."
-                )
-                upload_session.update_status(
-                    status=RawImageUploadSession.CANCELLED,
-                    error_message="Image processing canceled. "
-                    f"The associated {linked_model_name} not longer exists.",
-                )
-                return
-            else:
-                raise e
+        except (ArchiveItem.DoesNotExist, DisplaySet.DoesNotExist):
+            # users can delete archive items and display sets before this task runs
+            logger.info(
+                f"Nothing to do here: {linked_model_name} no longer exists."
+            )
+            upload_session.update_status(
+                status=RawImageUploadSession.CANCELLED,
+                error_message="Image processing canceled. "
+                f"The associated {linked_model_name} not longer exists.",
+            )
+            return
     else:
         linked_object = None
 

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1191,19 +1191,6 @@ def validate_voxel_values(*, civ_pk):
     civ.interface._validate_voxel_values(civ.image)
 
 
-def _get_object_with_lock(*, app_label, model_name, object_pk):
-    from grandchallenge.archives.models import ArchiveItem
-    from grandchallenge.reader_studies.models import DisplaySet
-
-    try:
-        object = lock_model_instance(
-            app_label=app_label, model_name=model_name, pk=object_pk
-        )
-    except (ArchiveItem.DoesNotExist, DisplaySet.DoesNotExist):
-        return None
-    return object
-
-
 @acks_late_micro_short_task(
     retry_on=(LockNotAcquiredException,), delayed_retry=False
 )
@@ -1218,15 +1205,18 @@ def add_image_to_object(  # noqa: C901
     linked_task=None,
 ):
     from grandchallenge.algorithms.models import Job
+    from grandchallenge.archives.models import ArchiveItem
     from grandchallenge.components.models import (
         ComponentInterface,
         ComponentInterfaceValue,
     )
+    from grandchallenge.reader_studies.models import DisplaySet
 
-    object = _get_object_with_lock(
-        app_label=app_label, model_name=model_name, object_pk=object_pk
-    )
-    if object is None:
+    try:
+        object = lock_model_instance(
+            app_label=app_label, model_name=model_name, object_pk=object_pk
+        )
+    except (ArchiveItem.DoesNotExist, DisplaySet.DoesNotExist):
         logger.info(f"Nothing to do: {model_name} no longer exists.")
         return
 
@@ -1309,15 +1299,18 @@ def add_file_to_object(
     linked_task=None,
 ):
     from grandchallenge.algorithms.models import Job
+    from grandchallenge.archives.models import ArchiveItem
     from grandchallenge.components.models import (
         ComponentInterface,
         ComponentInterfaceValue,
     )
+    from grandchallenge.reader_studies.models import DisplaySet
 
-    object = _get_object_with_lock(
-        app_label=app_label, model_name=model_name, object_pk=object_pk
-    )
-    if object is None:
+    try:
+        object = lock_model_instance(
+            app_label=app_label, model_name=model_name, object_pk=object_pk
+        )
+    except (ArchiveItem.DoesNotExist, DisplaySet.DoesNotExist):
         logger.info(f"Nothing to do: {model_name} no longer exists.")
         return
 

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1214,7 +1214,7 @@ def add_image_to_object(  # noqa: C901
 
     try:
         object = lock_model_instance(
-            app_label=app_label, model_name=model_name, object_pk=object_pk
+            app_label=app_label, model_name=model_name, pk=object_pk
         )
     except (ArchiveItem.DoesNotExist, DisplaySet.DoesNotExist):
         logger.info(f"Nothing to do: {model_name} no longer exists.")
@@ -1308,7 +1308,7 @@ def add_file_to_object(
 
     try:
         object = lock_model_instance(
-            app_label=app_label, model_name=model_name, object_pk=object_pk
+            app_label=app_label, model_name=model_name, pk=object_pk
         )
     except (ArchiveItem.DoesNotExist, DisplaySet.DoesNotExist):
         logger.info(f"Nothing to do: {model_name} no longer exists.")

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -20,7 +20,7 @@ from celery import (  # noqa: I251 TODO needs to be refactored
 )
 from django.apps import apps
 from django.conf import settings
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 from django.db import OperationalError, transaction
 from django.db.models import DateTimeField, ExpressionWrapper, F
@@ -1199,14 +1199,8 @@ def _get_object_with_lock(*, app_label, model_name, object_pk):
         object = lock_model_instance(
             app_label=app_label, model_name=model_name, pk=object_pk
         )
-    except ObjectDoesNotExist as e:
-        if model_name in [
-            ArchiveItem._meta.model_name,
-            DisplaySet._meta.model_name,
-        ]:
-            return None
-        else:
-            raise e
+    except (ArchiveItem.DoesNotExist, DisplaySet.DoesNotExist):
+        return None
     return object
 
 

--- a/app/tests/cases_tests/test_tasks.py
+++ b/app/tests/cases_tests/test_tasks.py
@@ -1,22 +1,30 @@
 import shutil
+from contextlib import nullcontext
 from pathlib import Path
 from uuid import uuid4
 
 import pytest
+from django.core.exceptions import ObjectDoesNotExist
 from panimg.models import ImageType, PanImgFile, PostProcessorResult
 from panimg.post_processors import DEFAULT_POST_PROCESSORS
 
-from grandchallenge.cases.models import ImageFile
+from grandchallenge.algorithms.models import Job
+from grandchallenge.cases.models import ImageFile, RawImageUploadSession
 from grandchallenge.cases.tasks import (
     POST_PROCESSORS,
     _check_post_processor_result,
+    build_images,
     import_images,
     post_process_image,
 )
 from grandchallenge.core.celery import acks_late_micro_short_task
 from grandchallenge.core.storage import protected_s3_storage
+from tests.algorithms_tests.factories import AlgorithmJobFactory
+from tests.archives_tests.factories import ArchiveItemFactory
 from tests.cases_tests import RESOURCE_PATH
+from tests.cases_tests.factories import RawImageUploadSessionFactory
 from tests.factories import UploadSessionFactory
+from tests.reader_studies_tests.factories import DisplaySetFactory
 
 
 @pytest.mark.django_db
@@ -174,3 +182,53 @@ def test_post_processing(
         sum(file.size_in_storage for file in ImageFile.objects.all())
         == expected_bytes
     )
+
+
+@pytest.mark.parametrize(
+    "object_factory, factory_kwargs, context, expected_status",
+    (
+        (
+            DisplaySetFactory,
+            {},
+            nullcontext(),
+            RawImageUploadSession.CANCELLED,
+        ),
+        (
+            ArchiveItemFactory,
+            {},
+            nullcontext(),
+            RawImageUploadSession.CANCELLED,
+        ),
+        (
+            AlgorithmJobFactory,
+            {"time_limit": 10, "status": Job.VALIDATING_INPUTS},  # Required
+            pytest.raises(ObjectDoesNotExist),
+            None,
+        ),
+    ),
+)
+@pytest.mark.django_db
+def test_build_images_with_deleted_object(
+    object_factory,
+    factory_kwargs,
+    context,
+    expected_status,
+):
+    obj = object_factory(**factory_kwargs)
+    linked_object_pk = str(obj.pk)
+    obj.delete()
+
+    us = RawImageUploadSessionFactory(status=RawImageUploadSession.REQUEUED)
+
+    with context:
+        build_images(
+            upload_session_pk=us.pk,
+            linked_app_label=obj._meta.app_label,
+            linked_model_name=obj._meta.model_name,
+            linked_object_pk=linked_object_pk,
+            linked_interface_slug=None,
+        )
+
+    us.refresh_from_db()
+    if expected_status is not None:
+        assert us.status == expected_status

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -425,7 +425,7 @@ def test_add_image_to_object_updates_upload_session_on_validation_fail(
     us = RawImageUploadSessionFactory(status=RawImageUploadSession.SUCCESS)
     ci = ComponentInterfaceFactory(kind="IMG")
 
-    error_message = f"Image validation for socket {ci.title} failed with error: Image imports should result in a single image."
+    error_message = f"Image validation for socket {ci.title} failed with error: Image imports should result in a single image. "
 
     linked_task = some_async_task.signature(
         kwargs={"foo": "bar"}, immutable=True


### PR DESCRIPTION
Closes #3929

There are three steps involved in image processing:

1. `RawImageUploadSession.process_images` (sync)
    A. Interval
2.  `tasks.build_images` (async)
    B. Interval
3. `task.assign_image_to_object` (async)

During both interval A and B the target `DisplaySet` / `ArchiveItem` could be removed by the user.

This PR adds some handling for that: it should gracefully ignore it when it refers to `DisplaySets` / `ArchiveItems`, never a `Job`.

It also applies the same logic to the adding of files.
