### PR TITLE
Fix `Image` shape missing or having `None`

### DIFF
--- a/app/grandchallenge/cases/models.py
+++ b/app/grandchallenge/cases/models.py
@@ -596,8 +596,10 @@ class Image(UUIDModel):
             result.append(self.timepoints)
         if self.depth is not None:
             result.append(self.depth)
-        result.append(self.height)
-        result.append(self.width)
+        if self.height is not None:
+            result.append(self.height)
+        if self.width is not None:
+            result.append(self.width)
         return result
 
     @property
@@ -610,9 +612,10 @@ class Image(UUIDModel):
             The shape of the image in NumPy ordering [(t), (z), y, x, (c)]
         """
         result = self.shape_without_color
-        color_components = self.COLOR_SPACE_COMPONENTS[self.color_space]
-        if color_components > 1:
-            result.append(color_components)
+        if self.color_space:
+            color_components = self.COLOR_SPACE_COMPONENTS[self.color_space]
+            if color_components > 1:
+                result.append(color_components)
         return result
 
     @property

--- a/app/tests/cases_tests/test_api.py
+++ b/app/tests/cases_tests/test_api.py
@@ -972,8 +972,13 @@ def test_dicom_image_set_serialized(client):
                     "stored_transfer_syntax_uid": "1.2.840.10008.1.2.4.202",
                 },
             ],
-        )
+        ),
+        # Fields set by the factory, but are not set for DicomImageSets
+        width=None,
+        height=None,
+        origin=None,
     )
+
     user = UserFactory()
     assign_perm("view_image", user, image)
 
@@ -984,9 +989,12 @@ def test_dicom_image_set_serialized(client):
         client=client,
     )
 
-    assert response.json()["dicom_image_set"] == {
+    returned_data = response.json()
+    assert returned_data["dicom_image_set"] == {
         "image_set_id": "test-image-set-id"
     }
+    assert returned_data["shape"] == []
+    assert returned_data["shape_without_color"] == []
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
For DICOM image sets the `HyperlinkedImage` model from the `HyperlinkedImageSerializer` is breaking on the GCAPI side:
- field `shape` is completely missing (but typed for `list[int]`)
- field `shape_without_color` was `[None, None]`, while typed for `list[int]`

This PR fixes this by effectively having both be `[]` for DICOM image sets.