### PR TITLE
Ensure save method is used when unpublishing

### DIFF
--- a/app/grandchallenge/algorithms/admin.py
+++ b/app/grandchallenge/algorithms/admin.py
@@ -91,8 +91,13 @@ class AlgorithmAdmin(admin.ModelAdmin):
         description="Unpublish selected algorithms", permissions=("change",)
     )
     def unpublish_algorithms(self, request, queryset):
-        updated = queryset.update(public=False)
-        self.message_user(request, f"{updated} algorithm(s) unpublished.")
+        for algorithm in queryset:
+            algorithm.public = False
+            algorithm.save()
+
+        self.message_user(
+            request, f"{len(queryset)} algorithm(s) unpublished."
+        )
 
 
 @admin.register(AlgorithmUserCredit)


### PR DESCRIPTION
The original implementation will skip the save method, leaving the "view_algorithm" permission unchanged.

See https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/611