### PR TITLE
Fix celery exception handling with direct invocation

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1234,11 +1234,19 @@ CELERY_BEAT_SCHEDULE = {
     },
     "update_publication_metadata": {
         "task": "grandchallenge.publications.tasks.update_publication_metadata",
-        "schedule": crontab(hour=1, minute=30),
+        "schedule": crontab(hour=0, minute=30),
     },
     "remove_inactive_container_images": {
         "task": "grandchallenge.components.tasks.remove_inactive_container_images",
-        "schedule": crontab(hour=2, minute=30),
+        "schedule": crontab(hour=1, minute=0),
+    },
+    "delete_failed_import_container_images": {
+        "task": "grandchallenge.components.tasks.delete_failed_import_container_images",
+        "schedule": crontab(hour=1, minute=30),
+    },
+    "delete_old_unsuccessful_container_images": {
+        "task": "grandchallenge.components.tasks.delete_old_unsuccessful_container_images",
+        "schedule": crontab(hour=2, minute=0),
     },
     "update_associated_challenges": {
         "task": "grandchallenge.algorithms.tasks.update_associated_challenges",

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -205,8 +205,8 @@ def remove_inactive_container_images():
                 is_in_registry=True
             )
 
-            if active_image := instance.active_image:
-                queryset = queryset.exclude(pk=active_image.pk)
+            if instance.active_image:
+                queryset = queryset.exclude(pk=instance.active_image.pk)
 
             for image in queryset:
                 on_commit(

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -201,23 +201,23 @@ def remove_inactive_container_images():
         model = apps.get_model(app_label=app_label, model_name=model_name)
 
         for instance in model.objects.all():
-            latest = instance.active_image
+            queryset = getattr(instance, related_name).filter(
+                is_in_registry=True
+            )
 
-            if latest is not None:
-                for image in (
-                    getattr(instance, related_name)
-                    .exclude(pk=latest.pk)
-                    .filter(is_in_registry=True)
-                ):
-                    on_commit(
-                        remove_container_image_from_registry.signature(
-                            kwargs={
-                                "pk": image.pk,
-                                "app_label": image._meta.app_label,
-                                "model_name": image._meta.model_name,
-                            }
-                        ).apply_async
-                    )
+            if active_image := instance.active_image:
+                queryset = queryset.exclude(pk=active_image.pk)
+
+            for image in queryset:
+                on_commit(
+                    remove_container_image_from_registry.signature(
+                        kwargs={
+                            "pk": image.pk,
+                            "app_label": image._meta.app_label,
+                            "model_name": image._meta.model_name,
+                        }
+                    ).apply_async
+                )
 
 
 @acks_late_2xlarge_task

--- a/app/grandchallenge/core/celery.py
+++ b/app/grandchallenge/core/celery.py
@@ -133,13 +133,14 @@ class AcksLateTaskDecorator:
                 else:
                     return func(*args, **kwargs)
             except Exception as error:
-                if is_in_celery_context and any(
-                    isinstance(error, e) for e in ignore_errors
-                ):
-                    logger.info(
-                        f"Ignoring error in task {task_func.name}: {error}"
-                    )
-                    return
+                if any(isinstance(error, e) for e in ignore_errors):
+                    if is_in_celery_context:
+                        logger.info(
+                            f"Ignoring error in task {task_func.name}: {error}"
+                        )
+                        return
+                    else:
+                        raise error
                 elif any(isinstance(error, e) for e in retry_on) or (
                     singleton and isinstance(error, LockError)
                 ):

--- a/app/grandchallenge/core/celery.py
+++ b/app/grandchallenge/core/celery.py
@@ -85,7 +85,7 @@ class AcksLateTaskDecorator:
             ignore_result: If the task should ignore the result
             retry_on: A tuple of exceptions that should trigger a retry on the delay queue
             delayed_retry: If the task should be retried after a delay
-            ignore_errors: A tuple of exceptions that should be ignored
+            ignore_errors: A tuple of exceptions that should be ignored when being run by celery
             singleton: If the task should be run as a singleton (only one concurrent execution at a time)
         """
         if func is None:
@@ -121,6 +121,7 @@ class AcksLateTaskDecorator:
     ):
         @wraps(func)
         def wrapper(*args, _retries=0, **kwargs):
+            is_in_celery_context = task_func.request.id is not None
             try:
                 if singleton:
                     with cache.lock(
@@ -132,7 +133,9 @@ class AcksLateTaskDecorator:
                 else:
                     return func(*args, **kwargs)
             except Exception as error:
-                if any(isinstance(error, e) for e in ignore_errors):
+                if is_in_celery_context and any(
+                    isinstance(error, e) for e in ignore_errors
+                ):
                     logger.info(
                         f"Ignoring error in task {task_func.name}: {error}"
                     )

--- a/app/tests/core_tests/test_celery.py
+++ b/app/tests/core_tests/test_celery.py
@@ -1,0 +1,26 @@
+import pytest
+
+from grandchallenge.core.celery import acks_late_micro_short_task
+
+
+def test_task_errors_raised_when_invoked(settings):
+    settings.CELERY_TASK_ALWAYS_EAGER = True
+    settings.CELERY_TASK_EAGER_PROPAGATES = True
+
+    counter = 0
+
+    @acks_late_micro_short_task(ignore_errors=(ValueError,))
+    def test_task():
+        nonlocal counter
+        counter += 1
+        raise ValueError
+
+    with pytest.raises(ValueError):
+        test_task()
+
+    assert counter == 1
+
+    result = test_task.apply_async()
+
+    assert result.status == "SUCCESS"
+    assert counter == 2


### PR DESCRIPTION
We have the option `ignore_errors=(...,)` for celery tasks that is set so that the task gets marked as successful if one of those errors is raised. However, when invoking the task directly those errors should still be raised so that the caller can then process the error. This can be in a try-except block, or by adding it to it's own `ignore_errors`.

This prevents the following:

```python
@task(ignore_errors=(Foo,))
def a():
    raise Foo

@task(ignore_errors=(Foo,))
def b():
    a()
    do_something_assuming_a_ran_successfully()
```

This PR will ensure that if `b` is invoked that `do_something_assuming_a_ran_successfully` will not run, but the task will still be marked as successful as the raised `Foo` is ignored.