### PR TITLE
Refactor object locking

### DIFF
--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -9,7 +9,6 @@ from typing import NamedTuple
 from billiard.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
 from celery import signature
 from django import forms
-from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import (
     MultipleObjectsReturned,
@@ -596,6 +595,8 @@ class ComponentInterface(OverlaySegmentsMixin):
         self._clean_default_value()
 
     def _clean_overlay_segments(self):
+        from grandchallenge.reader_studies.models import Question
+
         if (
             self.kind == InterfaceKindChoices.SEGMENTATION
             and not self.overlay_segments
@@ -617,7 +618,6 @@ class ComponentInterface(OverlaySegmentsMixin):
                 "Voxel values for overlay segments must be contiguous."
             )
 
-        Question = apps.get_model("reader_studies", "question")  # noqa: N806
         if (
             self.pk is not None
             and self._overlay_segments_orig != self.overlay_segments

--- a/app/grandchallenge/notifications/apps.py
+++ b/app/grandchallenge/notifications/apps.py
@@ -1,5 +1,6 @@
-from django.apps import AppConfig, apps
+from django.apps import AppConfig
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.db.models.signals import post_migrate
 
 
@@ -35,26 +36,48 @@ class NotificationsConfig(AppConfig):
     def ready(self):
         from actstream import registry
 
-        registry.register(apps.get_model("auth.User"))
-        registry.register(apps.get_model("algorithms.Algorithm"))
-        registry.register(
-            apps.get_model("algorithms.AlgorithmPermissionRequest")
+        from grandchallenge.algorithms.models import (
+            Algorithm,
+            AlgorithmPermissionRequest,
         )
-        registry.register(apps.get_model("archives.Archive"))
-        registry.register(apps.get_model("archives.ArchivePermissionRequest"))
-        registry.register(apps.get_model("reader_studies.ReaderStudy"))
-        registry.register(
-            apps.get_model("reader_studies.ReaderStudyPermissionRequest")
+        from grandchallenge.archives.models import (
+            Archive,
+            ArchivePermissionRequest,
         )
-        registry.register(apps.get_model("challenges.Challenge"))
-        registry.register(apps.get_model("participants.RegistrationRequest"))
-        registry.register(apps.get_model("evaluation.Submission"))
-        registry.register(apps.get_model("evaluation.Evaluation"))
-        registry.register(apps.get_model("evaluation.Phase"))
-        registry.register(apps.get_model("cases.RawImageUploadSession"))
-        registry.register(apps.get_model("discussion_forums.Forum"))
-        registry.register(apps.get_model("discussion_forums.ForumTopic"))
-        registry.register(apps.get_model("discussion_forums.ForumPost"))
+        from grandchallenge.cases.models import RawImageUploadSession
+        from grandchallenge.challenges.models import Challenge
+        from grandchallenge.discussion_forums.models import (
+            Forum,
+            ForumPost,
+            ForumTopic,
+        )
+        from grandchallenge.evaluation.models import (
+            Evaluation,
+            Phase,
+            Submission,
+        )
+        from grandchallenge.participants.models import RegistrationRequest
+        from grandchallenge.reader_studies.models import (
+            ReaderStudy,
+            ReaderStudyPermissionRequest,
+        )
+
+        registry.register(get_user_model())
+        registry.register(Algorithm)
+        registry.register(AlgorithmPermissionRequest)
+        registry.register(Archive)
+        registry.register(ArchivePermissionRequest)
+        registry.register(ReaderStudy)
+        registry.register(ReaderStudyPermissionRequest)
+        registry.register(Challenge)
+        registry.register(RegistrationRequest)
+        registry.register(Submission)
+        registry.register(Evaluation)
+        registry.register(Phase)
+        registry.register(RawImageUploadSession)
+        registry.register(Forum)
+        registry.register(ForumTopic)
+        registry.register(ForumPost)
         post_migrate.connect(init_notification_permissions, sender=self)
 
         # noinspection PyUnresolvedReferences

--- a/app/grandchallenge/uploads/views.py
+++ b/app/grandchallenge/uploads/views.py
@@ -47,15 +47,15 @@ class UserUploadViewSet(
         url_path="(?P<s3_upload_id>[^/]+)/list-parts",
     )
     def list_parts(self, request, pk, s3_upload_id):
-        object = self.get_object()
+        instance = self.get_object()
 
-        if object.s3_upload_id != s3_upload_id:
+        if instance.s3_upload_id != s3_upload_id:
             logger.warning(
-                f"Upload ID did not match: {object=}, {s3_upload_id=}"
+                f"Upload ID did not match: {instance=}, {s3_upload_id=}"
             )
             raise Http404
 
-        serializer = self.get_serializer(instance=object)
+        serializer = self.get_serializer(instance=instance)
         return Response(data=serializer.data)
 
     @action(
@@ -65,19 +65,19 @@ class UserUploadViewSet(
         url_path="(?P<s3_upload_id>[^/]+)/generate-presigned-urls",
     )
     def generate_presigned_urls(self, request, pk, s3_upload_id):
-        object = self.get_object()
+        instance = self.get_object()
 
-        if object.s3_upload_id != s3_upload_id:
+        if instance.s3_upload_id != s3_upload_id:
             logger.warning(
-                f"Upload ID did not match: {object=}, {s3_upload_id=}"
+                f"Upload ID did not match: {instance=}, {s3_upload_id=}"
             )
             raise Http404
 
-        if not object.can_upload_more:
+        if not instance.can_upload_more:
             self.permission_denied(request, message="Upload limit reached")
 
         serializer = self.get_serializer(
-            instance=object, data=request.data, partial=True
+            instance=instance, data=request.data, partial=True
         )
 
         if serializer.is_valid():
@@ -94,16 +94,16 @@ class UserUploadViewSet(
         url_path="(?P<s3_upload_id>[^/]+)/complete-multipart-upload",
     )
     def complete_multipart_upload(self, request, pk, s3_upload_id):
-        object = self.get_object()
+        instance = self.get_object()
 
-        if object.s3_upload_id != s3_upload_id:
+        if instance.s3_upload_id != s3_upload_id:
             logger.warning(
-                f"Upload ID did not match: {object=}, {s3_upload_id=}"
+                f"Upload ID did not match: {instance=}, {s3_upload_id=}"
             )
             raise Http404
 
         serializer = self.get_serializer(
-            instance=object, data=request.data, partial=True
+            instance=instance, data=request.data, partial=True
         )
 
         if serializer.is_valid():
@@ -120,16 +120,16 @@ class UserUploadViewSet(
         url_path="(?P<s3_upload_id>[^/]+)/abort-multipart-upload",
     )
     def abort_multipart_upload(self, request, pk, s3_upload_id):
-        object = self.get_object()
+        instance = self.get_object()
 
-        if object.s3_upload_id != s3_upload_id:
+        if instance.s3_upload_id != s3_upload_id:
             logger.warning(
-                f"Upload ID did not match: {object=}, {s3_upload_id=}"
+                f"Upload ID did not match: {instance=}, {s3_upload_id=}"
             )
             raise Http404
 
-        object.abort_multipart_upload()
-        object.save()
+        instance.abort_multipart_upload()
+        instance.save()
 
-        serializer = self.get_serializer(instance=object)
+        serializer = self.get_serializer(instance=instance)
         return Response(serializer.data)

--- a/app/grandchallenge/verifications/models.py
+++ b/app/grandchallenge/verifications/models.py
@@ -2,7 +2,6 @@ from datetime import timedelta
 
 from allauth.account.models import EmailAddress
 from allauth.account.signals import email_confirmed
-from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
@@ -137,6 +136,12 @@ class Verification(FieldChangeMixin, models.Model):
         )
 
     def accept_pending_requests_for_verified_users(self):
+        from grandchallenge.algorithms.models import AlgorithmPermissionRequest
+        from grandchallenge.archives.models import ArchivePermissionRequest
+        from grandchallenge.participants.models import RegistrationRequest
+        from grandchallenge.reader_studies.models import (
+            ReaderStudyPermissionRequest,
+        )
 
         if not self.is_verified:
             raise RuntimeError(
@@ -144,20 +149,10 @@ class Verification(FieldChangeMixin, models.Model):
             )
 
         permission_request_classes = {
-            "algorithm": apps.get_model(
-                app_label="algorithms",
-                model_name="AlgorithmPermissionRequest",
-            ),
-            "archive": apps.get_model(
-                app_label="archives", model_name="ArchivePermissionRequest"
-            ),
-            "reader_study": apps.get_model(
-                app_label="reader_studies",
-                model_name="ReaderStudyPermissionRequest",
-            ),
-            "challenge": apps.get_model(
-                app_label="participants", model_name="RegistrationRequest"
-            ),
+            "algorithm": AlgorithmPermissionRequest,
+            "archive": ArchivePermissionRequest,
+            "reader_study": ReaderStudyPermissionRequest,
+            "challenge": RegistrationRequest,
         }
 
         for (

--- a/app/grandchallenge/verifications/tasks.py
+++ b/app/grandchallenge/verifications/tasks.py
@@ -1,4 +1,3 @@
-from django.apps import apps
 from django.contrib.auth import get_user_model
 
 from grandchallenge.core.celery import acks_late_micro_short_task
@@ -6,9 +5,7 @@ from grandchallenge.core.celery import acks_late_micro_short_task
 
 @acks_late_micro_short_task
 def update_verification_user_set(*, usernames):
-    VerificationUserSet = apps.get_model(  # noqa: N806
-        app_label="verifications", model_name="VerificationUserSet"
-    )
+    from grandchallenge.verifications.models import VerificationUserSet
 
     users = get_user_model().objects.filter(username__in=usernames)
     user_sets = VerificationUserSet.objects.filter(users__in=users)

--- a/app/tests/components_tests/test_views.py
+++ b/app/tests/components_tests/test_views.py
@@ -464,17 +464,17 @@ def test_display_set_bulk_delete(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "object",
+    "factory",
     [
         ReaderStudyFactory,
         ArchiveFactory,
         AlgorithmFactory,
     ],
 )
-def test_file_upload_form_field_view(client, object):
-    object = object()
+def test_file_upload_form_field_view(client, factory):
+    instance = factory()
     u, editor = UserFactory.create_batch(2)
-    object.add_editor(editor)
+    instance.add_editor(editor)
 
     ci_json = ComponentInterfaceFactory(kind="JSON", store_in_database=False)
 
@@ -539,16 +539,16 @@ def test_display_ci_example_value(client):
 def test_interfaces_list_link_in_new_interface_form(
     client, object_factory, viewname, interface_list_viewname
 ):
-    object = object_factory()
+    instance = object_factory()
     u = UserFactory()
-    object.add_editor(u)
+    instance.add_editor(u)
 
     response = get_view_for_user(
         viewname=viewname,
         client=client,
         method=client.get,
         reverse_kwargs={
-            "slug": object.slug,
+            "slug": instance.slug,
         },
         user=u,
     )

--- a/app/tests/hanging_protocols_tests/test_forms.py
+++ b/app/tests/hanging_protocols_tests/test_forms.py
@@ -506,13 +506,13 @@ def test_archive_and_reader_study_forms_view_content_help_text(
     )
     civ_list = [ComponentInterfaceValueFactory(interface=ci) for ci in ci_list]
 
-    object = object_factory()
-    object.values.set(civ_list)
+    instance = object_factory()
+    instance.values.set(civ_list)
 
-    form = form_class(user=UserFactory(), instance=object.base_object)
+    form = form_class(user=UserFactory(), instance=instance.base_object)
 
     assert form.fields["view_content"].help_text == format_lazy(
-        expected_help_text, object.base_object._meta.verbose_name
+        expected_help_text, instance.base_object._meta.verbose_name
     )
 
 
@@ -827,8 +827,8 @@ def test_reader_study_forms_view_content_example_with_hanging_protocol(
     )
     civ_list = [ComponentInterfaceValueFactory(interface=ci) for ci in ci_list]
 
-    object = DisplaySetFactory()
-    object.values.set(civ_list)
+    instance = DisplaySetFactory()
+    instance.values.set(civ_list)
 
     ws = WorkstationFactory()
     creator = UserFactory()

--- a/app/tests/hanging_protocols_tests/test_serializers.py
+++ b/app/tests/hanging_protocols_tests/test_serializers.py
@@ -55,9 +55,9 @@ class TestHangingProtocolSerializer:
     ):
         """Each item should get the hanging protocol and content from the parent"""
         hp = HangingProtocolFactory(json=[{"viewport_name": "main"}])
-        object = factory(hanging_protocol=hp, view_content={"main": "test"})
+        instance = factory(hanging_protocol=hp, view_content={"main": "test"})
 
-        item_factory_kwargs.update({relation: object})
+        item_factory_kwargs.update({relation: instance})
 
         item = item_factory(**item_factory_kwargs)
 
@@ -86,10 +86,10 @@ class TestHangingProtocolSerializer:
     ):
         """Each item should get the optional hanging protocol from the parent"""
         hps = HangingProtocolFactory.create_batch(3)
-        object = factory()
-        object.optional_hanging_protocols.set(hps)
+        instance = factory()
+        instance.optional_hanging_protocols.set(hps)
 
-        item_factory_kwargs.update({relation: object})
+        item_factory_kwargs.update({relation: instance})
 
         item = item_factory(**item_factory_kwargs)
 
@@ -114,9 +114,9 @@ class TestHangingProtocolSerializer:
         serializer,
     ):
         """If no optional hanging protocols are present, none should be serialized"""
-        object = factory()
+        instance = factory()
 
-        item_factory_kwargs.update({relation: object})
+        item_factory_kwargs.update({relation: instance})
 
         item = item_factory(**item_factory_kwargs)
 


### PR DESCRIPTION
This PR refactors how we perform object locking. It introduces a context manager, `check_lock_acquired`, that will transform the operational error to a lock not acquired exception for use internally. This saves having to do the large construction.

The PR also removes `lock_model_instance`. This method turned out to be quite complex with all the locking options, so now we can use the Django constructs more closely.

The method also encouraged us to use `get_model`, which isn't a great practise as it uses string imports. Now we can use explicit imports everywhere possible which should improve the experience when working in IDEs.

Finally, I noticed that `object` was being shadowed in too many places so corrected that.