### PR TITLE
Set an end time to the logs

### DIFF
--- a/app/grandchallenge/components/backends/amazon_sagemaker_base.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_base.py
@@ -570,12 +570,15 @@ class AmazonSageMakerBaseExecutor(Executor, ABC):
             logger.warning(str(error))
             return
 
+        # Add buffer time to allow metrics to be delivered
+        buffer_time_ms = 5 * 60 * 1000  # 5 minutes
+
         response = self._logs_client.get_log_events(
             logGroupName=self._log_group_name,
             logStreamName=log_stream_name,
             limit=LOGLINES,
             startFromHead=False,
-            endTime=self._get_end_time(event=event),
+            endTime=self._get_end_time(event=event) + buffer_time_ms,
         )
         stdout = []
         stderr = []

--- a/app/grandchallenge/components/backends/amazon_sagemaker_base.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_base.py
@@ -570,15 +570,18 @@ class AmazonSageMakerBaseExecutor(Executor, ABC):
             logger.warning(str(error))
             return
 
-        # Add buffer time to allow metrics to be delivered
-        buffer_time_ms = 5 * 60 * 1000  # 5 minutes
+        end_time = self._get_end_time(event=event)
+
+        if end_time is not None:
+            # Add 5 minutes buffer time to allow metrics to be delivered
+            end_time += 5 * 60 * 1000
 
         response = self._logs_client.get_log_events(
             logGroupName=self._log_group_name,
             logStreamName=log_stream_name,
             limit=LOGLINES,
             startFromHead=False,
-            endTime=self._get_end_time(event=event) + buffer_time_ms,
+            endTime=end_time,
         )
         stdout = []
         stderr = []

--- a/app/grandchallenge/components/backends/amazon_sagemaker_base.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_base.py
@@ -497,7 +497,7 @@ class AmazonSageMakerBaseExecutor(Executor, ABC):
         job_status = self._get_job_status(event=event)
 
         self._set_duration(event=event)
-        self._set_task_logs()
+        self._set_task_logs(event=event)
         self._set_runtime_metrics(event=event)
 
         if job_status == "Completed":
@@ -563,7 +563,7 @@ class AmazonSageMakerBaseExecutor(Executor, ABC):
         else:
             raise LogStreamNotFound("Log stream not found")
 
-    def _set_task_logs(self):
+    def _set_task_logs(self, *, event):
         try:
             log_stream_name = self._get_log_stream_name(data_log=False)
         except LogStreamNotFound as error:
@@ -575,6 +575,7 @@ class AmazonSageMakerBaseExecutor(Executor, ABC):
             logStreamName=log_stream_name,
             limit=LOGLINES,
             startFromHead=False,
+            endTime=self._get_end_time(event=event),
         )
         stdout = []
         stderr = []

--- a/app/tests/components_tests/test_amazon_sagemaker_training_backend.py
+++ b/app/tests/components_tests/test_amazon_sagemaker_training_backend.py
@@ -392,7 +392,7 @@ def test_set_task_logs(settings):
                 "logStreamName": f"localhost-A-{pk}/i-whatever",
                 "limit": LOGLINES,
                 "startFromHead": False,
-                "endTime": 1654767481000,
+                "endTime": 1654767781000,
             },
         )
         executor._set_task_logs(
@@ -594,6 +594,7 @@ def test_handle_stopped_event(settings):
                 "logStreamName": f"localhost-A-{pk}/i-whatever",
                 "limit": LOGLINES,
                 "startFromHead": False,
+                "endTime": 1654767781000,
             },
         )
 
@@ -602,6 +603,7 @@ def test_handle_stopped_event(settings):
                 event={
                     "TrainingJobStatus": "Stopped",
                     "SecondaryStatus": "Stopped",
+                    "TrainingEndTime": 1654767481000,
                 }
             )
 

--- a/app/tests/components_tests/test_amazon_sagemaker_training_backend.py
+++ b/app/tests/components_tests/test_amazon_sagemaker_training_backend.py
@@ -392,9 +392,19 @@ def test_set_task_logs(settings):
                 "logStreamName": f"localhost-A-{pk}/i-whatever",
                 "limit": LOGLINES,
                 "startFromHead": False,
+                "endTime": 1654767481000,
             },
         )
-        executor._set_task_logs()
+        executor._set_task_logs(
+            event={
+                "TrainingStartTime": 1654767467000,
+                "TrainingEndTime": 1654767481000,
+                "ResourceConfig": {
+                    "InstanceType": "ml.m7i.large",
+                    "InstanceCount": 1,
+                },
+            }
+        )
 
     assert executor.stdout == "2022-06-08T10:23:58+00:00 hello from stdout"
     assert executor.stderr == "2022-06-08T10:23:58+00:00 hello from stderr"


### PR DESCRIPTION
This ensures that all logs are captured no matter when the request is made.