### PR TITLE
Account for null-valued fields in Job-creation POST serializer

### DIFF
--- a/app/grandchallenge/algorithms/serializers.py
+++ b/app/grandchallenge/algorithms/serializers.py
@@ -312,7 +312,9 @@ class JobPostSerializer(JobSerializer):
 
         data = []
         for civ in serialized_civs:
-            found_keys = [key for key in possible_keys if key in civ]
+            found_keys = [
+                key for key in possible_keys if civ.get(key) is not None
+            ]
 
             if not found_keys:
                 raise serializers.ValidationError(

--- a/app/tests/algorithms_tests/test_serializers.py
+++ b/app/tests/algorithms_tests/test_serializers.py
@@ -236,7 +236,15 @@ def test_algorithm_job_post_serializer_create(
     job = {
         "algorithm": algorithm_image.algorithm.api_url,
         "inputs": [
-            {"interface": ci_img1.slug, "upload_session": upload.api_url},
+            {
+                "interface": ci_img1.slug,
+                "upload_session": upload.api_url,
+                # Other attributes are optionally None
+                "user_upload": None,
+                "image": None,
+                "value": None,
+                "file": None,
+            },
             {"interface": ci_img2.slug, "image": image2.api_url},
             {"interface": ci_string.slug, "value": "foo"},
         ],


### PR DESCRIPTION
Tiny fix that accounts for some null-field values for Job creation via gcapi. Don't want to rewrite the `CIVData` handling atm so this will do.

Little sister to: 
- https://github.com/comic/grand-challenge.org/pull/4030