### PR TITLE
Update leaderboard and evaluation detail page

### DIFF
--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1339,7 +1339,6 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
 
 
 class CheckForOverlappingSocketsMixin:
-
     def clean(self):
         super().clean()
 
@@ -1974,6 +1973,10 @@ class Evaluation(CIVForObjectMixin, ComponentJob):
     @property
     def output_interfaces(self):
         return self.submission.phase.evaluation_outputs
+
+    @property
+    def additional_outputs(self):
+        return self.outputs.exclude(interface__slug="metrics-json-file")
 
     @cached_property
     def successful_jobs_per_interface(self):

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -177,37 +177,15 @@
             </dl>
         {% endif %}
         <br>
-        {% if json %}
-            <table class="table table-borderless table-hover table-sm">
-                <thead class="thead-light">
-                <tr>
-                    <th>Metric</th>
-                    <th>Value</th>
-                </tr>
-                </thead>
-                <tbody>
-                {% for object in json %}
-                    <tr>
-                        <td>{{ object.interface.title }}</td>
-                        {% if object.interface.kind == 'STR' %}
-                            <td>{{ object.value|slice:"1:-1" }} </td>
-                        {% else %}
-                            <td>{{ object.value }}</td>
-                        {% endif %}
-                    </tr>
-                {% endfor %}
-                </tbody>
-            </table>
-            {% if object.outputs.exist %}
-                <br>
-                <h3>Outputs</h3>
+        {% if object.additional_outputs.all %}
+            <br>
+            <h3>Additional Outputs</h3>
 
-                {% for output in object.outputs.all|sort_civs %}
-                    <h3 class="mt-3">{{ output.interface.title }}</h3>
-                    {% include 'components/partials/civ.html' with object=output only %}
-                {% endfor %}
+            {% for output in object.additional_outputs.all|sort_civs %}
+                <h3 class="mt-3">{{ output.interface.title }}</h3>
+                {% include 'components/partials/civ.html' with object=output only %}
+            {% endfor %}
 
-            {% endif %}
         {% endif %}
     {% endif %}
 

--- a/app/grandchallenge/evaluation/templates/evaluation/leaderboard_row.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/leaderboard_row.html
@@ -30,7 +30,7 @@
 {{ object.submission.created|date:"j N Y" }}
 <split></split>
 
-{% if object.submission.phase.additional_evaluation_inputs %}
+{% if object.submission.phase.additional_evaluation_inputs.all %}
     <td>
         {% for input in object.additional_inputs.all|sort_civs %}
             <dd>

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -574,7 +574,6 @@ class EvaluationAdminList(
 
 
 class EvaluationIncompleteJobsMixin:
-
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
@@ -743,7 +742,7 @@ class LeaderboardDetail(
             Column(title="Created", sort_field="submission__created")
         )
 
-        if self.phase.additional_evaluation_inputs:
+        if self.phase.additional_evaluation_inputs.exists():
             columns.append(Column(title="Inputs"))
 
         if self.phase.scoring_method_choice == self.phase.MEAN:
@@ -1304,7 +1303,6 @@ class PhaseArchiveInfo(
 
 
 class AlgorithmInterfaceForPhaseMixin:
-
     @property
     def phase(self):
         return get_object_or_404(


### PR DESCRIPTION
This makes sure that the inputs column only shows on the leaderboard, if there are additional inputs. 
This also fixes the evaluation detail page so that it shows additional outputs (again). 