### PR TITLE
Use window annotation for standard index

### DIFF
--- a/app/grandchallenge/reader_studies/serializers.py
+++ b/app/grandchallenge/reader_studies/serializers.py
@@ -121,7 +121,16 @@ class DisplaySetSerializer(HyperlinkedModelSerializer):
                 # The list is empty if no reader study is specified.
                 return None
         else:
-            return obj.standard_index
+            try:
+                return obj.standard_index - 1
+            except AttributeError:
+                # The annotation wasn't made when getting this object
+                return (
+                    DisplaySet.objects.with_standard_index()
+                    .get(pk=obj.pk)
+                    .standard_index
+                    - 1
+                )
 
     class Meta:
         model = DisplaySet

--- a/app/grandchallenge/reader_studies/serializers.py
+++ b/app/grandchallenge/reader_studies/serializers.py
@@ -122,15 +122,19 @@ class DisplaySetSerializer(HyperlinkedModelSerializer):
                 return None
         else:
             try:
-                return obj.standard_index - 1
+                standard_index = obj.standard_index
             except AttributeError:
                 # The annotation wasn't made when getting this object
-                return (
+                standard_index = (
                     DisplaySet.objects.with_standard_index()
                     .get(pk=obj.pk)
                     .standard_index
                     - 1
                 )
+
+            # standard_index is 1 based indexed as this comes from RowNumber
+            # index is 0 based indexed
+            return standard_index - 1
 
     class Meta:
         model = DisplaySet

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -1020,11 +1020,11 @@ class DisplaySetViewSet(
     serializer_class = DisplaySetSerializer
     queryset = (
         DisplaySet.objects.all()
+        .with_standard_index()
         .select_related("reader_study__hanging_protocol")
         .prefetch_related(
             "values__image",
             "values__interface",
-            "reader_study__display_sets",
             "reader_study__optional_hanging_protocols",
         )
     )
@@ -1046,7 +1046,8 @@ class DisplaySetViewSet(
     def get_serializer_class(self):
         if self.action in ["partial_update", "update", "create"]:
             return DisplaySetPostSerializer
-        return DisplaySetSerializer
+        else:
+            return DisplaySetSerializer
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())

--- a/app/tests/reader_studies_tests/test_api.py
+++ b/app/tests/reader_studies_tests/test_api.py
@@ -2106,7 +2106,7 @@ def test_display_set_index_with_duplicate_order(
     ds2.order = ds1.order
     ds2.save()
 
-    with django_assert_num_queries(34):
+    with django_assert_num_queries(33):
         response = get_view_for_user(
             viewname="api:reader-studies-display-set-list",
             data={"reader_study": str(reader_study.pk)},

--- a/app/tests/reader_studies_tests/test_models.py
+++ b/app/tests/reader_studies_tests/test_models.py
@@ -16,6 +16,7 @@ from grandchallenge.reader_studies.interactive_algorithms import (
 from grandchallenge.reader_studies.models import (
     Answer,
     AnswerType,
+    DisplaySet,
     Question,
     QuestionWidgetKindChoices,
     ReaderStudy,
@@ -1276,3 +1277,51 @@ def test_reader_study_not_launchable_when_max_credits_consumed():
     assert reader_study.session_utilizations.first().credits_consumed == 500
     assert reader_study.credits_consumed == 500
     assert not reader_study.is_launchable
+
+
+@pytest.mark.django_db
+def test_with_standard_index():
+    rs = ReaderStudyFactory()
+    ds1, ds2, ds3 = DisplaySetFactory.create_batch(3, reader_study=rs)
+
+    # Duplicate order should return unique indices
+    ds2.order = ds1.order
+    ds2.save()
+
+    ds4 = DisplaySetFactory()
+
+    # Test global access
+    queryset = DisplaySet.objects.with_standard_index()
+    assert [*queryset] == [ds1, ds2, ds4, ds3]
+    assert {ds: ds.standard_index for ds in queryset} == {
+        ds1: 1,
+        ds2: 2,
+        ds3: 3,
+        ds4: 1,
+    }
+
+    # Filtering should return the same indices
+    queryset = DisplaySet.objects.with_standard_index().filter(reader_study=rs)
+    assert {ds: ds.standard_index for ds in queryset} == {
+        ds1: 1,
+        ds2: 2,
+        ds3: 3,
+    }
+
+    # Getting a particular display set should return the correct order
+    last_display_set = (
+        DisplaySet.objects.with_standard_index().filter(reader_study=rs).last()
+    )
+    assert last_display_set.standard_index == 3
+
+    # Changing the order of the queryset should not change the index
+    queryset = DisplaySet.objects.with_standard_index().order_by(
+        "-order", "-created"
+    )
+    assert [*queryset] == [ds3, ds4, ds2, ds1]
+    assert {ds: ds.standard_index for ds in queryset} == {
+        ds1: 1,
+        ds2: 2,
+        ds3: 3,
+        ds4: 1,
+    }


### PR DESCRIPTION
Follow on from #4097, this saves having to lookup the index of a display set by having them all in memory. This only works when **not** shuffling the hanging list, that is much more difficult to change. 