### PR TITLE
Improve whitespace placement for pages

### DIFF
--- a/app/grandchallenge/core/templates/base.html
+++ b/app/grandchallenge/core/templates/base.html
@@ -88,13 +88,14 @@
                 {% block topbar %}
                     {% include 'challenges/challenge_topbar.html' %}
                 {% endblock %}
-                <div class="row">
+                <div class="row justify-content-between">
                     {% block sidebar %}{% endblock %}
-                    <div class="col overflow-auto">
+                    <div class="{% block content_col %}col{% endblock %} overflow-auto">
                         {% block content %}
                             {# Block used by us and django-allauth #}
                         {% endblock %}
                     </div>
+                    {% block sidebar_right %}{% endblock %}
                 </div>
             {% endblock %}
         </div>

--- a/app/grandchallenge/core/templates/base.html
+++ b/app/grandchallenge/core/templates/base.html
@@ -88,14 +88,13 @@
                 {% block topbar %}
                     {% include 'challenges/challenge_topbar.html' %}
                 {% endblock %}
-                <div class="row justify-content-between">
+                <div class="row">
                     {% block sidebar %}{% endblock %}
                     <div class="{% block content_col %}col{% endblock %} overflow-auto">
                         {% block content %}
                             {# Block used by us and django-allauth #}
                         {% endblock %}
                     </div>
-                    {% block sidebar_right %}{% endblock %}
                 </div>
             {% endblock %}
         </div>

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -22,7 +22,8 @@
 {% endblock %}
 
 {% block sidebar %}
-    <div class="col-lg-3 col-md-4 col-sm-6">
+    <div class="col-md-3 col-sm-6 pr-lg-3 pr-md-0">
+{#    <div class="col-lg-3 col-md-4 col-sm-6">#}
         <ul class="nav nav-pills flex-column mb-3">
             {% for page in pages %}
                 {% if not page.hidden %}
@@ -53,7 +54,7 @@
     </div>
 {% endblock %}
 
-{% block content_col %}col-xl-7 col-md-8 px-lg-5{% endblock %}
+{% block content_col %}col-xl-7 col-lg-8 col-md-9 px-lg-5{% endblock %}
 {% block content %}
     <div class="mx-3 mx-xl-5">
         {% if challenge.should_show_verification_warning and user_is_participant %}

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -22,7 +22,7 @@
 {% endblock %}
 
 {% block sidebar %}
-    <div class="col-xl-5 col-lg-4 col-md-3">
+    <div class="col-lg-3 col-md-4 col-sm-6">
         <ul class="nav nav-pills flex-column mb-3">
             {% for page in pages %}
                 {% if not page.hidden %}
@@ -53,6 +53,7 @@
     </div>
 {% endblock %}
 
+{% block content_col %}col-xl-6 col-lg-7 col-md-8{% endblock %}
 {% block content %}
     <div class="mx-3">
         {% if challenge.should_show_verification_warning and user_is_participant %}
@@ -94,4 +95,8 @@
             {% endif %}
         {% endif %}
     </div>
+{% endblock %}
+
+{% block sidebar_right %}
+    <div class="col-lg-1"></div>
 {% endblock %}

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -53,9 +53,9 @@
     </div>
 {% endblock %}
 
-{% block content_col %}col-xl-6 col-lg-7 col-md-8{% endblock %}
+{% block content_col %}col-xl-7 col-md-8 px-lg-5{% endblock %}
 {% block content %}
-    <div class="mx-3">
+    <div class="mx-3 mx-xl-5">
         {% if challenge.should_show_verification_warning and user_is_participant %}
             {% include "challenges/partials/participant_verification_warning.html" %}
         {% endif %}
@@ -95,8 +95,4 @@
             {% endif %}
         {% endif %}
     </div>
-{% endblock %}
-
-{% block sidebar_right %}
-    <div class="col-lg-1"></div>
 {% endblock %}

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -22,8 +22,7 @@
 {% endblock %}
 
 {% block sidebar %}
-    <div class="col-md-3 col-sm-6 pr-lg-3 pr-md-0">
-{#    <div class="col-lg-3 col-md-4 col-sm-6">#}
+    <div class="col-md-3 col-sm-6 pr-lg-3 pr-md-0 mr-xl-5">
         <ul class="nav nav-pills flex-column mb-3">
             {% for page in pages %}
                 {% if not page.hidden %}
@@ -54,9 +53,9 @@
     </div>
 {% endblock %}
 
-{% block content_col %}col-xl-7 col-lg-8 col-md-9 px-lg-5{% endblock %}
+{% block content_col %}col-xl-8 col-md-9 px-lg-5{% endblock %}
 {% block content %}
-    <div class="mx-3 mx-xl-5">
+    <div class="mx-3 mr-xl-5 ml-xl-4">
         {% if challenge.should_show_verification_warning and user_is_participant %}
             {% include "challenges/partials/participant_verification_warning.html" %}
         {% endif %}


### PR DESCRIPTION
Navigation pills for pages were very wide, they are now a relative size. 
Page content width is controlled separately and whitespace is placed around the content. This moves the page content from the right of the screen more to the center, on large screens. 

Closes #4198 