### PR TITLE
Add redirects for old forums

### DIFF
--- a/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
@@ -1,5 +1,6 @@
 {% load url %}
 {% load static %}
+{% load guardian_tags %}
 
 {% if challenge %}
     <div class="row mb-3 mx-0 border-bottom challenge-topbar">
@@ -18,7 +19,8 @@
                         </a>
                     </li>
 
-                    {% if challenge.display_forum_link %}
+                    {% get_obj_perms request.user for challenge.discussion_forum as "forum_perms" %}
+                    {% if challenge.display_forum_link and 'view_forum' in forum_perms %}
                         <li class="nav-item">
                             <a class="nav-link {% if request.resolver_match.view_name == 'discussion-forums:topic-list' or request.resolver_match.view_name == 'discussion-forums:topic-create' or request.resolver_match.view_name == 'discussion-forums:topic-post-list' or request.resolver_match.view_name == 'discussion-forums:topic-delete' %} show active {% endif %}"
                                href="{% url 'discussion-forums:topic-list' challenge_short_name=challenge.short_name %}">

--- a/app/grandchallenge/discussion_forums/admin.py
+++ b/app/grandchallenge/discussion_forums/admin.py
@@ -29,7 +29,14 @@ class ForumAdmin(admin.ModelAdmin):
 
 @admin.register(ForumTopic)
 class TopicAdmin(admin.ModelAdmin):
-    list_display = ("subject", "linked_forum", "kind", "creator", "created")
+    list_display = (
+        "subject",
+        "linked_forum",
+        "kind",
+        "creator",
+        "created",
+        "modified",
+    )
     search_fields = ("subject", "creator__username")
     list_filter = ("kind",)
     readonly_fields = (
@@ -48,7 +55,7 @@ class TopicAdmin(admin.ModelAdmin):
 
 @admin.register(ForumPost)
 class PostAdmin(admin.ModelAdmin):
-    list_display = ("topic", "creator", "created")
+    list_display = ("topic", "creator", "created", "modified")
     search_fields = ("creator__username",)
     readonly_fields = (
         "created",

--- a/app/grandchallenge/discussion_forums/migrations/0004_add_redirects.py
+++ b/app/grandchallenge/discussion_forums/migrations/0004_add_redirects.py
@@ -1,0 +1,82 @@
+from django.db import migrations
+
+from grandchallenge.subdomains.utils import reverse
+
+
+def add_redirects_for_old_forums_and_topics(apps, schema_editor):
+    Forum = apps.get_model("discussion_forums", "Forum")  # noqa: N806
+    ForumTopic = apps.get_model(  # noqa: N806
+        "discussion_forums", "ForumTopic"
+    )
+    Redirect = apps.get_model("redirects", "Redirect")  # noqa: N806
+    Site = apps.get_model("sites", "Site")  # noqa: N806
+
+    site = Site.objects.get_current()
+
+    batch_size = 500
+    redirects_to_add = []
+    n_created = 0
+
+    for forum in Forum.objects.filter(source_object__isnull=False):
+        redirects_to_add.append(
+            Redirect(
+                site=site,
+                old_path=f"/forums/forum/{forum.source_object.slug}-{forum.source_object.pk}/",
+                new_path=reverse(
+                    "discussion-forums:topic-list",
+                    kwargs={
+                        "challenge_short_name": forum.linked_challenge.short_name
+                    },
+                ),
+            )
+        )
+        if len(redirects_to_add) >= batch_size:
+            Redirect.objects.bulk_create(redirects_to_add)
+            n_created += len(redirects_to_add)
+            print(f"Created {n_created} new forum redirects")
+            redirects_to_add = []
+
+    if redirects_to_add:
+        Redirect.objects.bulk_create(redirects_to_add)
+        n_created += len(redirects_to_add)
+        print(f"Created {n_created} new forum redirects.")
+        redirects_to_add = []
+
+    for topic in ForumTopic.objects.filter(source_object__isnull=False):
+        redirects_to_add.append(
+            Redirect(
+                site=site,
+                old_path=f"/forums/forum/{topic.source_object.forum.slug}-{topic.source_object.forum.pk}/topic/{topic.source_object.slug}-{topic.source_object.pk}/",
+                new_path=reverse(
+                    "discussion-forums:topic-post-list",
+                    kwargs={
+                        "challenge_short_name": topic.forum.linked_challenge.short_name,
+                        "slug": topic.slug,
+                    },
+                ),
+            )
+        )
+        if len(redirects_to_add) >= batch_size:
+            Redirect.objects.bulk_create(redirects_to_add)
+            n_created += len(redirects_to_add)
+            print(f"Created {n_created} new topic redirects")
+            redirects_to_add = []
+
+    if redirects_to_add:
+        Redirect.objects.bulk_create(redirects_to_add)
+        n_created += len(redirects_to_add)
+        print(f"Created {n_created} new topic redirects.")
+
+    print("Finished adding redirects.")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("discussion_forums", "0003_add_auto_now"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            add_redirects_for_old_forums_and_topics, elidable=True
+        ),
+    ]


### PR DESCRIPTION
This adds redirects for the old forum pages to the new ones. The machina urls no longer exist, so I had to construct the original paths manually. 