### PR TITLE
Make session utilization fields in admin readonly

### DIFF
--- a/app/grandchallenge/utilization/admin.py
+++ b/app/grandchallenge/utilization/admin.py
@@ -28,7 +28,6 @@ class SessionUtilizationAdmin(admin.ModelAdmin):
         "reader_studies__pk",
     )
     readonly_fields = (
-        "pk",
         "created",
         "session",
         "creator",


### PR DESCRIPTION
The session and creator fields will otherwise call for a long query. 

Closes https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/711