### PR TITLE
Block forms on submit

### DIFF
--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_form.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_form.html
@@ -56,7 +56,6 @@
                 need to create 1 algorithm for this phase. Once created, you can upload new container images for it as
                 you improve your code and even switch back to older container images as you see fit.
             </p>
-            <div id="test-form-added-marker" class="d-none"></div>
             {% crispy form %}
         {% endif %}
     {% else %}

--- a/app/grandchallenge/algorithms/templates/algorithms/algorithm_form.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/algorithm_form.html
@@ -56,6 +56,7 @@
                 need to create 1 algorithm for this phase. Once created, you can upload new container images for it as
                 you improve your code and even switch back to older container images as you see fit.
             </p>
+            <div id="test-form-added-marker" class="d-none"></div>
             {% crispy form %}
         {% endif %}
     {% else %}

--- a/app/grandchallenge/core/forms.py
+++ b/app/grandchallenge/core/forms.py
@@ -27,13 +27,13 @@ class SaveFormInitMixin:
             Fieldset(
                 None,  # Legend
                 self.helper.layout,
-                StrictButton(
-                    "Save",
-                    css_class="btn-primary",
-                    type="submit",
-                    css_id="submit-id-save",
-                ),
-            )
+            ),
+            StrictButton(
+                "Save",
+                css_class="btn-primary",
+                type="submit",
+                css_id="submit-id-save",
+            ),
         )
 
     class Media:

