### PR TITLE
Invocation serializer

### DIFF
--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -1734,7 +1734,9 @@ class Endpoint(FieldChangeMixin, UUIDModel):
 
     @property
     def api_url(self) -> str:
-        return reverse("api:endpoint-detail", kwargs={"pk": self.pk})
+        return reverse(
+            "api:algorithms-endpoint-detail", kwargs={"pk": self.pk}
+        )
 
 
 class EndpointUserObjectPermission(UserObjectPermissionBase):

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -1732,6 +1732,10 @@ class Endpoint(FieldChangeMixin, UUIDModel):
             update_fields=["duration", "compute_cost_euro_millicents"]
         )
 
+    @property
+    def api_url(self) -> str:
+        return reverse("api:endpoint-detail", kwargs={"pk": self.pk})
+
 
 class EndpointUserObjectPermission(UserObjectPermissionBase):
     allowed_permissions = frozenset({"invoke_endpoint"})

--- a/app/grandchallenge/algorithms/serializers.py
+++ b/app/grandchallenge/algorithms/serializers.py
@@ -334,7 +334,7 @@ class HyperlinkedInvocationSerializer(serializers.ModelSerializer):
 
     endpoint = HyperlinkedRelatedField(
         queryset=Endpoint.objects.none(),
-        view_name="api:endpoint-detail",
+        view_name="api:algorithms-endpoint-detail",
         required=True,
     )
     inputs = HyperlinkedComponentInterfaceValueSerializer(many=True)
@@ -350,7 +350,7 @@ class InvocationPostSerializer(serializers.ModelSerializer):
 
     endpoint = HyperlinkedRelatedField(
         queryset=Endpoint.objects.none(),
-        view_name="api:endpoint-detail",
+        view_name="api:algorithms-endpoint-detail",
         required=True,
     )
 
@@ -368,7 +368,9 @@ class InvocationPostSerializer(serializers.ModelSerializer):
             user = self.context["request"].user
 
             self.fields["endpoint"].queryset = filter_by_permission(
-                queryset=Endpoint.objects.all(),
+                queryset=Endpoint.objects.filter(
+                    status=Endpoint.StatusChoices.RUNNING
+                ),
                 user=user,
                 codename="invoke_endpoint",
             )

--- a/app/grandchallenge/algorithms/serializers.py
+++ b/app/grandchallenge/algorithms/serializers.py
@@ -374,3 +374,40 @@ class InvocationPostSerializer(serializers.ModelSerializer):
                 user=user,
                 codename="invoke_endpoint",
             )
+
+    def validate(self, data):
+        self._endpoint = data.pop("endpoint")
+        inputs = data.pop("inputs")
+        data["algorithm_interface"] = (
+            self.validate_inputs_and_return_matching_interface(inputs=inputs)
+        )
+        data["civ_data_objects"] = convert_deserialized_civ_data(
+            deserialized_civ_data=inputs
+        )
+
+        return data
+
+    def validate_inputs_and_return_matching_interface(self, *, inputs):
+        """
+        Validates that the provided inputs match one of the endpoint's algorithm's configured interfaces
+        """
+        provided_inputs = {i["interface"] for i in inputs}
+        allowed_algorithm_interfaces = (
+            self._endpoint.algorithm_image.algorithm.interfaces.all()
+        )
+        annotated_qs = annotate_input_output_counts(
+            allowed_algorithm_interfaces, inputs=provided_inputs
+        )
+        try:
+            interface = annotated_qs.get(
+                relevant_input_count=len(provided_inputs),
+                input_count=len(provided_inputs),
+            )
+            return interface
+        except ObjectDoesNotExist:
+            raise serializers.ValidationError(
+                f"The set of inputs provided does not match "
+                f"any of the endpoint's algorithm's interfaces. This algorithm supports the "
+                f"following input combinations: "
+                f"{oxford_comma([f'Interface {n}: {oxford_comma(interface.inputs.all())}' for n, interface in enumerate(allowed_algorithm_interfaces, start=1)])}"
+            )

