### PR TITLE
Remove help forum

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -139,15 +139,6 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 DOCUMENTATION_HELP_VIEWER_CONTENT_SLUG = os.environ.get(
     "DOCUMENTATION_HELP_VIEWER_CONTENT_SLUG", "viewer-content"
 )
-
-# General forum
-DOCUMENTATION_HELP_FORUM_PK = os.environ.get(
-    "DOCUMENTATION_HELP_FORUM_PK", "1"
-)
-DOCUMENTATION_HELP_FORUM_SLUG = os.environ.get(
-    "DOCUMENTATION_HELP_FORUM_SLUG", "general"
-)
-
 DOCUMENTATION_HELP_INTERFACES_SLUG = os.environ.get(
     "DOCUMENTATION_HELP_INTERFACES_SLUG", "interfaces"
 )
@@ -468,7 +459,6 @@ TEMPLATES = [
                 "grandchallenge.core.context_processors.debug",
                 "grandchallenge.core.context_processors.sentry_dsn",
                 "grandchallenge.core.context_processors.footer_links",
-                "grandchallenge.core.context_processors.help_forum",
                 "grandchallenge.core.context_processors.about_page",
                 "grandchallenge.core.context_processors.newsletter_signup",
                 "grandchallenge.core.context_processors.viewport_names",

--- a/app/grandchallenge/core/context_processors.py
+++ b/app/grandchallenge/core/context_processors.py
@@ -70,13 +70,6 @@ def footer_links(*_, **__):
     return {"policy_pages": Policy.objects.all()}
 
 
-def help_forum(*_, **__):
-    return {
-        "DOCUMENTATION_HELP_FORUM_PK": settings.DOCUMENTATION_HELP_FORUM_PK,
-        "DOCUMENTATION_HELP_FORUM_SLUG": settings.DOCUMENTATION_HELP_FORUM_SLUG,
-    }
-
-
 def about_page(*_, **__):
     return {"about_page_url": settings.FLATPAGE_ABOUT_URL}
 

--- a/app/grandchallenge/core/templates/grandchallenge/partials/userlinks.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/userlinks.html
@@ -34,11 +34,6 @@
             <i class="fas fa-book fa-fw"></i>
             &nbsp;{{ request.site.name }} Documentation
         </a>
-        <a class="dropdown-item"
-           href="{% url 'forum:forum' slug=DOCUMENTATION_HELP_FORUM_SLUG pk=DOCUMENTATION_HELP_FORUM_PK %}">
-            <i class="fas fa-comments fa-fw"></i>
-            &nbsp;{{ request.site.name }} Forum
-        </a>
     </div>
 </li>
 {% if user.is_authenticated %}

--- a/scripts/development_fixtures.py
+++ b/scripts/development_fixtures.py
@@ -15,7 +15,6 @@ from django.db import IntegrityError
 from faker import Faker
 from knox.models import AuthToken, hash_token
 from knox.settings import CONSTANTS
-from machina.apps.forum.models import Forum
 
 from grandchallenge.algorithms.models import (
     Algorithm,
@@ -94,7 +93,6 @@ def run():
     _create_reader_studies(users)
     _create_archive(users)
     _create_user_tokens(users)
-    _create_help_forum()
     _create_flatpages()
 
     print("✨ Development fixtures successfully created ✨")
@@ -193,10 +191,6 @@ def _set_user_permissions(users):
     add_archive_perm = Permission.objects.get(codename="add_archive")
     users["archive"].user_permissions.add(add_archive_perm)
     users["demo"].user_permissions.add(add_archive_perm)
-
-
-def _create_help_forum():
-    Forum.objects.create(name="General", type=Forum.FORUM_POST)
 
 
 def _create_demo_challenge(users, algorithm):


### PR DESCRIPTION
This forum is not really used and is better served by the documentation page guiding the users about who to contact.