### PR TITLE
Ignore conflicts during redirect creation

### DIFF
--- a/app/grandchallenge/discussion_forums/management/commands/add_redirects.py
+++ b/app/grandchallenge/discussion_forums/management/commands/add_redirects.py
@@ -2,7 +2,7 @@ from django.contrib.redirects.models import Redirect
 from django.contrib.sites.models import Site
 from django.core.management import BaseCommand
 
-from grandchallenge.discussion_forums.models import Forum, ForumTopic
+from grandchallenge.discussion_forums.models import ForumTopic
 
 
 class Command(BaseCommand):
@@ -15,26 +15,6 @@ class Command(BaseCommand):
         redirects_to_add = []
         n_created = 0
 
-        for forum in Forum.objects.filter(source_object__isnull=False):
-            redirects_to_add.append(
-                Redirect(
-                    site=site,
-                    old_path=f"/forums/forum/{forum.source_object.slug}-{forum.source_object.pk}/",
-                    new_path=forum.get_absolute_url(),
-                )
-            )
-            if len(redirects_to_add) >= batch_size:
-                Redirect.objects.bulk_create(redirects_to_add)
-                n_created += len(redirects_to_add)
-                print(f"Created {n_created} new forum redirects")
-                redirects_to_add = []
-
-        if redirects_to_add:
-            Redirect.objects.bulk_create(redirects_to_add)
-            n_created += len(redirects_to_add)
-            print(f"Created {n_created} new forum redirects.")
-            redirects_to_add = []
-
         for topic in ForumTopic.objects.filter(source_object__isnull=False):
             redirects_to_add.append(
                 Redirect(
@@ -44,13 +24,17 @@ class Command(BaseCommand):
                 )
             )
             if len(redirects_to_add) >= batch_size:
-                Redirect.objects.bulk_create(redirects_to_add)
+                Redirect.objects.bulk_create(
+                    redirects_to_add, ignore_conflicts=True
+                )
                 n_created += len(redirects_to_add)
                 print(f"Created {n_created} new topic redirects")
                 redirects_to_add = []
 
         if redirects_to_add:
-            Redirect.objects.bulk_create(redirects_to_add)
+            Redirect.objects.bulk_create(
+                redirects_to_add, ignore_conflicts=True
+            )
             n_created += len(redirects_to_add)
             print(f"Created {n_created} new topic redirects.")
 


### PR DESCRIPTION
Some redirect paths for the old forums get too long (longer than the max char count of 200) - those should be skipped. Rather than adding a check whether a path would be too long (or whether a redirect already exists, another error source when rerunning the command), I've opted to just run the `bulk_create` with `ignore_conflicts=True`. I think for this one off migration this is fine. 