### PR TITLE
Make forum pages responsive and styling conform GC

### DIFF
--- a/app/grandchallenge/core/templates/grandchallenge/partials/pagination.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/pagination.html
@@ -1,24 +1,25 @@
 {% load update_search_params %}
 
 <div class="d-flex justify-content-end">
-        <ul class="pagination">
-            {% if page_obj.has_previous %}
-                <li class="page-item">
-                    <a class="page-link" href="?{% update_search_params page=page_obj.previous_page_number %}">Previous</a>
-                </li>
-            {% else %}
-                <li class="page-item disabled"><span class="page-link">Previous</span></li>
-            {% endif %}
-
-            <li class="page-item disabled"><span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+    <ul class="pagination mb-0">
+        {% if page_obj.has_previous %}
+            <li class="page-item">
+                <a class="page-link" href="?{% update_search_params page=page_obj.previous_page_number %}">Previous</a>
             </li>
+        {% else %}
+            <li class="page-item disabled"><span class="page-link">Previous</span></li>
+        {% endif %}
 
-            {% if page_obj.has_next %}
-                <li class="page-item">
-                    <a class="page-link" href="?{% update_search_params page=page_obj.next_page_number %}">Next</a>
-                </li>
-            {% else %}
-                <li class="page-item disabled"><span class="page-link">Next</span></li>
-            {% endif %}
-        </ul>
+        <li class="page-item disabled"><span
+                class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+        </li>
+
+        {% if page_obj.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="?{% update_search_params page=page_obj.next_page_number %}">Next</a>
+            </li>
+        {% else %}
+            <li class="page-item disabled"><span class="page-link">Next</span></li>
+        {% endif %}
+    </ul>
 </div>

--- a/app/grandchallenge/discussion_forums/templates/discussion_forums/forum_base.html
+++ b/app/grandchallenge/discussion_forums/templates/discussion_forums/forum_base.html
@@ -23,10 +23,18 @@
         {% endblock %}
         {% get_obj_perms request.user for forum as "user_perms" %}
         {% if 'view_forum' in user_perms %}
-            <div class="col-6">
+            <!-- Version for medium screens and up (≥768px) -->
+            <div class="d-none d-md-block col-6">
                 <div class="float-right controls-link-wrapper">
                     {% include 'actstream/partials/follow_unfollow_links.html' with object=forum %}
-                    <a href="{% url 'notifications:follow-list' %}" class="btn btn-dark btn-sm"><i class="fas fa-bookmark mr-1"></i>My Subscriptions</a>
+                    <a href="{% url 'notifications:follow-list' %}" class="btn btn-primary btn-sm"><i class="fas fa-bookmark mr-1"></i>My Subscriptions</a>
+                </div>
+            </div>
+            <!-- Version for small screens (phones) (<768px) -->
+            <div class="d-block d-md-none col-12">
+                <div class="float-right controls-link-wrapper">
+                    {% include 'actstream/partials/follow_unfollow_links.html' with object=forum %}
+                    <a href="{% url 'notifications:follow-list' %}" class="btn btn-primary btn-sm"><i class="fas fa-bookmark mr-1"></i>My Subscriptions</a>
                 </div>
             </div>
         {% endif %}

--- a/app/grandchallenge/discussion_forums/templates/discussion_forums/forumpost_list.html
+++ b/app/grandchallenge/discussion_forums/templates/discussion_forums/forumpost_list.html
@@ -20,10 +20,7 @@
 {% endblock %}
 
 {% block extra_top_row_buttons %}
-    <div class="col-6">
-        <a href="{% url 'discussion-forums:topic-list' %}" class="btn btn-dark btn-sm"><i class="fas fa-arrow-left mr-1"></i>Back to forum</a>
-        <a href="{% url 'discussion-forums:my-posts' %}" class="btn btn-dark btn-sm"><i class="fas fa-comments mr-1"></i>My posts</a>
-    </div>
+    {% include 'discussion_forums/partials/extra_top_row_buttons.html' %}
 {% endblock %}
 
 {% block extra_content %}
@@ -78,11 +75,18 @@
                     </form>
                 {% endif %}
             </div>
-            <div class="col-4 text-right">
+            <!-- Version for medium screens and up (≥768px) -->
+            <div class="d-none d-md-block col-4 text-right">
+                {% include 'actstream/partials/follow_unfollow_links.html' with object=topic %}
+            </div>
+            <!-- Version for small screens (phones) (<768px) -->
+            <div class="d-block d-md-none col-12 text-left">
                 {% include 'actstream/partials/follow_unfollow_links.html' with object=topic %}
             </div>
         </div>
     {% endif %}
+
+    <div class="d-flex justify-content-end mt-3"><div class="btn btn-sm m-0 p-0">{% include "grandchallenge/partials/pagination.html" %}</div></div>
 
     <div class="row">
         <div class="col-12" id="post-list">
@@ -102,7 +106,7 @@
                     {% crispy post_create_form %}
                 </div>
             </div>
-            {% include "grandchallenge/partials/pagination.html" %}
+            <div class="d-flex justify-content-end"><div class="btn btn-sm m-0 p-0">{% include "grandchallenge/partials/pagination.html" %}</div></div>
         {% else %}
             <div class="d-flex justify-content-between">
                 <div class="d-inline">
@@ -112,7 +116,7 @@
             </div>
         {% endif %}
     {% else %}
-        {% include "grandchallenge/partials/pagination.html" %}
+        <div class="d-flex justify-content-end"><div class="btn btn-sm m-0 p-0">{% include "grandchallenge/partials/pagination.html" %}</div></div>
     {% endif %}
 
 {% endblock %}

--- a/app/grandchallenge/discussion_forums/templates/discussion_forums/forumtopic_confirm_delete.html
+++ b/app/grandchallenge/discussion_forums/templates/discussion_forums/forumtopic_confirm_delete.html
@@ -10,12 +10,7 @@
 {% endblock %}
 
 {% block extra_top_row_buttons %}
-    <div class="col-6">
-        <a href="{% url 'discussion-forums:topic-list' %}" class="btn btn-dark btn-sm"><i
-                class="fas fa-arrow-left mr-1"></i>Back to forum</a>
-        <a href="{% url 'discussion-forums:my-posts' %}" class="btn btn-dark btn-sm"><i
-                class="fas fa-comments mr-1"></i>My posts</a>
-    </div>
+    {% include 'discussion_forums/partials/extra_top_row_buttons.html' %}
 {% endblock %}
 
 {% block extra_content %}

--- a/app/grandchallenge/discussion_forums/templates/discussion_forums/forumtopic_form.html
+++ b/app/grandchallenge/discussion_forums/templates/discussion_forums/forumtopic_form.html
@@ -11,12 +11,7 @@
 {% endblock %}
 
 {% block extra_top_row_buttons %}
-    <div class="col-6">
-        <a href="{% url 'discussion-forums:topic-list' %}" class="btn btn-dark btn-sm"><i
-                class="fas fa-arrow-left mr-1"></i>Back to forum</a>
-        <a href="{% url 'discussion-forums:my-posts' %}" class="btn btn-dark btn-sm"><i
-                class="fas fa-comments mr-1"></i>My posts</a>
-    </div>
+    {% include 'discussion_forums/partials/extra_top_row_buttons.html' %}
 {% endblock %}
 
 {% block extra_content %}

--- a/app/grandchallenge/discussion_forums/templates/discussion_forums/forumtopic_list.html
+++ b/app/grandchallenge/discussion_forums/templates/discussion_forums/forumtopic_list.html
@@ -6,17 +6,29 @@
 
 {% block extra_content %}
     {% get_obj_perms request.user for forum as "user_perms" %}
-    <div class="row">
+    <!-- Version for medium screens and up (≥768px) -->
+    <div class="row d-none d-md-block">
         <div class="col-12 d-flex justify-content-between">
             {% if 'create_forum_topic' in user_perms %}
                 <div><a href="{% url 'discussion-forums:topic-create' %}" class="btn btn-primary btn-sm mb-3 mt-2 py-1"><i class="fas fa-comments mr-1"></i>New topic</a></div>
             {% endif %}
-            <div class="btn btn-sm">{% include "grandchallenge/partials/pagination.html" %}</div>
+            <div class="btn btn-sm mx-0 p-0">{% include "grandchallenge/partials/pagination.html" %}</div>
          </div>
+    </div>
+    <!-- Version for small screens (phones) (<768px) -->
+    <div>
+        {% if 'create_forum_topic' in user_perms %}
+            <div class="d-flex d-block d-md-none">
+                <div><a href="{% url 'discussion-forums:topic-create' %}" class="btn btn-primary btn-sm"><i class="fas fa-comments mr-1"></i>New topic</a></div>
+            </div>
+        {% endif %}
+        <div class="d-flex d-block d-md-none justify-content-end">
+            <div class="btn btn-sm mx-0 mb-3 p-0">{% include "grandchallenge/partials/pagination.html" %}</div>
+        </div>
     </div>
     {% if announcements %}
         {% include 'discussion_forums/partials/topic_category_list.html' with topic_list_title="announcements" topics=announcements %}
     {% endif %}
     {% include 'discussion_forums/partials/topic_category_list.html' with topic_list_title="topics" topics=object_list show_page_counter_in_card_header=True %}
-    {% include "grandchallenge/partials/pagination.html" %}
+    <div class="d-flex justify-content-end"><div class="btn btn-sm m-0 p-0">{% include "grandchallenge/partials/pagination.html" %}</div></div>
 {% endblock %}

--- a/app/grandchallenge/discussion_forums/templates/discussion_forums/partials/extra_top_row_buttons.html
+++ b/app/grandchallenge/discussion_forums/templates/discussion_forums/partials/extra_top_row_buttons.html
@@ -1,0 +1,15 @@
+<!-- Version for medium screens and up (≥768px) -->
+<div class="d-none d-md-block col-6">
+    <a href="{% url 'discussion-forums:topic-list' %}" class="btn btn-primary btn-sm"><i
+            class="fas fa-arrow-left mr-1"></i>Back to forum</a>
+    <a href="{% url 'discussion-forums:my-posts' %}" class="btn btn-primary btn-sm"><i
+            class="fas fa-comments mr-1"></i>My posts</a>
+</div>
+
+<!-- Version for small screens (phones) (<768px) -->
+<div class="d-block d-md-none col-12">
+    <a href="{% url 'discussion-forums:topic-list' %}" class="btn btn-primary btn-sm"><i
+            class="fas fa-arrow-left mr-1"></i>Back to forum</a>
+    <a href="{% url 'discussion-forums:my-posts' %}" class="btn btn-primary btn-sm"><i
+            class="fas fa-comments mr-1"></i>My posts</a>
+</div>

--- a/app/grandchallenge/notifications/templates/actstream/partials/follow_unfollow_links.html
+++ b/app/grandchallenge/notifications/templates/actstream/partials/follow_unfollow_links.html
@@ -10,7 +10,7 @@
     {% if follow_object_pk %}
         <form class="d-inline" method="post" action="{% url 'notifications:follow-delete' pk=follow_object_pk %}">
             {% csrf_token %}
-            <button type="submit" class="btn btn-dark btn-sm"><i class="fas fa-bell-slash mr-1"></i>Unsubscribe
+            <button type="submit" class="btn btn-primary btn-sm"><i class="fas fa-bell-slash mr-1"></i>Unsubscribe
                 from {{ object|verbose_name }}
             </button>
         </form>
@@ -21,7 +21,7 @@
     <form class="d-inline" method="post" action="{% url 'notifications:follow-create' %}">
         {% csrf_token %}
         {{ follow_form|crispy }}
-        <button type="submit" class="btn btn-dark btn-sm"><i class="fas fa-bell mr-1"></i>Subscribe
+        <button type="submit" class="btn btn-primary btn-sm"><i class="fas fa-bell mr-1"></i>Subscribe
             to {{ object|verbose_name }}
         </button>
     </form>


### PR DESCRIPTION
- Makes all clickable buttons primary buttons (rather than dark grey) to conform with the rest of GC. 
- Adds navigation to both the top and the bottom of the list views. 
- Makes the pages work on both small and big screens.

Some screenshots:

![image](https://github.com/user-attachments/assets/41d6ae4b-b381-452e-98ea-df9bd67196bc)

![image](https://github.com/user-attachments/assets/b8222619-085a-4592-b2be-631800c3cdae)

![image](https://github.com/user-attachments/assets/aa49d73e-6eb2-4e29-b4cd-19ead7097568)

![image](https://github.com/user-attachments/assets/5a58856c-2314-4fe9-b3f7-a8b025755947)
