### PR TITLE
Update evaluation list and detail pages

### DIFF
--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -2020,7 +2020,7 @@ class EvaluationActionMessageBuilder:
     @property
     def evaluation_logs_message(self):
         return format_html(
-            "<a href={url}>inspect the evaluation logs</a>",
+            "<a href={url}#logs>inspect the evaluation logs</a>",
             url=self.evaluation.get_absolute_url(),
         )
 

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_admin_list_row.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_admin_list_row.html
@@ -27,15 +27,17 @@
 
 <split></split>
 
-{% for input in object.additional_inputs.all|sort_civs %}
-    <dd>
-        {% include 'components/partials/civ.html' with object=input display_inline=True only %}
-    </dd>
-{% empty %}
-    <span class="text-muted">Empty</span>
-{% endfor %}
+{% if phase.additional_evaluation_inputs.all %}
+    {% for input in object.additional_inputs.all|sort_civs %}
+        <dd>
+            {% include 'components/partials/civ.html' with object=input display_inline=True only %}
+        </dd>
+    {% empty %}
+        <span class="text-muted">Empty</span>
+    {% endfor %}
+    <split></split>
+{% endif %}
 
-<split></split>
 
 {% include 'evaluation/evaluation_status_detail.html' %}
 
@@ -49,15 +51,15 @@
             <input type="hidden" name="published"
                    value="false">
             <button type="submit"
-                    class="btn btn-xs btn-danger">
-                Hide Result
+                    class="btn btn-sm btn-danger">
+                Hide
             </button>
         {% else %}
             <input type="hidden" name="published"
                    value="true">
             <button type="submit"
-                    class="btn btn-xs btn-primary">
-                Publish Result
+                    class="btn btn-sm btn-primary">
+                Publish
             </button>
         {% endif %}
     </form>
@@ -67,9 +69,8 @@
 
 {% if object.submission.phase.submission_kind == object.submission.phase.SubmissionKindChoices.ALGORITHM and object.submission.algorithm_image %}
     <a href="{% url 'algorithms:job-list' slug=object.submission.algorithm_image.algorithm.slug %}">{{ object.submission.algorithm_image.algorithm.title }}</a>
+    <split></split>
 {% endif %}
-
-<split></split>
 
 {% if object.rank > 0 %}
     {{ object.rank }}
@@ -82,4 +83,6 @@
 
 <split></split>
 
-{{ object.submission.comment }}
+{% if object.allow_submission_comments %}
+    {{ object.submission.comment }}
+{% endif %}

--- a/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/evaluation_detail.html
@@ -38,7 +38,7 @@
 
     <dl>
 
-        <dt>ID</dt>
+        <dt>Evaluation ID</dt>
         <dd>{{ object.pk }}</dd>
 
         <dt>Submission ID</dt>
@@ -57,6 +57,8 @@
             <dd>
                 {{ object.error_message }}
             </dd>
+            <dt>Help with this error: </dt>
+            <dd>{{ object|get_action_message:request.user }}</dd>
         {% endif %}
 
         <dt>User</dt>
@@ -273,7 +275,7 @@
             {% endif %}
 
             <div class="card-body">
-                <h3 class="card-title">Logs</h3>
+                <h3 class="card-title" id="logs">Logs</h3>
 
                 {% if object.runtime_metrics %}
                     <h4>Runtime Metrics</h4>

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -560,21 +560,6 @@ class EvaluationAdminList(
     row_template = "evaluation/evaluation_admin_list_row.html"
     login_url = reverse_lazy("account_login")
     raise_exception = True
-    columns = [
-        Column(title="Submission ID", sort_field="submission__id"),
-        Column(title="Evaluation ID", sort_field="id"),
-        Column(title="Evaluation Created", sort_field="created"),
-        Column(title="User", sort_field="submission__creator__username"),
-        Column(title="Inputs"),
-        Column(title="Status", sort_field="status"),
-        Column(title="Hide/Publish", sort_field="published"),
-        Column(
-            title="Algorithm Results",
-            sort_field="submission__algorithm_image__algorithm__title",
-        ),
-        Column(title="Position", sort_field="rank"),
-        Column(title="Comment", sort_field="submission__comment"),
-    ]
     search_fields = [
         "submission__id",
         "id",
@@ -584,6 +569,54 @@ class EvaluationAdminList(
         "submission__comment",
     ]
     default_sort_column = 2
+
+    @property
+    def columns(self):
+        columns = [
+            Column(title="Submission ID", sort_field="submission__id"),
+            Column(title="Evaluation ID", sort_field="id"),
+            Column(title="Evaluation Created", sort_field="created"),
+            Column(title="User", sort_field="submission__creator__username"),
+        ]
+
+        if self.phase.additional_evaluation_inputs.exists():
+            columns.extend(
+                [
+                    Column(
+                        title="Inputs",
+                    )
+                ]
+            )
+
+        columns.extend(
+            [
+                Column(title="Status", sort_field="status"),
+                Column(title="Hide/Publish", sort_field="published"),
+            ]
+        )
+
+        if self.phase.submission_kind == SubmissionKindChoices.ALGORITHM:
+            columns.extend(
+                [
+                    Column(
+                        title="Algorithm Results",
+                        sort_field="submission__algorithm_image__algorithm__title",
+                    )
+                ]
+            )
+
+        columns.extend(
+            [
+                Column(title="Position", sort_field="rank"),
+            ]
+        )
+
+        if self.phase.allow_submission_comments:
+            columns.extend(
+                [Column(title="Comment", sort_field="submission__comment")]
+            )
+
+        return columns
 
     def get_permission_object(self):
         return self.request.challenge


### PR DESCRIPTION
Small follow-up PR that adds the action message to the evaluation detail page. Also cleans up the evaluation table to only show the columns that are relevant for the given phase. 

Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/482