### PR TITLE
Restrict sockets for archive uploads

### DIFF
--- a/app/grandchallenge/archives/forms.py
+++ b/app/grandchallenge/archives/forms.py
@@ -189,13 +189,17 @@ class ArchiveItemsToReaderStudyForm(SaveFormInitMixin, Form):
 
 
 class AddCasesForm(UploadRawImagesForm):
-    model = CharField(widget=HiddenInput)
-    object = CharField(widget=HiddenInput)
+    model_name = CharField(widget=HiddenInput)
+    object_slug = CharField(widget=HiddenInput)
     socket = ModelChoiceField(
         queryset=None,
         widget=autocomplete.ModelSelect2(
             url="components:component-interface-autocomplete",
-            forward=["model", "object", forward.Const(True, "image_only")],
+            forward=[
+                "model_name",
+                "object_slug",
+                forward.Const(True, "image_only"),
+            ],
             attrs={
                 "data-placeholder": "Search for a socket ...",
                 "data-minimum-input-length": 3,
@@ -208,8 +212,8 @@ class AddCasesForm(UploadRawImagesForm):
     def __init__(self, *args, base_obj, interface_viewname, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.fields["model"].initial = base_obj._meta.model_name
-        self.fields["object"].initial = base_obj.slug
+        self.fields["model_name"].initial = base_obj._meta.model_name
+        self.fields["object_slug"].initial = base_obj.slug
 
         try:
             socket_filter_kwargs = {"slug__in": base_obj.allowed_socket_slugs}

--- a/app/grandchallenge/archives/forms.py
+++ b/app/grandchallenge/archives/forms.py
@@ -217,7 +217,7 @@ class AddCasesForm(UploadRawImagesForm):
 
         try:
             socket_filter_kwargs = {"slug__in": base_obj.allowed_socket_slugs}
-        except NotImplementedError:
+        except AttributeError:
             socket_filter_kwargs = {}
 
         qs = (

--- a/app/grandchallenge/archives/forms.py
+++ b/app/grandchallenge/archives/forms.py
@@ -197,6 +197,7 @@ class AddCasesForm(UploadRawImagesForm):
         queryset=None,
         widget=autocomplete.ModelSelect2(
             url="components:component-interface-autocomplete",
+            forward=["model", "object", "image_only"],
             attrs={
                 "data-placeholder": "Search for a socket ...",
                 "data-minimum-input-length": 3,
@@ -226,11 +227,6 @@ class AddCasesForm(UploadRawImagesForm):
             .order_by("title")
         )
         self.fields["socket"].queryset = qs
-        self.fields["socket"].widget.forward = [
-            "model",
-            "object",
-            "image_only",
-        ]
 
         self.fields["socket"].help_text = format_lazy(
             (

--- a/app/grandchallenge/archives/forms.py
+++ b/app/grandchallenge/archives/forms.py
@@ -1,8 +1,7 @@
-from dal import autocomplete
+from dal import autocomplete, forward
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.forms import (
-    BooleanField,
     CharField,
     Form,
     ModelChoiceField,
@@ -192,12 +191,11 @@ class ArchiveItemsToReaderStudyForm(SaveFormInitMixin, Form):
 class AddCasesForm(UploadRawImagesForm):
     model = CharField(widget=HiddenInput)
     object = CharField(widget=HiddenInput)
-    image_only = BooleanField(widget=HiddenInput, initial=True)
     socket = ModelChoiceField(
         queryset=None,
         widget=autocomplete.ModelSelect2(
             url="components:component-interface-autocomplete",
-            forward=["model", "object", "image_only"],
+            forward=["model", "object", forward.Const(True, "image_only")],
             attrs={
                 "data-placeholder": "Search for a socket ...",
                 "data-minimum-input-length": 3,

--- a/app/grandchallenge/archives/models.py
+++ b/app/grandchallenge/archives/models.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models import Q
+from django.utils.functional import cached_property
 from django_extensions.db.models import TitleSlugDescriptionModel
 from guardian.shortcuts import assign_perm, remove_perm
 from stdimage import JPEGField
@@ -273,6 +274,22 @@ class Archive(
     @property
     def create_civ_set_batch_url(self):
         return reverse("archives:cases-create", kwargs={"slug": self.slug})
+
+    @cached_property
+    def allowed_socket_slugs(self):
+        if self.phase_set.count() != 0:
+            allowed_slugs = []
+            for phase in self.phase_set.all():
+                allowed_slugs.extend(
+                    [
+                        inp.slug
+                        for interface in phase.algorithm_interfaces.all()
+                        for inp in interface.inputs.all()
+                    ]
+                )
+            return allowed_slugs
+        else:
+            raise NotImplementedError
 
 
 class ArchiveUserObjectPermission(UserObjectPermissionBase):

--- a/app/grandchallenge/archives/models.py
+++ b/app/grandchallenge/archives/models.py
@@ -289,7 +289,7 @@ class Archive(
                 )
             return set(allowed_slugs)
         else:
-            raise NotImplementedError
+            raise AttributeError
 
 
 class ArchiveUserObjectPermission(UserObjectPermissionBase):

--- a/app/grandchallenge/archives/models.py
+++ b/app/grandchallenge/archives/models.py
@@ -287,7 +287,7 @@ class Archive(
                         for inp in interface.inputs.all()
                     ]
                 )
-            return allowed_slugs
+            return set(allowed_slugs)
         else:
             raise NotImplementedError
 

--- a/app/grandchallenge/archives/views.py
+++ b/app/grandchallenge/archives/views.py
@@ -342,6 +342,7 @@ class ArchiveUploadSessionCreate(
                     kwargs={"archive_pk": self.archive.pk}, immutable=True
                 ),
                 "interface_viewname": "components:component-interface-list-archives",
+                "base_obj": self.archive,
             }
         )
         return kwargs

--- a/app/grandchallenge/components/backends/exceptions.py
+++ b/app/grandchallenge/components/backends/exceptions.py
@@ -32,3 +32,10 @@ class CIVNotEditableException(ComponentBaseException):
     Raised during attempt to update an archive item,
     display set or algorithm job when they were not editable
     """
+
+
+class CINotAllowedException(ComponentBaseException):
+    """
+    Raised during attempt to update an archive item,
+    when the socket is not in the set of allowed sockets for the base object.
+    """

--- a/app/grandchallenge/components/forms.py
+++ b/app/grandchallenge/components/forms.py
@@ -297,8 +297,16 @@ class SingleCIVForm(Form):
     ):
         super().__init__(*args, **kwargs)
         data = kwargs.get("data")
-        qs = ComponentInterface.objects.exclude(
-            slug__in=base_obj.values_for_interfaces.keys()
+
+        try:
+            socket_filter_kwargs = {"slug__in": base_obj.allowed_socket_slugs}
+        except NotImplementedError:
+            socket_filter_kwargs = {}
+
+        qs = (
+            ComponentInterface.objects.all()
+            .filter(**socket_filter_kwargs)
+            .exclude(slug__in=base_obj.values_for_interfaces.keys())
         )
 
         if interface:

--- a/app/grandchallenge/components/forms.py
+++ b/app/grandchallenge/components/forms.py
@@ -300,7 +300,7 @@ class SingleCIVForm(Form):
 
         try:
             socket_filter_kwargs = {"slug__in": base_obj.allowed_socket_slugs}
-        except NotImplementedError:
+        except AttributeError:
             socket_filter_kwargs = {}
 
         qs = (

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -2440,16 +2440,14 @@ class CIVForObjectMixin:
                 f"{self} is not editable. CIVs cannot be added or removed from it.",
             )
 
+        base_object = self.base_object
         try:
-            if (
-                civ_data.interface_slug
-                not in self.base_object.allowed_socket_slugs
-            ):
+            if civ_data.interface_slug not in base_object.allowed_socket_slugs:
                 raise CINotAllowedException(
                     f"Socket {civ_data.interface_slug!r} is not allowed "
                     f"for this {self.base_object._meta.model_name}."
                 )
-        except NotImplementedError:
+        except AttributeError:
             pass
 
         ci = ComponentInterface.objects.get(slug=civ_data.interface_slug)
@@ -2724,10 +2722,6 @@ class ValuesForInterfacesMixin:
                 values__isnull=True
             ).values_list("values__interface__pk", flat=True)
         ).distinct()
-
-    @cached_property
-    def allowed_socket_slugs(self):
-        raise NotImplementedError
 
 
 class Tarball(UUIDModel):

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -40,6 +40,7 @@ from panimg.models import MAXIMUM_SEGMENTS_LENGTH
 from grandchallenge.cases.models import Image, ImageFile, RawImageUploadSession
 from grandchallenge.charts.specs import components_line
 from grandchallenge.components.backends.exceptions import (
+    CINotAllowedException,
     CIVNotEditableException,
 )
 from grandchallenge.components.schemas import (
@@ -2438,6 +2439,18 @@ class CIVForObjectMixin:
             raise CIVNotEditableException(
                 f"{self} is not editable. CIVs cannot be added or removed from it.",
             )
+
+        try:
+            if (
+                civ_data.interface_slug
+                not in self.base_object.allowed_socket_slugs
+            ):
+                raise CINotAllowedException(
+                    f"Socket {civ_data.interface_slug!r} is not allowed "
+                    f"for this {self.base_object._meta.model_name}."
+                )
+        except NotImplementedError:
+            pass
 
         ci = ComponentInterface.objects.get(slug=civ_data.interface_slug)
         current_civ = self.get_current_value_for_interface(

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -2440,9 +2440,11 @@ class CIVForObjectMixin:
                 f"{self} is not editable. CIVs cannot be added or removed from it.",
             )
 
-        base_object = self.base_object
         try:
-            if civ_data.interface_slug not in base_object.allowed_socket_slugs:
+            if (
+                civ_data.interface_slug
+                not in self.base_object.allowed_socket_slugs
+            ):
                 raise CINotAllowedException(
                     f"Socket {civ_data.interface_slug!r} is not allowed "
                     f"for this {self.base_object._meta.model_name}."

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -2712,6 +2712,10 @@ class ValuesForInterfacesMixin:
             ).values_list("values__interface__pk", flat=True)
         ).distinct()
 
+    @cached_property
+    def allowed_socket_slugs(self):
+        raise NotImplementedError
+
 
 class Tarball(UUIDModel):
     ImportStatusChoices = ImportStatusChoices

--- a/app/grandchallenge/components/serializers.py
+++ b/app/grandchallenge/components/serializers.py
@@ -7,6 +7,7 @@ from rest_framework.relations import SlugRelatedField
 
 from grandchallenge.cases.models import Image, RawImageUploadSession
 from grandchallenge.components.backends.exceptions import (
+    CINotAllowedException,
     CIVNotEditableException,
 )
 from grandchallenge.components.models import (
@@ -263,6 +264,8 @@ class CIVSetPostSerializerMixin:
                 user=request.user,
             )
             logger.error(e, exc_info=True)
+        except CINotAllowedException as e:
+            raise DRFValidationError(e)
 
         if not self.partial:
             instance.refresh_from_db()

--- a/app/grandchallenge/components/static/components/js/autocomplete_htmx.mjs
+++ b/app/grandchallenge/components/static/components/js/autocomplete_htmx.mjs
@@ -50,11 +50,11 @@ htmx.onLoad(elem => {
         );
     }
 
-    const objectSlugVal = document.getElementById("objectSlug").dataset.slug;
-    const objectModel = document.getElementById("modelName").dataset.modelName;
+    const objectSlug = document.getElementById("objectSlug").dataset.objectSlug;
+    const modelName = document.getElementById("modelName").dataset.modelName;
     vals.push(
-        `{"type": "const", "dst": "object", "val": "${objectSlugVal}"}`,
-        `{"type": "const", "dst": "model", "val": "${objectModel}"}`,
+        `{"type": "const", "dst": "object_slug", "val": "${objectSlug}"}`,
+        `{"type": "const", "dst": "model_name", "val": "${modelName}"}`,
     );
 
     for (const script of dalForwardConfScripts) {

--- a/app/grandchallenge/components/templates/components/civ_set_form.html
+++ b/app/grandchallenge/components/templates/components/civ_set_form.html
@@ -29,7 +29,7 @@
         {% endif %}
     </h3>
 
-    <div id="objectSlug" class="d-none" data-slug="{{ base_object.slug }}"></div>
+    <div id="objectSlug" class="d-none" data-object-slug="{{ base_object.slug }}"></div>
     <div id="modelName" class="d-none" data-model-name="{{ base_object|model_name }}"></div>
 
 

--- a/app/grandchallenge/components/views.py
+++ b/app/grandchallenge/components/views.py
@@ -127,7 +127,7 @@ class ComponentInterfaceAutocomplete(
 
         try:
             extra_filter_kwargs = {"slug__in": obj.allowed_socket_slugs}
-        except NotImplementedError:
+        except AttributeError:
             extra_filter_kwargs = {}
 
         if image_only:

--- a/app/grandchallenge/components/views.py
+++ b/app/grandchallenge/components/views.py
@@ -115,7 +115,7 @@ class ComponentInterfaceAutocomplete(
         if self.forwarded:
             object_slug = self.forwarded.pop("object")
             model_name = self.forwarded.pop("model")
-            image_only = self.forwarded.pop("image_only")
+            image_only = self.forwarded.pop("image_only", False)
 
             if model_name == ReaderStudy._meta.model_name:
                 object = ReaderStudy.objects.get(slug=object_slug)

--- a/app/grandchallenge/components/views.py
+++ b/app/grandchallenge/components/views.py
@@ -118,16 +118,16 @@ class ComponentInterfaceAutocomplete(
             image_only = self.forwarded.pop("image_only", False)
 
             if model_name == ReaderStudy._meta.model_name:
-                object = ReaderStudy.objects.get(slug=object_slug)
+                obj = ReaderStudy.objects.get(slug=object_slug)
             elif model_name == Archive._meta.model_name:
-                object = Archive.objects.get(slug=object_slug)
+                obj = Archive.objects.get(slug=object_slug)
             else:
                 raise RuntimeError(
                     f"Autocomplete for objects of type {model_name} not defined."
                 )
 
             try:
-                extra_filter_kwargs = {"slug__in": object.allowed_socket_slugs}
+                extra_filter_kwargs = {"slug__in": obj.allowed_socket_slugs}
             except NotImplementedError:
                 extra_filter_kwargs = {}
 
@@ -140,7 +140,7 @@ class ComponentInterfaceAutocomplete(
                 qs = (
                     ComponentInterface.objects.all()
                     .filter(**extra_filter_kwargs)
-                    .exclude(slug__in=object.values_for_interfaces.keys())
+                    .exclude(slug__in=obj.values_for_interfaces.keys())
                     .exclude(pk__in=self.forwarded.values())
                 )
 
@@ -212,15 +212,11 @@ class MultipleCIVProcessingBaseView(
         for form_class in self.included_form_classes:
             for widget in form_class.possible_widgets:
                 media = media + widget().media
-        if hasattr(self, "object"):
-            object = self.object
-        else:
-            object = None
         context.update(
             {
                 "base_object": self.base_object,
                 "form_media": media,
-                "object": object,
+                "object": getattr(self, "object", None),
             }
         )
         return context

--- a/app/grandchallenge/components/views.py
+++ b/app/grandchallenge/components/views.py
@@ -113,8 +113,8 @@ class ComponentInterfaceAutocomplete(
 ):
     def get_queryset(self):
         if self.forwarded:
-            object_slug = self.forwarded.pop("object")
-            model_name = self.forwarded.pop("model")
+            object_slug = self.forwarded.pop("object_slug")
+            model_name = self.forwarded.pop("model_name")
             image_only = self.forwarded.pop("image_only", False)
 
             if model_name == ReaderStudy._meta.model_name:

--- a/app/grandchallenge/reader_studies/views.py
+++ b/app/grandchallenge/reader_studies/views.py
@@ -693,6 +693,7 @@ class AddDisplaySetsToReaderStudy(BaseAddObjectToReaderStudyMixin, CreateView):
                     immutable=True,
                 ),
                 "interface_viewname": "components:component-interface-list-reader-studies",
+                "base_obj": self.reader_study,
             }
         )
         return kwargs

--- a/app/tests/archives_tests/test_models.py
+++ b/app/tests/archives_tests/test_models.py
@@ -1,8 +1,13 @@
 import pytest
 from django.db import IntegrityError, transaction
 
+from tests.algorithms_tests.factories import AlgorithmInterfaceFactory
 from tests.archives_tests.factories import ArchiveFactory, ArchiveItemFactory
-from tests.components_tests.factories import ComponentInterfaceValueFactory
+from tests.components_tests.factories import (
+    ComponentInterfaceFactory,
+    ComponentInterfaceValueFactory,
+)
+from tests.evaluation_tests.factories import PhaseFactory
 
 
 @pytest.mark.django_db
@@ -109,3 +114,15 @@ def test_archive_item_set_title():
 def test_archive_item_editable():
     ai = ArchiveItemFactory()
     assert ai.is_editable
+
+
+@pytest.mark.django_db
+def test_archive_allowed_socket_slugs():
+    archive = ArchiveFactory()
+    phase = PhaseFactory(archive=archive)
+    ci1, ci2, ci3, ci4, ci5 = ComponentInterfaceFactory.create_batch(5)
+    int1 = AlgorithmInterfaceFactory(inputs=[ci1, ci2], outputs=[ci4])
+    int2 = AlgorithmInterfaceFactory(inputs=[ci3], outputs=[ci5])
+    phase.algorithm_interfaces.set([int1, int2])
+
+    assert archive.allowed_socket_slugs == {ci1.slug, ci2.slug, ci3.slug}

--- a/app/tests/cases_tests/test_forms.py
+++ b/app/tests/cases_tests/test_forms.py
@@ -47,6 +47,8 @@ def test_upload_some_images(
             data={
                 "user_uploads": [user_upload.pk],
                 "socket": ComponentInterface.objects.first().pk,
+                "object_slug": rs.slug,
+                "model_name": rs._meta.model_name,
             },
             client=client,
             viewname="reader-studies:display-sets-create",

--- a/app/tests/components_tests/test_views.py
+++ b/app/tests/components_tests/test_views.py
@@ -69,11 +69,21 @@ def test_component_interface_autocomplete(client):
     ci_img = ComponentInterfaceFactory(title="test-img", kind="IMG")
     ci_img_2 = ComponentInterfaceFactory(title="foo-img", kind="IMG")
     user = UserFactory()
+    rs = ReaderStudyFactory()
 
     response = get_view_for_user(
         client=client,
         viewname="components:component-interface-autocomplete",
         user=user,
+        data={
+            "forward": json.dumps(
+                {
+                    "object_slug": rs.slug,
+                    "model_name": ReaderStudy._meta.model_name,
+                    "image_only": True,
+                }
+            )
+        },
     )
     assert response.status_code == 200
     ids = [x["id"] for x in response.json()["results"]]
@@ -85,7 +95,16 @@ def test_component_interface_autocomplete(client):
         client=client,
         viewname="components:component-interface-autocomplete",
         user=user,
-        data={"q": "test"},
+        data={
+            "q": "test",
+            "forward": json.dumps(
+                {
+                    "object_slug": rs.slug,
+                    "model_name": ReaderStudy._meta.model_name,
+                    "image_only": True,
+                }
+            ),
+        },
     )
     assert response.status_code == 200
     ids = [x["id"] for x in response.json()["results"]]
@@ -97,7 +116,15 @@ def test_component_interface_autocomplete(client):
         client=client,
         viewname="components:component-interface-autocomplete",
         user=user,
-        data={"q": "foo"},
+        data={
+            "q": "foo",
+            "forward": json.dumps(
+                {
+                    "object_slug": rs.slug,
+                    "model_name": ReaderStudy._meta.model_name,
+                },
+            ),
+        },
     )
     assert response.status_code == 200
     ids = [x["id"] for x in response.json()["results"]]
@@ -105,7 +132,6 @@ def test_component_interface_autocomplete(client):
     assert str(ci_img_2.id) in ids
     assert str(ci_json.id) not in ids
 
-    rs = ReaderStudyFactory()
     ds = DisplaySetFactory(reader_study=rs)
     civ = ComponentInterfaceValueFactory(interface=ci_img)
     ds.values.add(civ)

--- a/app/tests/components_tests/test_views.py
+++ b/app/tests/components_tests/test_views.py
@@ -116,7 +116,10 @@ def test_component_interface_autocomplete(client):
         user=user,
         data={
             "forward": json.dumps(
-                {"object": rs.slug, "model": ReaderStudy._meta.model_name}
+                {
+                    "object_slug": rs.slug,
+                    "model_name": ReaderStudy._meta.model_name,
+                }
             )
         },
     )
@@ -133,8 +136,8 @@ def test_component_interface_autocomplete(client):
         data={
             "forward": json.dumps(
                 {
-                    "object": rs.slug,
-                    "model": ReaderStudy._meta.model_name,
+                    "object_slug": rs.slug,
+                    "model_name": ReaderStudy._meta.model_name,
                     "interface-0": ci_img_2.pk,
                 }
             )
@@ -167,8 +170,8 @@ def test_ci_autocomplete_for_archives(client):
         data={
             "forward": json.dumps(
                 {
-                    "object": archive.slug,
-                    "model": Archive._meta.model_name,
+                    "object_slug": archive.slug,
+                    "model_name": Archive._meta.model_name,
                 }
             )
         },
@@ -186,8 +189,8 @@ def test_ci_autocomplete_for_archives(client):
         data={
             "forward": json.dumps(
                 {
-                    "object": archive.slug,
-                    "model": Archive._meta.model_name,
+                    "object_slug": archive.slug,
+                    "model_name": Archive._meta.model_name,
                     "image_only": True,
                 }
             )


### PR DESCRIPTION
Add an `allowed_socket_slugs` property to limit the sockets if an archive is linked to a phase. Then only the sockets defined on the phase's algorithm input interfaces can be added.

Related to #4151