### PR TITLE
Centralize evaluation error messages

### DIFF
--- a/app/grandchallenge/core/error_messages.py
+++ b/app/grandchallenge/core/error_messages.py
@@ -15,4 +15,4 @@ class EvaluationErrorMessages(StrEnum):
     INTERFACE_MISMATCH = (
         "The algorithm interfaces do not match those defined for the phase."
     )
-    UNSUPPORTED_INPUT = "files are not supported."
+    UNSUPPORTED_INPUT = "Input file type is not supported"

--- a/app/grandchallenge/core/error_messages.py
+++ b/app/grandchallenge/core/error_messages.py
@@ -7,3 +7,12 @@ class SystemErrorMessages(StrEnum):
     MEMORY_LIMIT_EXCEEDED = (
         "The container was killed as it exceeded its memory limit"
     )
+
+
+class EvaluationErrorMessages(StrEnum):
+    ALGORITHM_FAILURE = "The algorithm failed on one or more cases."
+    UNSUCCESSFUL_JOBS = "There are non-successful jobs for this submission."
+    INTERFACE_MISMATCH = (
+        "The algorithm interfaces do not match those defined for the phase."
+    )
+    UNSUPPORTED_INPUT = "files are not supported."

--- a/app/grandchallenge/evaluation/forms.py
+++ b/app/grandchallenge/evaluation/forms.py
@@ -32,6 +32,7 @@ from grandchallenge.components.forms import (
 from grandchallenge.components.models import ImportStatusChoices
 from grandchallenge.components.schemas import GPUTypeChoices
 from grandchallenge.components.tasks import assign_tarball_from_upload
+from grandchallenge.core.error_messages import EvaluationErrorMessages
 from grandchallenge.core.forms import (
     PhaseMixin,
     SaveFormInitMixin,
@@ -721,8 +722,7 @@ class EvaluationForm(SaveFormInitMixin, AdditionalInputsMixin, forms.Form):
                 "submission"
             ].has_matching_algorithm_interfaces:
                 raise ValidationError(
-                    "The algorithm interfaces do not match those "
-                    "defined for the phase."
+                    EvaluationErrorMessages.INTERFACE_MISMATCH,
                 )
 
             if (

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -44,7 +44,10 @@ from grandchallenge.components.schemas import (
     GPUTypeChoices,
     get_default_gpu_type_choices,
 )
-from grandchallenge.core.error_messages import EvaluationErrorMessages
+from grandchallenge.core.error_messages import (
+    EvaluationErrorMessages,
+    SystemErrorMessages,
+)
 from grandchallenge.core.guardian import (
     GroupObjectPermissionBase,
     UserObjectPermissionBase,
@@ -1941,6 +1944,226 @@ class EvaluationManager(ComponentJobManager):
         return existing_evaluations
 
 
+class EvaluationActionMessageBuilder:
+
+    def __init__(self, *, evaluation, user):
+        self.evaluation = evaluation
+        self.phase = evaluation.submission.phase
+        self.is_admin = self.phase.challenge.is_admin(user)
+        self.is_algorithm_phase = (
+            self.phase.submission_kind == SubmissionKindChoices.ALGORITHM
+        )
+        self.open_logs = self.phase.give_algorithm_editors_job_view_permissions
+
+    def build(self):
+        if self.evaluation.status not in (
+            Evaluation.FAILURE,
+            Evaluation.CANCELLED,
+        ):
+            return
+
+        if not self.evaluation.error_message:
+            return
+
+        if (
+            self.evaluation.error_message
+            == SystemErrorMessages.UNEXPECTED_ERROR
+        ):
+            return self._handle_unexpected()
+        elif (
+            self.evaluation.error_message
+            == SystemErrorMessages.MEMORY_LIMIT_EXCEEDED
+        ):
+            return self._handle_resource_limit()
+        elif (
+            self.evaluation.error_message
+            == SystemErrorMessages.TIME_LIMIT_EXCEEDED
+        ):
+            return self._handle_resource_limit()
+        elif (
+            self.evaluation.error_message
+            == EvaluationErrorMessages.ALGORITHM_FAILURE
+        ):
+            return self._handle_algorithm_failure()
+        elif (
+            self.evaluation.error_message
+            == EvaluationErrorMessages.UNSUCCESSFUL_JOBS
+        ):
+            return self._handle_reevaluation_blocker()
+        elif (
+            self.evaluation.error_message
+            == EvaluationErrorMessages.INTERFACE_MISMATCH
+        ):
+            return self._handle_reevaluation_blocker()
+        elif (
+            self.evaluation.error_message
+            == EvaluationErrorMessages.UNSUPPORTED_INPUT
+        ):
+            return self._handle_invalid_input()
+        else:
+            return self._handle_custom()
+
+    @property
+    def support_contact_message(self):
+        return format_html(
+            "<a href='mailto:{email}'>contact grand challenge support</a>",
+            email=settings.SUPPORT_EMAIL,
+        )
+
+    @property
+    def organiser_contact_message(self):
+        return format_html(
+            "<a href='mailto:{email}'>please contact the challenge organisers</a>",
+            email=self.phase.challenge.contact_email,
+        )
+
+    @property
+    def evaluation_logs_message(self):
+        return format_html(
+            "<a href={url}>inspect the evaluation logs</a>",
+            url=self.evaluation.get_absolute_url(),
+        )
+
+    @property
+    def exclamation_mark(self):
+        return format_html(
+            '<i class="fas fa-exclamation-triangle fa-fw text-warning pr-1"></i>'
+        )
+
+    def algorithm_logs_message(self, label):
+        return format_html(
+            "<a href={url}>{label}</a>",
+            url=reverse(
+                "algorithms:job-list",
+                kwargs={
+                    "slug": self.evaluation.submission.algorithm_image.algorithm.slug
+                },
+            ),
+            label=label,
+        )
+
+    def _handle_unexpected(self):
+        return format_html(
+            "The site administrators are investigating this issue. "
+            "If you would like more information, {contact_message}.",
+            contact_message=self.support_contact_message,
+        )
+
+    def _handle_resource_limit(self):
+        if self.is_admin:
+            if self.is_algorithm_phase:
+                return format_html(
+                    "{icon} The participant's algorithm ran successfully but your evaluation "
+                    "method failed, please {logs_message}.",
+                    icon=self.exclamation_mark,
+                    logs_message=self.evaluation_logs_message,
+                )
+            else:
+                return format_html(
+                    "{icon} Your evaluation method failed, please {logs_message}.",
+                    icon=self.exclamation_mark,
+                    logs_message=self.evaluation_logs_message,
+                )
+        else:
+            if self.is_algorithm_phase:
+                return format_html(
+                    "Your algorithm ran successfully, but the scoring failed. "
+                    "If you would like more information, {contact_message}.",
+                    contact_message=self.organiser_contact_message,
+                )
+            else:
+                return format_html(
+                    "The scoring of your submission failed. "
+                    "If you would like more information, {contact_message}.",
+                    contact_message=self.organiser_contact_message,
+                )
+
+    def _handle_algorithm_failure(self):
+        if self.is_admin:
+            if self.open_logs:
+                return format_html(
+                    "The challenge participant can {logs_message} and re-submit.",
+                    logs_message=self.algorithm_logs_message(
+                        label="review their algorithm logs"
+                    ),
+                )
+            else:
+                return format_html(
+                    "{icon} The participant's algorithm failed and they cannot read their logs. "
+                    "Please {logs_message} and inform the participant about what to do.",
+                    icon=self.exclamation_mark,
+                    logs_message=self.algorithm_logs_message(
+                        label="inspect the algorithm logs"
+                    ),
+                )
+        else:
+            if self.open_logs:
+                return format_html(
+                    "{icon} Please {logs_message} and re-submit.",
+                    icon=self.exclamation_mark,
+                    logs_message=self.algorithm_logs_message(
+                        label="review your algorithm logs"
+                    ),
+                )
+            else:
+                return format_html(
+                    "{icon} Please {contact_message} for more information.",
+                    icon=self.exclamation_mark,
+                    contact_message=self.organiser_contact_message,
+                )
+
+    def _handle_custom(self):
+        if self.is_admin:
+            if self.is_algorithm_phase:
+                return format_html(
+                    "The participant's algorithm ran successfully but your evaluation "
+                    "method failed. Please {logs_message} if necessary.",
+                    logs_message=self.evaluation_logs_message,
+                )
+            else:
+                return format_html(
+                    "Your evaluation method failed. Please {logs_message} if necessary.",
+                    logs_message=self.evaluation_logs_message,
+                )
+        else:
+            if self.is_algorithm_phase:
+                return format_html(
+                    "Your algorithm ran successfully, but the scoring failed. "
+                    "If you would like more information, {contact_message}.",
+                    contact_message=self.organiser_contact_message,
+                )
+            else:
+                return format_html(
+                    "If you would like more information, {contact_message}.",
+                    contact_message=self.organiser_contact_message,
+                )
+
+    def _handle_reevaluation_blocker(self):
+        if self.is_admin:
+            return format_html(
+                "{icon} Please {contact_message}.",
+                icon=self.exclamation_mark,
+                contact_message=self.support_contact_message,
+            )
+        else:
+            return format_html(
+                "Re-evaluation of your submission is blocked. "
+                "If you would like more information, {contact_message}.",
+                contact_message=self.organiser_contact_message,
+            )
+
+    def _handle_invalid_input(self):
+        if self.is_admin:
+            return format_html(
+                "The participant needs to resubmit with the correct input format."
+            )
+        else:
+            return format_html(
+                "{icon} Please make sure your submission is in the correct format and resubmit.",
+                icon=self.exclamation_mark,
+            )
+
+
 class Evaluation(CIVForObjectMixin, ComponentJob):
     """Stores information about an evaluation for a given submission."""
 
@@ -2251,6 +2474,7 @@ class EvaluationUserObjectPermission(UserObjectPermissionBase):
 
 
 class EvaluationGroupObjectPermission(GroupObjectPermissionBase):
+
     allowed_permissions = frozenset(
         {"change_evaluation", "view_evaluation", "claim_evaluation"}
     )

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -44,6 +44,7 @@ from grandchallenge.components.schemas import (
     GPUTypeChoices,
     get_default_gpu_type_choices,
 )
+from grandchallenge.core.error_messages import EvaluationErrorMessages
 from grandchallenge.core.guardian import (
     GroupObjectPermissionBase,
     UserObjectPermissionBase,
@@ -1713,7 +1714,7 @@ class Submission(FieldChangeMixin, UUIDModel):
             if not self.has_matching_algorithm_interfaces:
                 evaluation.update_status(
                     status=Evaluation.CANCELLED,
-                    error_message="The algorithm interfaces do not match those defined for the phase.",
+                    error_message=EvaluationErrorMessages.INTERFACE_MISMATCH,
                 )
 
         if additional_inputs:

--- a/app/grandchallenge/evaluation/tasks.py
+++ b/app/grandchallenge/evaluation/tasks.py
@@ -21,7 +21,10 @@ from grandchallenge.core.celery import (
     acks_late_2xlarge_task,
     acks_late_micro_short_task,
 )
-from grandchallenge.core.error_messages import SystemErrorMessages
+from grandchallenge.core.error_messages import (
+    EvaluationErrorMessages,
+    SystemErrorMessages,
+)
 from grandchallenge.core.exceptions import LockNotAcquiredException
 from grandchallenge.core.utils.query import check_lock_acquired
 from grandchallenge.core.validators import get_file_mimetype
@@ -91,9 +94,7 @@ def check_prerequisites_for_evaluation_execution(*, evaluation_pk):
     if any(jobs.values()):
         evaluation.update_status(
             status=Evaluation.CANCELLED,
-            error_message="There are non-successful jobs for this submission. "
-            "These need to be handled first before you can "
-            "re-evaluate. Please contact support.",
+            error_message=EvaluationErrorMessages.UNSUCCESSFUL_JOBS,
         )
         return
     else:
@@ -171,8 +172,8 @@ def prepare_and_execute_evaluation(*, evaluation_pk):
         else:
             evaluation.update_status(
                 status=Evaluation.FAILURE,
-                stderr=f"{mimetype} files are not supported.",
-                error_message=f"{mimetype} files are not supported.",
+                stderr=f"{mimetype} {EvaluationErrorMessages.UNSUPPORTED_INPUT}",
+                error_message=f"{mimetype} {EvaluationErrorMessages.UNSUPPORTED_INPUT}",
             )
             return
 
@@ -369,7 +370,7 @@ def handle_failed_jobs(*, evaluation_pk):
     if evaluation.status != evaluation.FAILURE:
         evaluation.update_status(
             status=evaluation.FAILURE,
-            error_message="The algorithm failed on one or more cases.",
+            error_message=EvaluationErrorMessages.ALGORITHM_FAILURE,
         )
 
     # Cancel any pending jobs for this algorithm image,

--- a/app/grandchallenge/evaluation/tasks.py
+++ b/app/grandchallenge/evaluation/tasks.py
@@ -172,8 +172,8 @@ def prepare_and_execute_evaluation(*, evaluation_pk):
         else:
             evaluation.update_status(
                 status=Evaluation.FAILURE,
-                stderr=f"{mimetype} {EvaluationErrorMessages.UNSUPPORTED_INPUT}",
-                error_message=f"{mimetype} {EvaluationErrorMessages.UNSUPPORTED_INPUT}",
+                stderr=EvaluationErrorMessages.UNSUPPORTED_INPUT,
+                error_message=EvaluationErrorMessages.UNSUPPORTED_INPUT,
             )
             return
 

--- a/app/tests/evaluation_tests/test_forms.py
+++ b/app/tests/evaluation_tests/test_forms.py
@@ -41,6 +41,7 @@ from grandchallenge.components.widgets import (
     FileSearchMultiWidget,
     SourceSelect,
 )
+from grandchallenge.core.error_messages import EvaluationErrorMessages
 from grandchallenge.evaluation.forms import (
     AlgorithmInterfaceForPhaseCopyForm,
     ConfigureAlgorithmPhasesForm,
@@ -1532,10 +1533,7 @@ def test_reschedule_evaluation_requires_matching_algorithm_interfaces(
 
     assert form.is_valid() == form_valid
     if not form_valid:
-        assert (
-            "The algorithm interfaces do not match those defined for the phase."
-            in str(form.errors)
-        )
+        assert EvaluationErrorMessages.INTERFACE_MISMATCH in str(form.errors)
 
 
 @pytest.mark.django_db

--- a/app/tests/evaluation_tests/test_models.py
+++ b/app/tests/evaluation_tests/test_models.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from typing import NamedTuple
 
 import pytest
+from django.conf import settings
 from django.core import mail
 from django.core.exceptions import ValidationError
 from django.utils import timezone
@@ -22,6 +23,7 @@ from grandchallenge.evaluation.models import (
     SUBMISSION_WINDOW_PARENT_VALIDATION_TEXT,
     CombinedLeaderboard,
     Evaluation,
+    EvaluationActionMessageBuilder,
     Method,
     Phase,
     PhaseAdditionalEvaluationInput,
@@ -2513,3 +2515,298 @@ def test_method_cannot_be_added_to_external_phase():
         method.full_clean()
 
     assert "You cannot add a method to an external evaluation." in str(e)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("is_admin", [True, False])
+@pytest.mark.parametrize(
+    "submission_kind",
+    [SubmissionKindChoices.ALGORITHM, SubmissionKindChoices.CSV],
+)
+@pytest.mark.parametrize("open_logs", [True, False])
+def test_handle_unexpected(is_admin, submission_kind, open_logs):
+    user = UserFactory()
+
+    phase = PhaseFactory(
+        submission_kind=submission_kind,
+        give_algorithm_editors_job_view_permissions=open_logs,
+    )
+    if is_admin:
+        phase.challenge.add_admin(user)
+    else:
+        phase.challenge.add_participant(user)
+
+    eval = EvaluationFactory(time_limit=10, submission__phase=phase)
+
+    builder = EvaluationActionMessageBuilder(evaluation=eval, user=user)
+    result = builder._handle_unexpected()
+    assert (
+        "The site administrators are investigating this issue. If you would like more information,"
+        in result
+    )
+    assert settings.SUPPORT_EMAIL in result
+
+
+@pytest.mark.parametrize(
+    "is_admin,submission_kind,open_logs,expected_message",
+    [
+        (
+            True,
+            SubmissionKindChoices.ALGORITHM,
+            True,
+            "The participant's algorithm ran successfully but your evaluation method failed",
+        ),
+        (
+            True,
+            SubmissionKindChoices.CSV,
+            True,
+            "Your evaluation method failed",
+        ),
+        (
+            False,
+            SubmissionKindChoices.ALGORITHM,
+            True,
+            "Your algorithm ran successfully, but the scoring failed. If you would like more information, ",
+        ),
+        (
+            False,
+            SubmissionKindChoices.CSV,
+            True,
+            "The scoring of your submission failed. If you would like more information, ",
+        ),
+        (
+            True,
+            SubmissionKindChoices.ALGORITHM,
+            False,
+            "The participant's algorithm ran successfully but your evaluation method failed",
+        ),
+        (
+            True,
+            SubmissionKindChoices.CSV,
+            False,
+            "Your evaluation method failed",
+        ),
+        (
+            False,
+            SubmissionKindChoices.ALGORITHM,
+            False,
+            "Your algorithm ran successfully, but the scoring failed. If you would like more information, ",
+        ),
+        (
+            False,
+            SubmissionKindChoices.CSV,
+            False,
+            "The scoring of your submission failed. If you would like more information, ",
+        ),
+    ],
+)
+@pytest.mark.django_db
+def test_handle_resource_limit(
+    is_admin, submission_kind, open_logs, expected_message
+):
+    user = UserFactory()
+
+    phase = PhaseFactory(
+        submission_kind=submission_kind,
+        give_algorithm_editors_job_view_permissions=open_logs,
+    )
+    if is_admin:
+        phase.challenge.add_admin(user)
+    else:
+        phase.challenge.add_participant(user)
+
+    eval = EvaluationFactory(time_limit=10, submission__phase=phase)
+
+    builder = EvaluationActionMessageBuilder(evaluation=eval, user=user)
+
+    result = builder._handle_resource_limit()
+    assert expected_message in result
+
+
+@pytest.mark.parametrize(
+    "is_admin,open_logs,expected_message",
+    [
+        (
+            True,
+            True,
+            "The challenge participant can",
+        ),
+        (
+            False,
+            True,
+            "review your algorithm logs",
+        ),
+        (
+            True,
+            False,
+            "The participant's algorithm failed and they cannot read their logs",
+        ),
+        (
+            False,
+            False,
+            "please contact the challenge organisers",
+        ),
+    ],
+)
+@pytest.mark.django_db
+def test_handle_algorithm_failure(is_admin, open_logs, expected_message):
+    user = UserFactory()
+
+    phase = PhaseFactory(
+        submission_kind=SubmissionKindChoices.ALGORITHM,
+        give_algorithm_editors_job_view_permissions=open_logs,
+    )
+    if is_admin:
+        phase.challenge.add_admin(user)
+    else:
+        phase.challenge.add_participant(user)
+
+    ai = AlgorithmImageFactory()
+
+    eval = EvaluationFactory(
+        time_limit=10, submission__phase=phase, submission__algorithm_image=ai
+    )
+
+    builder = EvaluationActionMessageBuilder(evaluation=eval, user=user)
+
+    result = builder._handle_algorithm_failure()
+    assert expected_message in result
+
+
+@pytest.mark.parametrize(
+    "is_admin,submission_kind,open_logs,expected_message",
+    [
+        (
+            True,
+            SubmissionKindChoices.ALGORITHM,
+            True,
+            "The participant's algorithm ran successfully but your evaluation method failed.",
+        ),
+        (
+            True,
+            SubmissionKindChoices.CSV,
+            False,
+            "Your evaluation method failed",
+        ),
+        (
+            False,
+            SubmissionKindChoices.ALGORITHM,
+            True,
+            "Your algorithm ran successfully, but the scoring failed.",
+        ),
+        (
+            False,
+            SubmissionKindChoices.CSV,
+            False,
+            "If you would like more information,",
+        ),
+        (
+            True,
+            SubmissionKindChoices.ALGORITHM,
+            False,
+            "The participant's algorithm ran successfully but your evaluation method failed",
+        ),
+        (
+            False,
+            SubmissionKindChoices.ALGORITHM,
+            False,
+            "Your algorithm ran successfully, but the scoring failed.",
+        ),
+    ],
+)
+@pytest.mark.django_db
+def test_handle_custom(is_admin, submission_kind, open_logs, expected_message):
+    user = UserFactory()
+
+    phase = PhaseFactory(
+        submission_kind=submission_kind,
+        give_algorithm_editors_job_view_permissions=open_logs,
+    )
+    if is_admin:
+        phase.challenge.add_admin(user)
+    else:
+        phase.challenge.add_participant(user)
+
+    eval = EvaluationFactory(time_limit=10, submission__phase=phase)
+
+    builder = EvaluationActionMessageBuilder(evaluation=eval, user=user)
+
+    result = builder._handle_custom()
+    assert expected_message in result
+
+
+@pytest.mark.parametrize(
+    "is_admin,open_logs,expected_message",
+    [
+        (
+            True,
+            True,
+            "contact grand challenge support",
+        ),
+        (
+            False,
+            True,
+            "please contact the challenge organisers",
+        ),
+        (
+            True,
+            False,
+            "contact grand challenge support",
+        ),
+        (
+            False,
+            False,
+            "please contact the challenge organisers",
+        ),
+    ],
+)
+@pytest.mark.django_db
+def test_reevaluation_blocker(is_admin, open_logs, expected_message):
+    user = UserFactory()
+
+    phase = PhaseFactory(
+        submission_kind=SubmissionKindChoices.ALGORITHM,
+        give_algorithm_editors_job_view_permissions=open_logs,
+    )
+    if is_admin:
+        phase.challenge.add_admin(user)
+    else:
+        phase.challenge.add_participant(user)
+
+    eval = EvaluationFactory(time_limit=10, submission__phase=phase)
+
+    builder = EvaluationActionMessageBuilder(evaluation=eval, user=user)
+
+    result = builder._handle_reevaluation_blocker()
+    assert expected_message in result
+
+
+@pytest.mark.parametrize(
+    "is_admin, expected_message",
+    [
+        (
+            True,
+            "The participant needs to resubmit with the correct input format.",
+        ),
+        (
+            False,
+            "Please make sure your submission is in the correct format and resubmit.",
+        ),
+    ],
+)
+@pytest.mark.django_db
+def test_invalid_input(is_admin, expected_message):
+    user = UserFactory()
+
+    phase = PhaseFactory()
+    if is_admin:
+        phase.challenge.add_admin(user)
+    else:
+        phase.challenge.add_participant(user)
+
+    eval = EvaluationFactory(time_limit=10, submission__phase=phase)
+
+    builder = EvaluationActionMessageBuilder(evaluation=eval, user=user)
+
+    result = builder._handle_invalid_input()
+    assert expected_message in result

--- a/app/tests/evaluation_tests/test_tasks.py
+++ b/app/tests/evaluation_tests/test_tasks.py
@@ -724,7 +724,9 @@ def test_non_zip_submission_failure(
     # The evaluation method should return the correct answer
     assert len(submission.evaluation_set.all()) == 1
     evaluation = submission.evaluation_set.first()
-    assert evaluation.error_message == EvaluationErrorMessages.UNSUPPORTED_INPUT
+    assert (
+        evaluation.error_message == EvaluationErrorMessages.UNSUPPORTED_INPUT
+    )
     assert evaluation.status == evaluation.FAILURE
 
 

--- a/app/tests/evaluation_tests/test_tasks.py
+++ b/app/tests/evaluation_tests/test_tasks.py
@@ -21,6 +21,7 @@ from grandchallenge.components.tasks import (
     push_container_image,
     validate_docker_image,
 )
+from grandchallenge.core.error_messages import EvaluationErrorMessages
 from grandchallenge.evaluation.models import Evaluation, Method, Submission
 from grandchallenge.evaluation.tasks import (
     cancel_external_evaluations_past_timeout,
@@ -724,7 +725,7 @@ def test_non_zip_submission_failure(
     assert len(submission.evaluation_set.all()) == 1
     evaluation = submission.evaluation_set.first()
     assert evaluation.error_message.endswith(
-        "7z-compressed files are not supported."
+        f"7z-compressed {EvaluationErrorMessages.UNSUPPORTED_INPUT}"
     )
     assert evaluation.status == evaluation.FAILURE
 

--- a/app/tests/evaluation_tests/test_tasks.py
+++ b/app/tests/evaluation_tests/test_tasks.py
@@ -724,9 +724,7 @@ def test_non_zip_submission_failure(
     # The evaluation method should return the correct answer
     assert len(submission.evaluation_set.all()) == 1
     evaluation = submission.evaluation_set.first()
-    assert evaluation.error_message.endswith(
-        f"7z-compressed {EvaluationErrorMessages.UNSUPPORTED_INPUT}"
-    )
+    assert evaluation.error_message == EvaluationErrorMessages.UNSUPPORTED_INPUT
     assert evaluation.status == evaluation.FAILURE
 
 

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -23,6 +23,7 @@ from grandchallenge.components.models import (
     InterfaceKindChoices,
 )
 from grandchallenge.components.schemas import GPUTypeChoices
+from grandchallenge.core.error_messages import EvaluationErrorMessages
 from grandchallenge.core.templatetags.remove_whitespace import oxford_comma
 from grandchallenge.evaluation.models import (
     CombinedLeaderboard,
@@ -2066,7 +2067,7 @@ def test_phase_archive_info_permissions(client):
 )
 @pytest.mark.django_db
 def test_algorithm_interface_for_phase_view_permission(client, viewname):
-    (participant, admin, user, user_with_perm) = UserFactory.create_batch(4)
+    participant, admin, user, user_with_perm = UserFactory.create_batch(4)
     assign_perm("evaluation.configure_algorithm_phase", user_with_perm)
 
     prediction_phase = PhaseFactory(submission_kind=SubmissionKindChoices.CSV)
@@ -2109,7 +2110,7 @@ def test_algorithm_interface_for_phase_view_permission(client, viewname):
 
 @pytest.mark.django_db
 def test_algorithm_interface_for_phase_delete_permission(client):
-    (participant, admin, user, user_with_perm) = UserFactory.create_batch(4)
+    participant, admin, user, user_with_perm = UserFactory.create_batch(4)
     assign_perm("evaluation.configure_algorithm_phase", user_with_perm)
     prediction_phase = PhaseFactory(submission_kind=SubmissionKindChoices.CSV)
     algorithm_phase = PhaseFactory(
@@ -2960,9 +2961,8 @@ def test_create_evaluation_requires_matching_algorithm_interfaces(
 
     assert eval.status == status
     if status == Evaluation.CANCELLED:
-        assert (
-            "The algorithm interfaces do not match those defined for the phase."
-            in str(eval.error_message)
+        assert EvaluationErrorMessages.INTERFACE_MISMATCH in str(
+            eval.error_message
         )
 
 
@@ -3054,9 +3054,8 @@ def test_create_evaluation_blocked_if_failed_jobs_exist(
     eval = Evaluation.objects.order_by("created").last()
     assert eval.status == status
     if status == Evaluation.CANCELLED:
-        assert (
-            "There are non-successful jobs for this submission. These need to be handled first before you can re-evaluate. Please contact support."
-            in str(eval.error_message)
+        assert EvaluationErrorMessages.UNSUCCESSFUL_JOBS in str(
+            eval.error_message
         )
 
 


### PR DESCRIPTION
In preparation for the action message builder I have been working on, it makes sense to also centralize the evaluation error messages. This class contains all error messages for which we want a different action message than for custom evaluation errors.  

Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/482