### PR TITLE
Add missing serializers for autosaving

### DIFF
--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -379,6 +379,7 @@ class ReaderStudy(
         "instant_verification",
         "roll_over_answers_for_n_cases",
         "allow_answer_modification",
+        "enable_autosaving",
         "allow_case_navigation",
         "allow_show_all_annotations",
         "access_request_handling",

--- a/app/grandchallenge/reader_studies/serializers.py
+++ b/app/grandchallenge/reader_studies/serializers.py
@@ -189,6 +189,7 @@ class ReaderStudySerializer(HyperlinkedModelSerializer):
             "instant_verification",
             "has_ground_truth",
             "allow_answer_modification",
+            "enable_autosaving",
             "allow_case_navigation",
             "allow_show_all_annotations",
             "roll_over_answers_for_n_cases",


### PR DESCRIPTION
I forgot two indirect references to "autosaving". One is the serializer for the api, which is kind of important for having this work with reader studies.