### PR TITLE
Make dicom_image_set optional

### DIFF
--- a/app/grandchallenge/cases/serializers.py
+++ b/app/grandchallenge/cases/serializers.py
@@ -42,7 +42,7 @@ class DICOMImageSetSerializer(serializers.ModelSerializer):
 class HyperlinkedImageSerializer(serializers.ModelSerializer):
     files = ImageFileSerializer(many=True, read_only=True)
     modality = ImagingModalitySerializer(allow_null=True, read_only=True)
-    dicom_image_set = DICOMImageSetSerializer(read_only=True)
+    dicom_image_set = DICOMImageSetSerializer(allow_null=True, read_only=True)
 
     class Meta:
         model = Image


### PR DESCRIPTION
When updating the models.py for gcapi I noticed that the dicom_image_set is not optional:

```Python
class HyperlinkedImage(BaseModel):
    pk: str
    name: str
    files: list[ImageFile]
    dicom_image_set: DICOMImageSet
    width: Optional[int]
    height: Optional[int]
    depth: Optional[int]
    ...
```    