### PR TITLE
Fix display set index with duplicate order

### DIFF
--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -987,13 +987,7 @@ class DisplaySet(
 
     @property
     def standard_index(self) -> int:
-        return len(
-            [
-                x
-                for x in self.reader_study.display_sets.all()
-                if x.order < self.order
-            ]
-        )
+        return [*self.reader_study.display_sets.all()].index(self)
 
     @property
     def update_url(self):

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -1022,7 +1022,10 @@ class DisplaySetViewSet(
         DisplaySet.objects.all()
         .select_related("reader_study__hanging_protocol")
         .prefetch_related(
-            "values__image", "values__interface", "reader_study__display_sets"
+            "values__image",
+            "values__interface",
+            "reader_study__display_sets",
+            "reader_study__optional_hanging_protocols",
         )
     )
     permission_classes = [DjangoObjectPermissions]


### PR DESCRIPTION
This is not efficient, the original implementation iterated over all of the display sets in the reader study and this keeps the same just to fix the bug. It can probably be replaced with a window function.

Closes #4095