### PR TITLE
Update submission detail page

### DIFF
--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -2475,21 +2475,23 @@ class Evaluation(CIVForObjectMixin, ComponentJob):
     def visibility_icon(self):
         if self.status == self.SUCCESS:
             if self.published and self.rank > 0:
-                return format_html(
-                    '<i class="fas fa-eye text-success" title="This result is published on the leaderboard."></i>'
-                )
+                classes = "fas fa-eye text-success"
+                title = "This result is published on the leaderboard."
             elif self.published:
-                return format_html(
-                    '<i class="fas fa-eye text-warning" title="This result is not visible on the leaderboard yet because it has not been ranked yet or the ranking failed."></i>'
-                )
+                classes = "fas fa-eye text-warning"
+                title = "This result is not visible on the leaderboard yet because it has not been ranked yet or the ranking failed."
             else:
-                return format_html(
-                    '<i class="fas fa-hourglass-half text-warning" title="This result is under review by the challenge admins."></i>'
-                )
+                classes = "fas fa-hourglass-half text-warning"
+                title = "This result is under review by the challenge admins."
         else:
-            return format_html(
-                '<i class="fas fa-eye-slash text-danger" title="There is no result for this submission."></i>'
-            )
+            classes = "fas fa-eye-slash text-danger"
+            title = "There is no result for this submission."
+
+        return format_html(
+            '<i class="{classes}" title="{title}"></i>',
+            classes=classes,
+            title=title,
+        )
 
 
 class EvaluationUserObjectPermission(UserObjectPermissionBase):

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -2107,7 +2107,7 @@ class EvaluationActionMessageBuilder:
                 )
             else:
                 return format_html(
-                    "{icon} Please {contact_message} for more information.",
+                    "{icon} {contact_message} for more information.",
                     icon=self.exclamation_mark,
                     contact_message=self.organiser_contact_message,
                 )
@@ -2465,6 +2465,31 @@ class Evaluation(CIVForObjectMixin, ComponentJob):
     @property
     def utilization(self):
         return self.evaluation_utilization
+
+    def build_action_message(self, *, user):
+        return EvaluationActionMessageBuilder(
+            evaluation=self, user=user
+        ).build()
+
+    @property
+    def visibility_icon(self):
+        if self.status == self.SUCCESS:
+            if self.published and self.rank > 0:
+                return format_html(
+                    '<i class="fas fa-eye text-success" title="This result is published on the leaderboard."></i>'
+                )
+            elif self.published:
+                return format_html(
+                    '<i class="fas fa-eye text-warning" title="This result is not visible on the leaderboard yet because it has not been ranked yet or the ranking failed."></i>'
+                )
+            else:
+                return format_html(
+                    '<i class="fas fa-hourglass-half text-warning" title="This result is under review by the challenge admins."></i>'
+                )
+        else:
+            return format_html(
+                '<i class="fas fa-eye-slash text-danger" title="There is no result for this submission."></i>'
+            )
 
 
 class EvaluationUserObjectPermission(UserObjectPermissionBase):

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_detail.html
@@ -65,20 +65,24 @@
             </dd>
         {% endif %}
 
-        {% if object.supplementary_url %}
-            <dt>Supplementary URL ({{ object.phase.supplementary_url_label }})</dt>
-            <dd>
-                <a href="{{ object.supplementary_url }}" target="_blank">
-                    <i class="fas fa-link"></i> {{ object.supplementary_url }}
-                </a>
-            </dd>
+        {% if object.phase.show_supplementary_url or "change_challenge" in challenge_perms %}
+            {% if object.supplementary_url %}
+                <dt>Supplementary URL ({{ object.phase.supplementary_url_label }})</dt>
+                <dd>
+                    <a href="{{ object.supplementary_url }}" target="_blank">
+                        <i class="fas fa-link"></i> {{ object.supplementary_url }}
+                    </a>
+                </dd>
+            {% endif %}
         {% endif %}
 
