### PR TITLE
Upgrade mc

### DIFF
--- a/dockerfiles/web-base/Dockerfile
+++ b/dockerfiles/web-base/Dockerfile
@@ -117,7 +117,7 @@ FROM base AS test-base
 USER root
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    # Add java and graphviz for plantuml documentation
+        # Add java and graphviz for plantuml documentation
         default-jre \
         graphviz \
         # make for sphinx docs

--- a/dockerfiles/web-base/Dockerfile
+++ b/dockerfiles/web-base/Dockerfile
@@ -8,34 +8,34 @@ FROM python:${PYTHON_VERSION}-slim-bookworm AS base
 # Install system dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        libpng-dev \
-        libjpeg-dev \
-        libjpeg62-turbo-dev \
-        libfreetype6-dev \
-        libxft-dev \
-        libffi-dev \
-        wget \
-        gettext \
-        # postgres packages for psycopg2
-        libpq-dev \
-        # curl and ssl for pycurl
-        libcurl4-openssl-dev \
-        libssl-dev \
-        # for python-magic
-        libmagic1 \
-        # openslide and vips for image imports with panimg
-        # gcc is required to compile the extensions
-        libopenslide-dev \
-        libvips-dev \
-        gcc \
-        # ruby3.1, rugged and nokogiri for licensee
-        ruby3.1 \
-        ruby-rugged \
-        ruby-nokogiri \
-        # git for CodeBuild integration
-        git \
-        # for dbshell \
-        postgresql-client \
+    libpng-dev \
+    libjpeg-dev \
+    libjpeg62-turbo-dev \
+    libfreetype6-dev \
+    libxft-dev \
+    libffi-dev \
+    wget \
+    gettext \
+    # postgres packages for psycopg2
+    libpq-dev \
+    # curl and ssl for pycurl
+    libcurl4-openssl-dev \
+    libssl-dev \
+    # for python-magic
+    libmagic1 \
+    # openslide and vips for image imports with panimg
+    # gcc is required to compile the extensions
+    libopenslide-dev \
+    libvips-dev \
+    gcc \
+    # ruby3.1, rugged and nokogiri for licensee
+    ruby3.1 \
+    ruby-rugged \
+    ruby-nokogiri \
+    # git for CodeBuild integration
+    git \
+    # for dbshell \
+    postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Fetch and install licensee for checking licenses
@@ -61,8 +61,8 @@ RUN mkdir -p /opt/git-lfs \
 
 # Get the minio client for development
 RUN mkdir -p /opt/mc \
-    && wget https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2024-01-28T16-23-14Z -O /opt/mc/mc \
-    && echo "fc195c3ad5c19b91d96bbb42d79af94173aa491ebcda9ca372c4f382546135ec  /opt/mc/mc" | shasum -c - || exit 1 \
+    && wget https://dl.min.io/client/mc/release/darwin-arm64/archive/mc.RELEASE.2025-07-16T15-35-03Z -O /opt/mc/mc \
+    && echo "61caf3c492ad86601739ff2e8278bede1bf5bfaee5b84bfc880f6549fc645952  /opt/mc/mc" | shasum -c - || exit 1 \
     && chmod a+x /opt/mc/mc \
     && mv /opt/mc/mc /usr/local/bin/ \
     && rm -r /opt/mc
