### PR TITLE
Remove deprecated flake8-docstrings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,6 @@ repos:
             additional_dependencies:
                 - flake8-bugbear!=24.4.21
                 - pep8-naming
-                - flake8-docstrings
                 - mccabe
                 - flake8-tidy-imports
     - repo: https://github.com/thibaudcolas/curlylint

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [flake8]
 max-line-length = 79
-docstring-convention = numpy
 max-complexity = 10
 ban-relative-imports = true
 banned-modules =
@@ -37,16 +36,6 @@ ignore =
     B950
     # TODO SEP21 JM Exception chaining, unsure on the consequences
     B904
-    # D1 are public documentation checks
-    D1
-    # D400 First line should end with a period, see D205
-    D400
-    # D401 First line should be in imperative mood, lots of false positives
-    D401
-    # D202 No blank lines allowed after function docstring, conflicts with black
-    D202
-    # D205 1 blank line required between summary line and description
-    D205
     # W503 is not PEP8 compliant (see black formatting)
     W503
     # N818 Exceptions should be named Error (TODO)


### PR DESCRIPTION
See https://github.com/PyCQA/flake8-docstrings/issues/68

We will need an alternative, but for now remove it so that CI works again.