### PR TITLE
Increase MFA_TOTP_TOLERANCE

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -643,6 +643,8 @@ SOCIALACCOUNT_PROVIDERS = {
     }
 }
 
+MFA_TOTP_TOLERANCE = 5
+
 # Use full paths as view name lookups do not work on subdomains
 LOGIN_URL = "/accounts/login/"
 LOGOUT_URL = "/accounts/logout/"


### PR DESCRIPTION
Allow ±5 seconds for TOTP codes to account for clock drift and user login delays. See https://docs.allauth.org/en/dev/mfa/configuration.html