### PR TITLE
Add (phase) algorithm interface copy form

### DIFF
--- a/app/grandchallenge/algorithms/templates/algorithms/partials/algorithminterface_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/partials/algorithminterface_list.html
@@ -1,6 +1,7 @@
 {% load crispy_forms_tags %}
 {% load remove_whitespace %}
 {% load meta_attr %}
+{% load url %}
 
 <h2>Algorithm Interfaces for {{ base_obj }}</h2>
 
@@ -10,9 +11,16 @@
         <a class="btn btn-primary {% if base_obj.algorithm_interfaces_locked %} disabled {% endif %}"
            href="{{ base_obj.algorithm_interface_create_url }}"
         >
-        <i class="fas fa-plus"></i> Add new interface
+        <i class="fas fa-plus pr-1"></i> Add new interface
         </a>
     </span>
+    {% if is_phase %}
+        <a class="btn btn-primary"
+            href="{% url 'evaluation:interfaces-copy' slug=base_obj.slug challenge_short_name=challenge.short_name %}"
+        >
+            <i class="fas fa-copy pr-1"></i> Copy interfaces
+        </a>
+    {% endif %}
 </p>
 
 {% include 'algorithms/partials/algorithminterface_table.html' with base_obj=base_obj interfaces=interfaces delete_option=True %}

--- a/app/grandchallenge/algorithms/templates/algorithms/partials/algorithminterface_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/partials/algorithminterface_list.html
@@ -9,7 +9,9 @@
     <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="{% if base_obj.algorithm_interfaces_locked %}Disabled because this phase is a parent or has a parent phase.{% endif %}">
         <a class="btn btn-primary {% if base_obj.algorithm_interfaces_locked %} disabled {% endif %}"
            href="{{ base_obj.algorithm_interface_create_url }}"
-        >Add new interface</a>
+        >
+        <i class="fas fa-plus"></i> Add new interface
+        </a>
     </span>
 </p>
 

--- a/app/grandchallenge/algorithms/templates/algorithms/partials/algorithminterface_list.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/partials/algorithminterface_list.html
@@ -14,7 +14,7 @@
         <i class="fas fa-plus pr-1"></i> Add new interface
         </a>
     </span>
-    {% if is_phase %}
+    {% if is_phase and interfaces %}
         <a class="btn btn-primary"
             href="{% url 'evaluation:interfaces-copy' slug=base_obj.slug challenge_short_name=challenge.short_name %}"
         >

--- a/app/grandchallenge/evaluation/forms.py
+++ b/app/grandchallenge/evaluation/forms.py
@@ -994,18 +994,14 @@ class AlgorithmInterfaceForPhaseCopyForm(Form):
         widget=CheckboxSelectMultiple,
     )
 
-    def __init__(self, *args, user, phase, **kwargs):
+    def __init__(self, *args, phase, **kwargs):
         super().__init__(*args, **kwargs)
         self._phase = phase
 
-        self.fields["phases"].queryset = filter_by_permission(
-            queryset=Phase.objects.filter(
-                challenge=phase.challenge,
-                submission_kind=phase.submission_kind,
-            ).exclude(pk=phase.pk),
-            codename="evaluation.configure_algorithm_phase",
-            user=user,
-        )
+        self.fields["phases"].queryset = Phase.objects.filter(
+            challenge=phase.challenge,
+            submission_kind=phase.submission_kind,
+        ).exclude(pk=phase.pk)
 
     def copy_algorithm_interfaces(self):
         for phase in self.cleaned_data["phases"]:

