### PR TITLE
Remove GeneratedField comments

### DIFF
--- a/app/grandchallenge/evaluation/forms.py
+++ b/app/grandchallenge/evaluation/forms.py
@@ -740,7 +740,6 @@ class EvaluationForm(SaveFormInitMixin, AdditionalInputsMixin, forms.Form):
                 )
 
         # Fetch from the db to get the cost annotations
-        # Maybe this is solved with GeneratedField (Django 5)?
         challenge = (
             Challenge.objects.filter(
                 pk=cleaned_data["submission"].phase.challenge.pk

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -230,7 +230,6 @@ class PhaseManager(models.Manager):
             .prefetch_related(
                 # This should be a select_related, but I cannot find a way
                 # to use a custom model manager with select_related
-                # Maybe this is solved with GeneratedField (Django 5)?
                 models.Prefetch(
                     "challenge",
                     queryset=Challenge.objects.with_available_compute(),

--- a/app/tests/evaluation_tests/test_forms.py
+++ b/app/tests/evaluation_tests/test_forms.py
@@ -440,7 +440,6 @@ class TestSubmissionForm:
         )
 
         # Fetch from the db to get the cost annotations
-        # Maybe this is solved with GeneratedField (Django 5)?
         p = Phase.objects.get(pk=p.pk)
 
         ai = AlgorithmImageFactory(
@@ -499,7 +498,6 @@ class TestSubmissionForm:
         )
 
         # Fetch from the db to get the cost annotations
-        # Maybe this is solved with GeneratedField (Django 5)?
         p = Phase.objects.get(pk=p.pk)
 
         ai = AlgorithmImageFactory(
@@ -563,7 +561,6 @@ class TestSubmissionForm:
         )
 
         # Fetch from the db to get the cost annotations
-        # Maybe this is solved with GeneratedField (Django 5)?
         phase = Phase.objects.get(pk=phase.pk)
 
         form = SubmissionForm(
@@ -612,8 +609,8 @@ class TestSubmissionForm:
                 compute_costs_euros=10,
                 payment_type=PaymentTypeChoices.COMPLIMENTARY,
             )
+
         # Fetch from the db to get the cost annotations
-        # Maybe this is solved with GeneratedField (Django 5)?
         p_alg = Phase.objects.get(pk=p_alg.pk)
         p_pred = Phase.objects.get(pk=p_pred.pk)
 
@@ -709,7 +706,6 @@ class TestSubmissionForm:
         )
 
         # Fetch from the db to get the cost annotations
-        # Maybe this is solved with GeneratedField (Django 5)?
         p = Phase.objects.get(pk=p.pk)
 
         ai = AlgorithmImageFactory(
@@ -804,7 +800,6 @@ class TestSubmissionForm:
         )
 
         # Fetch from the db to get the cost annotations
-        # Maybe this is solved with GeneratedField (Django 5)?
         p = Phase.objects.get(pk=p.pk)
 
         ai = AlgorithmImageFactory(

--- a/app/tests/evaluation_tests/test_models.py
+++ b/app/tests/evaluation_tests/test_models.py
@@ -319,7 +319,6 @@ class TestPhaseLimits:
         )
 
         # Fetch from the db to get the cost annotations
-        # Maybe this is solved with GeneratedField (Django 5)?
         self.phase = Phase.objects.get(pk=phase.pk)
         self.user = UserFactory()
 
@@ -540,7 +539,6 @@ def test_open_for_submission(
     )
 
     # Fetch from the db to get the cost annotations
-    # Maybe this is solved with GeneratedField (Django 5)?
     phase = Phase.objects.get(pk=phase.pk)
 
     assert phase.open_for_submissions == open_for_submissions


### PR DESCRIPTION
Unfortunately GeneratedFields cannot reference fields of other objects, which would be needed for the cost annotations.

See https://docs.djangoproject.com/en/5.2/ref/models/fields/#generatedfield