### PR TITLE
Improve responsiveness of navbar in header and on challenge page

### DIFF
--- a/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
@@ -4,7 +4,7 @@
 
 {% if challenge %}
     <nav class="navbar navbar-expand-sm navbar-light p-0 mb-3 mx-0 border-bottom align-items-start challenge-topbar">
-        <div class="col-auto mr-auto px-0">
+        <div class="col mr-auto px-0">
             <ul class="nav navbar-nav nav-tabs">
                 <li class="nav-item">
                     <a class="nav-link {% if request.resolver_match.view_name == 'pages:home' or request.resolver_match.view_name == 'pages:detail' %} show active{% endif %}"

--- a/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_topbar.html
@@ -3,7 +3,7 @@
 {% load guardian_tags %}
 
 {% if challenge %}
-    <nav class="navbar navbar-expand-lg navbar-light p-0 mb-3 mx-0 border-bottom align-items-start challenge-topbar">
+    <nav class="navbar navbar-expand-sm navbar-light p-0 mb-3 mx-0 border-bottom align-items-start challenge-topbar">
         <div class="col-auto mr-auto px-0">
             <ul class="nav navbar-nav nav-tabs">
                 <li class="nav-item">

--- a/app/grandchallenge/core/templates/grandchallenge/partials/navbar.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/navbar.html
@@ -1,7 +1,7 @@
 {% load url %}
 {% load flatpages %}
 
-<nav class="navbar navbar-light navbar-top navbar-expand-lg sticky-top shadow bg-white">
+<nav class="navbar navbar-light navbar-top navbar-expand-md sticky-top shadow bg-white">
     <div class="container">
         <a class="navbar-brand mr-md-2 text-capitalize"
            href="{% url 'home' %}">


### PR DESCRIPTION
The responsiveness of the main navbar and the secondary navbar on the challenge page is a bit too aggressive in my opinion. Both were set to `navbar-expand-lg` which meant that they collapse to a vertical form (+ hidden behind hamburger menu for main navbar) when the page width is less than 991px. I think this is too soon. The main navbar easily fits until the next breakpoint at 768px. The secondary navbar on the challenge page fits until the last breakpoint (576px). I've adjusted them accordingly, check the videos for a comparison.

## Before

 https://github.com/user-attachments/assets/896416af-a7e9-4c9f-a3ab-41eece27130c

## After

https://github.com/user-attachments/assets/3ead6e2b-7a6e-499d-9ad9-584ea50f1fb6



