### PR TITLE
Validate is_editable on form

### DIFF
--- a/app/grandchallenge/components/forms.py
+++ b/app/grandchallenge/components/forms.py
@@ -8,6 +8,7 @@ from dal.widgets import Select
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.forms import (
     CheckboxSelectMultiple,
     Field,
@@ -553,6 +554,12 @@ class CIVSetCreateFormMixin:
 
 
 class CIVSetUpdateFormMixin:
+    def clean(self):
+        if not self.instance.is_editable:
+            raise ValidationError(self.instance.not_editable_error_message)
+
+        return super().clean()
+
     def process_object_data(self):
         instance = self.instance
 

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -2491,6 +2491,7 @@ class CIVSetObjectPermissionsMixin:
 
 
 class CIVForObjectMixin:
+    not_editable_error_message = "This object cannot be updated."
 
     def add_civ(self, *, civ):
         if not self.is_editable:

--- a/app/grandchallenge/components/serializers.py
+++ b/app/grandchallenge/components/serializers.py
@@ -339,9 +339,6 @@ class HyperlinkedComponentInterfaceValueSerializer(
 
 
 class CIVSetPostSerializerMixin:
-
-    editability_error_message = "This object cannot be updated."
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -357,9 +354,8 @@ class CIVSetPostSerializerMixin:
         return super().create(validated_data)
 
     def update(self, instance, validated_data):
-
         if not instance.is_editable:
-            raise DRFValidationError(self.editability_error_message)
+            raise DRFValidationError(instance.not_editable_error_message)
 
         values = validated_data.pop("values", [])
 

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -938,6 +938,10 @@ class DisplaySet(
     order = models.PositiveIntegerField(default=0)
     title = models.CharField(max_length=255, default="", blank=True)
 
+    not_editable_error_message = (
+        "This display set cannot be changed, as answers for it already exist."
+    )
+
     def assign_permissions(self):
         assign_perm(
             self.delete_perm,

--- a/app/grandchallenge/reader_studies/serializers.py
+++ b/app/grandchallenge/reader_studies/serializers.py
@@ -1,5 +1,4 @@
 from django.core.exceptions import ValidationError
-from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.fields import (
     BooleanField,
     CharField,
@@ -171,17 +170,9 @@ class DisplaySetPostSerializer(
     CIVSetPostSerializerMixin,
     DisplaySetSerializer,
 ):
-    editability_error_message = (
-        "This display set cannot be changed, as answers for it already exist."
-    )
     reader_study = SlugRelatedField(
         slug_field="slug", queryset=ReaderStudy.objects.none(), required=False
     )
-
-    def create(self, validated_data):
-        if validated_data.pop("values", []) != []:
-            raise DRFValidationError("Values can only be added via update")
-        return super().create(validated_data)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -767,7 +767,7 @@ def test_add_display_set_to_reader_study_with_empty_value(
 
 
 @pytest.mark.django_db
-def test_add_display_set_update_when_disabled(client):
+def test_display_set_update_when_disabled(client):
     editor = UserFactory()
     rs = ReaderStudyFactory()
     ds = DisplaySetFactory(reader_study=rs)
@@ -789,12 +789,11 @@ def test_add_display_set_update_when_disabled(client):
         user=editor,
         method=client.post,
     )
-    assert response.status_code == 302
 
-    assert Notification.objects.count() == 1
-    notification = Notification.objects.first()
-    assert notification.user == editor
-    assert notification.message == "An unexpected error occurred"
+    assert response.status_code == 200
+    assert [
+        "This display set cannot be changed, as answers for it already exist."
+    ] == response.context["form"].errors["__all__"]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Add the validation for `is_editable` we have on the serializers in `CIVSetPostSerializerMixin` to the forms in `CIVSetUpdateFormMixin`. 
