### PR TITLE
Rename is_launchable to has_budget

### DIFF
--- a/app/grandchallenge/components/templates/components/civ_set_detail.html
+++ b/app/grandchallenge/components/templates/components/civ_set_detail.html
@@ -28,10 +28,10 @@
     <p>
         <button class="btn btn-primary"
             {% if object.base_object|model_name == base_model_options.READER_STUDY %}
-                {% if object.base_object.is_launchable %}
+                {% if object.base_object.has_budget %}
                     {% workstation_session_control_data workstation=object.base_object.workstation context_object=object display_set=object config=object.base_object.workstation_config %}
                 {% else %}
-                    disabled title="Reader study cannot be launched"
+                    disabled title="Reader study is out of budget and cannot be launched"
                 {% endif %}
             {% elif object.base_object|model_name == base_model_options.ARCHIVE %}
                 {% workstation_session_control_data workstation=object.base_object.workstation context_object=object archive_item=object config=object.base_object.workstation_config %}

--- a/app/grandchallenge/components/templates/components/civ_set_row.html
+++ b/app/grandchallenge/components/templates/components/civ_set_row.html
@@ -58,10 +58,10 @@
 {% if object.base_object.workstation %}
     <button class="btn btn-primary btn-sm"
     {% if object.base_object|model_name == base_model_options.READER_STUDY %}
-        {% if object.base_object.is_launchable %}
+        {% if object.base_object.has_budget %}
             {% workstation_session_control_data workstation=object.base_object.workstation context_object=object display_set=object config=object.base_object.workstation_config %}
         {% else %}
