### PR TITLE
Small improvements: Layout header and add fieldsets

### DIFF
--- a/app/grandchallenge/challenges/forms.py
+++ b/app/grandchallenge/challenges/forms.py
@@ -601,11 +601,11 @@ class ChallengeRequestBudgetUpdateForm(forms.ModelForm):
     class Meta:
         model = ChallengeRequest
         fields = (
+            "task_ids",
             "algorithm_selectable_gpu_type_choices_for_tasks",
             "algorithm_maximum_settable_memory_gb_for_tasks",
             "average_size_test_case_mb_for_tasks",
             "inference_time_average_minutes_for_tasks",
-            "task_ids",
             "task_id_for_phases",
             "number_of_teams_for_phases",
             "number_of_submissions_per_team_for_phases",
@@ -626,7 +626,29 @@ class ChallengeRequestBudgetUpdateForm(forms.ModelForm):
                 "hx-swap": "outerHTML",
             }
         )
-        self.helper.layout.append(Submit("save", "Save"))
+        self.helper.layout = Layout(
+            HTML("<h2>Update budget fields</h2>"),
+            Fieldset(
+                "Tasks",
+                "task_ids",
+                "algorithm_selectable_gpu_type_choices_for_tasks",
+                "algorithm_maximum_settable_memory_gb_for_tasks",
+                "average_size_test_case_mb_for_tasks",
+                "inference_time_average_minutes_for_tasks",
+                css_class="border rounded px-2 my-4",
+            ),
+            Fieldset(
+                "Phases",
+                "task_id_for_phases",
+                "number_of_teams_for_phases",
+                "number_of_submissions_per_team_for_phases",
+                "number_of_test_cases_for_phases",
+                css_class="border rounded px-2 my-4",
+            ),
+            ButtonHolder(
+                Submit("Save", "Save"),
+            ),
+        )
 
     def clean(self):
         cleaned_data = super().clean()

--- a/app/grandchallenge/challenges/templates/challenges/challengerequest_budget_form.html
+++ b/app/grandchallenge/challenges/templates/challenges/challengerequest_budget_form.html
@@ -1,5 +1,4 @@
 {% load crispy_forms_tags %}
 {% load static %}
-<h2 class="mb-4">Update budget fields</h2>
 {% crispy form %}
 <script type="text/javascript" src="{% static "js/unsavedform.js" %}"></script>


### PR DESCRIPTION
Fixes a bug where the header 'Update budget field' duplicating with validation errors (quite hilariously):

<img width="200"  alt="Screenshot 2026-02-10 at 11 43 58" src="https://github.com/user-attachments/assets/4966dac0-d34a-4d42-8fde-0a2724ed2f26" />

In addition, changed the order of fields and added some field sets for sorting.

I did play around a bit with a description/title per task. That would add a bit of human readability if you have >2 tasks. Pushed it out of scope for now as I just want to focus on getting the PRs merged. Maybe something for the future.

<details>
<summary>
Screenshot of 3 tasks
</summary>
<img width="817" height="1150" alt="Screenshot 2026-02-10 at 12 15 31" src="https://github.com/user-attachments/assets/abf6a400-82d4-4d2c-82bd-12ec2c72c73a" />
</details>




