### PR TITLE
Prevent upload_sessions from being assigned to multiple component images.

### DIFF
--- a/app/grandchallenge/components/forms.py
+++ b/app/grandchallenge/components/forms.py
@@ -101,6 +101,21 @@ class ContainerImageForm(SaveFormInitMixin, ModelForm):
 
         return creator
 
+    def clean_user_upload(self):
+        user_upload = self.cleaned_data["user_upload"]
+
+        for model in (AlgorithmImage, Method, WorkstationImage):
+            if model.objects.filter(
+                user_upload=user_upload,
+            ).exists():
+                self.add_error(
+                    "user_upload",
+                    "The selected upload is already used by another container image",
+                )
+                break
+
+        return user_upload
+
     def save(self, *args, **kwargs):
         instance = super().save(*args, **kwargs)
         instance.assign_docker_image_from_upload()


### PR DESCRIPTION
I am unsure if this is the right level to fix this. `UserUpload`s are used in so many places: I think a general platform wide check if the selected user_upload is not used _anywhere_ would be too expensive.

As such I've limited the checked scope to `ComponentImage`s and to this one `Form`.