### PR TITLE
Weekly open invoice email to staff

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1242,6 +1242,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "grandchallenge.challenges.tasks.send_onboarding_task_reminder_emails",
         "schedule": crontab(day_of_week="mon", hour=6, minute=0),
     },
+    "send_open_invoices_email": {
+        "task": "grandchallenge.invoices.tasks.send_open_invoices_email",
+        "schedule": crontab(day_of_week="wed", hour=6, minute=0),
+    },
     "send_challenge_invoice_overdue_reminder_emails": {
         "task": "grandchallenge.invoices.tasks.send_challenge_invoice_overdue_reminder_emails",
         "schedule": crontab(day_of_month=1, hour=6, minute=0),

--- a/app/grandchallenge/invoices/admin.py
+++ b/app/grandchallenge/invoices/admin.py
@@ -33,6 +33,19 @@ class OverdueListFilter(admin.SimpleListFilter):
         return queryset
 
 
+class ToCheckFilter(admin.SimpleListFilter):
+    title = "to check"
+    parameter_name = "to_check"
+
+    def lookups(self, request, model_admin):
+        return [("1", "Yes")]
+
+    def queryset(self, request, queryset):
+        if self.value() == "1":
+            return queryset.to_check()
+        return queryset
+
+
 @admin.register(Invoice)
 class InvoiceAdmin(admin.ModelAdmin):
     list_display = (
@@ -52,6 +65,7 @@ class InvoiceAdmin(admin.ModelAdmin):
     )
     list_filter = (
         OverdueListFilter,
+        ToCheckFilter,
         "payment_status",
         "payment_type",
         "challenge__short_name",

--- a/app/grandchallenge/invoices/models.py
+++ b/app/grandchallenge/invoices/models.py
@@ -107,7 +107,7 @@ class InvoiceQuerySet(models.QuerySet):
             | Q(
                 payment_type=Invoice.PaymentTypeChoices.POSTPAID,
                 payment_status=Invoice.PaymentStatusChoices.INITIALIZED,
-                follow_up_on__lt=now().date(),
+                follow_up_on__lte=now().date(),
             )
         )
 

--- a/app/grandchallenge/invoices/models.py
+++ b/app/grandchallenge/invoices/models.py
@@ -96,6 +96,21 @@ class InvoiceQuerySet(models.QuerySet):
             num_is_due=Count("is_due", filter=Q(is_due=True), distinct=True),
         )
 
