### PR TITLE
Fix API schema for `Answer`

### DIFF
--- a/app/grandchallenge/reader_studies/serializers.py
+++ b/app/grandchallenge/reader_studies/serializers.py
@@ -207,9 +207,14 @@ class AnswerSerializer(HyperlinkedModelSerializer):
         required=False,
     )
     answer_image = HyperlinkedRelatedField(
-        read_only=True, view_name="api:image-detail"
+        read_only=True,
+        view_name="api:image-detail",
+        allow_null=True,
     )
-    total_edit_duration = DurationField(read_only=True)
+    total_edit_duration = DurationField(
+        read_only=True,
+        allow_null=True,
+    )
     # At the moment only non-ground-truth answers are created over REST
     is_ground_truth = BooleanField(read_only=True)
 


### PR DESCRIPTION
Related:
- https://github.com/DIAGNijmegen/rse-gcapi/issues/201#issuecomment-2909524299

This allows the deduced schema to set `nullable: True`, and subsequent derived models to allow for `None` values.