-        {% if object.supplementary_file %}
-            <dt>Supplementary File ({{ object.phase.supplementary_file_label }})</dt>
-            <dd>
-                <a href="{{ object.supplementary_file.url }}"><i class="fa fa-file"></i> {{ object.supplementary_file.name }}</a>
-            </dd>
+        {% if object.phase.show_supplementary_file_link or "change_challenge" in challenge_perms %}
+            {% if object.supplementary_file %}
+                <dt>Supplementary File ({{ object.phase.supplementary_file_label }})</dt>
+                <dd>
+                    <a href="{{ object.supplementary_file.url }}"><i class="fa fa-file"></i> {{ object.supplementary_file.name }}</a>
+                </dd>
+            {% endif %}
         {% endif %}
 
         {% if object.predictions_file %}
@@ -124,7 +128,7 @@
                     <td data-order="{{ evaluation.modified|date:"c" }}">{{ evaluation.modified }}</td>
                     {% if "change_challenge" in challenge_perms %}
                         <td>
-                            <a href="{{ evaluation.method.get_absolute_url }}">{{ evaluation.method.id|split_first:"-" }}</a>
+                            <a href="{{ evaluation.method.get_absolute_url }}">{{ evaluation.method.pk|split_first:"-" }}</a>
                         </td>
                     {% endif %}
                     <td>

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_detail.html
@@ -2,6 +2,7 @@
 {% load url %}
 {% load humanize %}
 {% load static %}
+{% load evaluation_extras %}
 {% load user_profile_link from profiles %}
 
 {% block title %}
@@ -55,6 +56,36 @@
                 </a></dd>
         {% endif %}
 
+        {% if object.comment %}
+            <dt>Comment</dt>
+            <dd>
+                {{ object.comment }}
+            </dd>
+        {% endif %}
+
+        {% if object.supplementary_url %}
+            <dt>Supplementary URL ({{ object.phase.supplementary_url_label }})</dt>
+            <dd>
+                <a href="{{ object.supplementary_url }}" target="_blank">
+                    <i class="fas fa-link"></i> {{ object.supplementary_url }}
+                </a>
+            </dd>
+        {% endif %}
+
+        {% if object.supplementary_file %}
+            <dt>Supplementary File ({{ object.phase.supplementary_file_label }})</dt>
+            <dd>
+                <a href="{{ object.supplementary_file.url }}"><i class="fa fa-file"></i> {{ object.supplementary_file.name }}</a>
+            </dd>
+        {% endif %}
+
+        {% if object.predictions_file %}
+            <dt>Submission File</dt>
+            <dd>
+                <a href="{{ object.predictions_file.url }}"><i class="fa fa-download"></i> {{ object.predictions_file.name }}</a>
+            </dd>
+        {% endif %}
+
     </dl>
 
     <h3>Evaluations for this submission</h3>
@@ -72,10 +103,13 @@
             <tr>
                 <th>Created</th>
                 <th>Updated</th>
-                <th>Evaluation</th>
-                <th>Method</th>
+                {% if "change_challenge" in challenge_perms %}
+                    <th>Method</th>
+                {% endif %}
                 <th>Status</th>
-                <th>Result</th>
+                <th>Visibility</th>
+                <th>Details</th>
+                <th>Possible next step(s)</th>
             </tr>
             </thead>
             <tbody>
@@ -83,17 +117,60 @@
                 <tr>
                     <td data-order="{{ evaluation.created|date:"c" }}">{{ evaluation.created }}</td>
                     <td data-order="{{ evaluation.modified|date:"c" }}">{{ evaluation.modified }}</td>
-                    <td><a href="{{ evaluation.get_absolute_url }}">{{ evaluation.id }}</a>
-                    </td>
-                    <td>
-                        <a href="{{ evaluation.method.get_absolute_url }}">{{ evaluation.method.id }}</a>
-                    </td>
+                    {% if "change_challenge" in challenge_perms %}
+                        <td>
+                            <a href="{{ evaluation.method.get_absolute_url }}">{{ evaluation.method.id|split_first:"-" }}</a>
+                        </td>
+                    {% endif %}
                     <td>
                         {% include 'evaluation/evaluation_status_detail.html' with object=evaluation %}
                     </td>
                     <td>
+                        {{ evaluation.visibility_icon }}
+                    </td>
+                    <td>
                         {% if evaluation.status == evaluation.SUCCESS %}