--- a/app/grandchallenge/algorithms/serializers.py
+++ b/app/grandchallenge/algorithms/serializers.py
@@ -353,10 +353,22 @@ class InvocationPostSerializer(serializers.ModelSerializer):
         view_name="api:endpoint-detail",
         required=True,
     )
-    inputs = ComponentInterfaceValueSerializer(many=True)
-    outputs = ComponentInterfaceValueSerializer(many=True)
-    status = CharField(source="get_status_display", read_only=True)
 
     class Meta:
         model = Invocation
-        fields = ["pk", "endpoint", "inputs", "outputs", "status"]
+        fields = ["pk", "endpoint", "inputs", "status"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["inputs"] = ComponentInterfaceValuePostSerializer(
+            many=True, context=self.context
+        )
+
+        if "request" in self.context:
+            user = self.context["request"].user
+
+            self.fields["endpoint"].queryset = filter_by_permission(
+                queryset=Endpoint.objects.all(),
+                user=user,
+                codename="invoke_endpoint",
+            )

--- a/app/grandchallenge/algorithms/serializers.py
+++ b/app/grandchallenge/algorithms/serializers.py
@@ -176,6 +176,31 @@ class JobSerializer(serializers.ModelSerializer):
         ]
 
 
+def validate_inputs_and_return_matching_interface(
+    *, inputs, allowed_algorithm_interfaces
+):
+    """
+    Validates that the provided inputs match one of the allowed algorithm interfaces and returns the interface.
+    """
+    provided_inputs = {i["interface"] for i in inputs}
+    annotated_qs = annotate_input_output_counts(
+        allowed_algorithm_interfaces, inputs=provided_inputs
+    )
+    try:
+        interface = annotated_qs.get(
+            relevant_input_count=len(provided_inputs),
+            input_count=len(provided_inputs),
+        )
+        return interface
+    except ObjectDoesNotExist:
+        raise serializers.ValidationError(
+            f"The set of inputs provided does not match "
+            f"any of the allowed algorithm interfaces. The "
+            f"following input combinations are allowed: "
+            f"{oxford_comma([f'Interface {n}: {oxford_comma(interface.inputs.all())}' for n, interface in enumerate(allowed_algorithm_interfaces, start=1)])}"
+        )
+
+
 class HyperlinkedJobSerializer(JobSerializer):
     """Serializer with hyperlinks for use in public API"""
 
@@ -225,16 +250,16 @@ class JobPostSerializer(JobSerializer):
             )
 
     def validate(self, data):
-        self._algorithm = data.pop("algorithm")
+        algorithm = data.pop("algorithm")
         user = self.context["request"].user
 
-        if not self._algorithm.active_image:
+        if not algorithm.active_image:
             raise serializers.ValidationError(
                 "Algorithm image is not ready to be used"
             )
         data["creator"] = user
