### PR TITLE
Pin grand-challenge-forge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "pyjwt",
     "beautifulsoup4",
     "pymdown-extensions",
-    "grand-challenge-forge",
+    "grand-challenge-forge<=0.6.1",
     "biopython",
     "cachetools",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1339,7 +1339,7 @@ requires-dist = [
     { name = "djangorestframework-csv" },
     { name = "djangorestframework-guardian" },
     { name = "drf-spectacular" },
-    { name = "grand-challenge-forge" },
+    { name = "grand-challenge-forge", specifier = "<=0.6.1" },
     { name = "gunicorn" },
     { name = "humanize" },
     { name = "jsonschema" },
@@ -1877,6 +1877,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pkgconfig"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/e0/e05fee8b5425db6f83237128742e7e5ef26219b687ab8f0d41ed0422125e/pkgconfig-1.5.5.tar.gz", hash = "sha256:deb4163ef11f75b520d822d9505c1f462761b4309b1bb713d08689759ea8b899", size = 6082 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/af/89487c7bbf433f4079044f3dc32f9a9f887597fe04614a37a292e373e16b/pkgconfig-1.5.5-py3-none-any.whl", hash = "sha256:d20023bbeb42ee6d428a0fac6e0904631f545985a10cdd71a20aa58bc47a4209", size = 6732 },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.3.7"
 source = { registry = "https://pypi.org/simple" }
@@ -2388,6 +2397,7 @@ version = "2.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
+    { name = "pkgconfig" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7b/88/f73dae807ec68b228fba72507105e3ba80a561dc0bade0004ce24fd118fc/pyvips-2.2.3.tar.gz", hash = "sha256:43bceced0db492654c93008246a58a508e0373ae1621116b87b322f2ac72212f", size = 56626 }
 


### PR DESCRIPTION
Next release of forge (v0.7.0) **will** have breaking changes. Adaptation of those changes will flow via a different PR: meanwhile pinning will prevent undue breakage when updating dependencies.