-                            <a href="{{ evaluation.get_absolute_url }}">Result</a>
+                            {% if evaluation.published %}
+                                <a href="{{ evaluation.get_absolute_url }}"><i class="fas fa-search mr-1"></i></a>View public result
+                            {% elif "change_challenge" in challenge_perms %}
+                                <a href="{{ evaluation.get_absolute_url }}"><i class="fas fa-search mr-1"></i></a>View private result
+                            {% else %}
+                                Evaluation is under review by the challenge admins.
+                            {% endif %}
+                        {% elif evaluation.status == evaluation.FAILURE or evaluaton.status == evaluation.CANCELLED %}
+                            {% if "change_challenge" in challenge_perms %}
+                                <a href="{{ evaluation.get_absolute_url }}" title="View evaluation details"><i class="fas fa-search mr-1"></i></a>
+                            {% endif %}
+                            {{ evaluation.error_message }}
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if evaluation.status == evaluation.SUCCESS %}
+                            {% if "change_challenge" in challenge_perms %}
+                                {% if evaluation.published %}
+                                    <form method="post"
+                                        action="{% url 'evaluation:update' challenge_short_name=challenge.short_name pk=evaluation.pk %}">
+                                        {% csrf_token %}
+                                        <input type="hidden" name="published"
+                                            value="false">
+                                        <button type="submit" class="btn btn-link m-0 p-0">
+                                            Hide this result
+                                        </button>
+                                    </form>
+                                {% else %}
+                                    <form method="post"
+                                        action="{% url 'evaluation:update' challenge_short_name=challenge.short_name pk=evaluation.pk %}">
+                                        {% csrf_token %}
+                                        <input type="hidden" name="published"
+                                            value="true">
+                                        <button type="submit" class="btn btn-link m-0 p-0">
+                                            Publish this result
+                                        </button>
+                                    </form>
+                                {% endif %}
+                            {% endif %}
+                        {% elif evaluation.status == evaluation.FAILURE or evaluation.status == evaluation.CANCELLED %}
+                            {{ evaluation|get_action_message:request.user }}
                         {% endif %}
                     </td>
                 </tr>
@@ -103,63 +180,14 @@
     </div>
 
     {% if "change_challenge" in challenge_perms %}
-        <div class="card card-danger border-danger">
-            <div class="card-header bg-danger text-white">Submission Admin</div>
-
-            <div class="card-body">
-                <dl>
-
-                    <dt>Comment</dt>
-                    <dd>
-                        {% if object.comment %}
-                            {{ object.comment }}
-                        {% else %}
-                            No comment provided.
-                        {% endif %}
-                    </dd>
-
-                    <dt>Supplementary URL ({{ object.phase.supplementary_url_label }})</dt>
-                    <dd>
-                        {% if object.supplementary_url %}
-                            <a href="{{ object.supplementary_url }}" target="_blank">
-                                <i class="fas fa-link"></i> {{ object.supplementary_url }}
-                            </a>
-                        {% else %}
-                            No supplementary URL provided.
-                        {% endif %}
-                    </dd>
-
-                    <dt>Supplementary File ({{ object.phase.supplementary_file_label }})</dt>
-                    <dd>
-                        {% if object.supplementary_file %}
-                            <a href="{{ object.supplementary_file.url }}">
-                                <i class="fa fa-file"></i> {{ object.supplementary_file.name }}
-                            </a>
-                        {% else %}
-                            No supplementary file provided.
-                        {% endif %}
-                    </dd>
-
-                    <dt>Submission File</dt>
-                    <dd>
-                        {% if object.predictions_file %}
-                            <a href="{{ object.predictions_file.url }}">
-                                <i class="fa fa-download"></i> {{ object.predictions_file.name }}
-                            </a>
-                        {% else %}
-                            No submission file provided.
-                        {% endif %}
-                    </dd>
-
-                </dl>
-            </div>
-
-            {% with object.phase.additional_evaluation_inputs.all as additional_inputs_required %}
-
-                {% if not object.phase.external_evaluation and not object.is_evaluated_with_active_image_and_ground_truth or additional_inputs_required %}
+        {% with object.phase.additional_evaluation_inputs.all as additional_inputs_required %}
+            {% if not object.phase.external_evaluation and not object.is_evaluated_with_active_image_and_ground_truth or additional_inputs_required %}
+                <div class="card card-danger border-danger">
+                    <div class="card-header bg-danger text-white">Submission Admin</div>
                     <div class="card-body">
                         <h4 class="card-title">Re-Evaluate Submission with