-        data["algorithm_image"] = self._algorithm.active_image
-        data["algorithm_model"] = self._algorithm.active_model
+        data["algorithm_image"] = algorithm.active_image
+        data["algorithm_model"] = algorithm.active_model
 
         jobs_limit = data["algorithm_image"].get_remaining_jobs(
             user=data["creator"]
@@ -255,7 +280,10 @@ class JobPostSerializer(JobSerializer):
 
         inputs = data.pop("inputs")
         data["algorithm_interface"] = (
-            self.validate_inputs_and_return_matching_interface(inputs=inputs)
+            validate_inputs_and_return_matching_interface(
+                inputs=inputs,
+                allowed_algorithm_interfaces=algorithm.interfaces.all(),
+            )
         )
         data["civ_data_objects"] = convert_deserialized_civ_data(
             deserialized_civ_data=inputs
@@ -305,29 +333,6 @@ class JobPostSerializer(JobSerializer):
 
         return job
 
-    def validate_inputs_and_return_matching_interface(self, *, inputs):
-        """
-        Validates that the provided inputs match one of the configured interfaces of
-        the algorithm and returns that AlgorithmInterface
-        """
-        provided_inputs = {i["interface"] for i in inputs}
-        annotated_qs = annotate_input_output_counts(
-            self._algorithm.interfaces, inputs=provided_inputs
-        )
-        try:
-            interface = annotated_qs.get(
-                relevant_input_count=len(provided_inputs),
-                input_count=len(provided_inputs),
-            )
-            return interface
-        except ObjectDoesNotExist:
-            raise serializers.ValidationError(
-                f"The set of inputs provided does not match "
-                f"any of the algorithm's interfaces. This algorithm supports the "
-                f"following input combinations: "
-                f"{oxford_comma([f'Interface {n}: {oxford_comma(interface.inputs.all())}' for n, interface in enumerate(self._algorithm.interfaces.all(), start=1)])}"
-            )
-
 
 class HyperlinkedInvocationSerializer(serializers.ModelSerializer):
     """Serializer with hyperlinks for use in public API"""
@@ -376,38 +381,16 @@ class InvocationPostSerializer(serializers.ModelSerializer):
             )
 
     def validate(self, data):
-        self._endpoint = data.pop("endpoint")
+        endpoint = data.pop("endpoint")
         inputs = data.pop("inputs")
         data["algorithm_interface"] = (
-            self.validate_inputs_and_return_matching_interface(inputs=inputs)
+            validate_inputs_and_return_matching_interface(
+                inputs=inputs,
+                allowed_algorithm_interfaces=endpoint.algorithm_image.algorithm.interfaces.all(),
+            )
         )
         data["civ_data_objects"] = convert_deserialized_civ_data(
             deserialized_civ_data=inputs
         )
 
         return data
-
-    def validate_inputs_and_return_matching_interface(self, *, inputs):
-        """
-        Validates that the provided inputs match one of the endpoint's algorithm's configured interfaces
-        """
-        provided_inputs = {i["interface"] for i in inputs}
-        allowed_algorithm_interfaces = (
-            self._endpoint.algorithm_image.algorithm.interfaces.all()
-        )
-        annotated_qs = annotate_input_output_counts(
-            allowed_algorithm_interfaces, inputs=provided_inputs
-        )
-        try:
-            interface = annotated_qs.get(
-                relevant_input_count=len(provided_inputs),
-                input_count=len(provided_inputs),
-            )
-            return interface
-        except ObjectDoesNotExist:
-            raise serializers.ValidationError(
-                f"The set of inputs provided does not match "
-                f"any of the endpoint's algorithm's interfaces. This algorithm supports the "
-                f"following input combinations: "
-                f"{oxford_comma([f'Interface {n}: {oxford_comma(interface.inputs.all())}' for n, interface in enumerate(allowed_algorithm_interfaces, start=1)])}"
-            )

--- a/app/grandchallenge/algorithms/serializers.py
+++ b/app/grandchallenge/algorithms/serializers.py
@@ -20,6 +20,7 @@ from grandchallenge.algorithms.models import (
     AlgorithmInterface,
     AlgorithmModel,
     Endpoint,
+    Invocation,
     Job,
     annotate_input_output_counts,
 )
@@ -326,3 +327,36 @@ class JobPostSerializer(JobSerializer):
                 f"following input combinations: "
                 f"{oxford_comma([f'Interface {n}: {oxford_comma(interface.inputs.all())}' for n, interface in enumerate(self._algorithm.interfaces.all(), start=1)])}"
             )
