### PR TITLE
Update utilisation chart

### DIFF
--- a/app/grandchallenge/charts/specs.py
+++ b/app/grandchallenge/charts/specs.py
@@ -190,7 +190,7 @@ def world_map(*, values):
     }
 
 
-def components_line(*, values, title, cpu_limit, tooltip):
+def components_line(*, values, title, single_thread_limit, tooltip):
     return {
         "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
         "width": "container",
@@ -212,6 +212,7 @@ def components_line(*, values, title, cpu_limit, tooltip):
                         "field": "Percent100",
                         "type": "quantitative",
                         "title": "Utilization / %",
+                        "scale": {"domain": [0, 100]},
                     },
                     "color": {"field": "Metric", "type": "nominal"},
                 },
@@ -266,29 +267,14 @@ def components_line(*, values, title, cpu_limit, tooltip):
             {
                 "data": {"values": [{}]},
                 "mark": {"type": "rule", "strokeDash": [8, 8]},
-                "encoding": {"y": {"datum": cpu_limit}},
+                "encoding": {"y": {"datum": single_thread_limit}},
             },
             {
                 "data": {"values": [{}]},
                 "mark": {"type": "text", "baseline": "line-bottom"},
                 "encoding": {
-                    "text": {"datum": "CPU Utilization Limit"},
-                    "y": {"datum": cpu_limit},
-                },
-            },
-            {
-                "data": {"values": [{}]},
-                "mark": {"type": "rule", "strokeDash": [8, 8]},
-                "encoding": {"y": {"datum": 100}},
-            },
-            {
-                "data": {"values": [{}]},
-                "mark": {"type": "text", "baseline": "line-bottom"},
-                "encoding": {
-                    "text": {
-                        "datum": "Memory / GPU / GPU Memory Utilization Limit"
-                    },
-                    "y": {"datum": 100},
+                    "text": {"datum": "Single CPU Thread"},
+                    "y": {"datum": single_thread_limit},
                 },
             },
         ],

--- a/app/tests/components_tests/test_models.py
+++ b/app/tests/components_tests/test_models.py
@@ -915,12 +915,12 @@ def test_runtime_metrics_chart():
                 {
                     "Metric": "CPUUtilization",
                     "Timestamp": "2022-06-09T09:38:00+00:00",
-                    "Percent": 0.00677884,
+                    "Percent": 0.00338942,
                 },
                 {
                     "Metric": "CPUUtilization",
                     "Timestamp": "2022-06-09T09:37:00+00:00",
-                    "Percent": 0.00130367,
+                    "Percent": 0.000651835,
                 },
                 {
                     "Metric": "MemoryUtilization",
@@ -937,7 +937,7 @@ def test_runtime_metrics_chart():
         "layer": [
             {
                 "transform": [
-                    {"calculate": "100*datum.Percent", "as": "Percent100"},
+                    {"calculate": "100*datum.Percent", "as": "Percent100"}
                 ],
                 "encoding": {
                     "x": {
@@ -949,6 +949,7 @@ def test_runtime_metrics_chart():
                         "field": "Percent100",
                         "type": "quantitative",
                         "title": "Utilization / %",
+                        "scale": {"domain": [0, 100]},
                     },
                     "color": {"field": "Metric", "type": "nominal"},
                 },
@@ -1014,29 +1015,14 @@ def test_runtime_metrics_chart():
             {
                 "data": {"values": [{}]},
                 "mark": {"type": "rule", "strokeDash": [8, 8]},
-                "encoding": {"y": {"datum": 200}},
+                "encoding": {"y": {"datum": 50.0}},
             },
             {
                 "data": {"values": [{}]},
                 "mark": {"type": "text", "baseline": "line-bottom"},
                 "encoding": {
-                    "text": {"datum": "CPU Utilization Limit"},
-                    "y": {"datum": 200},
-                },
-            },
-            {
-                "data": {"values": [{}]},
-                "mark": {"type": "rule", "strokeDash": [8, 8]},
-                "encoding": {"y": {"datum": 100}},
-            },
-            {
-                "data": {"values": [{}]},
-                "mark": {"type": "text", "baseline": "line-bottom"},
-                "encoding": {
-                    "text": {
-                        "datum": "Memory / GPU / GPU Memory Utilization Limit"
-                    },
-                    "y": {"datum": 100},
+                    "text": {"datum": "Single CPU Thread"},
+                    "y": {"datum": 50.0},
                 },
             },
         ],


### PR DESCRIPTION
Now that we offer machines with 192 CPUs the memory utilisation was difficult to see. Instead we now scale the chart from 0-100%, noting the single thread limit.

Before:
<img width="846" height="275" alt="Screenshot 2025-08-05 at 17 46 33" src="https://github.com/user-attachments/assets/d7f02375-143f-4c90-b0de-813715532482" />

After:
<img width="831" height="266" alt="Screenshot 2025-08-05 at 17 46 18" src="https://github.com/user-attachments/assets/9d4c76d5-f045-44d0-b572-729f86d2bc4f" />
