### PR TITLE
Allow cancelling jobs in validating inputs state

### DIFF
--- a/app/grandchallenge/components/admin.py
+++ b/app/grandchallenge/components/admin.py
@@ -129,6 +129,7 @@ def cancel_jobs(modeladmin, request, queryset):
             ComponentJob.PARSING,
             ComponentJob.RETRY,
             ComponentJob.EXECUTING_PREREQUISITES,
+            ComponentJob.VALIDATING_INPUTS,
         ]
     ).select_for_update(of=("self",), skip_locked=True).update(
         status=ComponentJob.CANCELLED


### PR DESCRIPTION
There are currently 2 jobs stuck in validating inputs state. We should be able to cancel those in the admin. 

We should also look into why these got stuck, of course, but cancelling them should be possible anyway. 