### PR TITLE
Add slug to interface modal

### DIFF
--- a/app/grandchallenge/algorithms/templates/algorithms/partials/socket_modal_base.html
+++ b/app/grandchallenge/algorithms/templates/algorithms/partials/socket_modal_base.html
@@ -29,6 +29,9 @@
             </div>
             <dd class="text-left modal-body">
                 <dl>
+                    <dt>Slug</dt>
+                    <dd><code>{{ socket.slug }}</code></dd>
+
                     <dt>Description</dt>
                     <dd>{% if socket.description %}{{ socket.description }}{% else %} - {% endif %}</dd>
 


### PR DESCRIPTION
In the interface overview, we don't mention the slug of sockets anywhere. It can be found via the overview of sockets, but this PR makes it directly visible via the interface overview for both algorithms and challenge submissions.

Handy, if one needs to know the slugs of the input sockets to correctly call the API.

## Before
<img width="806" height="284" alt="Screenshot 2025-11-07 at 11 03 39" src="https://github.com/user-attachments/assets/c2de9b9d-671f-47c3-89d1-4d7a37e3ec4f" />

## After
<img width="806" height="336" alt="Screenshot 2025-11-07 at 11 12 37" src="https://github.com/user-attachments/assets/5749aa42-7c15-4277-9ecc-fd952c7e71b3" />