### PR TITLE
add token lifecycle management to AuthToken

### DIFF
--- a/app/knox/models.py
+++ b/app/knox/models.py
@@ -32,6 +32,23 @@ class AuthTokenManager(models.Manager):
         )
         return instance, token
 
+    def get_active(self, *, user=None):
+        qs = self.filter(
+            models.Q(expiry__isnull=True) | models.Q(expiry__gt=timezone.now())
+        )
+        if user is not None:
+            qs = qs.filter(user=user)
+        return qs
+
+    def get_expired(self, *, user=None):
+        qs = self.filter(expiry__lte=timezone.now())
+        if user is not None:
+            qs = qs.filter(user=user)
+        return qs
+
+    def purge_expired(self, *, user=None):
+        return self.get_expired(user=user).delete()
+
 
 class AuthToken(models.Model):
 
@@ -50,6 +67,38 @@ class AuthToken(models.Model):
     )
     created = models.DateTimeField(auto_now_add=True)
     expiry = models.DateTimeField(null=True, blank=True)
+    last_used = models.DateTimeField(null=True, blank=True)
+    use_count = models.PositiveIntegerField(default=0)
 
     def __str__(self):
         return f"{self.key} : {self.user}"
+
+    @property
+    def is_expired(self):
+        if self.expiry is None:
+            return False
+        return timezone.now() >= self.expiry
+
+    @property
+    def time_remaining(self):
+        if self.expiry is None:
+            return None
+        delta = self.expiry - timezone.now()
+        return delta if delta.total_seconds() > 0 else timedelta(0)
+
+    def update_last_used(self):
+        now = timezone.now()
+        AuthToken.objects.filter(pk=self.pk).update(
+            last_used=now,
+            use_count=models.F("use_count") + 1,
+        )
+        self.last_used = now
+        self.use_count += 1
+
+    def rotate(self, expiry=DEFAULT_EXPIRY):
+        new_instance, new_token = AuthToken.objects.create(
+            user=self.user,
+            expiry=expiry,
+        )
+        self.delete()
+        return new_instance, new_token


### PR DESCRIPTION
the AuthToken model has no way to check expiry, track usage, or rotate tokens without reimplementing that logic in every caller. added `is_expired`, `time_remaining`, `update_last_used`, and `rotate` to the model, plus `get_active`, `get_expired`, and `purge_expired` on the manager. also added `last_used` and `use_count` fields to support the usage tracking. `update_last_used` uses a filtered update to avoid race conditions on the counter.