### PR TITLE
Fix N+1 query in documentation pages

### DIFF
--- a/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
+++ b/app/grandchallenge/documentation/templates/documentation/docpage_detail.html
@@ -85,6 +85,7 @@
                                                             </a>
                                                         </li>
                                                         <ul class="border-left border-right border-bottom {% if currentdocpage == tertiarypage or currentdocpage in tertiarypage.children.all %} collapse show {% else %} collapse hide {% endif %} list-group mb-1">
+                                                            {# If the number of nesting levels is changed, also change the children prefetch and the test_docpage_detail_num_queries #}
                                                             {% for fourthpage in tertiarypage.children.all %}
                                                                 <li class="p-0 mb-1 ml-5 mr-3">
                                                                     <a class="nav-link {% if fourthpage == currentdocpage %}active font-weight-bold{% endif %} text-primary pl-2"

--- a/app/grandchallenge/documentation/views.py
+++ b/app/grandchallenge/documentation/views.py
@@ -33,7 +33,7 @@ class DocPageDetail(DetailView):
         context = super().get_context_data(**kwargs)
         top_level_pages = (
             DocPage.objects.filter(parent__isnull=True)
-            .prefetch_related("children__children")
+            .prefetch_related("children__children__children__children")
             .order_by("order")
         )
 

--- a/app/tests/documentation_tests/test_views.py
+++ b/app/tests/documentation_tests/test_views.py
@@ -191,19 +191,19 @@ def nested_docpages():
 @pytest.mark.parametrize(
     "level, num_queries",
     (
-        (0, 42),
-        (1, 44),  # +1 parent is not null, +1 page with lower order exists
-        (2, 45),  # +1 breadcrumb
-        (3, 46),  # +1 breadcrumb
+        (0, 40),
+        (1, 41),  # +1 parent is not null
+        (2, 42),  # +1 parent breadcrumb
+        (3, 43),  # +1 parent breadcrumb
     ),
 )
 def test_docpage_detail_num_queries(
-    client, django_assert_max_num_queries, nested_docpages, level, num_queries
+    client, django_assert_num_queries, nested_docpages, level, num_queries
 ):
     user = UserFactory()
     page = nested_docpages[level]
 
-    with django_assert_max_num_queries(num_queries) as _:
+    with django_assert_num_queries(num_queries) as _:
         response = get_view_for_user(
             viewname="documentation:detail",
             reverse_kwargs={"slug": page.slug},


### PR DESCRIPTION
Prefetch children four levels deep for nav menu. 

Closes https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/566