### PR TITLE
Highlight headline paragraphs after following a documentation search result

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,13 @@ superuser:
 		web \
 		python manage.py runscript create_superuser
 
+docpages:
+	docker compose run \
+		-v $(shell readlink -f ./scripts/):/app/scripts:ro \
+		--rm \
+		web \
+		python manage.py runscript create_docpages
+
 .PHONY: docs
 docs:
 	docker compose run --rm -u $(USER_ID) web bash -c "cd docs && make html"

--- a/app/grandchallenge/core/static/css/base.scss
+++ b/app/grandchallenge/core/static/css/base.scss
@@ -76,8 +76,7 @@ div.codehilite {
 }
 
 mark, .mark {
-    padding-left: 0;
-    padding-right: 0;
+    padding: 0;
 }
 
 a.mark {

--- a/app/grandchallenge/core/static/css/base.scss
+++ b/app/grandchallenge/core/static/css/base.scss
@@ -67,10 +67,6 @@ div.codehilite {
     font-weight: bold;
 }
 
-.docpage .highlight {
-  background-color: $mark-bg;
-}
-
 .challenge-topbar .nav-link {
     padding: $nav-link-padding-y 1rem;
 }

--- a/app/grandchallenge/core/static/css/base.scss
+++ b/app/grandchallenge/core/static/css/base.scss
@@ -74,3 +74,8 @@ div.codehilite {
 .challenge-topbar .nav-link {
     padding: $nav-link-padding-y 1rem;
 }
+
+mark, .mark {
+    padding-left: 0;
+    padding-right: 0;
+}

--- a/app/grandchallenge/core/static/css/base.scss
+++ b/app/grandchallenge/core/static/css/base.scss
@@ -67,6 +67,10 @@ div.codehilite {
     font-weight: bold;
 }
 
+.docpage .highlight {
+  background-color: $mark-bg;
+}
+
 .challenge-topbar .nav-link {
     padding: $nav-link-padding-y 1rem;
 }

--- a/app/grandchallenge/core/static/css/base.scss
+++ b/app/grandchallenge/core/static/css/base.scss
@@ -79,3 +79,13 @@ mark, .mark {
     padding-left: 0;
     padding-right: 0;
 }
+
+a.mark {
+    color: $link-color;
+    text-decoration: none;
+}
+
+a.mark:hover {
+    color: $link-hover-color;
+    text-decoration: underline;
+}

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -43,121 +43,62 @@ function highlightRangeAndScroll(startIndex, endIndex, rootElement) {
 
     const context = {
         characterCount: 0,
-        highlighting: false,
         first_node: null,
     };
 
     traverseAndHighlight(rootElement, startIndex, endIndex, context);
 
     if (context.first_node) {
-        // scrollIntoView works on elements, so if first_node is a text node,
-        // we use its parentElement.
-        const scrollTarget =
-            context.first_node.nodeType === Node.TEXT_NODE
-                ? context.first_node.parentElement
-                : context.first_node;
-
-        scrollTarget.scrollIntoView({
+        context.first_node.scrollIntoView({
             behavior: "smooth",
             block: "center",
         });
     }
 }
 
-// List of tags that should be wrapped entirely, not split.
-const FULL_HIGHLIGHT_NODES = ["STRONG", "B", "EM", "I", "MARK", "SPAN", "A"];
+// List of element tags that should be treated as a single, indivisible unit for highlighting.
+const ATOMIC_NODES = ["STRONG", "B", "EM", "I", "MARK", "SPAN", "A"];
 
 /**
- * Recursively traverses the DOM and highlights text based on character indices.
+ * Recursively traverses the DOM, highlighting full nodes that fall within a
+ * character range.
  */
 function traverseAndHighlight(node, startIndex, endIndex, context) {
-    if (context.characterCount >= endIndex || context.done) {
+    if (context.characterCount > endIndex) {
         return;
     }
 
-    if (node.nodeType === Node.ELEMENT_NODE) {
-        // Check if the current element is one we should wrap whole.
-        if (FULL_HIGHLIGHT_NODES.includes(node.tagName)) {
-            const nodeText = node.textContent.replace(/\s+/g, " ");
-            const nodeLength = nodeText.length;
-            const startOfNode = context.characterCount;
-            const endOfNode = startOfNode + nodeLength;
+    const isAtomic =
+        node.nodeType === Node.TEXT_NODE ||
+        (node.nodeType === Node.ELEMENT_NODE &&
+            ATOMIC_NODES.includes(node.tagName));
 
-            // Check if this node's text content falls within the highlight range
-            const shouldHighlight =
-                (context.highlighting && endOfNode <= endIndex) || // Already highlighting and this node is fully contained
-                (startOfNode < endIndex && endOfNode > startIndex); // Node overlaps with the highlight range
-
-            if (shouldHighlight) {
-                // If this is the very first thing we highlight, store it for scrolling
-                if (!context.first_node) {
-                    context.first_node = node;
-                }
-                // wrapElementNode(node); // Wrap the entire element
-                node.classList.add("mark"); // Add a class for styling (or wrap the element as desired)
-                context.highlighting = true; // Ensure we stay in highlighting mode
-            }
-
-            // Update character count and, crucially, DO NOT traverse children.
-            // We've treated this element as an atomic unit.
-            context.characterCount = endOfNode;
-            return;
-        }
-
-        for (const child of Array.from(node.childNodes)) {
-            traverseAndHighlight(child, startIndex, endIndex, context);
-        }
-        return;
-    }
-
-    if (node.nodeType === Node.TEXT_NODE) {
-        // Your whitespace handling is complex. For simplicity in this example,
-        // we'll use a more direct textContent length, but your logic
-        // for collapsing whitespace would go here. To correctly align with `normalizedInnerText`,
-        // the length of the text node's content must also be normalized.
-        const nodeLength = node.textContent.replace(/\s+/g, " ").length;
+    if (isAtomic) {
+        // Calculate the normalized length and character range of this atomic node.
+        // This normalization MUST match the one used to find startIndex/endIndex.
+        const nodeText = node.textContent.replace(/\s+/g, " ");
+        const nodeLength = nodeText.length;
         const startOfNode = context.characterCount;
         const endOfNode = startOfNode + nodeLength;
 
-        // This must be updated AFTER we use startOfNode
         context.characterCount = endOfNode;
 
-        // If this node is completely outside the range, do nothing.
-        if (endOfNode <= startIndex || startOfNode >= endIndex) {
-            return;
-        }
+        if (startOfNode < endIndex && endOfNode > startIndex) {
+            let highlightedElement;
+            if (node.nodeType === Node.TEXT_NODE) {
+                highlightedElement = wrapTextNode(node);
+            } else {
+                node.classList.add("mark");
+                highlightedElement = node;
+            }
 
-        // Determine if we are starting, ending, or fully inside the highlight
-        const shouldStart = startOfNode <= startIndex && endOfNode > startIndex;
-        const shouldEnd = startOfNode < endIndex && endOfNode >= endIndex;
-
-        // The node contains the entire highlight
-        if (shouldStart && shouldEnd) {
-            const startOffset = startIndex - startOfNode;
-            const endOffset = endIndex - startOfNode;
-            const middleBit = node.splitText(startOffset);
-            middleBit.splitText(endOffset - startOffset);
-            context.first_node = wrapTextNode(middleBit);
-            context.done = true;
+            if (!context.first_node) {
+                context.first_node = highlightedElement;
+            }
         }
-        // The node contains the start of the highlight
-        else if (shouldStart) {
-            const startOffset = startIndex - startOfNode;
-            const nodeToWrap = node.splitText(startOffset);
-            context.first_node = wrapTextNode(nodeToWrap);
-            context.highlighting = true;
-        }
-        // The node contains the end of the highlight
-        else if (shouldEnd) {
-            const endOffset = endIndex - startOfNode;
-            node.splitText(endOffset);
-            wrapTextNode(node);
-            context.highlighting = false;
-            context.done = true;
-        }
-        // The node is fully contained within the highlight
-        else if (context.highlighting) {
-            wrapTextNode(node);
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+        for (const child of Array.from(node.childNodes)) {
+            traverseAndHighlight(child, startIndex, endIndex, context);
         }
     }
 }

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -17,7 +17,7 @@ document.addEventListener("DOMContentLoaded", () => {
     let num_highlighted_elements = 0;
 
     for (const el of elements) {
-        const text = el.textContent.replace(/\s+/g, " ");
+        const text = el.textContent.replace(/\s+/g, " ").replace(/¶/g, "");
 
         if (!startNode && text.includes(startText)) {
             startNode = el;

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -15,9 +15,12 @@ document.addEventListener("DOMContentLoaded", () => {
     let startNode = null;
     let capturing = false;
     let num_highlighted_elements = 0;
+    let last_two_words = "";
 
     for (const el of elements) {
-        const text = el.textContent.replace(/\s+/g, " ").replace(/¶/g, "");
+        const text = last_two_words
+            .concat(" ", el.textContent.replace(/\s+/g, " ").replace(/¶/g, ""))
+            .trim();
 
         if (!startNode && text.includes(startText)) {
             startNode = el;
@@ -34,6 +37,8 @@ document.addEventListener("DOMContentLoaded", () => {
         if (!endText && startNode) break;
 
         if (endText && capturing && text.includes(endText)) break;
+
+        last_two_words = text.split(" ").slice(-2).join(" ");
     }
 
     if (startNode) {

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -53,18 +53,18 @@ function highlightRangeAndScroll(startIndex, endIndex, rootElement) {
         currentSequenceText: "",
         characterCount: 0,
         highlighting: false,
-        first_node: null,
+        firstNode: null,
     };
 
     traverseAndHighlight(rootElement, startIndex, endIndex, context);
 
-    if (context.first_node) {
-        // scrollIntoView works on elements, so if first_node is a text node,
+    if (context.firstNode) {
+        // scrollIntoView works on elements, so if firstNode is a text node,
         // we use its parentElement.
         const scrollTarget =
-            context.first_node.nodeType === Node.TEXT_NODE
-                ? context.first_node.parentElement
-                : context.first_node;
+            context.firstNode.nodeType === Node.TEXT_NODE
+                ? context.firstNode.parentElement
+                : context.firstNode;
 
         scrollTarget.scrollIntoView({
             behavior: "smooth",
@@ -80,7 +80,7 @@ const ATOMIC_NODES = ["STRONG", "B", "EM", "I", "MARK", "SPAN", "A"];
  * Recursively traverses the DOM and highlights text based on character indices.
  */
 function traverseAndHighlight(node, startIndex, endIndex, context) {
-    if (context.characterCount >= endIndex || context.done) {
+    if (context.characterCount >= endIndex) {
         return;
     }
     if (node.nodeType === Node.ELEMENT_NODE) {
@@ -89,7 +89,6 @@ function traverseAndHighlight(node, startIndex, endIndex, context) {
             context.currentSequenceText = normalizeText(
                 `${context.currentSequenceText}${node.textContent}`,
             );
-            // const startOfNode = context.characterCount;
             context.characterCount = context.currentSequenceText.length;
             const endOfNode = context.characterCount;
 
@@ -100,15 +99,12 @@ function traverseAndHighlight(node, startIndex, endIndex, context) {
 
             if (shouldHighlight) {
                 // If this is the very first thing we highlight, store it for scrolling
-                if (!context.first_node) {
-                    context.first_node = node;
+                if (!context.firstNode) {
+                    context.firstNode = node;
                 }
-                // wrapElementNode(node); // Wrap the entire element
-                node.classList.add("mark"); // Add a class for styling (or wrap the element as desired)
+                node.classList.add("mark"); // Add a class for styling
                 context.highlighting = true; // Ensure we stay in highlighting mode
             }
-
-            if (endOfNode >= endIndex) context.highlighting = false; // Stop highlighting.
 
             // DO NOT traverse children.
             // We've treated this element as an atomic unit.
@@ -144,14 +140,13 @@ function traverseAndHighlight(node, startIndex, endIndex, context) {
             const endOffset = endIndex - startOfNode;
             const middleBit = node.splitText(startOffset);
             middleBit.splitText(endOffset - startOffset);
-            context.first_node = wrapTextNode(middleBit);
-            context.done = true;
+            context.firstNode = wrapTextNode(middleBit);
         }
         // The node contains the start of the highlight
         else if (shouldStart) {
             const startOffset = startIndex - startOfNode;
             const nodeToWrap = node.splitText(startOffset);
-            context.first_node = wrapTextNode(nodeToWrap);
+            context.firstNode = wrapTextNode(nodeToWrap);
             context.highlighting = true;
         }
         // The node contains the end of the highlight
@@ -159,8 +154,6 @@ function traverseAndHighlight(node, startIndex, endIndex, context) {
             const endOffset = endIndex - startOfNode;
             node.splitText(endOffset);
             wrapTextNode(node);
-            context.highlighting = false;
-            context.done = true;
         }
         // The node is fully contained within the highlight
         else if (context.highlighting) {

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -12,8 +12,6 @@ document.addEventListener("DOMContentLoaded", () => {
     const normalizedInnerText = normalizeText(content.innerText);
     const startIndex = normalizedInnerText.indexOf(highlightText);
 
-    console.log(normalizedInnerText);
-
     if (startIndex === -1) {
         console.warn(`Highlight text not found: "${highlightText}"`);
         return;
@@ -58,8 +56,6 @@ function highlightRangeAndScroll(startIndex, endIndex, rootElement) {
         first_node: null,
     };
 
-    console.log(startIndex, endIndex);
-
     traverseAndHighlight(rootElement, startIndex, endIndex, context);
 
     if (context.first_node) {
@@ -96,8 +92,6 @@ function traverseAndHighlight(node, startIndex, endIndex, context) {
             // const startOfNode = context.characterCount;
             context.characterCount = context.currentSequenceText.length;
             const endOfNode = context.characterCount;
-            console.log(context.characterCount);
-            console.log(context.currentSequenceText);
 
             // Check if this node's text content falls within the highlight range
             const shouldHighlight =
@@ -134,8 +128,6 @@ function traverseAndHighlight(node, startIndex, endIndex, context) {
         const startOfNode = context.characterCount;
         context.characterCount = context.currentSequenceText.length;
         const endOfNode = context.characterCount;
-        console.log(context.characterCount);
-        console.log(context.currentSequenceText);
 
         // If this node is completely outside the range, do nothing.
         if (endOfNode <= startIndex || startOfNode >= endIndex) {

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -10,7 +10,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (!startText) return;
 
-    const elements = content.querySelectorAll("p, h3, h4, h5");
+    const elements = content.querySelectorAll("p, h3, h4, h5, pre, td");
 
     let startNode = null;
     let capturing = false;

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -14,6 +14,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     let startNode = null;
     let capturing = false;
+    let num_highlighted_elements = 0;
 
     for (const el of elements) {
         const text = el.textContent.replace(/\s+/g, " ");
@@ -25,7 +26,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
         if (capturing) {
             el.classList.add("highlight");
+            num_highlighted_elements += 1;
         }
+
+        if (num_highlighted_elements === 3) break;
 
         if (!endText && startNode) break;
 

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -1,0 +1,40 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const params = new URLSearchParams(window.location.search);
+    const highlightText = params.get("highlight");
+
+    if (highlightText) {
+        const content = document.getElementById("pageContainer");
+        const regex = new RegExp(highlightText, "i");
+
+        const walker = document.createTreeWalker(
+            content,
+            NodeFilter.SHOW_TEXT,
+            {
+                acceptNode: node =>
+                    regex.test(node.textContent)
+                        ? NodeFilter.FILTER_ACCEPT
+                        : NodeFilter.FILTER_SKIP,
+            },
+        );
+
+        const node = walker.nextNode();
+        if (node) {
+            const span = document.createElement("span");
+            span.textContent = node.textContent;
+            span.innerHTML = node.textContent.replace(
+                regex,
+                match => `<mark>${match}</mark>`,
+            );
+            const tempDiv = document.createElement("div");
+            tempDiv.innerHTML = span.innerHTML;
+
+            node.parentNode.replaceChild(tempDiv.firstChild, node);
+
+            // Scroll to the match
+            tempDiv.firstChild.scrollIntoView({
+                behavior: "smooth",
+                block: "center",
+            });
+        }
+    }
+});

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -10,7 +10,9 @@ document.addEventListener("DOMContentLoaded", () => {
     // IMPORTANT: This whitespace normalization is the source of complexity.
     // The traversal logic must perfectly match this.
     const normalizedInnerText = content.innerText.replace(/\s+/g, " ");
-    const startIndex = normalizedInnerText.indexOf(highlightText);
+    const startIndex = normalizedInnerText
+        .toLocaleLowerCase()
+        .indexOf(highlightText.toLocaleLowerCase());
 
     if (startIndex === -1) {
         console.warn(`Highlight text not found: "${highlightText}"`);

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -1,47 +1,182 @@
 document.addEventListener("DOMContentLoaded", () => {
     const params = new URLSearchParams(window.location.search);
-    const highlightText = params.get("highlight");
+    const highlightText = params.get("highlight").replace(/\s+/g, " ");
     if (!highlightText) return;
 
     const content = document.getElementById("pageContainer");
     if (!content) return;
 
-    const [startText, endText] = highlightText.split(":::");
-
-    if (!startText) return;
-
-    const elements = content.querySelectorAll("p, h3, h4, h5, pre, td, li");
-
-    let startNode = null;
-    let capturing = false;
-    let num_highlighted_elements = 0;
-    let last_two_words = "";
-
-    for (const el of elements) {
-        const text = last_two_words
-            .concat(" ", el.textContent.replace(/\s+/g, " ").replace(/¶/g, ""))
-            .trim();
-
-        if (!startNode && text.includes(startText)) {
-            startNode = el;
-            capturing = true;
-        }
-
-        if (capturing) {
-            el.classList.add("highlight");
-            num_highlighted_elements += 1;
-        }
-
-        if (num_highlighted_elements === 3) break;
-
-        if (!endText && startNode) break;
-
-        if (endText && capturing && text.includes(endText)) break;
-
-        last_two_words = text.split(" ").slice(-2).join(" ");
+    const startIndex = content.innerText
+        .replace(/\s+/g, " ")
+        .indexOf(highlightText);
+    if (startIndex === -1) {
+        return;
     }
+    const endIndex = startIndex + highlightText.length;
 
-    if (startNode) {
-        startNode.scrollIntoView({ behavior: "smooth", block: "center" });
-    }
+    highlightRangeAndScroll(startIndex, endIndex, content);
 });
+
+/**
+ * Wraps a DOM Node with a <mark> element.
+ * @param {Node} node The text node to wrap.
+ * @returns {HTMLElement} The created <mark> element.
+ */
+function wrapNode(node) {
+    const mark = document.createElement("mark");
+    node.parentNode.insertBefore(mark, node);
+    mark.appendChild(node);
+    return mark;
+}
+
+/**
+ * Highlights a range of text across multiple elements within a root container.
+ *
+ * @param {number} startIndex The starting character index of the selection.
+ * @param {number} endIndex The ending character index of the selection.
+ * @param {HTMLElement} rootElement The container element in which to perform the highlight.
+ */
+function highlightRangeAndScroll(startIndex, endIndex, rootElement) {
+    if (startIndex < 0 || endIndex < startIndex) {
+        return;
+    }
+
+    // This object will be passed by reference through the recursive calls
+    const context = {
+        characterCount: 0,
+        highlighting: false, // Are we currently in a state of highlighting?
+        skipping_whitespace: false,
+        first_node: null,
+    };
+
+    // Start the traversal
+    traverseAndHighlight(rootElement, startIndex, endIndex, context);
+
+    if (context.first_node) {
+        context.first_node.parentElement.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+        });
+    }
+}
+
+/**
+ * Determine whether a node's text content is entirely whitespace.
+ *
+ * @param {Node} node A node implementing the `CharacterData` interface (i.e.,
+ *                    a `Text`, `Comment`, or `CDATASection` node)
+ * @return            `true` if all of the text content of `nod` is whitespace,
+ *                    otherwise `false`.
+ */
+function isAllWhitespace(node) {
+    return !/[^\t\n\r ]/.test(node.textContent);
+}
+
+/**
+ * Recursively traverses the DOM and highlights text nodes based on the indices.
+ *
+ * @param {Node} node The current node to process.
+ * @param {number} startIndex The starting character index.
+ * @param {number} endIndex The ending character index.
+ * @param {object} context An object holding the traversal state (characterCount, highlighting).
+ */
+function traverseAndHighlight(node, startIndex, endIndex, context) {
+    if (context.characterCount > endIndex) return;
+
+    // We only care about text nodes and element nodes.
+    // We skip comments, etc.
+    if (
+        node.nodeType !== Node.ELEMENT_NODE &&
+        node.nodeType !== Node.TEXT_NODE
+    ) {
+        return;
+    }
+
+    // If it's an element, recurse on its children
+    if (node.nodeType === Node.ELEMENT_NODE) {
+        // We must convert childNodes to an array because the DOM manipulation
+        // ahead can change the live NodeList, causing issues with the loop.
+        for (const child of Array.from(node.childNodes)) {
+            traverseAndHighlight(child, startIndex, endIndex, context);
+        }
+        return;
+    }
+
+    // From here, we are only dealing with TEXT_NODE
+
+    if (isAllWhitespace(node)) {
+        if (!context.skipping_whitespace) {
+            context.characterCount += 1;
+            context.skipping_whitespace = true;
+        }
+        return;
+    }
+
+    const nodeText = node.textContent;
+    const nodeLength =
+        nodeText.length -
+        nodeText.includes("¶") -
+        (context.skipping_whitespace && nodeText.startsWith(" "));
+
+    context.skipping_whitespace = nodeText.endsWith(" ");
+
+    const startOfNode = context.characterCount;
+    const endOfNode = startOfNode + nodeLength;
+
+    // Update the global character count for the next node
+    context.characterCount = endOfNode;
+
+    // --- Core Logic: Determine if this node needs full or partial highlighting ---
+
+    // Case 1: The highlight is entirely contained within this single text node.
+    // [  start---end  ]
+    if (
+        !context.highlighting &&
+        startOfNode <= startIndex &&
+        endOfNode >= endIndex
+    ) {
+        context.first_node = node;
+        const startOffset = startIndex - startOfNode;
+        const endOffset = endIndex - startOfNode;
+
+        // Split the node at the end index first
+        const middleBit = node.splitText(startOffset);
+        middleBit.splitText(endOffset - startOffset);
+
+        // The middleBit is now the text to be highlighted
+        wrapNode(middleBit);
+        return;
+    }
+
+    // Case 2: The highlight starts here but ends in a later node.
+    // [  start-------->
+    if (
+        !context.highlighting &&
+        startOfNode <= startIndex &&
+        endOfNode > startIndex
+    ) {
+        context.first_node = node;
+        const offset = startIndex - startOfNode;
+        const nodeToWrap = node.splitText(offset);
+        wrapNode(nodeToWrap);
+        context.highlighting = true; // Enter highlighting mode
+        return;
+    }
+
+    // Case 3: This entire node is within the highlight range.
+    // <---- full node ---->
+    if (context.highlighting && endOfNode <= endIndex) {
+        wrapNode(node);
+        return;
+    }
+
+    // Case 4: The highlight started in a previous node and ends here.
+    // <--------end   ]
+    if (context.highlighting && endOfNode >= endIndex) {
+        const offset = endIndex - startOfNode;
+        node.splitText(offset); // The first part of the split is what we need to wrap
+        wrapNode(node);
+        context.highlighting = false; // We are done highlighting
+        return;
+    }
+}

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -3,38 +3,29 @@ document.addEventListener("DOMContentLoaded", () => {
     const highlightText = params.get("highlight");
 
     if (highlightText) {
-        const content = document.getElementById("pageContainer");
-        const regex = new RegExp(highlightText, "i");
-
-        const walker = document.createTreeWalker(
-            content,
-            NodeFilter.SHOW_TEXT,
-            {
-                acceptNode: node =>
-                    regex.test(node.textContent)
-                        ? NodeFilter.FILTER_ACCEPT
-                        : NodeFilter.FILTER_SKIP,
-            },
+        const paragraphs = document.querySelectorAll(
+            "#pageContainer p, #pageContainer h3, #pageContainer h4, #pageContainer h5",
         );
+        const cleanText = highlightText.toLowerCase().replace(/[^\w\s]/g, "");
 
-        const node = walker.nextNode();
-        if (node) {
-            const span = document.createElement("span");
-            span.textContent = node.textContent;
-            span.innerHTML = node.textContent.replace(
-                regex,
-                match => `<mark>${match}</mark>`,
-            );
-            const tempDiv = document.createElement("div");
-            tempDiv.innerHTML = span.innerHTML;
+        let bestMatch = null;
+        let maxMatchScore = 0;
 
-            node.parentNode.replaceChild(tempDiv.firstChild, node);
+        for (const el of paragraphs) {
+            const content = el.textContent.toLowerCase();
+            const score = content
+                .split(" ")
+                .filter(word => cleanText.includes(word)).length;
 
-            // Scroll to the match
-            tempDiv.firstChild.scrollIntoView({
-                behavior: "smooth",
-                block: "center",
-            });
+            if (score > maxMatchScore) {
+                maxMatchScore = score;
+                bestMatch = el;
+            }
+        }
+
+        if (bestMatch) {
+            bestMatch.classList.add("highlight");
+            bestMatch.scrollIntoView({ behavior: "smooth", block: "center" });
         }
     }
 });

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -10,7 +10,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (!startText) return;
 
-    const elements = content.querySelectorAll("p, h3, h4, h5, pre, td");
+    const elements = content.querySelectorAll("p, h3, h4, h5, pre, td, li");
 
     let startNode = null;
     let capturing = false;

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -88,6 +88,7 @@ function findAndHighlightSequence(rootElement, searchText) {
     for (let i = 0; i < nodes.length; i++) {
         currentSequenceText += ` ${nodes[i].textContent}`;
         const normalizedCurrentText = currentSequenceText
+            .replace(/¶/g, "")
             .replace(/\s+/g, " ")
             .trim()
             .toLowerCase();

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -1,27 +1,35 @@
 document.addEventListener("DOMContentLoaded", () => {
     const params = new URLSearchParams(window.location.search);
-    const highlightText = params.get("highlight");
-    if (!highlightText || highlightText.trim() === "") return;
+    // Added a fallback for empty highlight param to prevent errors
+    const highlightText = normalizeText(params.get("highlight") || "");
+    if (!highlightText) return;
 
     const content = document.getElementById("pageContainer");
     if (!content) return;
 
-    // The new function directly finds, highlights, and returns the first element.
-    const firstHighlightedElement = findAndHighlightSequence(
-        content,
-        highlightText,
-    );
+    // IMPORTANT: This whitespace normalization is the source of complexity.
+    // The traversal logic must perfectly match this.
+    const normalizedInnerText = normalizeText(content.innerText);
+    const startIndex = normalizedInnerText.indexOf(highlightText);
 
-    if (firstHighlightedElement) {
-        // If a match was found and highlighted, scroll it into view.
-        firstHighlightedElement.scrollIntoView({
-            behavior: "smooth",
-            block: "center",
-        });
-    } else {
+    console.log(normalizedInnerText);
+
+    if (startIndex === -1) {
         console.warn(`Highlight text not found: "${highlightText}"`);
+        return;
     }
+    const endIndex = startIndex + highlightText.length;
+
+    highlightRangeAndScroll(startIndex, endIndex, content);
 });
+
+function normalizeText(text) {
+    return text
+        .replace(/¶/g, "")
+        .replace(/\s+/g, " ")
+        .trimStart()
+        .toLowerCase();
+}
 
 /**
  * Wraps a TEXT_NODE with a <mark> element.
@@ -35,88 +43,136 @@ function wrapTextNode(node) {
     return mark;
 }
 
-// List of element tags that should be treated as a single, indivisible unit for highlighting.
+/**
+ * Highlights a range and scrolls the first highlighted element into view.
+ */
+function highlightRangeAndScroll(startIndex, endIndex, rootElement) {
+    if (startIndex < 0 || endIndex < startIndex) {
+        return;
+    }
+
+    const context = {
+        currentSequenceText: "",
+        characterCount: 0,
+        highlighting: false,
+        first_node: null,
+    };
+
+    console.log(startIndex, endIndex);
+
+    traverseAndHighlight(rootElement, startIndex, endIndex, context);
+
+    if (context.first_node) {
+        // scrollIntoView works on elements, so if first_node is a text node,
+        // we use its parentElement.
+        const scrollTarget =
+            context.first_node.nodeType === Node.TEXT_NODE
+                ? context.first_node.parentElement
+                : context.first_node;
+
+        scrollTarget.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+        });
+    }
+}
+
+// List of tags that should be wrapped entirely, not split.
 const ATOMIC_NODES = ["STRONG", "B", "EM", "I", "MARK", "SPAN", "A"];
 
 /**
- * Recursively traverses the DOM to collect all "atomic" nodes (text nodes and
- * specific inline elements) into a flat list, preserving their document order.
- * @param {Node} node The starting node for traversal.
- * @param {Array<Node>} nodes The accumulator array for collected nodes.
- * @returns {Array<Node>} The flat list of atomic nodes.
+ * Recursively traverses the DOM and highlights text based on character indices.
  */
-function collectAtomicNodes(node, nodes = []) {
-    const isAtomic =
-        node.nodeType === Node.TEXT_NODE ||
-        (node.nodeType === Node.ELEMENT_NODE &&
-            ATOMIC_NODES.includes(node.tagName));
-
-    if (isAtomic) {
-        // Only add non-empty text nodes
-        if (
-            node.nodeType !== Node.TEXT_NODE ||
-            node.textContent.trim() !== ""
-        ) {
-            nodes.push(node);
-        }
-    } else if (node.nodeType === Node.ELEMENT_NODE) {
-        for (const child of Array.from(node.childNodes)) {
-            collectAtomicNodes(child, nodes);
-        }
+function traverseAndHighlight(node, startIndex, endIndex, context) {
+    if (context.characterCount >= endIndex || context.done) {
+        return;
     }
-    return nodes;
-}
-
-/**
- * Finds a sequence of nodes that match the search text and highlights them.
- * This approach avoids the fragility of index-based highlighting by matching
- * against the text content of the nodes directly.
- * @param {HTMLElement} rootElement The element to search within.
- * @param {string} searchText The text to find.
- * @returns {HTMLElement|null} The first highlighted element, or null if not found.
- */
-function findAndHighlightSequence(rootElement, searchText) {
-    const nodes = collectAtomicNodes(rootElement);
-    const normalizedSearchText = searchText
-        .replace(/\s+/g, " ")
-        .trim()
-        .toLowerCase();
-
-    let currentSequenceText = "";
-    const charCountNodes = [];
-    let startIndex = -1;
-    for (let i = 0; i < nodes.length; i++) {
-        currentSequenceText += ` ${nodes[i].textContent}`;
-        const normalizedCurrentText = currentSequenceText
-            .replace(/¶/g, "")
-            .replace(/\s+/g, " ")
-            .trim()
-            .toLowerCase();
-        charCountNodes.push(normalizedCurrentText.length);
-
-        startIndex = normalizedCurrentText.indexOf(normalizedSearchText);
-
-        if (startIndex !== -1) {
-            const firstNode = charCountNodes.findIndex(
-                charCount => charCount > startIndex,
+    if (node.nodeType === Node.ELEMENT_NODE) {
+        // Check if the current element is one we should wrap whole.
+        if (ATOMIC_NODES.includes(node.tagName)) {
+            context.currentSequenceText = normalizeText(
+                `${context.currentSequenceText}${node.textContent}`,
             );
-            // Match found for the sequence of nodes from i to j.
-            const nodesToHighlight = nodes.slice(firstNode, i + 1);
-            let firstHighlightedElement = null;
-            for (const node of nodesToHighlight) {
-                let highlightedElement;
-                if (node.nodeType === Node.TEXT_NODE) {
-                    highlightedElement = wrapTextNode(node);
-                } else {
-                    node.classList.add("mark");
-                    highlightedElement = node;
+            // const startOfNode = context.characterCount;
+            context.characterCount = context.currentSequenceText.length;
+            const endOfNode = context.characterCount;
+            console.log(context.characterCount);
+            console.log(context.currentSequenceText);
+
+            // Check if this node's text content falls within the highlight range
+            const shouldHighlight =
+                context.highlighting || // Already highlighting
+                endOfNode > startIndex; // Highlighting should start
+
+            if (shouldHighlight) {
+                // If this is the very first thing we highlight, store it for scrolling
+                if (!context.first_node) {
+                    context.first_node = node;
                 }
-                if (!firstHighlightedElement) {
-                    firstHighlightedElement = highlightedElement;
-                }
+                // wrapElementNode(node); // Wrap the entire element
+                node.classList.add("mark"); // Add a class for styling (or wrap the element as desired)
+                context.highlighting = true; // Ensure we stay in highlighting mode
             }
-            return firstHighlightedElement;
+
+            if (endOfNode >= endIndex) context.highlighting = false; // Stop highlighting.
+
+            // DO NOT traverse children.
+            // We've treated this element as an atomic unit.
+            return;
+        }
+
+        for (const child of Array.from(node.childNodes)) {
+            traverseAndHighlight(child, startIndex, endIndex, context);
+        }
+        return;
+    }
+
+    if (node.nodeType === Node.TEXT_NODE) {
+        context.currentSequenceText = normalizeText(
+            `${context.currentSequenceText}${node.textContent}`,
+        );
+        const startOfNode = context.characterCount;
+        context.characterCount = context.currentSequenceText.length;
+        const endOfNode = context.characterCount;
+        console.log(context.characterCount);
+        console.log(context.currentSequenceText);
+
+        // If this node is completely outside the range, do nothing.
+        if (endOfNode <= startIndex || startOfNode >= endIndex) {
+            return;
+        }
+
+        // Determine if we are starting, ending, or fully inside the highlight
+        const shouldStart = startOfNode <= startIndex;
+        const shouldEnd = endOfNode >= endIndex;
+
+        // The node contains the entire highlight
+        if (shouldStart && shouldEnd) {
+            const startOffset = startIndex - startOfNode;
+            const endOffset = endIndex - startOfNode;
+            const middleBit = node.splitText(startOffset);
+            middleBit.splitText(endOffset - startOffset);
+            context.first_node = wrapTextNode(middleBit);
+            context.done = true;
+        }
+        // The node contains the start of the highlight
+        else if (shouldStart) {
+            const startOffset = startIndex - startOfNode;
+            const nodeToWrap = node.splitText(startOffset);
+            context.first_node = wrapTextNode(nodeToWrap);
+            context.highlighting = true;
+        }
+        // The node contains the end of the highlight
+        else if (shouldEnd) {
+            const endOffset = endIndex - startOfNode;
+            node.splitText(endOffset);
+            wrapTextNode(node);
+            context.highlighting = false;
+            context.done = true;
+        }
+        // The node is fully contained within the highlight
+        else if (context.highlighting) {
+            wrapTextNode(node);
         }
     }
-    return null;
 }

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -82,37 +82,39 @@ function findAndHighlightSequence(rootElement, searchText) {
         .trim()
         .toLowerCase();
 
+    let currentSequenceText = "";
+    const charCountNodes = [];
+    let startIndex = -1;
     for (let i = 0; i < nodes.length; i++) {
-        let currentSequenceText = "";
-        for (let j = i; j < nodes.length; j++) {
-            currentSequenceText += nodes[j].textContent;
-            const normalizedCurrentText = currentSequenceText
-                .replace(/\s+/g, " ")
-                .trim()
-                .toLowerCase();
+        currentSequenceText += ` ${nodes[i].textContent}`;
+        const normalizedCurrentText = currentSequenceText
+            .replace(/\s+/g, " ")
+            .trim()
+            .toLowerCase();
+        charCountNodes.push(normalizedCurrentText.length);
 
-            if (normalizedCurrentText.indexOf(normalizedSearchText) !== -1) {
-                // Match found for the sequence of nodes from i to j.
-                const nodesToHighlight = nodes.slice(i, j + 1);
-                let firstHighlightedElement = null;
-                for (const node of nodesToHighlight) {
-                    let highlightedElement;
-                    if (node.nodeType === Node.TEXT_NODE) {
-                        highlightedElement = wrapTextNode(node);
-                    } else {
-                        node.classList.add("mark");
-                        highlightedElement = node;
-                    }
-                    if (!firstHighlightedElement) {
-                        firstHighlightedElement = highlightedElement;
-                    }
+        startIndex = normalizedCurrentText.indexOf(normalizedSearchText);
+
+        if (startIndex !== -1) {
+            const firstNode = charCountNodes.findIndex(
+                charCount => charCount > startIndex,
+            );
+            // Match found for the sequence of nodes from i to j.
+            const nodesToHighlight = nodes.slice(firstNode, i + 1);
+            let firstHighlightedElement = null;
+            for (const node of nodesToHighlight) {
+                let highlightedElement;
+                if (node.nodeType === Node.TEXT_NODE) {
+                    highlightedElement = wrapTextNode(node);
+                } else {
+                    node.classList.add("mark");
+                    highlightedElement = node;
                 }
-                return firstHighlightedElement;
+                if (!firstHighlightedElement) {
+                    firstHighlightedElement = highlightedElement;
+                }
             }
-
-            if (!normalizedSearchText.startsWith(normalizedCurrentText)) {
-                break;
-            }
+            return firstHighlightedElement;
         }
     }
     return null;

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -1,31 +1,38 @@
 document.addEventListener("DOMContentLoaded", () => {
     const params = new URLSearchParams(window.location.search);
     const highlightText = params.get("highlight");
+    if (!highlightText) return;
 
-    if (highlightText) {
-        const paragraphs = document.querySelectorAll(
-            "#pageContainer p, #pageContainer h3, #pageContainer h4, #pageContainer h5",
-        );
-        const cleanText = highlightText.toLowerCase().replace(/[^\w\s]/g, "");
+    const content = document.getElementById("pageContainer");
+    if (!content) return;
 
-        let bestMatch = null;
-        let maxMatchScore = 0;
+    const [startText, endText] = highlightText.split(":::");
 
-        for (const el of paragraphs) {
-            const content = el.textContent.toLowerCase();
-            const score = content
-                .split(" ")
-                .filter(word => cleanText.includes(word)).length;
+    if (!startText) return;
 
-            if (score > maxMatchScore) {
-                maxMatchScore = score;
-                bestMatch = el;
-            }
+    const elements = content.querySelectorAll("p, h3, h4, h5");
+
+    let startNode = null;
+    let capturing = false;
+
+    for (const el of elements) {
+        const text = el.textContent.replace(/\s+/g, " ");
+
+        if (!startNode && text.includes(startText)) {
+            startNode = el;
+            capturing = true;
         }
 
-        if (bestMatch) {
-            bestMatch.classList.add("highlight");
-            bestMatch.scrollIntoView({ behavior: "smooth", block: "center" });
+        if (capturing) {
+            el.classList.add("highlight");
         }
+
+        if (!endText && startNode) break;
+
+        if (endText && capturing && text.includes(endText)) break;
+    }
+
+    if (startNode) {
+        startNode.scrollIntoView({ behavior: "smooth", block: "center" });
     }
 });

--- a/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
+++ b/app/grandchallenge/documentation/static/documentation/js/highlight.mjs
@@ -30,6 +30,15 @@ function normalizeText(text) {
 }
 
 /**
+ * Determine whether a node's text content is entirely whitespace.
+ * @param {Node} node A node implementing the `CharacterData` interface
+ * @return            `true` if all of the text content of `node` is whitespace.
+ */
+function isAllWhitespace(node) {
+    return !/[^\t\n\r ]/.test(node.textContent);
+}
+
+/**
  * Wraps a TEXT_NODE with a <mark> element.
  * @param {Node} node The text node to wrap.
  * @returns {HTMLElement} The created <mark> element.
@@ -127,6 +136,11 @@ function traverseAndHighlight(node, startIndex, endIndex, context) {
 
         // If this node is completely outside the range, do nothing.
         if (endOfNode <= startIndex || startOfNode >= endIndex) {
+            return;
+        }
+
+        // If this node is completely whitespace, do nothing.
+        if (isAllWhitespace(node)) {
             return;
         }
 

--- a/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
+++ b/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
@@ -1,7 +1,6 @@
 {% extends 'base.html' %}
 {% load docpage_extras %}
 {% load bleach %}
-{% load static %}
 
 {% block title %}
     {{ currentdocpage.title }} -
@@ -143,7 +142,7 @@
                                 </li>
                             {% endfor %}
                         </ol>
-                        <a href="{% url 'documentation:detail' slug=result.slug %}?highlight={{ result.headline|startend_text }}"><h5 class="pl-3 pt-1">{{ result.title }}</h5></a>
+                        <a href="{% url 'documentation:detail' slug=result.slug %}#:~:text={{ result.headline|startend_text }}"><h5 class="pl-3 pt-1">{{ result.title }}</h5></a>
                         <div class="mb-3 pl-3">{{ result.headline|clean }}</div>
                     </div>
                 {% endfor %}
@@ -166,11 +165,4 @@
             </div>
         </div>
     {% endif %}
-{% endblock %}
-
-{% block script %}
-    {{ block.super }}
-
-    <script type="module" src="{% static 'documentation/js/highlight.mjs' %}"></script>
-
 {% endblock %}

--- a/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
+++ b/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
@@ -143,7 +143,7 @@
                                 </li>
                             {% endfor %}
                         </ol>
-                        <a href="{% url 'documentation:detail' slug=result.slug %}?highlight={{ result.headline|startend_text }}"><h5 class="pl-3 pt-1">{{ result.title }}</h5></a>
+                        <a href="{% url 'documentation:detail' slug=result.slug %}?highlight={{ result.headline|striptags|urlencode }}"><h5 class="pl-3 pt-1">{{ result.title }}</h5></a>
                         <div class="mb-3 pl-3">{{ result.headline|clean }}</div>
                     </div>
                 {% endfor %}

--- a/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
+++ b/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load docpage_extras %}
 {% load bleach %}
+{% load static %}
 
 {% block title %}
     {{ currentdocpage.title }} -
@@ -142,7 +143,7 @@
                                 </li>
                             {% endfor %}
                         </ol>
-                        <a href="{% url 'documentation:detail' slug=result.slug %}"><h5 class="pl-3 pt-1">{{ result.title }}</h5></a>
+                        <a href="{% url 'documentation:detail' slug=result.slug %}?highlight={{ result.headline|striptags|urlencode }}"><h5 class="pl-3 pt-1">{{ result.title }}</h5></a>
                         <div class="mb-3 pl-3">{{ result.headline|clean }}</div>
                     </div>
                 {% endfor %}
@@ -165,4 +166,11 @@
             </div>
         </div>
     {% endif %}
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+
+    <script type="module" src="{% static 'documentation/js/highlight.mjs' %}"></script>
+
 {% endblock %}

--- a/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
+++ b/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
@@ -143,7 +143,7 @@
                                 </li>
                             {% endfor %}
                         </ol>
-                        <a href="{% url 'documentation:detail' slug=result.slug %}?highlight={{ result.headline|striptags|urlencode }}"><h5 class="pl-3 pt-1">{{ result.title }}</h5></a>
+                        <a href="{% url 'documentation:detail' slug=result.slug %}?highlight={{ result.headline|startend_text }}"><h5 class="pl-3 pt-1">{{ result.title }}</h5></a>
                         <div class="mb-3 pl-3">{{ result.headline|clean }}</div>
                     </div>
                 {% endfor %}

--- a/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
+++ b/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load docpage_extras %}
 {% load bleach %}
+{% load static %}
 
 {% block title %}
     {{ currentdocpage.title }} -
@@ -142,7 +143,7 @@
                                 </li>
                             {% endfor %}
                         </ol>
-                        <a href="{% url 'documentation:detail' slug=result.slug %}#:~:text={{ result.headline|startend_text }}"><h5 class="pl-3 pt-1">{{ result.title }}</h5></a>
+                        <a href="{% url 'documentation:detail' slug=result.slug %}?highlight={{ result.headline|startend_text }}"><h5 class="pl-3 pt-1">{{ result.title }}</h5></a>
                         <div class="mb-3 pl-3">{{ result.headline|clean }}</div>
                     </div>
                 {% endfor %}
@@ -165,4 +166,11 @@
             </div>
         </div>
     {% endif %}
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+
+    <script type="module" src="{% static 'documentation/js/highlight.mjs' %}"></script>
+
 {% endblock %}

--- a/app/grandchallenge/documentation/templatetags/docpage_extras.py
+++ b/app/grandchallenge/documentation/templatetags/docpage_extras.py
@@ -42,16 +42,14 @@ def get_breadcrumbs(page):
 
 @register.filter
 def startend_text(text):
-    text = striptags(text).strip().replace("-", "%2D")
+    text = striptags(text).strip()
 
-    lines = text.splitlines()
-
-    if len(lines) < 2:
+    # Split around center word and extract fixed-length windows
+    words = text.split()
+    n_words = min(3, len(words) // 2)
+    if n_words < 2:
         return quote(text)
+    start = " ".join(words[:n_words]).rstrip(":")
+    end = " ".join(words[-n_words:])
 
-    lines = [line for line in lines if len(line.split()) > 2]
-
-    if len(lines) < 2:
-        return quote(lines[0])
-
-    return f"{quote(lines[0])},{quote(lines[-1])}"
+    return f"{quote(start)}:::{quote(end)}"

--- a/app/grandchallenge/documentation/templatetags/docpage_extras.py
+++ b/app/grandchallenge/documentation/templatetags/docpage_extras.py
@@ -42,14 +42,16 @@ def get_breadcrumbs(page):
 
 @register.filter
 def startend_text(text):
-    text = striptags(text).strip()
+    text = striptags(text).strip().replace("-", "%2D")
 
-    # Split around center word and extract fixed-length windows
-    words = text.split()
-    n_words = min(3, len(words) // 2)
-    if n_words < 2:
+    lines = text.splitlines()
+
+    if len(lines) < 2:
         return quote(text)
-    start = " ".join(words[:n_words]).rstrip(":")
-    end = " ".join(words[-n_words:])
 
-    return f"{quote(start)}:::{quote(end)}"
+    lines = [line for line in lines if len(line.split()) > 2]
+
+    if len(lines) < 2:
+        return quote(lines[0])
+
+    return f"{quote(lines[0])},{quote(lines[-1])}"

--- a/app/grandchallenge/documentation/templatetags/docpage_extras.py
+++ b/app/grandchallenge/documentation/templatetags/docpage_extras.py
@@ -1,7 +1,4 @@
-from urllib.parse import quote
-
 from django import template
-from django.template.defaultfilters import striptags
 
 from grandchallenge.subdomains.utils import reverse
 
@@ -38,18 +35,3 @@ def get_breadcrumbs(page):
         current = current.parent
 
     return breadcrumbs
-
-
-@register.filter
-def startend_text(text):
-    text = striptags(text).strip()
-
-    # Split around center word and extract fixed-length windows
-    words = text.split()
-    n_words = min(3, len(words) // 2)
-    if n_words < 2:
-        return quote(text)
-    start = " ".join(words[:n_words]).rstrip(":")
-    end = " ".join(words[-n_words:])
-
-    return f"{quote(start)}:::{quote(end)}"

--- a/app/grandchallenge/documentation/templatetags/docpage_extras.py
+++ b/app/grandchallenge/documentation/templatetags/docpage_extras.py
@@ -1,4 +1,7 @@
+from urllib.parse import quote
+
 from django import template
+from django.template.defaultfilters import striptags
 
 from grandchallenge.subdomains.utils import reverse
 
@@ -35,3 +38,19 @@ def get_breadcrumbs(page):
         current = current.parent
 
     return breadcrumbs
+
+
+@register.filter
+def startend_text(text):
+    text = striptags(text).strip()
+
+    if len(text) <= 40:
+        return text
+
+    # Split around center word and extract fixed-length windows
+    words = text.split()
+    n_words = min(3, len(words) // 2)
+    start = " ".join(words[:n_words])
+    end = " ".join(words[-n_words:])
+
+    return f"{quote(start)}:::{quote(end)}"

--- a/app/grandchallenge/documentation/templatetags/docpage_extras.py
+++ b/app/grandchallenge/documentation/templatetags/docpage_extras.py
@@ -50,7 +50,7 @@ def startend_text(text):
     # Split around center word and extract fixed-length windows
     words = text.split()
     n_words = min(3, len(words) // 2)
-    start = " ".join(words[:n_words])
+    start = " ".join(words[:n_words]).rstrip(":")
     end = " ".join(words[-n_words:])
 
     return f"{quote(start)}:::{quote(end)}"

--- a/app/grandchallenge/documentation/templatetags/docpage_extras.py
+++ b/app/grandchallenge/documentation/templatetags/docpage_extras.py
@@ -44,12 +44,11 @@ def get_breadcrumbs(page):
 def startend_text(text):
     text = striptags(text).strip()
 
-    if len(text) <= 40:
-        return text
-
     # Split around center word and extract fixed-length windows
     words = text.split()
     n_words = min(3, len(words) // 2)
+    if n_words < 2:
+        return quote(text)
     start = " ".join(words[:n_words]).rstrip(":")
     end = " ".join(words[-n_words:])
 


### PR DESCRIPTION
Make searching through the documentation more user friendly by highlighting the headline on the page after clicking on a search result. 

Example search result:
<img width="636" alt="image" src="https://github.com/user-attachments/assets/3d708d83-4fa4-4e1d-a70d-9edc9e6b4b47" />

Highlighted elements containing the headline:
<img width="634" alt="image" src="https://github.com/user-attachments/assets/56cd3a8b-dc07-4d48-8b29-90114eed0927" />

Related to https://github.com/DIAGNijmegen/rse-roadmap/issues/417