### PR TITLE
Quick fix for errors on running celery tasks without celeryd

### DIFF
--- a/app/config/celery.py
+++ b/app/config/celery.py
@@ -68,8 +68,8 @@ def get_scale_in_protection_url():
 @task_prerun.connect()
 def set_ecs_scale_in_protection(*_, task, **__):
     if (
-        celery_app.is_solo_worker
-        and settings.ECS_ENABLE_CELERY_SCALE_IN_PROTECTION
+        settings.ECS_ENABLE_CELERY_SCALE_IN_PROTECTION
+        and celery_app.is_solo_worker
     ):
         expire_seconds = task.time_limit or settings.CELERY_TASK_TIME_LIMIT
         expire_minutes = max(ceil(expire_seconds / 60), 1)
@@ -91,8 +91,8 @@ def set_ecs_scale_in_protection(*_, task, **__):
 @task_postrun.connect()
 def remove_ecs_scale_in_protection(*_, **__):
     if (
-        celery_app.is_solo_worker
-        and settings.ECS_ENABLE_CELERY_SCALE_IN_PROTECTION
+        settings.ECS_ENABLE_CELERY_SCALE_IN_PROTECTION
+        and celery_app.is_solo_worker
     ):
         logger.info("Removing ECS scale-in protection")
 


### PR DESCRIPTION
The uv-based integration tests for gcapi run without workers. This entails that the `task_prerun` and `task_postrun` listeners fire, but not the `celeryd_after_setup`. 

As a result, this throws an error several times during setup (but isolated so nothing breaks):
> AttributeError: 'Celery' object has no attribute 'is_solo_worker'

Instead of re-adding the worker, I thought it's OK to instead have the prerun/postrun to take into account the attr hadn't been set.