### PR TITLE
Create dicom deidentifier uppy plugin

### DIFF
--- a/app/grandchallenge/uploads/static/js/dicom_deidentification.js
+++ b/app/grandchallenge/uploads/static/js/dicom_deidentification.js
@@ -336,7 +336,7 @@ class DicomDeidentifierPlugin extends Uppy.Core.BasePlugin {
     constructor(uppy, opts) {
         super(uppy, opts);
 
-        this.id = opts.id || "DicomDeidentifierPlugin";
+        this.id = opts?.id || "DicomDeidentifierPlugin";
         this.type = "modifier";
 
         this.prepareUpload = this.prepareUpload.bind(this);
@@ -376,6 +376,7 @@ if (typeof module !== "undefined" && module.exports) {
     module.exports = {
         getDummyValue,
         preprocessDicomFile,
+        DicomDeidentifierPlugin,
         // For testing only
         _uidMap: uidMap,
     };

--- a/app/grandchallenge/uploads/static/js/user_upload.js
+++ b/app/grandchallenge/uploads/static/js/user_upload.js
@@ -24,7 +24,7 @@
             document.getElementById(`${inputId}AllowedFileTypes`).textContent,
         );
         const maxNumberOfFiles = widget.getAttribute("data-max-number-files");
-        const isDicomWidget = widget.dataset.type === "dicom";
+        const widgetType = widget.dataset.type;
 
         const uppy = new Uppy.Core({
             id: `${window.location.pathname}-${inputId}`,
@@ -63,6 +63,10 @@
             completeMultipartUpload: completeMultipartUpload,
         });
 
+        if (widgetType === "dicom") {
+            uppy.use(DicomDeidentifierPlugin, {});
+        }
+
         uppy.on("upload-success", (file, response) => {
             const uploadedPK = file.s3Multipart.key.split("/")[2];
             const fileList = document.getElementById(`${inputId}-file-list`);
@@ -99,10 +103,6 @@
             );
             fileList.prepend(newFile);
         });
-
-        if (isDicomWidget) {
-            uppy.use(DicomDeidentifierPlugin, {});
-        }
     }
 
     function getCookie(name) {


### PR DESCRIPTION
Use an uppy plugin, replacing the event hook to `file-added`, to enable processing multiple files. 

Closes #4447