### PR TITLE
Reduce GitHub API page request load by 20%

### DIFF
--- a/app/grandchallenge/github/views.py
+++ b/app/grandchallenge/github/views.py
@@ -172,7 +172,7 @@ class RepositoriesList(
         Currently, there is no way to filter the repositories, see
         https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28#list-repositories-accessible-to-the-user-access-token
         """
-        per_page = 100
+        per_page = 80
 
         def get_page(*, page):
             return requests.get(


### PR DESCRIPTION
The GitHub api is hitting timeouts on requests. Reduce the requested page size from 100 to 80 to reduce the chance of hitting this.