### PR TITLE
Remove pytest-timeout

### DIFF
--- a/app/tests/forge_tests/test_evaluate_helpers.py
+++ b/app/tests/forge_tests/test_evaluate_helpers.py
@@ -1,4 +1,6 @@
+import functools
 import shutil
+import signal
 import sys
 import tempfile
 import time
@@ -34,6 +36,30 @@ def helpers():
             yield helpers_module
         finally:
             sys.path.remove(temp_dir)
+
+
+def timeout(seconds):
+    def decorator(func):
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if sys.platform == "win32":
+                pytest.skip("timeout not supported on Windows")
+
+            def handler(signum, frame):
+                raise TimeoutError(f"Test timed out after {seconds}s")
+
+            signal.signal(signal.SIGALRM, handler)
+            signal.alarm(seconds)
+
+            try:
+                return func(*args, **kwargs)
+            finally:
+                signal.alarm(0)
+
+        return wrapper
+
+    return decorator
 
 
 def working_process(p):
@@ -86,7 +112,7 @@ def fail_on_prediction_2(p):
         return f"{p['pk']} result"
 
 
-@pytest.mark.timeout(4)
+@timeout(4)
 @pytest.mark.forge_integration
 def test_prediction_processing(helpers):
     predictions = [{"pk": "prediction1"}, {"pk": "prediction2"}]
@@ -96,7 +122,7 @@ def test_prediction_processing(helpers):
     assert {"prediction1 result", "prediction2 result"} == set(result)
 
 
-@pytest.mark.timeout(4)
+@timeout(4)
 @pytest.mark.forge_integration
 def test_prediction_processing_error(helpers):
     predictions = [
@@ -108,7 +134,7 @@ def test_prediction_processing_error(helpers):
         )
 
 
-@pytest.mark.timeout(4)
+@timeout(4)
 @pytest.mark.forge_integration
 def test_prediction_processing_killing_of_child_processes(helpers):
     # If something goes wrong, this test could deadlock
@@ -124,7 +150,7 @@ def test_prediction_processing_killing_of_child_processes(helpers):
     assert len(result) == len(predictions)
 
 
-@pytest.mark.timeout(4)
+@timeout(4)
 @pytest.mark.forge_integration
 def test_prediction_processing_catching_killing_of_child_processes(helpers):
     predictions = [{"pk": "prediction1"}, {"pk": "prediction2"}]
@@ -158,7 +184,7 @@ def test_prediction_processing_catching_killing_of_child_processes(helpers):
             child_stopper.terminate()
 
 
-@pytest.mark.timeout(4)
+@timeout(4)
 @pytest.mark.forge_integration
 def test_prediction_processing_canceling_processes_correctly(helpers):
     predictions = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ dev = [
     "boto3-stubs[cloudwatch,codebuild,ecr,lambda,logs,medical-imaging,rds,s3,sagemaker,ses]",
     "celery-types",
     "psutil",
-    "pytest-timeout",
 ]
 
 [tool.isort]

--- a/uv.lock
+++ b/uv.lock
@@ -1239,7 +1239,6 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-randomly" },
     { name = "pytest-rerunfailures" },
-    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "sphinx" },
     { name = "sphinx-autobuild" },
@@ -1329,7 +1328,6 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-randomly" },
     { name = "pytest-rerunfailures" },
-    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "sphinx" },
     { name = "sphinx-autobuild" },
@@ -2197,18 +2195,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/de/04/71e9520551fc8fe2cf5c1a1842e4e600265b0815f2016b7c27ec85688682/pytest_rerunfailures-16.1.tar.gz", hash = "sha256:c38b266db8a808953ebd71ac25c381cb1981a78ff9340a14bcb9f1b9bff1899e", size = 30889, upload-time = "2025-10-10T07:06:01.238Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/54/60eabb34445e3db3d3d874dc1dfa72751bfec3265bd611cb13c8b290adea/pytest_rerunfailures-16.1-py3-none-any.whl", hash = "sha256:5d11b12c0ca9a1665b5054052fcc1084f8deadd9328962745ef6b04e26382e86", size = 14093, upload-time = "2025-10-10T07:06:00.019Z" },
-]
-
-[[package]]
-name = "pytest-timeout"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace with a solution that uses signals, unix only.

Closes #4451