### PR TITLE
Use `form_id` in place of `id`

### DIFF
--- a/app/grandchallenge/components/forms.py
+++ b/app/grandchallenge/components/forms.py
@@ -588,7 +588,7 @@ class SingleCIVForm(InterfaceFormFieldsMixin, Form):
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
-        self.id = form_id
+        self.form_id = form_id
         data = kwargs.get("data")
 
         try:

--- a/app/grandchallenge/components/templates/components/new_interface_create.html
+++ b/app/grandchallenge/components/templates/components/new_interface_create.html
@@ -1,6 +1,6 @@
 {% load crispy_forms_tags %}
 
-<form class="extra-interface-form border rounded p-2 my-2" id="form-{{ form.id }}">
+<form class="extra-interface-form border rounded p-2 my-2" id="form-{{ form.form_id }}">
     {% csrf_token %}
     {{ form|crispy }}
     <button type="button" class="btn btn-danger remove-form">Remove</button>


### PR DESCRIPTION
Nit from #4473: prefer the use of an explicit `form_id` rather than `id` to avoid confusion with the `id()` built-in. This is why we use `pk` everywhere on Django models, rather than `id`.