### PR TITLE
Iterate over all logs

### DIFF
--- a/app/grandchallenge/components/backends/utils.py
+++ b/app/grandchallenge/components/backends/utils.py
@@ -14,7 +14,7 @@ from django.utils._os import safe_join
 logger = logging.getLogger(__name__)
 
 
-LOGLINES = 2000  # The number of loglines to keep
+LOGLINES = 500  # The number of loglines to keep
 
 # Docker logline error message with optional RFC3339 timestamp
 LOGLINE_REGEX = r"^(?P<timestamp>([\d]+)-(0[1-9]|1[012])-(0[1-9]|[12][\d]|3[01])[Tt]([01][\d]|2[0-3]):([0-5][\d]):([0-5][\d]|60)(\.[\d]+)?(([Zz])|([\+|\-]([01][\d]|2[0-3]):[0-5][\d])))?(?P<error_message>.*)$"


### PR DESCRIPTION
Maximum of 10 calls to fetch all of the logs between the start and end time of the sagemaker job.

Limits each stream to 500 lines.

See https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/629