-            disabled title="Reader study cannot be launched"
+            disabled title="Reader study is out of budget and cannot be launched"
         {% endif %}
     {% elif object.base_object|model_name == base_model_options.ARCHIVE %}
         {% workstation_session_control_data workstation=object.base_object.workstation context_object=object archive_item=object config=object.base_object.workstation_config %}

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -924,7 +924,7 @@ class ReaderStudy(
         return ceil(total)
 
     @property
-    def is_launchable(self):
+    def has_budget(self):
         return (
             self.max_credits is None
             or self.credits_consumed < self.max_credits

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_detail.html
@@ -122,7 +122,7 @@
             {% endif %}
 
             {% if "read_readerstudy" in readerstudy_perms %}
-                {% if object.is_launchable %}
+                {% if object.has_budget %}
                     <p>
                         <button class="btn btn-primary" {% workstation_session_control_data workstation=object.workstation context_object=object reader_study=object %}>
                             <i class="fas fa-eye"></i> Launch this Reader Study

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_progress.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_progress.html
@@ -57,7 +57,7 @@
                                     {% if reader_study.has_budget %}
                                         {% workstation_session_control_data workstation=reader_study.workstation context_object=reader_study reader_study=reader_study user=user.obj %}
                                     {% else %}
-                                    disabled title="Reader study cannot be launched"
+                                    disabled title="Reader study is out of budget and cannot be launched"
                                     {% endif %}
                             >
                                 <i class="fa fa-eye"></i> View User's Answers

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_progress.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_progress.html
@@ -54,10 +54,10 @@
                     <div class="col-6 col-md-3 p-1">
                         <div class="d-flex justify-content-md-end justify-content-start align-items-center">
                             <button class="btn btn-primary"
-                                    {% if reader_study.is_launchable %}
+                                    {% if reader_study.has_budget %}
                                         {% workstation_session_control_data workstation=reader_study.workstation context_object=reader_study reader_study=reader_study user=user.obj %}
                                     {% else %}
-                                        disabled title="Reader study cannot be launched"
+                                    disabled title="Reader study cannot be launched"
                                     {% endif %}
                             >
                                 <i class="fa fa-eye"></i> View User's Answers
@@ -81,7 +81,7 @@
                     </div>
                 </div>
             </li>
-        {% empty %}
+            {% empty %}
             <li class="list-group-item">
                 No-one has answered any questions in this reader study.
             </li>
@@ -110,7 +110,8 @@
                             data-dismiss="modal">Cancel
                     </button>
                     <button type="button" class="btn btn-danger"
-                            id="proceed" data-baseurl="{{ reader_study.get_absolute_url }}" data-csrf="{{ csrf_token }}">
+                            id="proceed" data-baseurl="{{ reader_study.get_absolute_url }}"
+                            data-csrf="{{ csrf_token }}">
                         <i class="fa fa-trash"></i> <span class="modal-action"></span>
                     </button>
                 </div>

--- a/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_statistics.html
+++ b/app/grandchallenge/reader_studies/templates/reader_studies/readerstudy_statistics.html
@@ -51,12 +51,12 @@
                             {% get_ground_truth object entry.id question as ground_truth %}
                             <td>{{ ground_truth }}</td>
                         {% endfor %}
-                        <td data-order="{{ object.is_launchable }}">
+                        <td data-order="{{ object.has_budget }}">
                             <button class="btn btn-primary badge badge-primary"
-                                    {% if object.is_launchable %}
+                                    {% if object.has_budget %}
                                         {% workstation_session_control_data workstation=object.workstation context_object=object display_set=entry reader_study=object %} title="Open in viewer"
                                     {% else %}
-                                        disabled title="Reader study cannot be launched"
+                                        disabled title="Reader study is out of budget and cannot be launched"
                                     {% endif %}
                             >
                                 <i class="fa fa-eye"></i>

--- a/app/grandchallenge/workstations/forms.py
+++ b/app/grandchallenge/workstations/forms.py
@@ -68,8 +68,10 @@ class SessionForm(ModelForm):
         self.fields["ping_times"].required = False
 
     def clean(self):
-        if self.__reader_study and not self.__reader_study.is_launchable:
-            raise ValidationError("Reader study cannot be launched.")
+        if self.__reader_study and not self.__reader_study.has_budget:
+            raise ValidationError(
+                "Reader study is out of budget and cannot be launched."
+            )
         return super().clean()
 
     class Meta:
@@ -98,7 +100,7 @@ class DebugSessionForm(SaveFormInitMixin, ModelForm):
         ]
 
     def clean(self):
-        if self.__reader_study and not self.__reader_study.is_launchable:
+        if self.__reader_study and not self.__reader_study.has_budget:
             raise ValidationError("Reader study cannot be launched.")
 
         cleaned_data = super().clean()

--- a/app/grandchallenge/workstations/forms.py
+++ b/app/grandchallenge/workstations/forms.py
@@ -101,7 +101,9 @@ class DebugSessionForm(SaveFormInitMixin, ModelForm):
 
     def clean(self):
         if self.__reader_study and not self.__reader_study.has_budget:
-            raise ValidationError("Reader study cannot be launched.")
+            raise ValidationError(
+                "Reader study is out of budget and cannot be launched."
+            )
 
         cleaned_data = super().clean()
 

--- a/app/tests/reader_studies_tests/test_models.py
+++ b/app/tests/reader_studies_tests/test_models.py
@@ -1249,10 +1249,10 @@ def test_answer_score_calculation():
 
 
 @pytest.mark.django_db
-def test_reader_study_not_launchable_when_max_credits_consumed():
+def test_reader_study_out_of_budget_when_max_credits_consumed():
     reader_study = ReaderStudyFactory(max_credits=100)
 
-    assert reader_study.is_launchable
+    assert reader_study.has_budget
 
     session_utilization = SessionUtilizationFactory(
         duration=timedelta(hours=1)
@@ -1262,7 +1262,7 @@ def test_reader_study_not_launchable_when_max_credits_consumed():
     assert reader_study.session_utilizations.count() == 1
     assert reader_study.session_utilizations.first().credits_consumed == 500
     assert reader_study.credits_consumed == 500
-    assert not reader_study.is_launchable
+    assert not reader_study.has_budget
 
 
 @pytest.mark.django_db

--- a/app/tests/reader_studies_tests/test_views.py
+++ b/app/tests/reader_studies_tests/test_views.py
@@ -1196,14 +1196,14 @@ def test_leaderboard_user_visibility(client):
 
 
 @pytest.mark.django_db
-def test_reader_study_launch_disabled_when_not_launchable(client):
+def test_reader_study_launch_disabled_when_out_of_budget(client):
     reader_study = ReaderStudyFactory()
 
     editor, reader = UserFactory.create_batch(2)
     reader_study.add_editor(editor)
     reader_study.add_reader(reader)
 
-    assert reader_study.is_launchable
+    assert reader_study.has_budget
 
     for usr in [reader, editor]:
         response = get_view_for_user(
@@ -1219,7 +1219,7 @@ def test_reader_study_launch_disabled_when_not_launchable(client):
     reader_study.max_credits = 0
     reader_study.save()
 
-    assert not reader_study.is_launchable
+    assert not reader_study.has_budget
 
     for usr in [reader, editor]:
         response = get_view_for_user(

--- a/app/tests/workstations_tests/test_views.py
+++ b/app/tests/workstations_tests/test_views.py
@@ -616,7 +616,7 @@ def test_session_create_reader_study_with_algorithm_implementation_skip_active_e
 
 
 @pytest.mark.django_db
-def test_session_create_reader_study_not_launchable(client):
+def test_session_create_reader_study_out_of_budget(client):
     user = UserFactory()
     ws = WorkstationFactory()
     WorkstationImageFactory(
@@ -630,7 +630,7 @@ def test_session_create_reader_study_not_launchable(client):
     reader_study.readers_group.user_set.add(user)
     path, _ = get_workstation_path_and_query_string(reader_study=reader_study)
 
-    assert not reader_study.is_launchable
+    assert not reader_study.has_budget
     assert Session.objects.count() == 0
 
     response = get_view_for_user(


### PR DESCRIPTION
In preparation for the changes for https://github.com/DIAGNijmegen/rse-roadmap/issues/469, this renames the `is_launchable` property on reader studies to `has_budget`. That describes the property better. With the changes in this pitch, reader studies will still be launchable for editors even when they are out of budget. 