### PR TITLE
Add event listener to stable ancestor

### DIFF
--- a/app/grandchallenge/components/static/components/js/create_extra_interfaces.mjs
+++ b/app/grandchallenge/components/static/components/js/create_extra_interfaces.mjs
@@ -17,8 +17,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
 // force client side field validation for extra interface form fields
 // htmx post won't get sent otherwise
-const objForm = document.getElementById("obj-form");
-objForm.addEventListener("htmx:validation:validate", event => {
+document.addEventListener("htmx:validation:validate", event => {
     const extraInterfaceForms = document.getElementsByClassName(
         "extra-interface-form",
     );


### PR DESCRIPTION
The form element is replaced after server side validation errors, so if the event listener was added to the original form element, the validation ui on new extra sockets is no longer invoked afterwards. We now add the listener to the document instead.