### PR TITLE
Fix WorkstationConfig causing server errors on blank input

### DIFF
--- a/app/grandchallenge/workstation_configs/forms.py
+++ b/app/grandchallenge/workstation_configs/forms.py
@@ -101,6 +101,20 @@ class WorkstationConfigForm(SaveFormInitMixin, ModelForm):
         else:
             self.helper.layout.append(Submit("save", "Save"))
 
+    def clean_overlay_segments(self):
+        overlay_segments = self.cleaned_data["overlay_segments"]
+        if overlay_segments is None:
+            return []
+        else:
+            return overlay_segments
+
+    def clean_key_bindings(self):
+        key_bindings = self.cleaned_data["key_bindings"]
+        if key_bindings is None:
+            return []
+        else:
+            return key_bindings
+
     class Meta:
         model = WorkstationConfig
         fields = (

--- a/app/grandchallenge/workstation_configs/models.py
+++ b/app/grandchallenge/workstation_configs/models.py
@@ -437,15 +437,6 @@ class WorkstationConfig(TitleSlugDescriptionModel, UUIDModel):
             "workstation-configs:detail", kwargs={"slug": self.slug}
         )
 
-    def clean(self):
-        super().clean()
-        if self.overlay_segments is None:
-            self.overlay_segments = self._meta.get_field(
-                "overlay_segments"
-            ).default()
-        if self.key_bindings is None:
-            self.key_bindings = self._meta.get_field("key_bindings").default()
-
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
         if self.creator:

--- a/app/grandchallenge/workstation_configs/models.py
+++ b/app/grandchallenge/workstation_configs/models.py
@@ -437,6 +437,14 @@ class WorkstationConfig(TitleSlugDescriptionModel, UUIDModel):
             "workstation-configs:detail", kwargs={"slug": self.slug}
         )
 
+    def clean(self):
+        if self.overlay_segments is None:
+            self.overlay_segments = self._meta.get_field(
+                "overlay_segments"
+            ).default()
+        if self.key_bindings is None:
+            self.key_bindings = self._meta.get_field("key_bindings").default()
+
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
         if self.creator:

--- a/app/grandchallenge/workstation_configs/models.py
+++ b/app/grandchallenge/workstation_configs/models.py
@@ -438,6 +438,7 @@ class WorkstationConfig(TitleSlugDescriptionModel, UUIDModel):
         )
 
     def clean(self):
+        super().clean()
         if self.overlay_segments is None:
             self.overlay_segments = self._meta.get_field(
                 "overlay_segments"


### PR DESCRIPTION
Sentry noted me to that the  form allows blanking of these JSON fields. 

This PR ensures (as is done in other places) that there are no server errors when this is submitted.