### PR TITLE
Correctly send notification at job failure

### DIFF
--- a/app/grandchallenge/algorithms/tasks.py
+++ b/app/grandchallenge/algorithms/tasks.py
@@ -51,7 +51,7 @@ def execute_algorithm_job_for_inputs(*, job_pk):
         raise TooManyJobsScheduled
 
     logger.info("Job is ready, creating execution task")
-    
+
     # Notify the job creator on failure
     job.task_on_failure = send_failed_job_notification.signature(
         kwargs={"job_pk": str(job.pk)}, immutable=True


### PR DESCRIPTION
Source: https://github.com/comic/grand-challenge.org/commit/d8af5b8cca7c133c8a652d92b49e437c9ed0fbb0

I think this is a re-name gone wrong. Way old. `task_on_success` should be `task_on_failure`

A sentry issue had this pop-up and I could not figure out why it would fire when the job had success. Now I know!