### PR TITLE
Add deidentification step

### DIFF
--- a/app/grandchallenge/cases/models.py
+++ b/app/grandchallenge/cases/models.py
@@ -952,20 +952,13 @@ class DICOMImageSetUpload(UUIDModel):
                 outputS3Uri=self._import_output_s3_uri,
             )
         except ClientError as e:
-            if e.response["Error"]["Code"] == "ThrottlingException":
-                raise RetryStep("Request throttled") from e
-            elif (
-                e.response["Error"]["Code"] == " ServiceQuotaExceededException"
-            ):
-                raise RetryStep("Service quota exceeded") from e
+            if e.response["Error"]["Code"] in {
+                "ThrottlingException",
+                "ServiceQuotaExceededException",
+            }:
+                raise RetryStep from e
             else:
-                self._mark_failed(
-                    error_message="An unexpected error occurred", exc=e
-                )
-        except Exception as e:
-            self._mark_failed(
-                error_message="An unexpected error occurred", exc=e
-            )
+                raise
 
     def _deidentify_files(self):
         # this will need to iterate over all linked UserUploads

--- a/app/grandchallenge/cases/tasks.py
+++ b/app/grandchallenge/cases/tasks.py
@@ -533,13 +533,18 @@ def import_dicom_to_healthimaging(*, dicom_imageset_upload_pk):
         pk=dicom_imageset_upload_pk,
     )
 
-    # the status to check here will ultimately have to be something like DICOMImageSetUploadStatusChoices.DEIDENTIFIED
     if not upload.status == DICOMImageSetUploadStatusChoices.INITIALIZED:
         raise RuntimeError(
-            "Upload is not ready for importing into HealthImaging."
+            "Upload is not ready for de-identification and importing into HealthImaging."
         )
 
-    upload.status = DICOMImageSetUploadStatusChoices.STARTED
-    upload.save()
-
-    upload.start_dicom_import_job()
+    try:
+        upload.deidentify()
+    except Exception as e:
+        upload._mark_failed(
+            error_message="An unexpected error occurred", exc=e
+        )
+    else:
+        upload.status = DICOMImageSetUploadStatusChoices.STARTED
+        upload.save()
+        upload.start_dicom_import_job()

--- a/app/grandchallenge/cases/tasks.py
+++ b/app/grandchallenge/cases/tasks.py
@@ -540,6 +540,9 @@ def import_dicom_to_healthimaging(*, dicom_imageset_upload_pk):
 
     try:
         upload.deidentify_user_uploads()
