### PR TITLE
Only preload interactive algorithms for reader studies with budget

### DIFF
--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1312,9 +1312,12 @@ def preload_interactive_algorithms():
 
     reader_studies_out_of_budget = [
         rs.pk
-        for rs in ReaderStudy.objects.exclude(max_credits__isnull=True).only(
-            "pk", "max_credits"
+        for rs in ReaderStudy.objects.exclude(max_credits__isnull=True)
+        .prefetch_related(
+            "session_utilizations__reader_studies",
+            "endpoint_utilizations__reader_studies",
         )
+        .only("pk", "max_credits")
         if not rs.has_budget
     ]
 

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1307,8 +1307,16 @@ class InteractiveAlgorithmLambda:
 @acks_late_micro_short_task
 @transaction.atomic
 def preload_interactive_algorithms():
-    from grandchallenge.reader_studies.models import Question
+    from grandchallenge.reader_studies.models import Question, ReaderStudy
     from grandchallenge.workstations.models import Session
+
+    reader_studies_out_of_budget = [
+        rs.pk
+        for rs in ReaderStudy.objects.exclude(max_credits__isnull=True).only(
+            "pk", "max_credits"
+        )
+        if not rs.has_budget
+    ]
 
     active_interactive_algorithms = (
         Question.objects.filter(
@@ -1318,6 +1326,7 @@ def preload_interactive_algorithms():
                 Session.RUNNING,
             ],
         )
+        .exclude(reader_study__pk__in=reader_studies_out_of_budget)
         .exclude(interactive_algorithm="")
         .values_list("interactive_algorithm", flat=True)
         .distinct()

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1310,15 +1310,13 @@ def preload_interactive_algorithms():
     from grandchallenge.reader_studies.models import Question, ReaderStudy
     from grandchallenge.workstations.models import Session
 
-    reader_studies_out_of_budget = [
+    reader_studies_with_budget = [
         rs.pk
-        for rs in ReaderStudy.objects.exclude(max_credits__isnull=True)
-        .prefetch_related(
+        for rs in ReaderStudy.objects.prefetch_related(
             "session_utilizations__reader_studies",
             "endpoint_utilizations__reader_studies",
-        )
-        .only("pk", "max_credits")
-        if not rs.has_budget
+        ).only("pk", "max_credits")
+        if rs.has_budget
     ]
 
     active_interactive_algorithms = (
@@ -1328,8 +1326,8 @@ def preload_interactive_algorithms():
                 Session.STARTED,
                 Session.RUNNING,
             ],
+            reader_study__pk__in=reader_studies_with_budget,
         )
-        .exclude(reader_study__pk__in=reader_studies_out_of_budget)
         .exclude(interactive_algorithm="")
         .values_list("interactive_algorithm", flat=True)
         .distinct()

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -109,6 +109,7 @@ from tests.uploads_tests.factories import (
     UserUploadFactory,
     create_upload_from_file,
 )
+from tests.utilization_tests.factories import SessionUtilizationFactory
 
 
 @pytest.mark.django_db
@@ -1317,6 +1318,58 @@ def test_preload_interactive_algorithms(settings):
             arn=arn,
             qualifier="1",
             should_be_active=True,
+        )
+
+        assert mock_instance.consolidate.call_count == 1
+
+
+@pytest.mark.django_db
+def test_preload_interactive_algorithms_excludes_reader_studies_without_budget(
+    settings,
+):
+    arn = f"arn:aws:lambda:eu-central-1:1234567890:function:org-proj-e-uls23-baseline-{uuid.uuid4()}"
+
+    settings.INTERACTIVE_ALGORITHMS_LAMBDA_FUNCTIONS = {
+        "io_bucket_name": "org-proj-e-some-bucket",
+        "lambda_functions": [
+            {
+                # Add a uuid to avoid cache key clashes in testing
+                "arn": arn,
+                "internal_name": "uls23-baseline",
+                "minimum_duration": 1,
+                "timeout": 60,
+                "version": "1",
+            }
+        ],
+    }
+
+    rs_with_exhausted_credit = ReaderStudyFactory(max_credits=100)
+    session_utilization = SessionUtilizationFactory(
+        duration=timedelta(hours=1)
+    )
+    session_utilization.reader_studies.add(rs_with_exhausted_credit)
+
+    QuestionFactory(
+        reader_study=rs_with_exhausted_credit,
+        interactive_algorithm=InteractiveAlgorithmLambdaChoices.ULS23_BASELINE,
+    )
+
+    assert not rs_with_exhausted_credit.has_budget
+
+    with patch(
+        "grandchallenge.components.tasks.InteractiveAlgorithmLambda"
+    ) as mock_interactive_algorithm:
+        mock_instance = mock_interactive_algorithm.return_value
+        mock_instance.consolidate.return_value = "mocked_consolidation_result"
+
+        assert preload_interactive_algorithms() == {
+            "uls23-baseline": "mocked_consolidation_result"
+        }
+
+        mock_interactive_algorithm.assert_any_call(
+            arn=arn,
+            qualifier="1",
+            should_be_active=False,
         )
 
         assert mock_instance.consolidate.call_count == 1


### PR DESCRIPTION
Only preload interactive algorithms of reader studies with budget. 

Part of https://github.com/DIAGNijmegen/rse-roadmap/issues/469