### PR TITLE
Fix url reversing when deactivating ground truth

### DIFF
--- a/app/grandchallenge/evaluation/templates/evaluation/ground_truth_version_management.html
+++ b/app/grandchallenge/evaluation/templates/evaluation/ground_truth_version_management.html
@@ -1,5 +1,6 @@
 {% extends "pages/challenge_settings_base.html" %}
 {% load crispy_forms_tags %}
+{% load url %}
 
 {% block title %}
     Ground Truth Version Management - Ground Truths - {{ block.super }}


### PR DESCRIPTION
This template does not work on the challenge subdomains and results in a Django template error. Caused by `{% url 'challenges:list' %}`.