--- a/app/grandchallenge/evaluation/templates/evaluation/phase_copy_algorithminterfaces_form.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/phase_copy_algorithminterfaces_form.html
@@ -1,0 +1,37 @@
+{% extends "pages/challenge_settings_base.html" %}
+{% load url %}
+{% load static %}
+{% load crispy_forms_tags %}
+
+{% block title %}
+    Copy Algorithm interfaces for {{ phase.title }} - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
+{% endblock %}
+
+{% block breadcrumbs %}
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a
+                href="{% url 'challenges:list' %}">Challenges</a>
+        </li>
+        <li class="breadcrumb-item"><a
+                href="{{ challenge.get_absolute_url }}">{% firstof challenge.title challenge.short_name %}</a></li>
+        <li class="breadcrumb-item active"
+            aria-current="page">Copy Algorithm Interfaces from {{ phase.title }}</li>
+    </ol>
+{% endblock %}
+
+{% block content %}
+    <h2>Copy Algorithm interfaces from {{ phase.title }}</h2>
+
+    <p>
+        Copy the algorithm interfaces below from this phase the selected phases.
+    </p>
+
+    {% include 'algorithms/partials/algorithminterface_table.html' with base_obj=phase interfaces=interfaces delete_option=False %}
+
+    <form method="post">
+        {% csrf_token %}
+        {{ form|crispy }}
+        <button type="submit" class="btn btn-primary">Copy</button>
+    </form>
+
+{% endblock %}

--- a/app/grandchallenge/evaluation/templates/evaluation/phasealgorithminterface_list.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/phasealgorithminterface_list.html
@@ -19,5 +19,5 @@
 {% endblock %}
 
 {% block content %}
-    {% include 'algorithms/partials/algorithminterface_list.html' with base_obj=phase %}
+    {% include 'algorithms/partials/algorithminterface_list.html' with base_obj=phase is_phase=True %}
 {% endblock %}

