### PR TITLE
Fix lock exception handling

### DIFF
--- a/app/grandchallenge/cases/tasks.py
+++ b/app/grandchallenge/cases/tasks.py
@@ -7,6 +7,7 @@ from shutil import rmtree
 from tempfile import TemporaryDirectory
 
 from billiard.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
+from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files import File
@@ -16,7 +17,6 @@ from django.utils._os import safe_join
 from django.utils.module_loading import import_string
 from panimg import convert, post_process
 from panimg.models import PanImgFile, PanImgResult
-from psycopg.errors import LockNotAvailable
 
 from grandchallenge.archives.models import ArchiveItem
 from grandchallenge.cases.models import Image, ImageFile, RawImageUploadSession
@@ -24,6 +24,7 @@ from grandchallenge.components.backends.utils import safe_extract
 from grandchallenge.components.models import ComponentInterface
 from grandchallenge.components.tasks import lock_model_instance
 from grandchallenge.core.celery import acks_late_2xlarge_task
+from grandchallenge.core.exceptions import LockNotAcquiredException
 from grandchallenge.reader_studies.models import DisplaySet
 from grandchallenge.uploads.models import UserUpload
 
@@ -92,7 +93,7 @@ def extract_files(*, source_path: Path, checked_paths=None):
         )
 
 
