### PR TITLE
Fix the algorithm memory requirements on creation

### DIFF
--- a/app/grandchallenge/algorithms/forms.py
+++ b/app/grandchallenge/algorithms/forms.py
@@ -521,6 +521,7 @@ class AlgorithmForPhaseForm(
             "structures": MultipleHiddenInput(),
             "logo": HiddenInput(),
             "time_limit": HiddenInput(),
+            "job_requires_memory_gb": HiddenInput(),
         }
         help_texts = {
             "description": (
@@ -590,6 +591,10 @@ class AlgorithmForPhaseForm(
             MinValueValidator(settings.ALGORITHMS_MIN_MEMORY_GB),
             MaxValueValidator(phase.algorithm_maximum_settable_memory_gb),
         ]
+        self.fields["job_requires_memory_gb"].initial = min(
+            16, phase.algorithm_maximum_settable_memory_gb
+        )
+        self.fields["job_requires_memory_gb"].disabled = True
 
     def clean(self):
         cleaned_data = super().clean()

--- a/app/tests/evaluation_tests/test_forms.py
+++ b/app/tests/evaluation_tests/test_forms.py
@@ -953,7 +953,7 @@ def test_algorithm_for_phase_form():
     assert not form.fields["title"].disabled
     assert not form.fields["description"].disabled
     assert not form.fields["job_requires_gpu_type"].disabled
-    assert not form.fields["job_requires_memory_gb"].disabled
+    assert form.fields["job_requires_memory_gb"].disabled
 
     assert {
         form.fields["interfaces"],
@@ -968,13 +968,13 @@ def test_algorithm_for_phase_form():
         form.fields["contact_email"],
         form.fields["logo"],
         form.fields["time_limit"],
+        form.fields["job_requires_memory_gb"],
     } == {field.field for field in form.hidden_fields()}
 
     assert {
         form.fields["title"],
         form.fields["description"],
         form.fields["job_requires_gpu_type"],
-        form.fields["job_requires_memory_gb"],
     } == {field.field for field in form.visible_fields()}
 
 

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -1057,7 +1057,7 @@ def test_create_algorithm_for_phase_presets(client):
         user=admin,
         data={
             "title": "Test algorithm",
-            "job_requires_memory_gb": 8,
+            "job_requires_memory_gb": 8,  # Fixed at 16 in disabled field
             "interfaces": [
                 interface.pk
                 for interface in response.context_data["form"][
@@ -1100,7 +1100,7 @@ def test_create_algorithm_for_phase_presets(client):
     assert {*algorithm.modalities.all()} == set()
     assert algorithm.logo == phase.challenge.logo
     assert algorithm.time_limit == 10 * 60
-    assert algorithm.job_requires_memory_gb == 8
+    assert algorithm.job_requires_memory_gb == 16
 
     # try to set different values
     ci3, ci4 = ComponentInterfaceFactory.create_batch(2)
@@ -1120,7 +1120,7 @@ def test_create_algorithm_for_phase_presets(client):
         user=admin,
         data={
             "title": "Test algorithm",
-            "job_requires_memory_gb": 8,
+            "job_requires_memory_gb": 8,  # Fixed at 16 in disabled field
             "interfaces": [interface1.pk],
             "workstation": ws.pk,
             "hanging_protocol": hp.pk,
@@ -1143,7 +1143,7 @@ def test_create_algorithm_for_phase_presets(client):
     assert alg2.view_content != "{}"
     assert alg2.workstation.slug != ws
     assert alg2.logo == phase.challenge.logo
-    assert alg2.job_requires_memory_gb == 8
+    assert alg2.job_requires_memory_gb == 16
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This will set the default memory requirements to 16gb, this is the amount of memory the smallest GPU instances have. Most users leave this unset, or overestimate it at this point. If the user really needs more memory they can set it later in their algorithm settings.