### PR TITLE
Replace`add_images_to_archive_item` with `add_image_to_object`

### DIFF
--- a/app/grandchallenge/archives/tasks.py
+++ b/app/grandchallenge/archives/tasks.py
@@ -1,14 +1,10 @@
 from django.db import transaction
-from django.db.transaction import on_commit
 
 from grandchallenge.archives.models import Archive, ArchiveItem
-from grandchallenge.cases.models import Image, RawImageUploadSession
+from grandchallenge.cases.models import Image
 from grandchallenge.components.models import (
     ComponentInterface,
     ComponentInterfaceValue,
-)
-from grandchallenge.components.tasks import (
-    add_image_to_component_interface_value,
 )
 from grandchallenge.core.celery import acks_late_micro_short_task
 
@@ -39,34 +35,3 @@ def add_images_to_archive(*, upload_session_pk, archive_pk, interface_pk=None):
                 continue
             item = ArchiveItem.objects.create(archive=archive)
             item.values.set([civ])
-
-
-@acks_late_micro_short_task
-def add_images_to_archive_item(
-    *, upload_session_pk, archive_item_pk, interface_pk
-):
-    archive_item = ArchiveItem.objects.get(pk=archive_item_pk)
-    interface = ComponentInterface.objects.get(pk=interface_pk)
-    session = RawImageUploadSession.objects.get(pk=upload_session_pk)
-
-    if archive_item.values.filter(
-        interface=interface, image__in=session.image_set.all()
-    ).exists():
-        return
-
-    with transaction.atomic():
-        archive_item.values.remove(
-            *archive_item.values.filter(interface=interface)
-        )
-        new_civ = ComponentInterfaceValue.objects.create(interface=interface)
-        archive_item.values.add(new_civ)
-
-        on_commit(
-            add_image_to_component_interface_value.signature(
-                kwargs={
-                    "component_interface_value_pk": new_civ.pk,
-                    "upload_session_pk": upload_session_pk,
-                },
-                immutable=True,
-            ).apply_async
-        )

--- a/app/grandchallenge/cases/serializers.py
+++ b/app/grandchallenge/cases/serializers.py
@@ -8,10 +8,7 @@ from rest_framework.relations import (
 )
 
 from grandchallenge.archives.models import Archive, ArchiveItem
-from grandchallenge.archives.tasks import (
-    add_images_to_archive,
-    add_images_to_archive_item,
-)
+from grandchallenge.archives.tasks import add_images_to_archive
 from grandchallenge.cases.models import Image, ImageFile, RawImageUploadSession
 from grandchallenge.components.models import ComponentInterface
 from grandchallenge.components.tasks import add_image_to_object
@@ -268,9 +265,11 @@ def _get_linked_task(*, targets, interface):
             kwargs["interface_pk"] = interface.pk
         return add_images_to_archive.signature(kwargs=kwargs, immutable=True)
     elif "archive_item" in targets:
-        return add_images_to_archive_item.signature(
+        return add_image_to_object.signature(
             kwargs={
-                "archive_item_pk": targets["archive_item"].pk,
+                "app_label": targets["archive_item"]._meta.app_label,
+                "model_name": targets["archive_item"]._meta.model_name,
+                "object_pk": targets["archive_item"].pk,
                 "interface_pk": interface.pk,
             },
             immutable=True,

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1186,30 +1186,6 @@ def preload_interactive_algorithms():
     return consolidation_results
 
 
-@acks_late_micro_short_task
-@transaction.atomic
-def add_image_to_component_interface_value(
-    *, component_interface_value_pk, upload_session_pk
-):
-    from grandchallenge.components.models import ComponentInterfaceValue
-
-    session = RawImageUploadSession.objects.get(pk=upload_session_pk)
-
-    if session.image_set.count() != 1:
-        session.status = RawImageUploadSession.FAILURE
-        session.error_message = "Image imports should result in a single image"
-        session.save()
-        return
-
-    civ = ComponentInterfaceValue.objects.get(pk=component_interface_value_pk)
-
-    civ.image = session.image_set.get()
-    civ.full_clean()
-    civ.save()
-
-    civ.image.update_viewer_groups_permissions()
-
-
 @acks_late_2xlarge_task
 @transaction.atomic
 def civ_value_to_file(*, civ_pk):

--- a/app/tests/algorithms_tests/test_tasks.py
+++ b/app/tests/algorithms_tests/test_tasks.py
@@ -21,10 +21,7 @@ from grandchallenge.components.models import (
     InterfaceKindChoices,
 )
 from grandchallenge.components.schemas import GPUTypeChoices
-from grandchallenge.components.tasks import (
-    add_image_to_component_interface_value,
-    validate_docker_image,
-)
+from grandchallenge.components.tasks import validate_docker_image
 from grandchallenge.notifications.models import Notification
 from tests.algorithms_tests.factories import (
     AlgorithmFactory,
@@ -34,7 +31,6 @@ from tests.algorithms_tests.factories import (
     AlgorithmModelFactory,
 )
 from tests.archives_tests.factories import ArchiveFactory, ArchiveItemFactory
-from tests.cases_tests.factories import RawImageUploadSessionFactory
 from tests.components_tests.factories import (
     ComponentInterfaceFactory,
     ComponentInterfaceValueFactory,
@@ -504,34 +500,6 @@ def test_algorithm_with_invalid_output(
         == "The output file 'some_text.txt' is not valid json"
     )
     assert len(jobs[0].outputs.all()) == 0
-
-
-@pytest.mark.django_db
-def test_add_image_to_component_interface_value():
-    # Override the celery settings
-    us = RawImageUploadSessionFactory()
-    ImageFactory(origin=us)
-    ImageFactory(origin=us)
-    ci = ComponentInterface.objects.get(slug="generic-medical-image")
-
-    civ = ComponentInterfaceValueFactory(interface=ci, image=None, file=None)
-
-    add_image_to_component_interface_value(
-        component_interface_value_pk=civ.pk, upload_session_pk=us.pk
-    )
-    us.refresh_from_db()
-    civ.refresh_from_db()
-    assert us.error_message == "Image imports should result in a single image"
-    assert civ.image is None
-
-    us2 = RawImageUploadSessionFactory()
-    image = ImageFactory(origin=us2)
-    civ2 = ComponentInterfaceValueFactory(interface=ci, image=None, file=None)
-    add_image_to_component_interface_value(
-        component_interface_value_pk=civ2.pk, upload_session_pk=us2.pk
-    )
-    civ2.refresh_from_db()
-    assert civ2.image == image
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
There was some lock contention trouble with `add_images_to_archive_item`. Instead of adding a retry wrapper I favored replacing it with the already lock-contention safe `add_image_to_object`.

Less code!