### PR TITLE
Allow searching for pk in session admin

### DIFF
--- a/app/grandchallenge/workstations/admin.py
+++ b/app/grandchallenge/workstations/admin.py
@@ -57,6 +57,7 @@ class SessionHistoryAdmin(SimpleHistoryAdmin):
         "extra_env_vars",
     ]
     search_fields = [
+        "pk",
         "creator__username",
     ]
 


### PR DESCRIPTION
This is useful when investigating sentry issues to find the related session.