### PR TITLE
Use CRC64NVME as the model checksum algorithm

### DIFF
--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1604,14 +1604,15 @@ def assign_tarball_from_upload(
         to_field=getattr(current_tarball, field_to_copy)
     )
 
-    sha256 = get_object_sha256(getattr(current_tarball, field_to_copy))
+    checksum = get_object_checksum(getattr(current_tarball, field_to_copy))
+
     if (
-        TarballModel.objects.filter(sha256=sha256)
+        TarballModel.objects.filter(sha256=checksum)
         .exclude(pk=current_tarball.pk)
         .exists()
     ):
         current_tarball.import_status = ImportStatusChoices.FAILED
-        current_tarball.status = f"{TarballModel._meta.verbose_name} with this sha256 already exists."
+        current_tarball.status = f"{TarballModel._meta.verbose_name} with this checksum already exists."
         current_tarball.save()
 
         getattr(current_tarball, field_to_copy).delete()
@@ -1619,7 +1620,7 @@ def assign_tarball_from_upload(
 
         return
 
-    current_tarball.sha256 = sha256
+    current_tarball.sha256 = checksum
     current_tarball.size_in_storage = getattr(
         current_tarball, field_to_copy
     ).size
@@ -1633,7 +1634,7 @@ def assign_tarball_from_upload(
     current_tarball.mark_desired_version(peer_tarballs=peer_tarballs)
 
 
-def get_object_sha256(file_field):
+def get_object_checksum(file_field):
     response = file_field.storage.connection.meta.client.head_object(
         Bucket=file_field.storage.bucket.name,
         Key=file_field.name,
@@ -1641,11 +1642,11 @@ def get_object_sha256(file_field):
     )
 
     try:
-        checksum_sha256 = response["ChecksumSHA256"]
-        return f"sha256:{hexlify(b64decode(checksum_sha256)).decode('utf-8')}"
+        checksum = response["ChecksumCRC64NVME"]
+        return f"crc64nvme:{hexlify(b64decode(checksum)).decode('utf-8')}"
     except KeyError:
         # The checksums are not calculated on local s3
-        logger.error("sha256 checksum was not calculated", exc_info=True)
+        logger.error("checksum was not calculated", exc_info=True)
         return ""
 
 

--- a/app/grandchallenge/core/storage.py
+++ b/app/grandchallenge/core/storage.py
@@ -169,7 +169,7 @@ def copy_s3_object(
     extra_args = {
         "ContentType": mimetype,
         "MetadataDirective": "REPLACE",
-        "ChecksumAlgorithm": "SHA256",
+        "ChecksumAlgorithm": "CRC64NVME",
     }
 
     if target_bucket == settings.PUBLIC_S3_STORAGE_KWARGS["bucket_name"]:

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -1235,7 +1235,7 @@ def test_assign_tarball_from_upload(
     obj2.refresh_from_db()
     assert not obj2.is_desired_version
     assert obj2.import_status == ImportStatusChoices.FAILED
-    assert "with this sha256 already exists." in obj2.status
+    assert "with this checksum already exists." in obj2.status
     assert not obj2.user_upload
     with pytest.raises(ValueError):
         getattr(obj2, field_to_copy).file

--- a/app/tests/uploads_tests/test_models.py
+++ b/app/tests/uploads_tests/test_models.py
@@ -177,7 +177,7 @@ def test_upload_copy_sets_sha256():
                 "Key": f"models/algorithms/algorithmmodel/{am.pk}/test.tar.gz",
                 # We rely on ChecksumAlgorithm being set so that the checksum is calculated
                 # This is used to identify multiple versions of the same file
-                "ChecksumAlgorithm": "SHA256",
+                "ChecksumAlgorithm": "CRC64NVME",
                 "MetadataDirective": "REPLACE",
             },
         )


### PR DESCRIPTION
This is a speculative fix as I'm not totally sure that this will work, need to test it out in staging. If it does, the database column `sha256` should be renamed to `checksum`.

See https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/761