### PR TITLE
Add CORS_ALLOW_HEADERS

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -9,6 +9,7 @@ from subprocess import CalledProcessError
 
 import sentry_sdk
 from celery.schedules import crontab
+from corsheaders.defaults import default_headers
 from csp import constants as csp_constants
 from disposable_email_domains import blocklist
 from django.contrib.messages import constants as messages
@@ -990,6 +991,14 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
 # SESSION_COOKIE_SAMESITE should be set to "lax" so won't send credentials
 # across domains, but this will allow workstations to access the api
 CORS_ALLOW_CREDENTIALS = True
+CORS_ALLOW_HEADERS = (
+    *default_headers,
+    "hx-trigger",
+    "hx-target",
+    "hx-current-url",
+    "hx-request",
+    "hx-trigger-name",
+)
 
 ###############################################################################
 #


### PR DESCRIPTION
This adds the accidentally deleted cors headers back for the widgets on the submit page. 

Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/357