### PR TITLE
Revert pages width change

### DIFF
--- a/app/grandchallenge/core/templates/base.html
+++ b/app/grandchallenge/core/templates/base.html
@@ -90,7 +90,7 @@
                 {% endblock %}
                 <div class="row">
                     {% block sidebar %}{% endblock %}
-                    <div class="{% block content_col %}col{% endblock %} overflow-auto">
+                    <div class="col overflow-auto">
                         {% block content %}
                             {# Block used by us and django-allauth #}
                         {% endblock %}

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -54,7 +54,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="mx-3">
+    <div class="ml-lg-3">
         {% if challenge.should_show_verification_warning and user_is_participant %}
             {% include "challenges/partials/participant_verification_warning.html" %}
         {% endif %}

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -22,7 +22,7 @@
 {% endblock %}
 
 {% block sidebar %}
-    <div class="col-12 col-sm-5 col-md-4 col-lg-3 pl-3">
+    <div class="col-md-3">
         <ul class="nav nav-pills flex-column mb-3">
             {% for page in pages %}
                 {% if not page.hidden %}

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -22,7 +22,7 @@
 {% endblock %}
 
 {% block sidebar %}
-    <div class="col-md-3 col-sm-6 pr-lg-3 pr-md-0 mr-xl-5">
+    <div class="col-xl-5 col-lg-4 col-md-3">
         <ul class="nav nav-pills flex-column mb-3">
             {% for page in pages %}
                 {% if not page.hidden %}
@@ -53,9 +53,8 @@
     </div>
 {% endblock %}
 
-{% block content_col %}col-xl-8 col-md-9 px-lg-5{% endblock %}
 {% block content %}
-    <div class="mx-3 mr-xl-5 ml-xl-4">
+    <div class="mx-3">
         {% if challenge.should_show_verification_warning and user_is_participant %}
             {% include "challenges/partials/participant_verification_warning.html" %}
         {% endif %}

--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -22,7 +22,7 @@
 {% endblock %}
 
 {% block sidebar %}
-    <div class="col-xl-5 col-lg-4 col-md-3">
+    <div class="col-12 col-sm-5 col-md-4 col-lg-3 pl-3">
         <ul class="nav nav-pills flex-column mb-3">
             {% for page in pages %}
                 {% if not page.hidden %}


### PR DESCRIPTION
Revert pages width to before #4166. Changes compared to then are: 

- the page pills now shrink with the screen size, no longer exacerbating the problem of reduced space available for the page content
- page content breaks to the next row on screens smaller than `md` rather then `sm`
- the right margin for the page content is removed and is only shown on the left on screens of `lg` or wider.

<img width="1222" height="409" alt="Screenshot 2025-08-04 at 22 41 38" src="https://github.com/user-attachments/assets/c7e61dd6-ec54-46d0-8663-c729ae77335d" />

Closes #4198