### PR TITLE
Filter structured logs on task

### DIFF
--- a/app/grandchallenge/components/backends/amazon_sagemaker_base.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_base.py
@@ -561,15 +561,14 @@ class AmazonSageMakerBaseExecutor(Executor, ABC):
         else:
             raise LogStreamNotFound("Log stream not found")
 
-    def _set_task_logs(self, *, event, task=None):
+    def _set_task_logs(self, *, event):
         stdout = []
         stderr = []
 
         for log_event in self._get_log_events(event=event):
             try:
                 parsed_log = parse_structured_log(
-                    log=log_event["message"].replace("\x00", ""),
-                    task=task,
+                    log=log_event["message"].replace("\x00", "")
                 )
                 timestamp = ms_timestamp_to_datetime(log_event["timestamp"])
             except (JSONDecodeError, KeyError, ValueError):

--- a/app/grandchallenge/components/backends/amazon_sagemaker_base.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_base.py
@@ -561,14 +561,15 @@ class AmazonSageMakerBaseExecutor(Executor, ABC):
         else:
             raise LogStreamNotFound("Log stream not found")
 
-    def _set_task_logs(self, *, event):
+    def _set_task_logs(self, *, event, task=None):
         stdout = []
         stderr = []
 
         for log_event in self._get_log_events(event=event):
             try:
                 parsed_log = parse_structured_log(
-                    log=log_event["message"].replace("\x00", "")
+                    log=log_event["message"].replace("\x00", ""),
+                    task=task,
                 )
                 timestamp = ms_timestamp_to_datetime(log_event["timestamp"])
             except (JSONDecodeError, KeyError, ValueError):

--- a/app/grandchallenge/components/backends/utils.py
+++ b/app/grandchallenge/components/backends/utils.py
@@ -55,7 +55,7 @@ class ParsedLog(NamedTuple):
     inference_result_skipped: bool | None
 
 
-def parse_structured_log(*, log: str) -> ParsedLog | None:
+def parse_structured_log(*, log: str, task=None) -> ParsedLog | None:
     """Parse the structured logs from SageMaker Shim"""
     structured_log = json.loads(log.strip())
 
@@ -63,7 +63,9 @@ def parse_structured_log(*, log: str) -> ParsedLog | None:
     source = SourceChoices(structured_log["source"])
     inference_result_skipped = structured_log.get("inference_result_skipped")
 
-    if structured_log["internal"] is False:
+    if structured_log["internal"] is False and (
+        task is None or structured_log["task"] == task
+    ):
         # Defensive, in case the type of structured_log["internal"] is str
         return ParsedLog(
             message=message,

--- a/app/grandchallenge/components/backends/utils.py
+++ b/app/grandchallenge/components/backends/utils.py
@@ -63,15 +63,17 @@ def parse_structured_log(*, log: str, task=None) -> ParsedLog | None:
     source = SourceChoices(structured_log["source"])
     inference_result_skipped = structured_log.get("inference_result_skipped")
 
+    # Defensive, in case the type of structured_log["internal"] is str
     if structured_log["internal"] is False and (
         task is None or structured_log["task"] == task
     ):
-        # Defensive, in case the type of structured_log["internal"] is str
         return ParsedLog(
             message=message,
             source=source,
             inference_result_skipped=inference_result_skipped,
         )
+    else:
+        return None
 
 
 def safe_extract(*, src: File, dest: Path):

--- a/app/tests/components_tests/test_backends.py
+++ b/app/tests/components_tests/test_backends.py
@@ -24,6 +24,7 @@ from grandchallenge.components.backends.base import (
 from grandchallenge.components.backends.exceptions import ComponentException
 from grandchallenge.components.backends.utils import (
     _filter_members,
+    parse_structured_log,
     user_error,
 )
 from grandchallenge.components.models import (
@@ -867,3 +868,39 @@ def test_invocation_results_signature_verified(settings):
     )
 
     assert executor._get_inference_result() == inference_result
+
+
+def test_parse_structured_logs_filters_task():
+    log_with_task = json.dumps(
+        {
+            "log": "message with task",
+            "source": "stdout",
+            "internal": False,
+            "task": "1",
+        }
+    )
+    log_without_task = json.dumps(
+        {
+            "log": "message without task",
+            "source": "stdout",
+            "internal": False,
+            "task": None,
+        }
+    )
+
+    parsed_log = parse_structured_log(log=log_with_task, task="1")
+
+    assert parsed_log.message == "message with task"
+
+    parsed_log = parse_structured_log(log=log_without_task, task="1")
+
+    assert parsed_log is None
+
+    parsed_log = parse_structured_log(log=log_with_task, task=None)
+
+    # when `task` is None, messages with a task are __included__
+    assert parsed_log.message == "message with task"
+
+    parsed_log = parse_structured_log(log=log_without_task, task=None)
+
+    assert parsed_log.message == "message without task"


### PR DESCRIPTION
Structured logs from algorithm endpoints can contain messages from multiple invocations. By filtering on `task` these can be separated. 

If no task is provided, all logs will be included, i.e. also the logs from the invocations. 

Related to https://github.com/DIAGNijmegen/rse-roadmap/issues/481