+    def to_check(self):
+        return self.filter(
+            Q(payment_status=Invoice.PaymentStatusChoices.REQUESTED)
+            | Q(payment_status=Invoice.PaymentStatusChoices.ISSUED)
+            | Q(
+                payment_type=Invoice.PaymentTypeChoices.PREPAID,
+                payment_status=Invoice.PaymentStatusChoices.INITIALIZED,
+            )
+            | Q(
+                payment_type=Invoice.PaymentTypeChoices.POSTPAID,
+                payment_status=Invoice.PaymentStatusChoices.INITIALIZED,
+                follow_up_on__lt=now().date(),
+            )
+        )
+
 
 def default_invoice_expiry():
     return now().date() + relativedelta(

--- a/app/grandchallenge/invoices/tasks.py
+++ b/app/grandchallenge/invoices/tasks.py
@@ -1,4 +1,7 @@
+from django.core.mail import mail_managers
 from django.db import transaction
+from django.template.loader import render_to_string
+from django.utils.timezone import now
 
 from grandchallenge.core.celery import (
     acks_late_2xlarge_task,
@@ -29,3 +32,42 @@ def send_challenge_invoice_issued_notification_emails(*, pk):
 
     invoice = Invoice.objects.get(pk=pk)
     send_challenge_invoice_issued_notification(invoice)
+
+
+@acks_late_micro_short_task
+@transaction.atomic
+def send_open_invoices_email():
+    from grandchallenge.invoices.models import Invoice
+
+    subject = "Invoices to check"
+
+    post_paid_invoices_to_follow_up = Invoice.objects.filter(
+        payment_type=Invoice.PaymentTypeChoices.POSTPAID,
+        payment_status=Invoice.PaymentStatusChoices.INITIALIZED,
+        follow_up_on__lte=now().date(),
+    )
+    initialized_prepaid_invoices = Invoice.objects.filter(
+        payment_type=Invoice.PaymentTypeChoices.PREPAID,
+        payment_status=Invoice.PaymentStatusChoices.INITIALIZED,
+    )
+    requested_invoices = Invoice.objects.filter(
+        payment_status=Invoice.PaymentStatusChoices.REQUESTED,
+    )
+    issued_invoices = Invoice.objects.filter(
+        payment_status=Invoice.PaymentStatusChoices.ISSUED,
+    )
+
+    message = render_to_string(
+        "invoices/partials/open_invoices_email.md",
+        context={
+            "post_paid_invoices_to_follow_up": post_paid_invoices_to_follow_up,
+            "initialized_prepaid_invoices": initialized_prepaid_invoices,
+            "requested_invoices": requested_invoices,
+            "issued_invoices": issued_invoices,
+        },
+    )
+
+    mail_managers(
+        subject=subject,
+        message=message,
+    )

--- a/app/grandchallenge/invoices/tasks.py
+++ b/app/grandchallenge/invoices/tasks.py
@@ -57,6 +57,15 @@ def send_open_invoices_email():
         payment_status=Invoice.PaymentStatusChoices.ISSUED,
     )
 
+    # Only send email if there is at least one invoice in any category
+    if not (
+        post_paid_invoices_to_follow_up.exists()
+        or initialized_prepaid_invoices.exists()
+        or requested_invoices.exists()
+        or issued_invoices.exists()
+    ):
+        return
+
     message = render_to_string(
         "invoices/partials/open_invoices_email.md",
         context={

--- a/app/grandchallenge/invoices/tasks.py
+++ b/app/grandchallenge/invoices/tasks.py
@@ -44,7 +44,7 @@ def send_open_invoices_email():
     post_paid_invoices_to_follow_up = Invoice.objects.filter(
         payment_type=Invoice.PaymentTypeChoices.POSTPAID,
         payment_status=Invoice.PaymentStatusChoices.INITIALIZED,
-        follow_up_on__lt=now().date(),
+        follow_up_on__lte=now().date(),
     )
     initialized_prepaid_invoices = Invoice.objects.filter(
         payment_type=Invoice.PaymentTypeChoices.PREPAID,

--- a/app/grandchallenge/invoices/tasks.py
+++ b/app/grandchallenge/invoices/tasks.py
@@ -44,7 +44,7 @@ def send_open_invoices_email():
     post_paid_invoices_to_follow_up = Invoice.objects.filter(
         payment_type=Invoice.PaymentTypeChoices.POSTPAID,
         payment_status=Invoice.PaymentStatusChoices.INITIALIZED,
-        follow_up_on__lte=now().date(),
+        follow_up_on__lt=now().date(),
     )
     initialized_prepaid_invoices = Invoice.objects.filter(
         payment_type=Invoice.PaymentTypeChoices.PREPAID,

--- a/app/grandchallenge/invoices/templates/invoices/partials/open_invoices_email.md
+++ b/app/grandchallenge/invoices/templates/invoices/partials/open_invoices_email.md
@@ -1,0 +1,18 @@
+{% load url %}
+The following invoices need to be checked:
+{% if post_paid_invoices_to_follow_up %}
+Unprocessed post-paid invoices with a follow-up date in the past:
+{% for invoice in post_paid_invoices_to_follow_up %} {{ invoice }}: {% url 'admin:invoices_invoice_change' invoice.pk %}
+{% endfor %}{% endif %}
+{% if initialized_prepaid_invoices %}
+Initialized prepaid:
+{% for invoice in initialized_prepaid_invoices %} {{ invoice }}: {% url 'admin:invoices_invoice_change' invoice.pk %}
+{% endfor %}{% endif %}
+{% if requested_invoices %}
+Requested invoices:
+{% for invoice in requested_invoices %} {{ invoice }}: {% url 'admin:invoices_invoice_change' invoice.pk %}
+{% endfor %}{% endif %}
+{% if issued_invoices %}
+Issued invoices:
+{% for invoice in issued_invoices %} {{ invoice }}: {% url 'admin:invoices_invoice_change' invoice.pk %}
+{% endfor %}{% endif %}

--- a/app/tests/invoices_tests/test_tasks.py
+++ b/app/tests/invoices_tests/test_tasks.py
@@ -411,7 +411,12 @@ def test_send_open_invoices_email(settings):
         payment_status=Invoice.PaymentStatusChoices.ISSUED,
     )
     i5 = InvoiceFactory(payment_status=Invoice.PaymentStatusChoices.PAID)
-    i6 = InvoiceFactory(
+    i6 = InvoiceFactory(payment_status=Invoice.PaymentStatusChoices.CANCELLED)
+    i7 = InvoiceFactory(
+        payment_status=Invoice.PaymentStatusChoices.INITIALIZED,
+        payment_type=Invoice.PaymentTypeChoices.COMPLIMENTARY,
+    )
+    i8 = InvoiceFactory(
         payment_type=Invoice.PaymentTypeChoices.POSTPAID,
         payment_status=Invoice.PaymentStatusChoices.INITIALIZED,
         follow_up_on=now().date() + timedelta(days=30),
@@ -429,3 +434,18 @@ def test_send_open_invoices_email(settings):
     assert str(i4) in mail.outbox[0].body
     assert str(i5) not in mail.outbox[0].body
     assert str(i6) not in mail.outbox[0].body
+    assert str(i7) not in mail.outbox[0].body
+    assert str(i8) not in mail.outbox[0].body
+
+
+@pytest.mark.django_db
+def test_send_open_invoices_email_not_sent_when_no_invoices(settings):
+    staff_user = UserFactory(is_staff=True)
+    settings.MANAGERS = [(staff_user.last_name, staff_user.email)]
+
+    InvoiceFactory(payment_status=Invoice.PaymentStatusChoices.PAID)
+    InvoiceFactory(payment_status=Invoice.PaymentStatusChoices.CANCELLED)
+
+    send_open_invoices_email()
+
+    assert len(mail.outbox) == 0

--- a/app/tests/invoices_tests/test_tasks.py
+++ b/app/tests/invoices_tests/test_tasks.py
@@ -391,14 +391,14 @@ def test_challenge_invoice_issued_notification_emails_on_create(
 
 
 @pytest.mark.django_db
-def test_send_open_invoices_email(mocker, settings):
+def test_send_open_invoices_email(settings):
     staff_user = UserFactory(is_staff=True)
     settings.MANAGERS = [(staff_user.last_name, staff_user.email)]
 
     i1 = InvoiceFactory(
         payment_type=Invoice.PaymentTypeChoices.POSTPAID,
         payment_status=Invoice.PaymentStatusChoices.INITIALIZED,
-        follow_up_on=now().date() + timedelta(days=1),
+        follow_up_on=now().date() - timedelta(days=1),
     )
     i2 = InvoiceFactory(
         payment_status=Invoice.PaymentStatusChoices.INITIALIZED,
@@ -417,11 +417,6 @@ def test_send_open_invoices_email(mocker, settings):
         follow_up_on=now().date() + timedelta(days=30),
     )
 
-    now_in_future = now() + timedelta(days=2)
-    mocker.patch(
-        "grandchallenge.invoices.tasks.now",
-        return_value=now_in_future,
-    )
     send_open_invoices_email()
 
     assert len(mail.outbox) == 1

--- a/app/tests/invoices_tests/test_tasks.py
+++ b/app/tests/invoices_tests/test_tasks.py
@@ -2,12 +2,13 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from django.core import mail
-from django.utils.timezone import datetime, timedelta
+from django.utils.timezone import datetime, now, timedelta
 
 from grandchallenge.invoices.models import Invoice
 from grandchallenge.invoices.tasks import (
     send_challenge_invoice_issued_notification_emails,
     send_challenge_invoice_overdue_reminder_emails,
+    send_open_invoices_email,
 )
 from tests.factories import ChallengeFactory, UserFactory
 from tests.invoices_tests.factories import InvoiceFactory
@@ -387,3 +388,49 @@ def test_challenge_invoice_issued_notification_emails_on_create(
     assert expected_subject in contact_person_mail.subject
     assert "Dear John Doe" in contact_person_mail.body
     assert expected_body in contact_person_mail.body
+
+
+@pytest.mark.django_db
+def test_send_open_invoices_email(mocker, settings):
+    staff_user = UserFactory(is_staff=True)
+    settings.MANAGERS = [(staff_user.last_name, staff_user.email)]
+
+    i1 = InvoiceFactory(
+        payment_type=Invoice.PaymentTypeChoices.POSTPAID,
+        payment_status=Invoice.PaymentStatusChoices.INITIALIZED,
+        follow_up_on=now().date() + timedelta(days=1),
+    )
+    i2 = InvoiceFactory(
+        payment_status=Invoice.PaymentStatusChoices.INITIALIZED,
+        payment_type=Invoice.PaymentTypeChoices.PREPAID,
+    )
+    i3 = InvoiceFactory(
+        payment_status=Invoice.PaymentStatusChoices.REQUESTED,
+    )
+    i4 = InvoiceFactory(
+        payment_status=Invoice.PaymentStatusChoices.ISSUED,
+    )
+    i5 = InvoiceFactory(payment_status=Invoice.PaymentStatusChoices.PAID)
+    i6 = InvoiceFactory(
+        payment_type=Invoice.PaymentTypeChoices.POSTPAID,
+        payment_status=Invoice.PaymentStatusChoices.INITIALIZED,
+        follow_up_on=now().date() + timedelta(days=30),
+    )
+
+    now_in_future = now() + timedelta(days=2)
+    mocker.patch(
+        "grandchallenge.invoices.tasks.now",
+        return_value=now_in_future,
+    )
+    send_open_invoices_email()
+
+    assert len(mail.outbox) == 1
+
+    assert "Invoices to check" in mail.outbox[0].subject
+    assert mail.outbox[0].to == [staff_user.email]
+    assert str(i1) in mail.outbox[0].body
+    assert str(i2) in mail.outbox[0].body
+    assert str(i3) in mail.outbox[0].body
+    assert str(i4) in mail.outbox[0].body
+    assert str(i5) not in mail.outbox[0].body
+    assert str(i6) not in mail.outbox[0].body


### PR DESCRIPTION
This adds a weekly task that checks if there are post-paid invoices that require our attention or invoices in intermediate state (issues, requested). If any of those invoices exist, it sends an email to staff listing those invoices. 

Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/475