### PR TITLE
Display job duration as precisedelta

### DIFF
--- a/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/job_detail.html
@@ -130,7 +130,7 @@
 
                 {% if object.job_utilization.duration %}
                     <dt class="col-sm-3">Duration</dt>
-                    <dd class="col-sm-9">{{ object.job_utilization.duration|naturaldelta }}</dd>
+                    <dd class="col-sm-9">{{ object.job_utilization.duration|precisedelta }}</dd>
                 {% endif %}
 
                 {% if object.comment %}

--- a/app/grandchallenge/core/templatetags/naturaldelta.py
+++ b/app/grandchallenge/core/templatetags/naturaldelta.py
@@ -9,6 +9,9 @@ register = template.Library()
 def naturaldelta(value):
     return humanize.naturaldelta(value, months=False)
 
+@register.filter
+def precisedelta(value):
+    return humanize.precisedelta(value, minimum_unit="milliseconds")
 
 @register.filter
 def timedifference(value):


### PR DESCRIPTION
The precise duration of a job could be useful to know for performance optimisation purposes, or to compare submissions based on their runtime.

The current naturaldelta filter presents the duration only very generally as for example "2 minutes" for a runtime of 1 minute 56 seconds and 200 milliseconds.

This PR changes the naturaldelta to a precisedelta filter, which prints the precise time.