### PR TITLE
Allow model-based POSTs to create SocketValues

### DIFF
--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -528,6 +528,10 @@ class ComponentInterface(OverlaySegmentsMixin):
         )
 
     @property
+    def requires_value(self):
+        return self.is_json_kind and self.store_in_database
+
+    @property
     def default_field(self):
         if self.requires_file:
             return ModelChoiceField
@@ -2296,7 +2300,7 @@ class CIVData:
 
         ci = ComponentInterface.objects.get(slug=interface_slug)
 
-        if ci.is_json_kind and not ci.requires_file:
+        if ci.requires_value:
             self._init_json_civ_data()
         elif ci.is_image_kind:
             self._init_image_civ_data()
@@ -2441,7 +2445,7 @@ class CIVForObjectMixin:
             interface=ci, user=user
         )
 
-        if ci.is_json_kind and not ci.requires_file:
+        if ci.requires_value:
             return self.create_civ_for_value(
                 ci=ci,
                 current_civ=current_civ,

--- a/app/grandchallenge/components/serializers.py
+++ b/app/grandchallenge/components/serializers.py
@@ -149,7 +149,21 @@ class ComponentInterfaceValuePostSerializer(serializers.ModelSerializer):
                     f"value is required for interface "
                     f"kind {interface.kind}"
                 )
+        elif interface.requires_file:
+            if not any(
+                [
+                    attrs.get("file"),
+                    attrs.get("user_upload"),
+                ]
+            ):
+                raise serializers.ValidationError(
+                    f"user_upload or file is required for interface "
+                    f"kind {interface.kind}"
+                )
+        else:
+            NotImplementedError(f"Unsupported interface {interface}")
 
+        if not attrs.get("upload_session") and not attrs.get("user_upload"):
             # Instances without an image or a file are never valid, this will be checked
             # later, but for now check everything else. DRF 3.0 dropped calling
             # full_clean on instances, so we need to do it ourselves.
@@ -157,14 +171,6 @@ class ComponentInterfaceValuePostSerializer(serializers.ModelSerializer):
                 **{k: v for k, v in attrs.items() if v is not None}
             )
             instance.full_clean()
-        elif interface.requires_file:
-            if not attrs.get("user_upload"):
-                raise serializers.ValidationError(
-                    f"user_upload is required for interface "
-                    f"kind {interface.kind}"
-                )
-        else:
-            NotImplementedError(f"Unsupported interface {interface}")
 
         return attrs
 

--- a/app/tests/components_tests/test_serializers.py
+++ b/app/tests/components_tests/test_serializers.py
@@ -298,10 +298,6 @@ def test_civ_post_value_validation(kind):
         civ = {
             "interface": interface.slug,
             "value": TEST_DATA[test],
-            "file": None,
-            "image": None,
-            "upload_session": None,
-            "user_upload": None,
         }
 
         # test

--- a/app/tests/components_tests/test_serializers.py
+++ b/app/tests/components_tests/test_serializers.py
@@ -295,7 +295,14 @@ def test_civ_post_value_validation(kind):
     interface = ComponentInterfaceFactory(kind=kind)
 
     for test in TEST_DATA:
-        civ = {"interface": interface.slug, "value": TEST_DATA[test]}
+        civ = {
+            "interface": interface.slug,
+            "value": TEST_DATA[test],
+            "file": None,
+            "image": None,
+            "upload_session": None,
+            "user_upload": None,
+        }
 
         # test
         serializer = ComponentInterfaceValuePostSerializer(data=civ)
@@ -339,12 +346,24 @@ def test_civ_post_value_validation(kind):
         InterfaceKind.InterfaceKindChoices.MULTIPLE_ELLIPSES,
         InterfaceKind.InterfaceKindChoices.THREE_POINT_ANGLE,
         InterfaceKind.InterfaceKindChoices.MULTIPLE_THREE_POINT_ANGLES,
-        # Do not test ANY type here as that is always valid
+        InterfaceKind.InterfaceKindChoices.ANY,
     ),
 )
-def test_civ_post_value_required(kind):
+@pytest.mark.parametrize(
+    "store_in_database, expected_error",
+    (
+        (True, "value is required for interface kind {kind}"),
+        (False, "user_upload is required for interface kind {kind}"),
+    ),
+)
+def test_civ_post_value_or_user_upload_required_validation(
+    kind, store_in_database, expected_error
+):
     # setup
-    interface = ComponentInterfaceFactory(kind=kind)
+    interface = ComponentInterfaceFactory(
+        kind=kind,
+        store_in_database=store_in_database,
+    )
 
     civ = {"interface": interface.slug}
 
@@ -353,8 +372,9 @@ def test_civ_post_value_required(kind):
 
     # verify
     assert not serializer.is_valid()
-    assert "JSON does not fulfill schema: instance is not of type" in str(
-        serializer.errors["__all__"][0]
+    assert (
+        expected_error.format(kind=kind)
+        in serializer.errors["non_field_errors"]
     )
 
 

--- a/app/tests/components_tests/test_serializers.py
+++ b/app/tests/components_tests/test_serializers.py
@@ -349,7 +349,7 @@ def test_civ_post_value_validation(kind):
     "store_in_database, expected_error",
     (
         (True, "value is required for interface kind {kind}"),
-        (False, "user_upload is required for interface kind {kind}"),
+        (False, "user_upload or file is required for interface kind {kind}"),
     ),
 )
 def test_civ_post_value_or_user_upload_required_validation(


### PR DESCRIPTION
In rse-gcapi we have this definition of a request:
```Python
@dataclass
class ComponentInterfaceValuePostRequest(BaseModel):
    interface: str
    value: Optional[Any]
    file: Optional[bytes]
    image: Optional[str]
    upload_session: Optional[str]
    user_upload: Optional[str]
 ```
 
However, if one would try to submit using this model as a base we run into trouble with fields which are not allowed to be null.
 
This PR cleans up the fields and validation of the PostRequest as to account for some of the fields to be there but have a null value.
 
 This opens up the option to use local-validated models when POSTing from gcapi:
 
 ```Python
 
  c.archive_items.partial_update(
        pk=ai.pk,
        values=[
            ComponentInterfaceValuePostRequest(
                interface=socket.slug,
                value="foo",
                file=None,
                image=None,
                upload_session=None,
                user_upload=None,
            )
        ],
    )
```