### PR TITLE
Check for partial algorithm interface match

### DIFF
--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1696,9 +1696,14 @@ class Submission(FieldChangeMixin, UUIDModel):
 
     @cached_property
     def has_matching_algorithm_interfaces(self):
-        return {*self.phase.algorithm_interfaces.all()} == {
-            *self.algorithm_image.algorithm.interfaces.all()
-        }
+        algorithm_interfaces = set(
+            self.algorithm_image.algorithm.interfaces.all()
+        )
+        phase_algorithm_interfaces = set(self.phase.algorithm_interfaces.all())
+        if not phase_algorithm_interfaces.issubset(algorithm_interfaces):
+            return False
+        else:
+            return True
 
 
 class SubmissionUserObjectPermission(UserObjectPermissionBase):

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1700,10 +1700,7 @@ class Submission(FieldChangeMixin, UUIDModel):
             self.algorithm_image.algorithm.interfaces.all()
         )
         phase_algorithm_interfaces = set(self.phase.algorithm_interfaces.all())
-        if not phase_algorithm_interfaces.issubset(algorithm_interfaces):
-            return False
-        else:
-            return True
+        return phase_algorithm_interfaces.issubset(algorithm_interfaces)
 
 
 class SubmissionUserObjectPermission(UserObjectPermissionBase):

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -2734,6 +2734,10 @@ def test_reschedule_evaluation_with_additional_inputs(
             [0, 1, 3],
             Evaluation.CANCELLED,
         ],  # same number, partially overlapping
+        [
+            [0, 1, 2, 3],
+            Evaluation.VALIDATING_INPUTS,
+        ],  # different number, but covering all the phase interfaces
     ),
 )
 @pytest.mark.django_db


### PR DESCRIPTION
`has_matching_algorithm_interfaces` should return `True` for algorithms that implement at least the interfaces defined for the phase, not only algorithms with an exact match. 