### PR TITLE
Update allowed file types for predictions file

### DIFF
--- a/app/grandchallenge/evaluation/forms.py
+++ b/app/grandchallenge/evaluation/forms.py
@@ -293,12 +293,9 @@ class SubmissionForm(
         widget=UserUploadSingleWidget(
             allowed_file_types=[
                 "application/zip",
-                "application/x-zip-compressed",
                 "application/csv",
-                "application/vnd.ms-excel",
                 "text/csv",
                 "text/plain",
-                "application/json",
             ]
         ),
         label="Predictions File",


### PR DESCRIPTION
The allowed file types for user uploads on the `SubmissionForm` should match those checked in `prepare_and_execute_evaluation`, I think. 