### PR TITLE
Remove network requirements for docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build_web_test:
 			-f dockerfiles/web-base/Dockerfile \
 			.; \
 	}
-	docker buildx build\
+	docker buildx build \
 		--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
 		--build-arg COMMIT_ID=$(GIT_COMMIT_ID) \
 		--build-arg LOCKFILE_HASH=$(LOCKFILE_HASH) \
@@ -42,13 +42,12 @@ build_web_dist:
 			-f dockerfiles/web-base/Dockerfile \
 			.; \
 	}
-	DOCKER_BUILDKIT=0 docker build \
+	docker buildx build \
 		--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
 		--build-arg COMMIT_ID=$(GIT_COMMIT_ID) \
 		--build-arg LOCKFILE_HASH=$(LOCKFILE_HASH) \
 		--build-arg GRAND_CHALLENGE_WEB_TEST_BASE_REPOSITORY_URI=$(GRAND_CHALLENGE_WEB_TEST_BASE_REPOSITORY_URI) \
 		--build-arg GRAND_CHALLENGE_WEB_BASE_REPOSITORY_URI=$(GRAND_CHALLENGE_WEB_BASE_REPOSITORY_URI) \
-		--network grand-challengeorg_default \
 		--target dist \
 		-t $(GRAND_CHALLENGE_WEB_REPOSITORY_URI):$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(LOCKFILE_HASH) \
 		-t $(GRAND_CHALLENGE_WEB_REPOSITORY_URI):latest \
@@ -56,14 +55,14 @@ build_web_dist:
 		.
 
 build_web_lambda:
-	DOCKER_BUILDKIT=0 docker build \
+	docker buildx build \
 		--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
 		--build-arg COMMIT_ID=$(GIT_COMMIT_ID) \
 		--build-arg LOCKFILE_HASH=$(LOCKFILE_HASH) \
 		--build-arg GRAND_CHALLENGE_WEB_TEST_BASE_REPOSITORY_URI=$(GRAND_CHALLENGE_WEB_TEST_BASE_REPOSITORY_URI) \
 		--build-arg GRAND_CHALLENGE_WEB_BASE_REPOSITORY_URI=$(GRAND_CHALLENGE_WEB_BASE_REPOSITORY_URI) \
-		--network grand-challengeorg_default \
 		--target dist-lambda \
+		--provenance=false \
 		-t $(GRAND_CHALLENGE_WEB_REPOSITORY_URI):lambda-$(GIT_COMMIT_ID)-$(GIT_BRANCH_NAME)-$(LOCKFILE_HASH) \
 		-f dockerfiles/web/Dockerfile \
 		-t docker-image:test \

--- a/dockerfiles/web/Dockerfile
+++ b/dockerfiles/web/Dockerfile
@@ -26,8 +26,6 @@ COPY --chown=django:django ./app/ /app/
 ARG COMMIT_ID=unknown
 ENV COMMIT_ID=$COMMIT_ID
 
-RUN python manage.py collectstatic --noinput && python manage.py compress --force
-
 ####################
 # Lambda Container #
 ####################


### PR DESCRIPTION
`--provenance=false` is required for lambda compatibility, which requires use of `buildx`, which requires that no network is used, which requires that `python manage.py collectstatic --noinput && python manage.py compress --force` is done during migration. Minimises what is contained in the distributable image, so this is a win.

See https://github.com/DIAGNijmegen/rse-cloud-infrastructure/issues/373