### PR TITLE
Add d-none to boundfield css classes

### DIFF
--- a/app/grandchallenge/components/form_fields.py
+++ b/app/grandchallenge/components/form_fields.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db.models import TextChoices
-from django.forms import ModelChoiceField, MultiValueField
+from django.forms import BoundField, ModelChoiceField, MultiValueField
 
 from grandchallenge.components.models import ComponentInterfaceValue
 from grandchallenge.components.widgets import FlexibleFileWidget
@@ -106,3 +106,8 @@ class FlexibleFileField(MultiValueField):
             if len(non_empty_values) != 1:
                 raise ValidationError("Too many values returned.")
             return non_empty_values[0]
+
+
+class BoundFieldWithDNoneClass(BoundField):
+    def css_classes(self, extra_classes=None):
+        return f"d-none {super().css_classes(extra_classes)}"

--- a/app/grandchallenge/components/forms.py
+++ b/app/grandchallenge/components/forms.py
@@ -35,7 +35,10 @@ from grandchallenge.cases.widgets import (
 from grandchallenge.components.backends.exceptions import (
     CIVNotEditableException,
 )
-from grandchallenge.components.form_fields import FlexibleFileField
+from grandchallenge.components.form_fields import (
+    BoundFieldWithDNoneClass,
+    FlexibleFileField,
+)
 from grandchallenge.components.models import (
     CIVData,
     ComponentInterface,
@@ -204,11 +207,13 @@ class InterfaceFormFieldsMixin:
                         user=user,
                         label="",
                         required=False,
+                        bound_field_class=BoundFieldWithDNoneClass,
                     ),
                     f"{FlexibleWidgetPrefixes.SEARCH.value}{interface.slug}": ModelChoiceField(
                         queryset=image_search_queryset,
                         label="",
                         required=False,
+                        bound_field_class=BoundFieldWithDNoneClass,
                         widget=ImageSearchWidget(
                             prefixed_interface_slug=prefixed_interface_slug
                         ),


### PR DESCRIPTION
Make the flexible widgets on an InterfaceFormField hidden by default. This avoids the flickering when loading these widgets on HTMX before the javascript hides them. 