### PR TITLE
Invalidate email as first or last name

### DIFF
--- a/app/grandchallenge/profiles/forms.py
+++ b/app/grandchallenge/profiles/forms.py
@@ -2,6 +2,7 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit
 from django import forms
 from django.core.exceptions import ValidationError
+from django.core.validators import EmailValidator
 from django.forms import CheckboxInput, Select
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
@@ -105,21 +106,29 @@ class SignupForm(UserProfileForm):
     def clean(self):
         cleaned_data = super().clean()
 
-        email = self.cleaned_data.get("email")
+        first_name = self.cleaned_data.get("first_name", "")
+        try:
+            EmailValidator()(first_name)
+        except ValidationError:
+            # Name is not an email address
+            pass
+        else:
+            self.add_error(
+                "first_name",
+                "First Name cannot be an email address.",
+            )
 
-        if email:
-            first_name = self.cleaned_data.get("first_name", "")
-            last_name = self.cleaned_data.get("last_name", "")
-            if email.casefold() in first_name.casefold():
-                self.add_error(
-                    "first_name",
-                    "First Name cannot contain your email address.",
-                )
-            if email.casefold() in last_name.casefold():
-                self.add_error(
-                    "last_name",
-                    "Last Name cannot contain your email address.",
-                )
+        last_name = self.cleaned_data.get("last_name", "")
+        try:
+            EmailValidator()(last_name)
+        except ValidationError:
+            # Name is not an email address
+            pass
+        else:
+            self.add_error(
+                "last_name",
+                "Last Name cannot be an email address.",
+            )
 
         return cleaned_data
 

--- a/app/tests/profiles_tests/test_views.py
+++ b/app/tests/profiles_tests/test_views.py
@@ -450,64 +450,47 @@ def test_policies_must_be_accepted(client):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "first_name,last_name,email,expected_errors",
+    "first_name,last_name,expected_errors",
     [
         (
             "John",
             "Doe",
-            "john.doe@example.test",
             {},
         ),
         (
             "john.doe@example.test",
             "Doe",
-            "john.doe@example.test",
-            {"first_name": {"First Name cannot contain your email address."}},
+            {"first_name": {"First Name cannot be an email address."}},
         ),
         (
             "John",
             "john.doe@example.test",
-            "john.doe@example.test",
-            {"last_name": {"Last Name cannot contain your email address."}},
+            {"last_name": {"Last Name cannot be an email address."}},
         ),
         (
             "john.doe@example.test",
             "john.doe@example.test",
-            "john.doe@example.test",
             {
                 "first_name": {
-                    "First Name cannot contain your email address.",
+                    "First Name cannot be an email address.",
                 },
                 "last_name": {
-                    "Last Name cannot contain your email address.",
-                },
-            },
-        ),
-        (
-            "123john.doe@example.test",
-            "john.doe@example.test123",
-            "john.doe@example.test",
-            {
-                "first_name": {
-                    "First Name cannot contain your email address.",
-                },
-                "last_name": {
-                    "Last Name cannot contain your email address.",
+                    "Last Name cannot be an email address.",
                 },
             },
         ),
     ],
 )
 def test_signup_form_validation(
-    first_name, last_name, email, expected_errors, client
+    first_name, last_name, expected_errors, client
 ):
     response = get_view_for_user(
         url="/accounts/signup/",
         client=client,
         method=client.post,
         data={
-            "email": email,
-            "email2": email,
+            "email": "john.doe@example.test",
+            "email2": "john.doe@example.test",
             "username": "user123",
             "first_name": first_name,
             "last_name": last_name,


### PR DESCRIPTION
Closes: https://github.com/DIAGNijmegen/rse-grand-challenge/issues/4254

I don't think we should disable email-like usernames, but instead add a quick contain check that covers an exact copy or a sneaky `'foo@example.test+1'` attempt.