-@acks_late_2xlarge_task(retry_on=(LockNotAvailable,))
+@acks_late_2xlarge_task(retry_on=(LockNotAcquiredException,))
 @transaction.atomic
 def build_images(  # noqa:C901
     *,
@@ -137,12 +138,12 @@ def build_images(  # noqa:C901
     )
 
     if linked_object_pk:
+        linked_model = apps.get_model(
+            app_label=linked_app_label, model_name=linked_model_name
+        )
+
         try:
-            linked_object = lock_model_instance(
-                pk=linked_object_pk,
-                app_label=linked_app_label,
-                model_name=linked_model_name,
-            )
+            linked_object = linked_model.objects.get(pk=linked_object_pk)
         except (ArchiveItem.DoesNotExist, DisplaySet.DoesNotExist):
             # users can delete archive items and display sets before this task runs
             logger.info(

--- a/app/grandchallenge/cases/tasks.py
+++ b/app/grandchallenge/cases/tasks.py
@@ -7,7 +7,6 @@ from shutil import rmtree
 from tempfile import TemporaryDirectory
 
 from billiard.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
-from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files import File
@@ -138,12 +137,12 @@ def build_images(  # noqa:C901
     )
 
     if linked_object_pk:
-        linked_model = apps.get_model(
-            app_label=linked_app_label, model_name=linked_model_name
-        )
-
         try:
-            linked_object = linked_model.objects.get(pk=linked_object_pk)
+            linked_object = lock_model_instance(
+                pk=linked_object_pk,
+                app_label=linked_app_label,
+                model_name=linked_model_name,
+            )
         except (ArchiveItem.DoesNotExist, DisplaySet.DoesNotExist):
             # users can delete archive items and display sets before this task runs
             logger.info(

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -23,13 +23,12 @@ from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
-from django.db import transaction
+from django.db import OperationalError, transaction
 from django.db.models import Count, DateTimeField, ExpressionWrapper, F, Q
 from django.db.transaction import on_commit
 from django.utils.module_loading import import_string
 from django.utils.timezone import now
 from panimg.models import SimpleITKImage
-from psycopg.errors import LockNotAvailable
 
 from grandchallenge.cases.models import Image, ImageFile, RawImageUploadSession
 from grandchallenge.components.backends.exceptions import (
@@ -47,6 +46,7 @@ from grandchallenge.core.celery import (
     acks_late_2xlarge_task,
     acks_late_micro_short_task,
 )
+from grandchallenge.core.exceptions import LockNotAcquiredException
 from grandchallenge.core.templatetags.remove_whitespace import oxford_comma
 from grandchallenge.core.utils.error_messages import (
     format_validation_error_message,
@@ -729,14 +729,18 @@ def lock_model_instance(*, app_label, model_name, **kwargs):
     sure that no other process is updating the same instance at the same time.
     Must be used inside a transaction.
 
-    Raises `LockNotAvailable` if the lock could not be acquired.
+    Raises `LockNotAcquiredException` if the lock could not be acquired.
     """
     model = apps.get_model(app_label=app_label, model_name=model_name)
     queryset = model.objects.filter(**kwargs).select_for_update(nowait=True)
-    return queryset.get()
+
+    try:
+        return queryset.get()
+    except OperationalError as error:
+        raise LockNotAcquiredException from error
 
 
-@acks_late_2xlarge_task(retry_on=(LockNotAvailable,))
+@acks_late_2xlarge_task(retry_on=(LockNotAcquiredException,))
 @transaction.atomic
 def provision_job(
     *, job_pk: uuid.UUID, job_app_label: str, job_model_name: str, backend: str
@@ -860,7 +864,7 @@ def get_update_status_kwargs(*, executor=None):
         return {}
 
 
-@acks_late_micro_short_task(retry_on=(RetryStep, LockNotAvailable))
+@acks_late_micro_short_task(retry_on=(RetryStep, LockNotAcquiredException))
 @transaction.atomic
 def handle_event(*, event, backend):  # noqa: C901
     """
@@ -879,12 +883,20 @@ def handle_event(*, event, backend):  # noqa: C901
     job_name = Backend.get_job_name(event=event)
     job_params = Backend.get_job_params(job_name=job_name)
 
-    job = lock_model_instance(
+    model = apps.get_model(
+        app_label=job_params.app_label, model_name=job_params.model_name
+    )
+
+    queryset = model.objects.filter(
         pk=job_params.pk,
         attempt=job_params.attempt,
-        app_label=job_params.app_label,
-        model_name=job_params.model_name,
-    )
+    ).select_for_update(nowait=True)
+
+    try:
+        # Acquire the lock
+        job = queryset.get()
+    except OperationalError as error:
+        raise LockNotAcquiredException from error
 
     executor = job.get_executor(backend=backend)
 
@@ -930,7 +942,7 @@ def handle_event(*, event, backend):  # noqa: C901
         )
 
 
-@acks_late_2xlarge_task(retry_on=(LockNotAvailable,))
+@acks_late_2xlarge_task(retry_on=(LockNotAcquiredException,))
 @transaction.atomic
 def parse_job_outputs(
     *, job_pk: uuid.UUID, job_app_label: str, job_model_name: str, backend: str
@@ -1241,7 +1253,9 @@ def validate_voxel_values(*, civ_pk):
     civ.interface._validate_voxel_values(civ.image)
 
 
-@acks_late_micro_short_task(retry_on=(LockNotAvailable,), delayed_retry=False)
+@acks_late_micro_short_task(
+    retry_on=(LockNotAcquiredException,), delayed_retry=False
+)
 @transaction.atomic
 def add_image_to_object(  # noqa: C901
     *,
@@ -1333,7 +1347,9 @@ def add_image_to_object(  # noqa: C901
         on_commit(signature(linked_task).apply_async)
 
 
-@acks_late_micro_short_task(retry_on=(LockNotAvailable,), delayed_retry=False)
+@acks_late_micro_short_task(
+    retry_on=(LockNotAcquiredException,), delayed_retry=False
+)
 @transaction.atomic
 def add_file_to_object(
     *,
@@ -1410,7 +1426,7 @@ def add_file_to_object(
         on_commit(signature(linked_task).apply_async)
 
 
-@acks_late_2xlarge_task(retry_on=(LockNotAvailable,))
+@acks_late_2xlarge_task(retry_on=(LockNotAcquiredException,))
 @transaction.atomic
 def assign_tarball_from_upload(
     *, app_label, model_name, tarball_pk, field_to_copy
@@ -1421,18 +1437,21 @@ def assign_tarball_from_upload(
         app_label=app_label, model_name=model_name
     )
 
-    # Acquire locks
-    current_tarball = (
-        TarballModel.objects.filter(
-            pk=tarball_pk,
-            import_status=TarballModel.ImportStatusChoices.INITIALIZED,
+    try:
+        # Acquire locks
+        current_tarball = (
+            TarballModel.objects.filter(
+                pk=tarball_pk,
+                import_status=TarballModel.ImportStatusChoices.INITIALIZED,
+            )
+            .select_for_update(nowait=True)
+            .get()
         )
-        .select_for_update(nowait=True)
-        .get()
-    )
-    peer_tarballs = list(
-        current_tarball.get_peer_tarballs().select_for_update(nowait=True)
-    )
+        peer_tarballs = list(
+            current_tarball.get_peer_tarballs().select_for_update(nowait=True)
+        )
+    except OperationalError as error:
+        raise LockNotAcquiredException from error
 
     current_tarball.user_upload.copy_object(
         to_field=getattr(current_tarball, field_to_copy)

--- a/app/grandchallenge/core/exceptions.py
+++ b/app/grandchallenge/core/exceptions.py
@@ -1,9 +1,2 @@
-class PathResolutionException(Exception):
-    """
-    Raised when a path given to a template tag contained variables that could
-    not be resolved.
-    """
-
-
 class LockNotAcquiredException(Exception):
     """Raised when a lock could not be acquired."""

--- a/app/grandchallenge/core/exceptions.py
+++ b/app/grandchallenge/core/exceptions.py
@@ -1,0 +1,9 @@
+class PathResolutionException(Exception):
+    """
+    Raised when a path given to a template tag contained variables that could
+    not be resolved.
+    """
+
+
+class LockNotAcquiredException(Exception):
+    """Raised when a lock could not be acquired."""

--- a/app/grandchallenge/evaluation/tasks.py
+++ b/app/grandchallenge/evaluation/tasks.py
@@ -17,6 +17,7 @@ from grandchallenge.components.models import (
     ComponentInterface,
     ComponentInterfaceValue,
 )
+from grandchallenge.components.tasks import check_operational_error
 from grandchallenge.core.celery import (
     acks_late_2xlarge_task,
     acks_late_micro_short_task,
@@ -359,7 +360,8 @@ def set_evaluation_inputs(*, evaluation_pk):
         # Acquire lock
         evaluation = evaluation_queryset.get()
     except OperationalError as error:
-        raise LockNotAcquiredException from error
+        check_operational_error(error)
+        raise
 
     if evaluation.status != evaluation.EXECUTING_PREREQUISITES:
         logger.info(
@@ -462,7 +464,8 @@ def calculate_ranks(*, phase_pk: uuid.UUID):
             .prefetch_related("outputs__interface")
         )
     except OperationalError as error:
-        raise LockNotAcquiredException from error
+        check_operational_error(error)
+        raise
 
     valid_evaluations = [
         e


### PR DESCRIPTION
There was a bug in #4017 as `LockNotAvailable` is not included as part of the Django `OperationalError`, so we need to parse that instead.

Closes #4023 