### PR TITLE
Show cancelled state on invoice overview

### DIFF
--- a/app/grandchallenge/invoices/templates/invoices/invoice_list.html
+++ b/app/grandchallenge/invoices/templates/invoices/invoice_list.html
@@ -66,16 +66,31 @@
                         <td>{{ invoice.get_payment_type_display }}</td>
                         <td>
                             {% if invoice.payment_type == invoice.PaymentTypeChoices.COMPLIMENTARY %}
-                                -
-                            {% elif invoice.is_overdue %}
-                                <span class="badge badge-danger">Overdue</span>
-                            {% elif invoice.is_due %}
-                                <span class="badge badge-warning">Due</span>
-                            {% elif invoice.payment_status == invoice.PaymentStatusChoices.PAID %}
-                                <span class="badge badge-success">Paid</span>
-                            {% else %}
-                                <span class="badge badge-info">Initialized</span>
-                            {% endif %}
+                                    -
+                                {% else %}
+                                    <span class="badge
+                                            {% if invoice.payment_status == invoice.PaymentStatusChoices.PAID %}
+                                                badge-success
+                                            {% elif invoice.is_overdue %}
+                                                badge-danger
+                                            {% elif invoice.payment_status == invoice.PaymentStatusChoices.ISSUED %}
+                                                badge-warning
+                                            {% elif invoice.payment_status == invoice.PaymentStatusChoices.CANCELLED %}
+                                                badge-dark
+                                            {% else %}
+                                                badge-info
+                                            {% endif %}">
+                                        {% if invoice.is_due %}
+                                            Due
+                                        {% elif invoice.is_overdue %}
+                                            Overdue
+                                        {% elif invoice.payment_status == invoice.PaymentStatusChoices.REQUESTED %}
+                                            Initialized
+                                        {% else %}
+                                            {{ invoice.get_payment_status_display }}
+                                        {% endif %}
+                                    </span>
+                                {% endif %}
                         </td>
                     </tr>
                 {% endfor %}

--- a/app/grandchallenge/pages/templates/pages/challenge_statistics.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_statistics.html
@@ -69,7 +69,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% for invoice in challenge.invoices.all %}
+                    {% for invoice in challenge.invoices.with_overdue_status %}
                         <tr>
                             <td>{{ invoice.internal_invoice_number }}</td>
                             <td>{{ invoice.issued_on }}</td>
@@ -85,14 +85,22 @@
                                     <span class="badge
                                             {% if invoice.payment_status == invoice.PaymentStatusChoices.PAID %}
                                                 badge-success
+                                            {% elif invoice.is_overdue %}
+                                                badge-danger
                                             {% elif invoice.payment_status == invoice.PaymentStatusChoices.ISSUED %}
                                                 badge-warning
                                             {% elif invoice.payment_status == invoice.PaymentStatusChoices.CANCELLED %}
-                                                badge-danger
+                                                badge-dark
                                             {% else %}
                                                 badge-info
                                             {% endif %}">
-                                        {{ invoice.get_payment_status_display }}
+                                        {% if invoice.is_due %}
+                                            Due
+                                        {% elif invoice.is_overdue %}
+                                            Overdue
+                                        {% else %}
+                                            {{ invoice.get_payment_status_display }}
+                                        {% endif %}
                                     </span>
                                 {% endif %}
                             </td>

--- a/app/tests/invoices_tests/test_views.py
+++ b/app/tests/invoices_tests/test_views.py
@@ -102,6 +102,12 @@ def test_invoice_list_view_num_invoices_shown(client):
             ),
             '<td><span class="badge badge-success">Paid</span></td>',
         ),
+        (
+            dict(
+                payment_status=Invoice.PaymentStatusChoices.CANCELLED,
+            ),
+            '<td><span class="badge badge-dark">Cancelled</span></td>',
+        ),
     ),
 )
 def test_invoice_list_view_content(client, invoice_kwargs, badge_and_status):


### PR DESCRIPTION
The cancelled state was not yet shown on the invoice overview. It instead showed "initialized". 

Additionally, the badge for cancelled invoices is now shown as "dark" instead of "danger". 