### PR TITLE
3916 admin page with warning appears on a new row

### DIFF
--- a/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
@@ -3,14 +3,14 @@
 
 {% if challenge %}
     <div class="row mb-3 mx-0 border-bottom challenge-topbar">
-        <div class="col-11 px-0">
+        <div class="col-auto mr-auto px-0">
             <div class="nav-tab-dropdown-container">
                 <a class="d-lg-none btn btn-outline-dark mb-1"
                    data-toggle="dropdown"
                    href="#"
                    role="button"
                    aria-expanded="false"><i class="fas fa-bars"></i></a>
-                <ul class="nav nav-tabs border-0 nav-fill">
+                <ul class="nav nav-tabs border-0">
                     <li class="nav-item">
                         <a class="nav-link {% if request.resolver_match.view_name == 'pages:home' or request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"
                            href="{% url 'pages:home' challenge_short_name=challenge.short_name %}">
@@ -88,8 +88,8 @@
             </div>
         </div>
 
-        <div class="col-1 py-0 px-0 d-flex justify-content-end">
-            {% if challenge.use_registration_page and not user_is_participant %}
+        {% if challenge.use_registration_page and not user_is_participant %}
+            <div class="col-auto py-0 px-0">
                 <div>
                     <a class="btn btn-success"
                        href="{% url 'participants:registration-create' challenge_short_name=challenge.short_name %}"
@@ -97,8 +97,8 @@
                             Join
                     </a>
                 </div>
-            {% endif %}
-        </div>
+            </div>
+        {% endif %}
     </div>
 
     <script src="{% static 'js/challenges/dropdown.js' %}" type="module" defer></script>

--- a/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
@@ -10,7 +10,7 @@
                    href="#"
                    role="button"
                    aria-expanded="false"><i class="fas fa-bars"></i></a>
-                <ul class="nav nav-tabs border-0">
+                <ul class="nav nav-tabs border-0 nav-fill">
                     <li class="nav-item">
                         <a class="nav-link {% if request.resolver_match.view_name == 'pages:home' or request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"
                            href="{% url 'pages:home' challenge_short_name=challenge.short_name %}">

--- a/app/grandchallenge/core/static/css/base.scss
+++ b/app/grandchallenge/core/static/css/base.scss
@@ -68,5 +68,5 @@ div.codehilite {
 }
 
 .challenge-topbar .nav-link {
-    padding: $nav-link-padding-y 1.5rem;
+    padding: $nav-link-padding-y 1rem;
 }


### PR DESCRIPTION
Closes https://github.com/comic/grand-challenge.org/issues/3916

Padding for navbar items in challenge topbar is reduced and space for the items is maximized. 

Continuation of https://github.com/comic/grand-challenge.org/issues/3923. Failed to test it at the time with the Teams tab present. 

![Image](https://github.com/user-attachments/assets/e4095cc7-4f86-4977-a710-a2059205f694)

![Image](https://github.com/user-attachments/assets/eec54ad0-063c-43cf-a5f2-b58d354eb686)
