### PR TITLE
Add openjpeg as requirement for forge templates that have DICOM

### DIFF
--- a/app/grandchallenge/forge/templates/forge/partials/example_algorithm/requirements.txt.template
+++ b/app/grandchallenge/forge/templates/forge/partials/example_algorithm/requirements.txt.template
@@ -10,4 +10,5 @@ pydicom
 # Required to decompress some DICOM transfer syntaxes
 pylibjpeg
 pylibjpeg-libjpeg
+pylibjpeg-openjpeg
 {% endif %}

--- a/app/grandchallenge/forge/templates/forge/partials/example_evaluation_method/requirements.txt.template
+++ b/app/grandchallenge/forge/templates/forge/partials/example_evaluation_method/requirements.txt.template
@@ -11,4 +11,5 @@ pydicom
 # Required to decompress some DICOM transfer syntaxes
 pylibjpeg
 pylibjpeg-libjpeg
+pylibjpeg-openjpeg
 {% endif %}

--- a/app/grandchallenge/forge/templates/forge/partials/functions/load_dicom_image.py.template
+++ b/app/grandchallenge/forge/templates/forge/partials/functions/load_dicom_image.py.template
@@ -11,7 +11,10 @@ def load_dicom_image_set_as_array(*, location):
 
     # Read all slices
     slices = [pydicom.dcmread(f, force=True) for f in dicom_files]
-    decompressed_slices = [slice.decompress() for slice in slices]
+
+    for idx, slice in enumerate(slices):  # Decompress the pixel data in-place.
+        slice.decompress()
+        print(f"Slice {idx} shape:", slice.pixel_array.shape)
 
     # Extracting pixel-data is non-trivial:
     # - Slices need to be sorted in case of a 3D volume or 4D volume


### PR DESCRIPTION
While debugging an algorithm, I found that we also require `pylibjpeg-openjpeg` for decompression of: `'High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only)'`.

At the same time, I found out the `slice.decompress()` is actually in-place. Cleaned that up as well.
