### PR TITLE
Improve client deid procedure

### DIFF
--- a/app/grandchallenge/uploads/static/js/file_preprocessors.js
+++ b/app/grandchallenge/uploads/static/js/file_preprocessors.js
@@ -1,5 +1,3 @@
-const GRAND_CHALLENGE_ROOT_UID = "1.2.826.0.1.3680043.10.1666.";
-
 /**
  * Returns a dummy value based on the DICOM Value Representation (VR).
  * This is used to replace sensitive data during de-identification.
@@ -138,15 +136,6 @@ async function isDicomFile(file) {
 
 const uidMap = new Map(); // Map to store unique identifiers for UIDs
 
-const generateUid = () => {
-    let uid = GRAND_CHALLENGE_ROOT_UID + Math.floor(1 + Math.random() * 9);
-    const numbersToAdd = 64 - uid.length;
-    for (let index = 0; index < numbersToAdd; index++) {
-        uid = uid + Math.floor(Math.random() * 10);
-    }
-    return uid;
-};
-
 // Recursive de-identification for a dataset (object with DICOM tags)
 function deidentifyDataset(
     dataset,
@@ -261,7 +250,10 @@ function deidentifyDataset(
             case "U":
                 if (tagValue) {
                     if (!uidMap.has(tagValue)) {
-                        uidMap.set(tagValue, generateUid());
+                        uidMap.set(
+                            tagValue,
+                            dcmjs.data.DicomMetaDictionary.uid(),
+                        );
                     }
                     newDataset[tagKey] = {
                         ...dataset[tagKey],
@@ -386,7 +378,6 @@ globalThis.UPPY_FILE_PREPROCESSORS = [
 // Export for testing in Node.js environment
 if (typeof module !== "undefined" && module.exports) {
     module.exports = {
-        GRAND_CHALLENGE_ROOT_UID,
         getDummyValue,
         isDicomFile,
         preprocessDicomFile,

--- a/app/tests/uploads_tests/js/file_preprocessors.test.js
+++ b/app/tests/uploads_tests/js/file_preprocessors.test.js
@@ -1,5 +1,4 @@
 const {
-    GRAND_CHALLENGE_ROOT_UID,
     getDummyValue,
     isDicomFile,
     preprocessDicomFile,
@@ -219,8 +218,6 @@ describe("preprocessDicomFile", () => {
 
         expect(newUID).toBeDefined();
         expect(newUID).not.toBe(originalUID);
-        expect(newUID.length).toBe(64);
-        expect(newUID.startsWith(GRAND_CHALLENGE_ROOT_UID)).toBe(true);
 
         // Check consistency with a new file using the same original UID
         expect(_uidMap.get(originalUID)).toBe(newUID);


### PR DESCRIPTION
This copies over some improvements from Chris' python based deidentifier:

- Set PatientIdentityRemoved (00120062) tag to YES.
- Set DeidentificationMethod (00120063) to use value multiplicity and append method with version and timestamp.
- Add grand challenge root UID as prefix for consistently replaced UIDs.