--- a/app/grandchallenge/core/forms.py
+++ b/app/grandchallenge/core/forms.py
@@ -16,7 +16,7 @@ class SaveFormInitMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper(self)
-        self.helper.attrs["gc-disable-fieldsets-after-submit"] = True
+        self.helper.attrs["gc-disable-after-submit"] = True
         self.helper.layout = Layout(
             Fieldset(
                 None,  # Legend

--- a/app/grandchallenge/core/forms.py
+++ b/app/grandchallenge/core/forms.py
@@ -1,8 +1,11 @@
+from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Submit
+from crispy_forms.layout import Fieldset, Layout
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms import CharField, ModelForm
+from django.templatetags.static import static
+from django.utils.html import format_html
 
 from grandchallenge.core.guardian import filter_by_permission
 from grandchallenge.workstation_configs.models import WorkstationConfig
@@ -13,7 +16,27 @@ class SaveFormInitMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper(self)
-        self.helper.layout.append(Submit("save", "Save"))
+        self.helper.attrs["gc-disable-fieldsets-after-submit"] = True
+        self.helper.layout = Layout(
+            Fieldset(
+                None,  # Legend
+                self.helper.layout,
+                StrictButton(
+                    "Save",
+                    css_class="btn-primary",
+                    type="submit",
+                    css_id="submit-id-save",
+                ),
+            )
+        )
+
+    class Media:
+        js = [
+            format_html(
+                '<script type="module" src="{}"></script>',
+                static("js/disable_after_submit.mjs"),
+            )
+        ]
 
 
 class WorkstationUserFilterMixin:

--- a/app/grandchallenge/core/forms.py
+++ b/app/grandchallenge/core/forms.py
@@ -4,8 +4,6 @@ from crispy_forms.layout import Fieldset, Layout
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms import CharField, ModelForm
-from django.templatetags.static import static
-from django.utils.html import format_html
 
 from grandchallenge.core.guardian import filter_by_permission
 from grandchallenge.workstation_configs.models import WorkstationConfig
@@ -37,12 +35,7 @@ class SaveFormInitMixin:
         )
 
     class Media:
-        js = [
-            format_html(
-                '<script type="module" src="{}"></script>',
-                static("js/disable_after_submit.mjs"),
-            )
-        ]
+        js = ["js/disable_after_submit.mjs"]
 
 
 class WorkstationUserFilterMixin:

--- a/app/grandchallenge/core/forms.py
+++ b/app/grandchallenge/core/forms.py
@@ -13,6 +13,12 @@ from grandchallenge.workstations.models import Workstation
 
 
 class SaveFormInitMixin:
+    """
+    Mixin that adds some save features to a form via init:
+      - a 'Save' button
+      - disabling fieldsets after the form is submitted
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper(self)

--- a/app/grandchallenge/core/static/js/disable_after_submit.mjs
+++ b/app/grandchallenge/core/static/js/disable_after_submit.mjs
@@ -1,0 +1,117 @@
+/**
+ * @description
+ * This module provides functionality to temporarily disable all fieldsets (and indirectly their children)
+ * and show a spinner on submit buttons within forms, when the forms have the
+ * `gc-disable-fieldsets-after-submit` attribute. This prevents duplicate submissions.
+ *
+ * Fieldsets are re-enabled and spinners removed after a short timeout.
+ */
+
+// Timeout in milliseconds before re-enabling fieldsets and removing spinners.
+const reEnableTimeout = 10000;
+
+// Attribute names
+const baseAttributeName = "gc-disable-after-submit";
+const initAttributeName = `${baseAttributeName}-initialized`;
+const activeAttributeName = `${baseAttributeName}-disabled`;
+const spinnerAttributeName = `${baseAttributeName}-spinner`;
+
+function disableFieldSets(form) {
+    if (!form) {
+        // Form no longer exists.
+        return;
+    }
+
+    // Sanity: ensure we don't disable something twice.
+    if (form.hasAttribute(activeAttributeName)) {
+        return;
+    }
+
+    form.setAttribute(activeAttributeName, "true");
+
+    // Disable fieldsets.
+    const fieldsets = form.querySelectorAll("fieldset");
+    for (const fs of fieldsets) {
+        fs.disabled = true;
+    }
+
+    // Add a spinner
+    const submitButtons = form.querySelectorAll('button[type="submit"]');
+    for (const btn of submitButtons) {
+        const spinner = document.createElement("span");
+        spinner.className = "spinner-border spinner-border-sm mr-1";
+        spinner.setAttribute("role", "status");
+        spinner.setAttribute("aria-hidden", "true");
+        spinner.setAttribute(spinnerAttributeName, "true");
+        btn.prepend(spinner);
+    }
+
+    // Re-enable after a while to safeguard against unforeseen errors / cancelations.
+    setTimeout(enableFieldSets, reEnableTimeout, form);
+}
+
+function enableFieldSets(form) {
+    if (!form) {
+        // Form no longer exists.
+        return;
+    }
+
+    // Sanity: ensure we don't enable something twice.
+    if (!form.hasAttribute(activeAttributeName)) {
+        return;
+    }
+
+    form.removeAttribute(activeAttributeName);
+
+    // Re-enable fieldsets.
+    const fieldsets = form.querySelectorAll("fieldset");
+    for (const fs of fieldsets) {
+        fs.disabled = false;
+    }
+
+    // Remove the spinners.
+    const spinners = form.querySelectorAll(`span[${spinnerAttributeName}]`);
+    for (const spinner of spinners) {
+        spinner.remove();
+    }
+}
+
+function handleFormSubmit(event) {
+    const form = event.currentTarget;
+
+    if (form.hasAttribute(activeAttributeName)) {
+        event.preventDefault();
+        return;
+    }
+
+    // Delay the disable so form data is actually submitted.
+    // Disabled-element values are thus not excluded.
+    setTimeout(disableFieldSets, 0, form);
+}
+
+function initDisableAfterSubmit(elem) {
+    const forms = elem.querySelectorAll(
+        "form[gc-disable-fieldsets-after-submit]",
+    );
+
+    for (const form of forms) {
+        if (!form.hasAttribute(initAttributeName)) {
+            form.addEventListener("submit", handleFormSubmit);
+            form.setAttribute(initAttributeName, "true");
+        }
+    }
+}
+
+// Initialize when DOM is ready.
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () =>
+        initDisableAfterSubmit(document),
+    );
+} else {
+    initDisableAfterSubmit(document);
+}
+
+// Handle inserted forms via HTMX.
+if (typeof htmx !== "undefined" && htmx.onLoad) {
+    htmx.onLoad(elem => initDisableAfterSubmit(elem));
+}

--- a/app/grandchallenge/core/static/js/disable_after_submit.mjs
+++ b/app/grandchallenge/core/static/js/disable_after_submit.mjs
@@ -67,9 +67,11 @@ function disable(form) {
         fs.disabled = true;
     }
 
-    // Add a spinner
+    // Disable buttons and add a spinner
     const submitButtons = form.querySelectorAll('button[type="submit"]');
     for (const btn of submitButtons) {
+        btn.disabled = true;
+
         const spinner = document.createElement("span");
         spinner.setAttribute(spinnerAttributeName, "");
         spinner.setAttribute("role", "status");
@@ -103,10 +105,15 @@ function enable(form) {
         fs.disabled = false;
     }
 
-    // Remove the spinners.
-    const spinners = form.querySelectorAll(`span[${spinnerAttributeName}]`);
-    for (const spinner of spinners) {
-        spinner.remove();
+    // Re-enable buttons and remove the spinners.
+    const submitButtons = form.querySelectorAll('button[type="submit"]');
+    for (const btn of submitButtons) {
+        btn.disabled = false;
+
+        const spinners = btn.querySelectorAll(`span[${spinnerAttributeName}]`);
+        for (const spinner of spinners) {
+            spinner.remove();
+        }
     }
 }
 
@@ -124,7 +131,7 @@ function cleanUp() {
     for (const form of forms) {
         enable(form);
 
-        // Revernt initialization
+        // Revert initialization
         form.removeEventListener("submit", handleFormSubmit);
         form.removeAttribute(initAttributeName);
     }

--- a/app/tests/core_tests/js/disable_after_submit.test.js
+++ b/app/tests/core_tests/js/disable_after_submit.test.js
@@ -1,0 +1,124 @@
+jest.useFakeTimers();
+
+const formHtml = `
+<form gc-disable-after-submit>
+  <fieldset>
+    <button id="fieldset-button" type="submit">Save</button>
+  </fieldset>
+  <button id="form-button" type="submit">Save</button>
+</form>`;
+
+describe("disableAfterSubmit module", () => {
+    require("../../../grandchallenge/core/static/js/disable_after_submit");
+
+    let form;
+    let fieldset;
+    let fieldset_button;
+    let form_button;
+
+    beforeEach(() => {
+        document.body.innerHTML = formHtml;
+        document.dispatchEvent(new Event("DOMContentLoaded"));
+
+        form = document.querySelector("form");
+        fieldset = form.querySelector("fieldset");
+        fieldset_button = form.querySelector("#fieldset-button");
+        form_button = form.querySelector("#form-button");
+    });
+
+    function submit() {
+        form.dispatchEvent(new Event("submit"));
+        jest.advanceTimersByTime(0); // Only hits the 0
+    }
+
+    test("form disables on submit", () => {
+        expect(fieldset.disabled).toBe(false); // Sanity
+
+        submit();
+
+        // fieldset is disabled
+        expect(fieldset.disabled).toBe(true);
+
+        // note: we dont't test fieldset other internals as
+        // these are not disabled in jsdom; they are
+        // in browser engines
+        expect(form_button.disabled).toBe(true);
+
+        // there are spinners
+        const fieldset_button_spinner = fieldset_button.querySelector(
+            "span.spinner-border",
+        );
+        expect(fieldset_button_spinner).not.toBeNull();
+        const form_button_spinner = form_button.querySelector(
+            "span.spinner-border",
+        );
+        expect(form_button_spinner).not.toBeNull();
+    });
+
+    test("form re-enables after timeout", () => {
+        submit();
+
+        expect(fieldset.disabled).toBe(true); // Sanity
+        jest.runAllTimers();
+
+        // fieldset enabled
+        expect(fieldset.disabled).toBe(false);
+
+        // buttons enabled
+        expect(fieldset_button.disabled).toBe(false);
+        expect(form_button.disabled).toBe(false);
+
+        // Spinners removed
+        const fieldset_button_spinner = fieldset_button.querySelector(
+            "span.spinner-border",
+        );
+        expect(fieldset_button_spinner).toBeNull();
+
+        const form_button_spinner = form_button.querySelector(
+            "span.spinner-border",
+        );
+        expect(form_button_spinner).toBeNull();
+    });
+
+    test("pageshow persisted resets form state", () => {
+        submit();
+
+        expect(fieldset.disabled).toBe(true); // sanity
+
+        window.dispatchEvent(
+            new PageTransitionEvent("pageshow", { persisted: true }),
+        );
+
+        // fieldset enabled
+        expect(fieldset.disabled).toBe(false);
+
+        // buttons enabled
+        expect(fieldset_button.disabled).toBe(false);
+        expect(form_button.disabled).toBe(false);
+
+        // Spinners removed
+        const fieldset_button_spinner = fieldset_button.querySelector(
+            "span.spinner-border",
+        );
+        expect(fieldset_button_spinner).toBeNull();
+        const form_button_spinner = form_button.querySelector(
+            "span.spinner-border",
+        );
+        expect(form_button_spinner).toBeNull();
+    });
+
+    test("subsequent form submits are prevented", () => {
+        const mockEvent = new Event("submit");
+        mockEvent.preventDefault = jest.fn();
+
+        form.dispatchEvent(mockEvent);
+        jest.advanceTimersByTime(0); // Only hits the 0
+
+        // First time: not prevented
+        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+
+        // Second time: prevented
+        form.dispatchEvent(mockEvent);
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+    });
+});

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -1201,7 +1201,7 @@ def test_create_algorithm_for_phase_limits(client):
     )
     # u3 has not created any algorithms for the phase yet,
     # so will immediately see the form
-    assert '<div id="test-form-added-marker" class="d-none"></div>' in str(
+    assert "Use the below form to create a new algorithm." in str(
         response.content
     )
 
@@ -1232,7 +1232,7 @@ def test_create_algorithm_for_phase_limits(client):
         user=u2,
         data={"show_form": "True"},
     )
-    assert '<div id="test-form-added-marker" class="d-none"></div>' in str(
+    assert "Use the below form to create a new algorithm." in str(
         response.content
     )
 

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -1201,7 +1201,9 @@ def test_create_algorithm_for_phase_limits(client):
     )
     # u3 has not created any algorithms for the phase yet,
     # so will immediately see the form
-    assert '<form  method="post" >' in str(response.content)
+    assert '<div id="test-form-added-marker" class="d-none"></div>' in str(
+        response.content
+    )
 
     # u2 has created 2 algos, so will see a confirmation button and links to
     # existing algorithms with the same inputs and outputs
@@ -1230,7 +1232,9 @@ def test_create_algorithm_for_phase_limits(client):
         user=u2,
         data={"show_form": "True"},
     )
-    assert '<form  method="post" >' in str(response.content)
+    assert '<div id="test-form-added-marker" class="d-none"></div>' in str(
+        response.content
+    )
 
     # u1 has reached the limit of algorithms,
     # will see links to existing algorithms


### PR DESCRIPTION
This PR adds some vanilla JS that effectively disables several forms after submitting. Both the input elements and the actual subsequent submitting is disabled. This is a client-side fix that should be followed-up by a server-side fix to prevent duplicate slugs.

The element `<form>` does not have a way to disable all elements within. Going through a list of possible input elements however, doesn't really sound fool proof either. Luckily, an container within forms: `<fieldset>` does disable and disables all elements withing when it disables. So I've opted to use that.

Since the vector is a much used mixin, I'v tried to hammer down as many corner cases I could come up with and covered it with JS tests.


## Showcase
Here the response is slow, on purpose:

https://github.com/user-attachments/assets/694f6594-c77e-481a-876f-e8f00d6f49e1



Related (private issues):
- https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/107
- https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/558