@@ -117,19 +117,19 @@ FROM base AS test-base
 USER root
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        # Add java and graphviz for plantuml documentation
-        default-jre \
-        graphviz \
-        # make for sphinx docs
-        make \
-        # playwright dependencies
-        libatk1.0-0 \
-        libatk-bridge2.0-0 \
-        libatspi2.0-0 \
-        libxcomposite1 \
-        libxrandr2 \
-        libgbm1 \
-        libxkbcommon0 \
+    # Add java and graphviz for plantuml documentation
+    default-jre \
+    graphviz \
+    # make for sphinx docs
+    make \
+    # playwright dependencies
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libatspi2.0-0 \
+    libxcomposite1 \
+    libxrandr2 \
+    libgbm1 \
+    libxkbcommon0 \
     && rm -rf /var/lib/apt/lists/*
 USER django:django
 

--- a/dockerfiles/web-base/Dockerfile
+++ b/dockerfiles/web-base/Dockerfile
@@ -61,8 +61,8 @@ RUN mkdir -p /opt/git-lfs \
 
 # Get the minio client for development
 RUN mkdir -p /opt/mc \
-    && wget https://dl.min.io/client/mc/release/darwin-arm64/archive/mc.RELEASE.2025-07-16T15-35-03Z -O /opt/mc/mc \
-    && echo "61caf3c492ad86601739ff2e8278bede1bf5bfaee5b84bfc880f6549fc645952  /opt/mc/mc" | shasum -c - || exit 1 \
+    && wget https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2025-07-16T15-35-03Z -O /opt/mc/mc \
+    && echo "a5c3695b6f76ed958c0f099795f32091fced0d748ddc749c8b24e07681bbfbb9  /opt/mc/mc" | shasum -c - || exit 1 \
     && chmod a+x /opt/mc/mc \
     && mv /opt/mc/mc /usr/local/bin/ \
     && rm -r /opt/mc

--- a/dockerfiles/web-base/Dockerfile
+++ b/dockerfiles/web-base/Dockerfile
@@ -8,34 +8,34 @@ FROM python:${PYTHON_VERSION}-slim-bookworm AS base
 # Install system dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    libpng-dev \
-    libjpeg-dev \
-    libjpeg62-turbo-dev \
-    libfreetype6-dev \
-    libxft-dev \
-    libffi-dev \
-    wget \
-    gettext \
-    # postgres packages for psycopg2
-    libpq-dev \
-    # curl and ssl for pycurl
-    libcurl4-openssl-dev \
-    libssl-dev \
-    # for python-magic
-    libmagic1 \
-    # openslide and vips for image imports with panimg
-    # gcc is required to compile the extensions
-    libopenslide-dev \
-    libvips-dev \
-    gcc \
-    # ruby3.1, rugged and nokogiri for licensee
-    ruby3.1 \
-    ruby-rugged \
-    ruby-nokogiri \
-    # git for CodeBuild integration
-    git \
-    # for dbshell \
-    postgresql-client \
+        libpng-dev \
+        libjpeg-dev \
+        libjpeg62-turbo-dev \
+        libfreetype6-dev \
+        libxft-dev \
+        libffi-dev \
+        wget \
+        gettext \
+        # postgres packages for psycopg2
+        libpq-dev \
+        # curl and ssl for pycurl
+        libcurl4-openssl-dev \
+        libssl-dev \
+        # for python-magic
+        libmagic1 \
+        # openslide and vips for image imports with panimg
+        # gcc is required to compile the extensions
+        libopenslide-dev \
+        libvips-dev \
+        gcc \
+        # ruby3.1, rugged and nokogiri for licensee
+        ruby3.1 \
+        ruby-rugged \
+        ruby-nokogiri \
+        # git for CodeBuild integration
+        git \
+        # for dbshell \
+        postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Fetch and install licensee for checking licenses
@@ -118,18 +118,18 @@ USER root
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     # Add java and graphviz for plantuml documentation
-    default-jre \
-    graphviz \
-    # make for sphinx docs
-    make \
-    # playwright dependencies
-    libatk1.0-0 \
-    libatk-bridge2.0-0 \
-    libatspi2.0-0 \
-    libxcomposite1 \
-    libxrandr2 \
-    libgbm1 \
-    libxkbcommon0 \
+        default-jre \
+        graphviz \
+        # make for sphinx docs
+        make \
+        # playwright dependencies
+        libatk1.0-0 \
+        libatk-bridge2.0-0 \
+        libatspi2.0-0 \
+        libxcomposite1 \
+        libxrandr2 \
+        libgbm1 \
+        libxkbcommon0 \
     && rm -rf /var/lib/apt/lists/*
 USER django:django
 

--- a/scripts/minio.py
+++ b/scripts/minio.py
@@ -48,9 +48,8 @@ def _setup_public_storage():
     subprocess.check_call(
         [
             "mc",
-            "config",
-            "host",
-            "add",
+            "alias",
+            "set",
             host_alias,
             settings.AWS_S3_ENDPOINT_URL,
             os.environ["AWS_ACCESS_KEY_ID"],
@@ -108,9 +107,8 @@ def _setup_components_storage():
     subprocess.check_call(
         [
             "mc",
-            "config",
-            "host",
-            "add",
+            "alias",
+            "set",
             host_alias,
             settings.AWS_S3_ENDPOINT_URL,
             os.environ["AWS_ACCESS_KEY_ID"],

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,7 @@ version = 1
 revision = 2
 requires-python = ">=3.11, <3.13"
 
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
`mc` is always throwing warnings in my face while pulling up my local dev instance.

The latest update no longer supports the `mc config` but suggests `mc alias`.

This PR updates the `minio.py` script and updates the `mc` used for local testing.