--- a/app/grandchallenge/evaluation/urls.py
+++ b/app/grandchallenge/evaluation/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from grandchallenge.evaluation.views import (
     AlgorithmInterfaceForPhaseCreate,
     AlgorithmInterfaceForPhaseDelete,
+    AlgorithmInterfacesForPhaseCopy,
     AlgorithmInterfacesForPhaseList,
     CombinedLeaderboardCreate,
     CombinedLeaderboardDelete,
@@ -108,6 +109,11 @@ urlpatterns = [
         "<slug:slug>/interfaces/<uuid:interface_pk>/delete/",
         AlgorithmInterfaceForPhaseDelete.as_view(),
         name="interface-delete",
+    ),
+    path(
+        "<slug:slug>/interfaces/copy/",
+        AlgorithmInterfacesForPhaseCopy.as_view(),
+        name="interfaces-copy",
     ),
     path(
         "<slug:slug>/linked-archive/",

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -56,6 +56,7 @@ from grandchallenge.core.utils.grand_challenge_forge import (
 from grandchallenge.datatables.views import Column, PaginatedTableListView
 from grandchallenge.direct_messages.forms import ConversationForm
 from grandchallenge.evaluation.forms import (
+    AlgorithmInterfaceForPhaseCopyForm,
     CombinedLeaderboardForm,
     ConfigureAlgorithmPhasesForm,
     EvaluationForm,
@@ -1382,6 +1383,55 @@ class AlgorithmInterfacesForPhaseList(
             }
         )
         return context
+
+
+class AlgorithmInterfacesForPhaseCopy(
+    ConfigureAlgorithmPhasesPermissionMixin,
+    AlgorithmInterfaceForPhaseMixin,
+    ObjectPermissionRequiredMixin,
+    SuccessMessageMixin,
+    FormView,
+):
+    form_class = AlgorithmInterfaceForPhaseCopyForm
+    template_name = "evaluation/phase_copy_algorithminterfaces_form.html"
+    success_message = "Algorithm interfaces copied successfully."
+
+    def get_permission_object(self):
+        return self.phase
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context.update(
+            {
+                "phase": self.phase,
+                "interfaces": self.phase.algorithm_interfaces.all(),
+            }
+        )
+        return context
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs.update(
+            {
+                "user": self.request.user,
+                "phase": self.phase,
+            }
+        )
+        return kwargs
+
+    def form_valid(self, form):
+        response = super().form_valid(form=form)
+        form.copy_algorithm_interfaces()
+        return response
+
+    def get_success_url(self):
+        return reverse(
+            "evaluation:interface-list",
+            kwargs={
+                "slug": self.phase.slug,
+                "challenge_short_name": self.request.challenge.short_name,
+            },
+        )
 
 
 class AlgorithmInterfaceForPhaseDelete(

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -1388,16 +1388,12 @@ class AlgorithmInterfacesForPhaseList(
 class AlgorithmInterfacesForPhaseCopy(
     ConfigureAlgorithmPhasesPermissionMixin,
     AlgorithmInterfaceForPhaseMixin,
-    ObjectPermissionRequiredMixin,
     SuccessMessageMixin,
     FormView,
 ):
     form_class = AlgorithmInterfaceForPhaseCopyForm
     template_name = "evaluation/phase_copy_algorithminterfaces_form.html"
     success_message = "Algorithm interfaces copied successfully."
-
-    def get_permission_object(self):
-        return self.phase
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
@@ -1411,12 +1407,7 @@ class AlgorithmInterfacesForPhaseCopy(
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        kwargs.update(
-            {
-                "user": self.request.user,
-                "phase": self.phase,
-            }
-        )
+        kwargs["phase"] = self.phase
         return kwargs
 
     def form_valid(self, form):

--- a/app/tests/evaluation_tests/test_forms.py
+++ b/app/tests/evaluation_tests/test_forms.py
@@ -21,6 +21,7 @@ from grandchallenge.components.models import (
 )
 from grandchallenge.components.schemas import GPUTypeChoices
 from grandchallenge.evaluation.forms import (
+    AlgorithmInterfaceForPhaseCopyForm,
     ConfigureAlgorithmPhasesForm,
     EvaluationForm,
     EvaluationGroundTruthForm,
@@ -1401,3 +1402,46 @@ def test_reschedule_evaluation_requires_matching_algorithm_interfaces(
             "The algorithm interfaces do not match those defined for the phase."
             in str(form.errors)
         )
+
+
+@pytest.mark.django_db
+def test_phase_copy_algorithm_interfaces():
+    challenge = ChallengeFactory()
+
+    source_phase = PhaseFactory(challenge=challenge)
+    ai1 = AlgorithmInterfaceFactory()
+    source_phase.algorithm_interfaces.set([ai1])
+
+    target_phase = PhaseFactory(challenge=challenge)
+
+    assert (
+        not target_phase.algorithm_interfaces.exists()
+    ), "Sanity: no algorithm interfaces to start with"
+
+    form = AlgorithmInterfaceForPhaseCopyForm(
+        phase=source_phase,
+        data={
+            "phases": [
+                target_phase.pk,
+            ],
+        },
+    )
+
+    assert form.is_valid()
+    form.copy_algorithm_interfaces()
+
+    assert (
+        target_phase.algorithm_interfaces.get() == ai1
+    ), "Algorithm interface copied correctly"
+
+    # Can run it multiple times without trouble
+    form.copy_algorithm_interfaces()
+
+    # Existing interfaces pose no problem
+    ai2 = AlgorithmInterfaceFactory()
+    target_phase.algorithm_interfaces.set([ai2])
+
+    assert form.is_valid()
+    form.copy_algorithm_interfaces()
+
+    assert set(target_phase.algorithm_interfaces.all()) == {ai1, ai2}

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -1922,7 +1922,12 @@ def test_phase_archive_info_permissions(client):
 
 
 @pytest.mark.parametrize(
-    "viewname", ["evaluation:interface-list", "evaluation:interface-create"]
+    "viewname",
+    [
+        "evaluation:interface-list",
+        "evaluation:interface-create",
+        "evaluation:interfaces-copy",
+    ],
 )
 @pytest.mark.django_db
 def test_algorithm_interface_for_phase_view_permission(client, viewname):


### PR DESCRIPTION
This PR adds a form that allows copying the algorithm interfaces configured for one phase to another.

Generally there are at least 2 Phases that require te same setup (sometimes more). Generating these interfaces is tidious and also error prone. Moreover, the complexer the interfaces the more likely the initial setup was missing something and it has to be re-done, sometimes multiple times.

Adding an interface edit form would be an option, but Anne warned that might be complex and adding this (simple) copy form already cuts the work in half.

## Showcase


https://github.com/user-attachments/assets/cf27a1a6-391e-406a-a9d4-30d0e3283727

