### PR TITLE
Exclude the `deidentification.done` file from the dicom import job input files

### DIFF
--- a/app/grandchallenge/cases/models.py
+++ b/app/grandchallenge/cases/models.py
@@ -1190,12 +1190,12 @@ class DICOMImageSetUpload(UUIDModel):
         return f"inputs/{self.pk}"
 
     @property
-    def _input_files_location(self):
+    def _input_files_prefix(self):
         return f"{self._input_prefix}/files"
 
     @property
     def _import_input_s3_uri(self):
-        return f"s3://{settings.AWS_HEALTH_IMAGING_BUCKET_NAME}/{self._input_files_location}"
+        return f"s3://{settings.AWS_HEALTH_IMAGING_BUCKET_NAME}/{self._input_files_prefix}"
 
     @property
     def _import_output_s3_uri(self):
@@ -1305,7 +1305,7 @@ class DICOMImageSetUpload(UUIDModel):
                 self._s3_client.upload_fileobj(
                     Fileobj=outfile,
                     Bucket=settings.AWS_HEALTH_IMAGING_BUCKET_NAME,
-                    Key=f"{self._input_files_location}/{upload.pk}.dcm",
+                    Key=f"{self._input_files_prefix}/{upload.pk}.dcm",
                 )
 
     def deidentify_user_uploads(self):

--- a/app/tests/cases_tests/test_models.py
+++ b/app/tests/cases_tests/test_models.py
@@ -180,7 +180,7 @@ def test_dicomimagesetupload_import_properties():
     )
     assert (
         di_upload._import_input_s3_uri
-        == f"s3://{settings.AWS_HEALTH_IMAGING_BUCKET_NAME}/inputs/files/{di_upload.pk}"
+        == f"s3://{settings.AWS_HEALTH_IMAGING_BUCKET_NAME}/inputs/{di_upload.pk}/files"
     )
     assert (
         di_upload._import_output_s3_uri


### PR DESCRIPTION
Related to https://github.com/DIAGNijmegen/rse-roadmap/issues/445