+        upload.start_dicom_import_job()
+    except RetryStep:
+        raise
     except Exception as e:
         upload._mark_failed(
             error_message="An unexpected error occurred", exc=e
@@ -547,4 +550,3 @@ def import_dicom_to_healthimaging(*, dicom_imageset_upload_pk):
     else:
         upload.status = DICOMImageSetUploadStatusChoices.STARTED
         upload.save()
-        upload.start_dicom_import_job()

--- a/app/tests/cases_tests/test_models.py
+++ b/app/tests/cases_tests/test_models.py
@@ -3,13 +3,11 @@ from pathlib import Path
 
 import factory
 import pytest
-from botocore.exceptions import ClientError
 from botocore.stub import Stubber
 from django.conf import settings
 from django.core.exceptions import MultipleObjectsReturned
 from django.core.files import File
 
-from grandchallenge.cases.models import DICOMImageSetUploadStatusChoices
 from tests.cases_tests.factories import (
     DICOMImageSetUploadFactory,
     ImageFactory,
@@ -202,23 +200,3 @@ def test_start_dicom_import_job(settings):
         response = di_upload.start_dicom_import_job()
 
     assert response["jobStatus"] == "SUBMITTED"
-
-
-@pytest.mark.django_db
-def test_error_in_start_dicom_import_job(mocker):
-    di_upload = DICOMImageSetUploadFactory()
-    fake_client = mocker.Mock()
-    fake_client.start_dicom_import_job.side_effect = ClientError(
-        error_response={
-            "Error": {"Code": "ValidationError", "Message": "Foo"}
-        },
-        operation_name="StartDICOMImportJob",
-    )
-    mocker.patch(
-        "grandchallenge.cases.models.boto3.client", return_value=fake_client
-    )
-
-    di_upload.start_dicom_import_job()
-
-    assert di_upload.status == DICOMImageSetUploadStatusChoices.FAILED
-    assert di_upload.error_message == "An unexpected error occurred"

--- a/app/tests/cases_tests/test_tasks.py
+++ b/app/tests/cases_tests/test_tasks.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
+from botocore.exceptions import ClientError
 from django.db import IntegrityError
 from panimg.models import ImageType, PanImgFile, PostProcessorResult
 from panimg.post_processors import DEFAULT_POST_PROCESSORS
@@ -263,5 +264,35 @@ def test_start_dicom_import_job_does_not_run_when_deid_fails(
 
     di_upload.refresh_from_db()
     # upload gets marked as failed
+    assert di_upload.status == DICOMImageSetUploadStatusChoices.FAILED
+    assert di_upload.error_message == "An unexpected error occurred"
+
+
+@pytest.mark.django_db
+def test_error_in_start_dicom_import_job(django_capture_on_commit_callbacks):
+    di_upload = DICOMImageSetUploadFactory()
+
+    with (
+        patch.object(
+            DICOMImageSetUpload,
+            "start_dicom_import_job",
+            side_effect=ClientError(
+                error_response={
+                    "Error": {"Code": "ValidationError", "Message": "Foo"}
+                },
+                operation_name="StartDICOMImportJob",
+            ),
+        ),
+        patch.object(
+            DICOMImageSetUpload,
+            "deidentify_user_uploads",
+        ),
+    ):
+        with django_capture_on_commit_callbacks(execute=True):
+            import_dicom_to_healthimaging(
+                dicom_imageset_upload_pk=di_upload.pk
+            )
+
+    di_upload.refresh_from_db()
     assert di_upload.status == DICOMImageSetUploadStatusChoices.FAILED
     assert di_upload.error_message == "An unexpected error occurred"

--- a/app/tests/cases_tests/test_tasks.py
+++ b/app/tests/cases_tests/test_tasks.py
@@ -225,12 +225,39 @@ def test_import_dicom_to_healthimaging_updates_status_when_successful(
     with patch.object(
         DICOMImageSetUpload, "start_dicom_import_job"
     ) as mocked_method:
-        with django_capture_on_commit_callbacks(execute=True):
-            import_dicom_to_healthimaging(
-                dicom_imageset_upload_pk=di_upload.pk
-            )
+        with patch.object(DICOMImageSetUpload, "deidentify_user_uploads"):
+            with django_capture_on_commit_callbacks(execute=True):
+                import_dicom_to_healthimaging(
+                    dicom_imageset_upload_pk=di_upload.pk
+                )
 
         mocked_method.assert_called_once()
 
     di_upload.refresh_from_db()
     assert di_upload.status == DICOMImageSetUploadStatusChoices.STARTED
+
+
+@pytest.mark.django_db
+def test_start_dicom_import_job_does_not_run_when_deid_fails(
+    django_capture_on_commit_callbacks,
+):
+    di_upload = DICOMImageSetUploadFactory()
+    with patch.object(
+        DICOMImageSetUpload, "start_dicom_import_job"
+    ) as mocked_method:
+        with patch.object(
+            DICOMImageSetUpload,
+            "deidentify_user_uploads",
+            side_effect=Exception(),
+        ):
+            with django_capture_on_commit_callbacks(execute=True):
+                import_dicom_to_healthimaging(
+                    dicom_imageset_upload_pk=di_upload.pk
+                )
+        # start_dicom_import_job does not get called
+        mocked_method.assert_not_called()
+
+    di_upload.refresh_from_db()
+    # upload gets marked as failed
+    assert di_upload.status == DICOMImageSetUploadStatusChoices.FAILED
+    assert di_upload.error_message == "An unexpected error occurred"


### PR DESCRIPTION
This adds the de-identification step to the import task. For now, just a placeholder method that copies rather than download and uploads files. 

Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/431