### PR TITLE
Initialize view_leaderboard permission

### DIFF
--- a/app/grandchallenge/reader_studies/migrations/0063_init_view_leaderboard_perm.py
+++ b/app/grandchallenge/reader_studies/migrations/0063_init_view_leaderboard_perm.py
@@ -4,7 +4,7 @@ from django.db import migrations
 def init_view_leaderboard_permission(apps, _schema_editor):
     ReaderStudy = apps.get_model("reader_studies", "ReaderStudy")  # noqa: N806
 
-    for rs in ReaderStudy.objects.filter(is_educational=True).all():
+    for rs in ReaderStudy.objects.all():
         rs.save()
 
 

--- a/app/grandchallenge/reader_studies/migrations/0063_init_view_leaderboard_perm.py
+++ b/app/grandchallenge/reader_studies/migrations/0063_init_view_leaderboard_perm.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+def init_view_leaderboard_permission(apps, _schema_editor):
+    ReaderStudy = apps.get_model("reader_studies", "ReaderStudy")  # noqa: N806
+
+    for rs in ReaderStudy.objects.filter(is_educational=True).all():
+        rs.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        (
+            "reader_studies",
+            "0062_readerstudy_leaderboard_accessible_to_readers",
+        ),
+    ]
+
+    operations = [
+        migrations.RunPython(init_view_leaderboard_permission, elidable=True),
+    ]


### PR DESCRIPTION
At the moment, noone has the newly introduced `view_leaderboard` permission. Simply opening the reader study settings and saving the form again (with or without changes) fixes that, but I think the cleaner way to initialize these permissions is via a migration. 