### PR TITLE
Avoid linebreak due to heading permalink

### DIFF
--- a/app/grandchallenge/core/static/css/base.scss
+++ b/app/grandchallenge/core/static/css/base.scss
@@ -33,6 +33,8 @@ $pagination-disabled-bg: lighten($blue, 15%) !default;
 // Show heading permalinks only on hover
 :is(h1, h2, h3, h4, h5, h6) > .headerlink {
     visibility: hidden;
+    position: absolute;
+    align-self: end;
 }
 
 :is(h1, h2, h3, h4, h5, h6):hover > .headerlink {


### PR DESCRIPTION
The permalink sometimes caused linebreaks showing an empty line underneath headings. It is not positioned absolutely, avoiding these line breaks. 

<img width="648" height="108" alt="Screenshot 2025-07-31 at 17 37 26" src="https://github.com/user-attachments/assets/497caf29-6c6f-4729-aeca-8089cab26229" />

Related to #4198 