### PR TITLE
Avoid "empty" editors list

### DIFF
--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -260,7 +260,8 @@ class AlgorithmDetail(ObjectPermissionRequiredMixin, DetailView):
             ).count()
         )
 
-        editors = reversed(self.object.editors_group.user_set.all())
+        editors = list(self.object.editors_group.user_set.all())
+        editors.reverse()  # Reverse order to show original creator first.
 
         context.update(
             {


### PR DESCRIPTION
Closes #4190 

Reversed object of queryset has no length, which caused the editors to not be listed in the editors tab.