### PR TITLE
Allow parallel submissions to the same challenge

### DIFF
--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1056,7 +1056,7 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
         return (
             Evaluation.objects.active()
             .filter(
-                submission__phase__challenge=self.challenge,
+                submission__phase=self,
                 submission__creator__in=users,
             )
             .exists()


### PR DESCRIPTION
Using the queued status is not ideal here, but it allows us to continue to monitor that the `create_algorithm_jobs_for_evaluation` task is working correctly by filtering on executing pre-requisites.

Closes https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/642