### PR TITLE
Unwrap invocation json contents for invocations

### DIFF
--- a/app/grandchallenge/components/backends/amazon_sagemaker_endpoint.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_endpoint.py
@@ -1,6 +1,7 @@
 import boto3
 from botocore.exceptions import ClientError
 from django.conf import settings
+from pydantic_core import to_json
 
 from grandchallenge.components.backends.amazon_sagemaker_training import (
     AmazonSageMakerTrainingExecutor,
@@ -223,7 +224,12 @@ class EndpointOrchestrator:
         self.deprovision_auxiliary_data()
 
     def provision_invocation_input_data(self, *, input_civs):
+        self._executor._get_invocation_json = self._get_invocation_json
         self._executor.provision(input_civs=input_civs, input_prefixes={})
+
+    @staticmethod
+    def _get_invocation_json(*, inference_task):
+        return to_json(inference_task)
 
     def invoke_endpoint(self, *, inference_id):
         self._sagemaker_runtime_client.invoke_endpoint_async(

--- a/app/grandchallenge/components/backends/amazon_sagemaker_endpoint.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_endpoint.py
@@ -1,7 +1,6 @@
 import boto3
 from botocore.exceptions import ClientError
 from django.conf import settings
-from pydantic_core import to_json
 
 from grandchallenge.components.backends.amazon_sagemaker_training import (
     AmazonSageMakerTrainingExecutor,
@@ -36,6 +35,7 @@ class EndpointOrchestrator:
             algorithm_model=None,
             input_bucket_name=settings.ALGORITHM_ENDPOINTS_INPUT_BUCKET_NAME,
             output_bucket_name=settings.ALGORITHM_ENDPOINTS_OUTPUT_BUCKET_NAME,
+            use_task_list=False,
         )
         self._endpoint_name = endpoint_name
         self._exec_image_repo_tag = exec_image_repo_tag
@@ -224,12 +224,7 @@ class EndpointOrchestrator:
         self.deprovision_auxiliary_data()
 
     def provision_invocation_input_data(self, *, input_civs):
-        self._executor._get_invocation_json = self._get_invocation_json
         self._executor.provision(input_civs=input_civs, input_prefixes={})
-
-    @staticmethod
-    def _get_invocation_json(*, inference_task):
-        return to_json(inference_task)
 
     def invoke_endpoint(self, *, inference_id):
         self._sagemaker_runtime_client.invoke_endpoint_async(

--- a/app/grandchallenge/components/backends/base.py
+++ b/app/grandchallenge/components/backends/base.py
@@ -721,19 +721,25 @@ class Executor(ABC):
                 f"Unknown interface super kind: {civ.interface.super_kind}"
             )
 
+    def _get_inference_task(self, *, invocation_inputs):
+        return InferenceTask(
+            pk=self._job_id,
+            inputs=invocation_inputs,
+            output_bucket_name=self._output_bucket_name,
+            output_prefix=self._io_prefix,
+            timeout=self._time_limit,
+        )
+
+    @staticmethod
+    def _get_invocation_json(*, inference_task):
+        return to_json([inference_task])
+
     def _get_create_invocation_json_task(self, *, invocation_inputs):
+        inference_task = self._get_inference_task(
+            invocation_inputs=invocation_inputs
+        )
         return self._get_upload_input_content_task(
-            content=to_json(
-                [
-                    InferenceTask(
-                        pk=self._job_id,
-                        inputs=invocation_inputs,
-                        output_bucket_name=self._output_bucket_name,
-                        output_prefix=self._io_prefix,
-                        timeout=self._time_limit,
-                    )
-                ]
-            ),
+            content=self._get_invocation_json(inference_task=inference_task),
             key=self._invocation_key,
         )
 

--- a/app/grandchallenge/components/backends/base.py
+++ b/app/grandchallenge/components/backends/base.py
@@ -330,6 +330,7 @@ class Executor(ABC):
         ground_truth=None,
         input_bucket_name=settings.COMPONENTS_INPUT_BUCKET_NAME,
         output_bucket_name=settings.COMPONENTS_OUTPUT_BUCKET_NAME,
+        use_task_list=True,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -345,6 +346,9 @@ class Executor(ABC):
         self._api_method = api_method
         self._algorithm_model = algorithm_model
         self._ground_truth = ground_truth
+        self._input_bucket_name = input_bucket_name
+        self._output_bucket_name = output_bucket_name
+        self._use_task_list = use_task_list
 
         self._exec_duration = None
         self._invoke_duration = None
@@ -352,9 +356,6 @@ class Executor(ABC):
         self._stderr = []
 
         self._inference_result_skipped = False
-
-        self._input_bucket_name = input_bucket_name
-        self._output_bucket_name = output_bucket_name
 
         self.__s3_client = None
 
@@ -721,8 +722,8 @@ class Executor(ABC):
                 f"Unknown interface super kind: {civ.interface.super_kind}"
             )
 
-    def _get_inference_task(self, *, invocation_inputs):
-        return InferenceTask(
+    def _get_create_invocation_json_task(self, *, invocation_inputs):
+        inference_task = InferenceTask(
             pk=self._job_id,
             inputs=invocation_inputs,
             output_bucket_name=self._output_bucket_name,
@@ -730,16 +731,13 @@ class Executor(ABC):
             timeout=self._time_limit,
         )
 
-    @staticmethod
-    def _get_invocation_json(*, inference_task):
-        return to_json([inference_task])
+        if self._use_task_list:
+            content = to_json([inference_task])
+        else:
+            content = to_json(inference_task)
 
-    def _get_create_invocation_json_task(self, *, invocation_inputs):
-        inference_task = self._get_inference_task(
-            invocation_inputs=invocation_inputs
-        )
         return self._get_upload_input_content_task(
-            content=self._get_invocation_json(inference_task=inference_task),
+            content=content,
             key=self._invocation_key,
         )
 

--- a/app/tests/components_tests/test_amazon_sagemaker_endpoint_backend.py
+++ b/app/tests/components_tests/test_amazon_sagemaker_endpoint_backend.py
@@ -565,7 +565,7 @@ def test_endpoint_orchestrator_provision_invocation_input_data_tasks(
         create_invocation_json_task.keywords["content"]
     )
 
-    assert invocation_json == [expected_invocation_json]
+    assert invocation_json == expected_invocation_json
 
 
 def test_invocation_invoke_endpoint(settings):


### PR DESCRIPTION
The invocation.json content for jobs are inference task(s) in a list. For an endpoint invocation there can be only one inference task. The content should not be a list, otherwise the invocation fails.  

See https://github.com/DIAGNijmegen/rse-roadmap/issues/481