-                            {% if not object.is_evaluated_with_active_image_and_ground_truth %} Active Method and Active Ground Truth {% endif %}
+                            {% if not object.is_evaluated_with_active_image_and_ground_truth %} Active Method and Active
+                                Ground Truth {% endif %}
                             {% if additional_inputs_required %}
                                 {% if not object.is_evaluated_with_active_image_and_ground_truth %} and {% endif %}
                                 different inputs
@@ -171,7 +199,7 @@
                             This submission has
                             {% if not object.is_evaluated_with_active_image_and_ground_truth %} not {% endif %}
                             been evaluated with the active evaluation method and active ground truth for this phase
-                            {% if additional_inputs_required %}, and can be re-evaluated with different inputs {% endif %}.
+                            {% if additional_inputs_required %}, and can be re-evaluated with different inputs{% endif %}.
                             {% if challenge.available_compute_euro_millicents <= 0 %}
                                 However, an evaluation cannot be created as this challenge has exceeded its budget.
                             {% endif %}
@@ -180,7 +208,7 @@
                         {% if challenge.available_compute_euro_millicents > 0 %}
                             {% if additional_inputs_required %}
                                 <a class="btn btn-sm btn-primary"
-                                    href="{% url 'evaluation:evaluation-create' challenge_short_name=challenge.short_name slug=object.phase.slug pk=object.pk %}">
+                                   href="{% url 'evaluation:evaluation-create' challenge_short_name=challenge.short_name slug=object.phase.slug pk=object.pk %}">
                                     Re-Evaluate with different inputs
                                     {% if not object.is_evaluated_with_active_image_and_ground_truth %}
                                         and with the Active Method and Active Ground Truth
@@ -198,8 +226,8 @@
                             {% endif %}
                         {% endif %}
                     </div>
-                {% endif %}
-            {% endwith %}
-        </div>
+                </div>
+            {% endif %}
+        {% endwith %}
     {% endif %}
 {% endblock %}

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_detail.html
@@ -33,6 +33,8 @@
     <h2>Submission {{ object.pk }}</h2>
 
     <dl>
+        <dt>Submission Id</dt>
+        <dd>{{ object.pk }}</dd>
 
         <dt>Challenge</dt>
         <dd>
@@ -101,6 +103,7 @@
         >
             <thead class="thead-light">
             <tr>
+                <th>Evaluation Id</th>
                 <th>Created</th>
                 <th>Updated</th>
                 {% if "change_challenge" in challenge_perms %}
@@ -115,6 +118,7 @@
             <tbody>
             {% for evaluation in object.evaluation_set.all %}
                 <tr>
+                    <td>{{ evaluation.pk }}</td>
                     <td data-order="{{ evaluation.created|date:"c" }}">{{ evaluation.created }}</td>
                     <td data-order="{{ evaluation.modified|date:"c" }}">{{ evaluation.modified }}</td>
                     {% if "change_challenge" in challenge_perms %}
@@ -131,15 +135,15 @@
                     <td>
                         {% if evaluation.status == evaluation.SUCCESS %}
                             {% if evaluation.published %}
-                                <a href="{{ evaluation.get_absolute_url }}"><i class="fas fa-search mr-1"></i></a>View public result
+                                <a href="{{ evaluation.get_absolute_url }}"><i class="fas fa-info-circle mr-1"></i></a>View public result
                             {% elif "change_challenge" in challenge_perms %}
-                                <a href="{{ evaluation.get_absolute_url }}"><i class="fas fa-search mr-1"></i></a>View private result
+                                <a href="{{ evaluation.get_absolute_url }}"><i class="fas fa-info-circle mr-1"></i></a>View private result
                             {% else %}
                                 Evaluation is under review by the challenge admins.
                             {% endif %}
                         {% elif evaluation.status == evaluation.FAILURE or evaluaton.status == evaluation.CANCELLED %}
                             {% if "change_challenge" in challenge_perms %}
