### PR TITLE
Add page title to doc page navigation

### DIFF
--- a/app/grandchallenge/documentation/models.py
+++ b/app/grandchallenge/documentation/models.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.db.models import Max
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from django.utils.functional import cached_property
 from django_extensions.db.fields import AutoSlugField
 
 from grandchallenge.core.templatetags.bleach import md2html
@@ -130,7 +131,7 @@ class DocPage(models.Model):
         url = reverse("documentation:detail", kwargs={"slug": self.slug})
         return url
 
-    @property
+    @cached_property
     def next(self):
         try:
             next_page = DocPage.objects.filter(order__gt=self.order).first()
@@ -138,7 +139,7 @@ class DocPage(models.Model):
             next_page = None
         return next_page
 
-    @property
+    @cached_property
     def previous(self):
         try:
             previous_page = DocPage.objects.filter(order__lt=self.order).last()

--- a/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
+++ b/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
@@ -151,18 +151,8 @@
             {% endif %}
         </div>
     {% else %}
+        {% include "documentation/partials/navigation_links.html" with page=currentdocpage %}
         <div class="mt-4 docpage" id=pageContainer>{{ currentdocpage.content|md2html }}</div>
-        <div class="row">
-            <div class="d-inline-block col-6 text-left">
-                {% if currentdocpage.previous %}
-                    <a class="btn btn-md btn-outline-dark" href="{% url 'documentation:detail' slug=currentdocpage.previous.slug %}">Previous section</a>
-                {% endif %}
-            </div>
-            <div class="d-inline col-6 text-right">
-                {% if currentdocpage.next %}
-                    <a class="btn btn-md btn-outline-dark" href="{% url 'documentation:detail' slug=currentdocpage.next.slug %}">Next section</a>
-                {% endif %}
-            </div>
-        </div>
+        {% include "documentation/partials/navigation_links.html" with page=currentdocpage %}
     {% endif %}
 {% endblock %}

--- a/app/grandchallenge/documentation/templates/documentation/partials/navigation_links.html
+++ b/app/grandchallenge/documentation/templates/documentation/partials/navigation_links.html
@@ -1,4 +1,3 @@
-
 <div class="row mt-3">
     <div class="d-inline-block col-6 text-left">
         {% if page.previous %}

--- a/app/grandchallenge/documentation/templates/documentation/partials/navigation_links.html
+++ b/app/grandchallenge/documentation/templates/documentation/partials/navigation_links.html
@@ -1,0 +1,23 @@
+
+<div class="row mt-3">
+    <div class="d-inline-block col-6 text-left">
+        {% if page.previous %}
+            <a href="{% url 'documentation:detail' slug=page.previous.slug %}">
+                <div class="row">
+                    <div class="col-auto my-auto pr-2">←</div>
+                    <div class="col pl-0">{{ page.previous.title }}</div>
+                </div>
+            </a>
+        {% endif %}
+    </div>
+    <div class="d-inline col-6 text-right">
+        {% if page.next %}
+            <a href="{% url 'documentation:detail' slug=page.next.slug %}">
+                <div class="row">
+                    <div class="col pr-0">{{ page.next.title }}</div>
+                    <div class="col-auto my-auto pl-2">→</div>
+                </div>
+            </a>
+        {% endif %}
+    </div>
+</div>


### PR DESCRIPTION
The next and previous buttons shown below a docpage are replace with navigation links showing the target page title. 
The links are also shown above the docpage. 

Example:
<img width="505" alt="image" src="https://github.com/user-attachments/assets/967a19ff-bba1-4d9c-8fcf-600dcab96a17" />

Related to https://github.com/DIAGNijmegen/rse-roadmap/issues/417