### PR TITLE
Admin phase links

### DIFF
--- a/app/grandchallenge/evaluation/admin.py
+++ b/app/grandchallenge/evaluation/admin.py
@@ -102,7 +102,8 @@ class PhaseAdmin(admin.ModelAdmin):
     readonly_fields = (
         "give_algorithm_editors_job_view_permissions",
         "algorithm_interfaces",
-        "algorithm_interface_configuration_links",
+        "algorithm_interface_configuration_link",
+        "download_starter_kit_link",
     )
     form = PhaseAdminForm
 
@@ -111,7 +112,7 @@ class PhaseAdmin(admin.ModelAdmin):
         return instance.open_for_submissions
 
     @staticmethod
-    def algorithm_interface_configuration_links(obj):
+    def algorithm_interface_configuration_link(obj):
         if obj.submission_kind != SubmissionKindChoices.ALGORITHM:
             return "-"
         else:
@@ -119,6 +120,25 @@ class PhaseAdmin(admin.ModelAdmin):
                 '<a href="{link}">{link}</a>',
                 link=reverse(
                     "evaluation:interface-list",
+                    kwargs={
+                        "challenge_short_name": obj.challenge.short_name,
+                        "slug": obj.slug,
+                    },
+                ),
+            )
+
+    @staticmethod
+    def download_starter_kit_link(obj):
+        if (
+            obj.submission_kind != SubmissionKindChoices.ALGORITHM
+            or not obj.algorithm_interfaces.exists()
+        ):
+            return "-"
+        else:
+            return format_html(
+                '<a href="{link}">{link}</a>',
+                link=reverse(
+                    "evaluation:phase-starter-kit-download",
                     kwargs={
                         "challenge_short_name": obj.challenge.short_name,
                         "slug": obj.slug,

--- a/app/grandchallenge/evaluation/admin.py
+++ b/app/grandchallenge/evaluation/admin.py
@@ -34,6 +34,8 @@ from grandchallenge.evaluation.models import (
     SubmissionGroupObjectPermission,
     SubmissionUserObjectPermission,
 )
+from grandchallenge.evaluation.utils import SubmissionKindChoices
+from grandchallenge.subdomains.utils import reverse
 
 
 class PhaseAdminForm(ModelForm):
@@ -100,12 +102,29 @@ class PhaseAdmin(admin.ModelAdmin):
     readonly_fields = (
         "give_algorithm_editors_job_view_permissions",
         "algorithm_interfaces",
+        "algorithm_interface_configuration_links",
     )
     form = PhaseAdminForm
 
     @admin.display(boolean=True)
     def open_for_submissions(self, instance):
         return instance.open_for_submissions
+
+    @staticmethod
+    def algorithm_interface_configuration_links(obj):
+        if obj.submission_kind != SubmissionKindChoices.ALGORITHM:
+            return "-"
+        else:
+            return format_html(
+                '<a href="{link}">{link}</a>',
+                link=reverse(
+                    "evaluation:interface-list",
+                    kwargs={
+                        "challenge_short_name": obj.challenge.short_name,
+                        "slug": obj.slug,
+                    },
+                ),
+            )
 
 
 @admin.action(

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -1582,6 +1582,7 @@ class PhaseStarterKitDownload(
     View,
 ):
     permission_required = "evaluation.change_phase"
+    accept_global_perms = True
     raise_exception = True
 
     def get_permission_object(self):

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -1576,17 +1576,12 @@ class PhaseStarterKitDetail(
         return self.phase
 
 
-class PhaseStarterKitDownload(
-    CachedPhaseMixin,
-    ObjectPermissionRequiredMixin,
-    View,
-):
-    permission_required = "evaluation.change_phase"
-    accept_global_perms = True
-    raise_exception = True
-
-    def get_permission_object(self):
-        return self.phase
+class PhaseStarterKitDownload(UserPassesTestMixin, CachedPhaseMixin, View):
+    def test_func(self):
+        return (
+            self.request.user.has_perm("evaluation.change_phase", self.phase)
+            or self.request.user.is_staff
+        )
 
     def get(self, *_, **__):
         phase = self.phase


### PR DESCRIPTION
As a non superuser, but being able to support challenges I found I can't readily download starter kits. That is not very handy.

This change set adds a link and sets to use global permissions on the view that downloads starter kits for a challenge phase.

Moreover, it adds a link to configure the algorithm interfaces to the Phase admin, which I've missed a few times already.