-                                <a href="{{ evaluation.get_absolute_url }}" title="View evaluation details"><i class="fas fa-search mr-1"></i></a>
+                                <a href="{{ evaluation.get_absolute_url }}" title="View evaluation details"><i class="fas fa-info-circle mr-1"></i></a>
                             {% endif %}
                             {{ evaluation.error_message }}
                         {% endif %}
@@ -153,7 +157,8 @@
                                         {% csrf_token %}
                                         <input type="hidden" name="published"
                                             value="false">
-                                        <button type="submit" class="btn btn-link m-0 p-0">
+                                        <button type="submit" class="btn btn-sm btn-danger">
+                                            <i class="fas fa-eye-slash"></i>
                                             Hide this result
                                         </button>
                                     </form>
@@ -163,7 +168,8 @@
                                         {% csrf_token %}
                                         <input type="hidden" name="published"
                                             value="true">
-                                        <button type="submit" class="btn btn-link m-0 p-0">
+                                        <button type="submit" class="btn btn-sm btn-success">
+                                            <i class="fas fa-eye"></i>
                                             Publish this result
                                         </button>
                                     </form>

--- a/app/grandchallenge/evaluation/templates/evaluation/submission_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/submission_detail.html
@@ -99,6 +99,7 @@
             data-length-change="false"
             data-filter="false"
             data-info="false"
+            data-order='[[1, "asc"]]'
             class="table table-hover table-borderless table-sm w-100"
         >
             <thead class="thead-light">
@@ -111,8 +112,8 @@
                 {% endif %}
                 <th>Status</th>
                 <th>Visibility</th>
-                <th>Details</th>
-                <th>Possible next step(s)</th>
+                <th class="nonSortable">Details</th>
+                <th class="nonSortable">Possible next step(s)</th>
             </tr>
             </thead>
             <tbody>

--- a/app/grandchallenge/evaluation/templatetags/evaluation_extras.py
+++ b/app/grandchallenge/evaluation/templatetags/evaluation_extras.py
@@ -38,3 +38,8 @@ def get_key(obj: dict, key):
 @register.filter
 def split_first(object, character):
     return str(object).split(character, 1)[0]
+
+
+@register.filter
+def get_action_message(evaluation, user):
+    return evaluation.build_action_message(user=user)

--- a/app/tests/evaluation_tests/test_models.py
+++ b/app/tests/evaluation_tests/test_models.py
@@ -2810,3 +2810,52 @@ def test_invalid_input(is_admin, expected_message):
 
     result = builder._handle_invalid_input()
     assert expected_message in result
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "status,published,rank,expected_classes,expected_title_fragment",
+    [
+        (
+            Evaluation.SUCCESS,
+            True,
+            1,
+            "fas fa-eye text-success",
+            "published on the leaderboard",
+        ),
+        (
+            Evaluation.SUCCESS,
+            True,
+            0,
+            "fas fa-eye text-warning",
+            "not visible on the leaderboard",
+        ),
+        (
+            Evaluation.SUCCESS,
+            False,
+            0,
+            "fas fa-hourglass-half text-warning",
+            "under review",
+        ),
+        (
+            Evaluation.FAILURE,
+            False,
+            0,
+            "fas fa-eye-slash text-danger",
+            "no result for this submission",
+        ),
+    ],
+)
+def test_visibility_icon(
+    status, published, rank, expected_classes, expected_title_fragment
+):
+    evaluation = EvaluationFactory(
+        status=status,
+        published=published,
+        rank=rank,
+        time_limit=10,
+        submission__phase__auto_publish_new_results=published,
+    )
+    icon = evaluation.visibility_icon
+    assert expected_classes in icon
+    assert expected_title_fragment in icon


### PR DESCRIPTION
This updates the submission detail page in the following ways:
- Moves non-admin stuff out of the admin section
- Updates the evaluation table to include "next steps", "details" and "visibility" columns

<img width="1131" height="337" alt="Screenshot 2026-04-30 at 10 43 49" src="https://github.com/user-attachments/assets/65216bd8-c946-4fef-85e2-d9422ebb25be" />


Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/482