+
+
+class HyperlinkedInvocationSerializer(serializers.ModelSerializer):
+    """Serializer with hyperlinks for use in public API"""
+
+    endpoint = HyperlinkedRelatedField(
+        queryset=Endpoint.objects.none(),
+        view_name="api:endpoint-detail",
+        required=True,
+    )
+    inputs = HyperlinkedComponentInterfaceValueSerializer(many=True)
+    outputs = HyperlinkedComponentInterfaceValueSerializer(many=True)
+    status = CharField(source="get_status_display", read_only=True)
+
+    class Meta:
+        model = Invocation
+        fields = ["pk", "endpoint", "inputs", "outputs", "status"]
+
+
+class InvocationPostSerializer(serializers.ModelSerializer):
+
+    endpoint = HyperlinkedRelatedField(
+        queryset=Endpoint.objects.none(),
+        view_name="api:endpoint-detail",
+        required=True,
+    )
+    inputs = ComponentInterfaceValueSerializer(many=True)
+    outputs = ComponentInterfaceValueSerializer(many=True)
+    status = CharField(source="get_status_display", read_only=True)
+
+    class Meta:
+        model = Invocation
+        fields = ["pk", "endpoint", "inputs", "outputs", "status"]

--- a/app/tests/algorithms_tests/test_api.py
+++ b/app/tests/algorithms_tests/test_api.py
@@ -13,6 +13,8 @@ from grandchallenge.algorithms.models import Endpoint, Job
 from grandchallenge.algorithms.serializers import (
     AlgorithmImageSerializer,
     AlgorithmModelSerializer,
+    HyperlinkedInvocationSerializer,
+    InvocationPostSerializer,
 )
 from grandchallenge.components.models import (
     ComponentInterfaceValue,
@@ -25,6 +27,7 @@ from tests.algorithms_tests.factories import (
     AlgorithmJobFactory,
     AlgorithmModelFactory,
     EndpointFactory,
+    InvocationFactory,
 )
 from tests.cases_tests import RESOURCE_PATH
 from tests.cases_tests.factories import (
@@ -806,3 +809,44 @@ class TestEndpointReadOnly:
         client.force_login(user=endpoint.creator)
         response = client.delete(f"{self.url}{endpoint.pk}/")
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_hyperlinked_invocation_serializer(rf):
+    invocation = InvocationFactory()
+    civ = ComponentInterfaceValueFactory(
+        interface__kind=InterfaceKindChoices.PANIMG_IMAGE, image=ImageFactory()
+    )
+    invocation.inputs.set([civ])
+    serializer = HyperlinkedInvocationSerializer(
+        invocation, context={"request": rf.get("/foo", secure=True)}
+    )
+    assert serializer.data["status"] == invocation.get_status_display()
+    assert serializer.data["endpoint"] == invocation.endpoint.api_url
+    assert serializer.data["inputs"][0]["image"] == str(
+        invocation.inputs.first().image.api_url
+    )
+
+
+@pytest.mark.django_db
+def test_invocation_post_serializer_endpoint_queryset(rf):
+    user = UserFactory()
+    endpoint_with_perm_running = EndpointFactory(
+        creator=user, status=Endpoint.StatusChoices.RUNNING
+    )
+    endpoint_with_perm_pending = EndpointFactory(creator=user)
+    endpoint_without_perm = EndpointFactory(
+        status=Endpoint.StatusChoices.RUNNING
+    )
+    request = rf.get("/foo", secure=True)
+    request.user = user
+
+    serializer = InvocationPostSerializer(
+        InvocationFactory(), context={"request": request}
+    )
+    assert endpoint_with_perm_running in serializer.fields["endpoint"].queryset
+    assert (
+        endpoint_with_perm_pending
+        not in serializer.fields["endpoint"].queryset
+    )
+    assert endpoint_without_perm not in serializer.fields["endpoint"].queryset

--- a/app/tests/algorithms_tests/test_api.py
+++ b/app/tests/algorithms_tests/test_api.py
@@ -13,8 +13,6 @@ from grandchallenge.algorithms.models import Endpoint, Job
 from grandchallenge.algorithms.serializers import (
     AlgorithmImageSerializer,
     AlgorithmModelSerializer,
-    HyperlinkedInvocationSerializer,
-    InvocationPostSerializer,
 )
 from grandchallenge.components.models import (
     ComponentInterfaceValue,
@@ -27,7 +25,6 @@ from tests.algorithms_tests.factories import (
     AlgorithmJobFactory,
     AlgorithmModelFactory,
     EndpointFactory,
-    InvocationFactory,
 )
 from tests.cases_tests import RESOURCE_PATH
 from tests.cases_tests.factories import (
@@ -809,44 +806,3 @@ class TestEndpointReadOnly:
         client.force_login(user=endpoint.creator)
         response = client.delete(f"{self.url}{endpoint.pk}/")
         assert response.status_code == status.HTTP_403_FORBIDDEN
-
-
-@pytest.mark.django_db
-def test_hyperlinked_invocation_serializer(rf):
-    invocation = InvocationFactory()
-    civ = ComponentInterfaceValueFactory(
-        interface__kind=InterfaceKindChoices.PANIMG_IMAGE, image=ImageFactory()
-    )
-    invocation.inputs.set([civ])
-    serializer = HyperlinkedInvocationSerializer(
-        invocation, context={"request": rf.get("/foo", secure=True)}
-    )
-    assert serializer.data["status"] == invocation.get_status_display()
-    assert serializer.data["endpoint"] == invocation.endpoint.api_url
-    assert serializer.data["inputs"][0]["image"] == str(
-        invocation.inputs.first().image.api_url
-    )
-
-
-@pytest.mark.django_db
-def test_invocation_post_serializer_endpoint_queryset(rf):
-    user = UserFactory()
-    endpoint_with_perm_running = EndpointFactory(
-        creator=user, status=Endpoint.StatusChoices.RUNNING
-    )
-    endpoint_with_perm_pending = EndpointFactory(creator=user)
-    endpoint_without_perm = EndpointFactory(
-        status=Endpoint.StatusChoices.RUNNING
-    )
-    request = rf.get("/foo", secure=True)
-    request.user = user
-
-    serializer = InvocationPostSerializer(
-        InvocationFactory(), context={"request": request}
-    )
-    assert endpoint_with_perm_running in serializer.fields["endpoint"].queryset
-    assert (
-        endpoint_with_perm_pending
-        not in serializer.fields["endpoint"].queryset
-    )
-    assert endpoint_without_perm not in serializer.fields["endpoint"].queryset

--- a/app/tests/algorithms_tests/test_serializers.py
+++ b/app/tests/algorithms_tests/test_serializers.py
@@ -6,18 +6,23 @@ from rest_framework.exceptions import ErrorDetail
 
 from grandchallenge.algorithms.models import Endpoint, Job
 from grandchallenge.algorithms.serializers import (
+    HyperlinkedInvocationSerializer,
     HyperlinkedJobSerializer,
     InvocationPostSerializer,
     JobPostSerializer,
 )
 from grandchallenge.cases.models import RawImageUploadSession
-from grandchallenge.components.models import ComponentInterface
+from grandchallenge.components.models import (
+    ComponentInterface,
+    InterfaceKindChoices,
+)
 from tests.algorithms_tests.factories import (
     AlgorithmFactory,
     AlgorithmImageFactory,
     AlgorithmInterfaceFactory,
     AlgorithmJobFactory,
     EndpointFactory,
+    InvocationFactory,
 )
 from tests.cases_tests.factories import RawImageUploadSessionFactory
 from tests.components_tests.factories import (
@@ -588,6 +593,47 @@ def test_validate_inputs_on_job_serializer(inputs, interface, rf):
             in str(serializer.errors)
         )
         assert "algorithm_interface" not in serializer.validated_data
+
+
+@pytest.mark.django_db
+def test_hyperlinked_invocation_serializer(rf):
+    invocation = InvocationFactory()
+    civ = ComponentInterfaceValueFactory(
+        interface__kind=InterfaceKindChoices.PANIMG_IMAGE, image=ImageFactory()
+    )
+    invocation.inputs.set([civ])
+    serializer = HyperlinkedInvocationSerializer(
+        invocation, context={"request": rf.get("/foo", secure=True)}
+    )
+    assert serializer.data["status"] == invocation.get_status_display()
+    assert serializer.data["endpoint"] == invocation.endpoint.api_url
+    assert serializer.data["inputs"][0]["image"] == str(
+        invocation.inputs.first().image.api_url
+    )
+
+
+@pytest.mark.django_db
+def test_invocation_post_serializer_endpoint_queryset(rf):
+    user = UserFactory()
+    endpoint_with_perm_running = EndpointFactory(
+        creator=user, status=Endpoint.StatusChoices.RUNNING
+    )
+    endpoint_with_perm_pending = EndpointFactory(creator=user)
+    endpoint_without_perm = EndpointFactory(
+        status=Endpoint.StatusChoices.RUNNING
+    )
+    request = rf.get("/foo", secure=True)
+    request.user = user
+
+    serializer = InvocationPostSerializer(
+        InvocationFactory(), context={"request": request}
+    )
+    assert endpoint_with_perm_running in serializer.fields["endpoint"].queryset
+    assert (
+        endpoint_with_perm_pending
+        not in serializer.fields["endpoint"].queryset
+    )
+    assert endpoint_without_perm not in serializer.fields["endpoint"].queryset
 
 
 @pytest.mark.parametrize(

--- a/app/tests/algorithms_tests/test_serializers.py
+++ b/app/tests/algorithms_tests/test_serializers.py
@@ -4,9 +4,10 @@ import pytest
 from guardian.shortcuts import assign_perm
 from rest_framework.exceptions import ErrorDetail
 
-from grandchallenge.algorithms.models import Job
+from grandchallenge.algorithms.models import Endpoint, Job
 from grandchallenge.algorithms.serializers import (
     HyperlinkedJobSerializer,
+    InvocationPostSerializer,
     JobPostSerializer,
 )
 from grandchallenge.cases.models import RawImageUploadSession
@@ -16,6 +17,7 @@ from tests.algorithms_tests.factories import (
     AlgorithmImageFactory,
     AlgorithmInterfaceFactory,
     AlgorithmJobFactory,
+    EndpointFactory,
 )
 from tests.cases_tests.factories import RawImageUploadSessionFactory
 from tests.components_tests.factories import (
@@ -583,6 +585,93 @@ def test_validate_inputs_on_job_serializer(inputs, interface, rf):
         assert not serializer.is_valid()
         assert (
             "The set of inputs provided does not match any of the algorithm's interfaces."
+            in str(serializer.errors)
+        )
+        assert "algorithm_interface" not in serializer.validated_data
+
+
+@pytest.mark.parametrize(
+    "inputs, interface",
+    (
+        ([1], 1),  # matches interface 1 of algorithm
+        ([1, 2], 2),  # matches interface 2 of algorithm
+        ([3, 4, 5], 3),  # matches interface 3 of algorithm
+        ([4], None),  # matches interface 4, but not configured for algorithm
+        (
+            [1, 2, 3],
+            None,
+        ),  # matches interface 5, but not configured for algorithm
+        ([2], None),  # matches no interface (implements part of interface 2)
+        (
+            [1, 3, 4],
+            None,
+        ),  # matches no interface (implements interface 3 and an additional input)
+    ),
+)
+@pytest.mark.django_db
+def test_input_validation_on_invocation_serializer(inputs, interface, rf):
+    user = UserFactory()
+    algorithm = AlgorithmFactory()
+    algorithm.add_editor(user)
+    ai = AlgorithmImageFactory(
+        algorithm=algorithm,
+        is_desired_version=True,
+        is_manifest_valid=True,
+        is_in_registry=True,
+    )
+    endpoint = EndpointFactory(
+        algorithm_image=ai, creator=user, status=Endpoint.StatusChoices.RUNNING
+    )
+
+    io1, io2, io3, io4, io5 = AlgorithmInterfaceFactory.create_batch(5)
+    ci1, ci2, ci3, ci4, ci5, ci6 = ComponentInterfaceFactory.create_batch(
+        6, kind=ComponentInterface.Kind.STRING
+    )
+
+    interfaces = [io1, io2, io3]
+    cis = [ci1, ci2, ci3, ci4, ci5, ci6]
+
+    io1.inputs.set([ci1])
+    io2.inputs.set([ci1, ci2])
+    io3.inputs.set([ci3, ci4, ci5])
+    io4.inputs.set([ci1, ci2, ci3])
+    io5.inputs.set([ci4])
+    io1.outputs.set([ci6])
+    io2.outputs.set([ci3])
+    io3.outputs.set([ci1])
+    io4.outputs.set([ci1])
+    io5.outputs.set([ci1])
+
+    algorithm.interfaces.add(io1)
+    algorithm.interfaces.add(io2)
+    algorithm.interfaces.add(io3)
+
+    algorithm_interface = interfaces[interface - 1] if interface else None
+    inputs = [cis[i - 1] for i in inputs]
+
+    invocation = {
+        "endpoint": endpoint.api_url,
+        "inputs": [
+            {"interface": int.slug, "value": "dummy"} for int in inputs
+        ],
+    }
+
+    request = rf.get("/foo")
+    request.user = user
+    serializer = InvocationPostSerializer(
+        data=invocation, context={"request": request}
+    )
+
+    if interface:
+        assert serializer.is_valid()
+        assert (
+            serializer.validated_data["algorithm_interface"]
+            == algorithm_interface
+        )
+    else:
+        assert not serializer.is_valid()
+        assert (
+            "The set of inputs provided does not match any of the endpoint's algorithm's interfaces."
             in str(serializer.errors)
         )
         assert "algorithm_interface" not in serializer.validated_data

--- a/app/tests/algorithms_tests/test_serializers.py
+++ b/app/tests/algorithms_tests/test_serializers.py
@@ -88,7 +88,7 @@ def test_algorithm_relations_on_job_serializer(rf):
             True,
             ("TestInterface 1", "TestInterface 2"),
             ("testinterface-1",),
-            "The set of inputs provided does not match any of the algorithm's interfaces.",
+            "The set of inputs provided does not match any of the allowed algorithm interfaces.",
             False,
         ),
         (
@@ -97,7 +97,7 @@ def test_algorithm_relations_on_job_serializer(rf):
             True,
             ("TestInterface 1",),
             ("testinterface-1", "testinterface-2"),
-            "The set of inputs provided does not match any of the algorithm's interfaces.",
+            "The set of inputs provided does not match any of the allowed algorithm interfaces.",
             False,
         ),
         (
@@ -589,7 +589,7 @@ def test_validate_inputs_on_job_serializer(inputs, interface, rf):
     else:
         assert not serializer.is_valid()
         assert (
-            "The set of inputs provided does not match any of the algorithm's interfaces."
+            "The set of inputs provided does not match any of the allowed algorithm interfaces."
             in str(serializer.errors)
         )
         assert "algorithm_interface" not in serializer.validated_data
@@ -717,7 +717,7 @@ def test_input_validation_on_invocation_serializer(inputs, interface, rf):
     else:
         assert not serializer.is_valid()
         assert (
-            "The set of inputs provided does not match any of the endpoint's algorithm's interfaces."
+            "The set of inputs provided does not match any of the allowed algorithm interfaces"
             in str(serializer.errors)
         )
         assert "algorithm_interface" not in serializer.validated_data


### PR DESCRIPTION
This add serializers for the invocation model, a `InvocationPostSerializer` to create invocations and a `HyperlinkedInvocationSerializer` to represent invocations via the public API. 

The post serializer still needs a custom create method that takes care of processing the inputs. And the viewset is also still missing. 

Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/481