### PR TITLE
Link utilization and challenge invoices - new utilizations

### DIFF
--- a/app/grandchallenge/algorithms/tasks.py
+++ b/app/grandchallenge/algorithms/tasks.py
@@ -79,6 +79,7 @@ def create_algorithm_jobs(
     task_on_failure=None,
     job_utilization_phase=None,
     job_utilization_challenge=None,
+    job_utilization_invoice=None,
 ):
     """
     Creates algorithm jobs for sets of component interface values
@@ -114,6 +115,8 @@ def create_algorithm_jobs(
         The phase that should be assigned for utilization tracking
     job_utilization_challenge
         The challenge that should be assigned for utilization tracking
+    job_utilization_invoice
+        The invoice that should be assigned for utilization tracking
     """
     from grandchallenge.algorithms.models import Job
 
@@ -167,6 +170,7 @@ def create_algorithm_jobs(
             job.utilization.archive = ai.archive
             job.utilization.phase = job_utilization_phase
             job.utilization.challenge = job_utilization_challenge
+            job.utilization.invoice = job_utilization_invoice
             job.utilization.save()
 
             job.execute()

--- a/app/grandchallenge/challenges/exceptions.py
+++ b/app/grandchallenge/challenges/exceptions.py
@@ -1,0 +1,2 @@
+class InsufficientBudgetError(Exception):
+    pass

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -44,6 +44,7 @@ from grandchallenge.challenges.emails import (
     send_challenge_requested_email_to_reviewers,
     send_email_percent_budget_consumed_alert,
 )
+from grandchallenge.challenges.exceptions import InsufficientBudgetError
 from grandchallenge.challenges.utils import ChallengeTypeChoices
 from grandchallenge.components.models import APIMethodChoices
 from grandchallenge.components.schemas import GPUTypeChoices
@@ -855,9 +856,28 @@ class Challenge(ChallengeBase, FieldChangeMixin):
     def available_compute_euro_millicents_via_invoices(self):
         return sum(
             invoice.available_compute_cost_euro_millicents
-            for invoice in self.invoices.all()
-            if invoice.available_compute_cost_euro_millicents > 0
+            for invoice in self.get_bookable_invoices()
         )
+
+    @property
+    def active_invoice(self):
+        bookable_invoices = self.get_bookable_invoices()
+        if bookable_invoices:
+            return bookable_invoices[0]
+        else:
+            raise InsufficientBudgetError
+
+    def get_bookable_invoices(self):
+        invoices = (
+            self.invoices.with_budget_authorization()
+            .order_by("expires_on", "created")
+            .all()
+        )
+        return [
+            invoice
+            for invoice in invoices
+            if invoice.available_compute_cost_euro_millicents > 0
+        ]
 
     def send_alert_if_budget_consumed_warning_threshold_exceeded(self):
         for percent_threshold in sorted(

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -856,18 +856,18 @@ class Challenge(ChallengeBase, FieldChangeMixin):
     def available_compute_euro_millicents_via_invoices(self):
         return sum(
             invoice.available_compute_cost_euro_millicents
-            for invoice in self.get_bookable_invoices()
+            for invoice in self.get_available_invoices()
         )
 
     @property
     def active_invoice(self):
-        bookable_invoices = self.get_bookable_invoices()
-        if bookable_invoices:
-            return bookable_invoices[0]
+        available_invoices = self.get_available_invoices()
+        if available_invoices:
+            return available_invoices[0]
         else:
             raise InsufficientBudgetError
 
-    def get_bookable_invoices(self):
+    def get_available_invoices(self):
         invoices = (
             self.invoices.with_budget_authorization()
             .order_by("expires_on", "created")

--- a/app/grandchallenge/evaluation/admin.py
+++ b/app/grandchallenge/evaluation/admin.py
@@ -3,6 +3,7 @@ from django.contrib import admin, messages
 from django.forms import ModelForm
 from django.utils.html import format_html
 
+from grandchallenge.challenges.exceptions import InsufficientBudgetError
 from grandchallenge.components.admin import (
     ComponentImageAdmin,
     cancel_jobs,
@@ -169,7 +170,19 @@ def reevaluate_submissions(modeladmin, request, queryset):
                 messages.WARNING,
             )
         else:
-            submission.create_evaluation(additional_inputs=None)
+            try:
+                invoice = submission.phase.challenge.active_invoice
+            except InsufficientBudgetError:
+                modeladmin.message_user(
+                    request,
+                    f"Submission {submission.pk} cannot be reevaluated. Challenge has insufficient budget.",
+                    messages.WARNING,
+                )
+            else:
+                submission.create_evaluation(
+                    additional_inputs=None,
+                    invoice=invoice,
+                )
 
 
 @admin.register(Submission)

--- a/app/grandchallenge/evaluation/forms.py
+++ b/app/grandchallenge/evaluation/forms.py
@@ -24,7 +24,7 @@ from django.utils.text import format_lazy
 
 from grandchallenge.algorithms.forms import UserAlgorithmsForPhaseMixin
 from grandchallenge.algorithms.models import Job
-from grandchallenge.challenges.models import Challenge
+from grandchallenge.challenges.exceptions import InsufficientBudgetError
 from grandchallenge.components.forms import (
     AdditionalInputsMixin,
     ContainerImageForm,
@@ -471,6 +471,15 @@ class SubmissionForm(
                 "You must confirm that you want to submit to this phase."
             )
 
+        try:
+            invoice = self._phase.challenge.active_invoice
+        except InsufficientBudgetError:
+            raise ValidationError(
+                "Challenge has insufficient budget. Please contact the challenge organizers."
+            )
+        else:
+            cleaned_data["invoice"] = invoice
+
         return cleaned_data
 
     def clean_phase(self):
@@ -655,7 +664,8 @@ class SubmissionForm(
         instance = super().save(*args, **kwargs)
 
         instance.create_evaluation(
-            additional_inputs=self.cleaned_data["additional_inputs"]
+            additional_inputs=self.cleaned_data["additional_inputs"],
+            invoice=self.cleaned_data["invoice"],
         )
 
         return instance
@@ -741,17 +751,14 @@ class EvaluationForm(SaveFormInitMixin, AdditionalInputsMixin, forms.Form):
                     "Please wait for the other evaluation to complete."
                 )
 
-        # Fetch from the db to get the cost annotations
-        challenge = (
-            Challenge.objects.filter(
-                pk=cleaned_data["submission"].phase.challenge.pk
+        try:
+            invoice = cleaned_data["submission"].phase.challenge.active_invoice
+        except InsufficientBudgetError:
+            raise ValidationError(
+                "Challenge has insufficient budget. Please contact support to add more funds."
             )
-            .with_available_compute()
-            .get()
-        )
-
-        if challenge.available_compute_euro_millicents <= 0:
-            raise ValidationError("This challenge has exceeded its budget")
+        else:
+            cleaned_data["invoice"] = invoice
 
         if Evaluation.objects.get_evaluations_with_same_inputs(
             inputs=cleaned_data["additional_inputs"],

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1650,7 +1650,7 @@ class Submission(FieldChangeMixin, UUIDModel):
                     send_action=False,
                 )
 
-    def create_evaluation(self, *, additional_inputs):
+    def create_evaluation(self, *, additional_inputs, invoice):
         if (
             self.phase.additional_evaluation_inputs.exists()
             and not additional_inputs
@@ -1711,6 +1711,8 @@ class Submission(FieldChangeMixin, UUIDModel):
                 requires_memory_gb=self.phase.evaluation_requires_memory_gb,
                 status=Evaluation.VALIDATING_INPUTS,
             )
+            evaluation.utilization.invoice = invoice
+            evaluation.utilization.save()
 
         if self.phase.submission_kind == SubmissionKindChoices.ALGORITHM:
             if not self.has_matching_algorithm_interfaces:

--- a/app/grandchallenge/evaluation/tasks.py
+++ b/app/grandchallenge/evaluation/tasks.py
@@ -334,6 +334,7 @@ def create_algorithm_jobs_for_evaluation(*, evaluation_pk, first_run):
             requires_memory_gb=evaluation.submission.algorithm_requires_memory_gb,
             job_utilization_phase=evaluation.submission.phase,
             job_utilization_challenge=evaluation.submission.phase.challenge,
+            job_utilization_invoice=evaluation.utilization.invoice,
         )
     except TooManyJobsScheduled:
         if not first_run:

--- a/app/grandchallenge/evaluation/views/__init__.py
+++ b/app/grandchallenge/evaluation/views/__init__.py
@@ -535,7 +535,8 @@ class EvaluationCreate(
     def form_valid(self, form):
         redirect = super().form_valid(form)
         self.submission.create_evaluation(
-            additional_inputs=form.cleaned_data["additional_inputs"]
+            additional_inputs=form.cleaned_data["additional_inputs"],
+            invoice=form.cleaned_data["invoice"],
         )
         return redirect
 

--- a/app/grandchallenge/invoices/admin.py
+++ b/app/grandchallenge/invoices/admin.py
@@ -71,7 +71,7 @@ class InvoiceAdmin(admin.ModelAdmin):
         "challenge__short_name",
     )
     autocomplete_fields = ("challenge",)
-    readonly_fields = ["invoice_request_text"]
+    readonly_fields = ["invoice_request_text", "compute_cost_euro_millicents"]
 
     def has_delete_permission(self, request, obj=None):
         # invoices cannot be deleted

--- a/app/tests/challenges_tests/test_models.py
+++ b/app/tests/challenges_tests/test_models.py
@@ -966,7 +966,7 @@ def test_active_invoice_orders_by_expiry():
 
 
 @pytest.mark.django_db
-def test_active_invoice_ignores_overall_balance():
+def test_active_invoice_ignores_invoices_with_negative_balance():
     challenge = ChallengeFactory()
 
     InvoiceFactory(

--- a/app/tests/challenges_tests/test_models.py
+++ b/app/tests/challenges_tests/test_models.py
@@ -10,13 +10,14 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models import ProtectedError
 from django.utils.timezone import datetime, now, timedelta
 
+from grandchallenge.challenges.exceptions import InsufficientBudgetError
 from grandchallenge.challenges.models import (
     Challenge,
     ChallengeRequest,
     OnboardingTask,
 )
 from grandchallenge.discussion_forums.models import ForumTopicKindChoices
-from grandchallenge.invoices.models import Invoice
+from grandchallenge.invoices.models import Invoice, PaymentTypeChoices
 from grandchallenge.notifications.models import Notification
 from tests.discussion_forums_tests.factories import ForumTopicFactory
 from tests.factories import (
@@ -877,3 +878,110 @@ def test_challenge_available_compute_euro_millicents():
         challenge.available_compute_euro_millicents_via_invoices
         == (1 + 2) * 1000 * 100
     )
+
+
+@pytest.mark.django_db
+def test_active_invoice():
+    challenge = ChallengeFactory()
+    invoice = InvoiceFactory(
+        challenge=challenge,
+        compute_costs_euros=1,
+        compute_cost_euro_millicents=0,
+        payment_type=PaymentTypeChoices.PREPAID,
+        payment_status=Invoice.PaymentStatusChoices.PAID,
+    )
+    assert challenge.active_invoice == invoice
+
+
+@pytest.mark.django_db
+def test_active_invoice_no_invoice():
+    challenge = ChallengeFactory()
+    with pytest.raises(InsufficientBudgetError):
+        challenge.active_invoice
+
+
+@pytest.mark.django_db
+def test_active_invoice_raises_on_negative_balance():
+    challenge = ChallengeFactory()
+    InvoiceFactory(
+        challenge=challenge,
+        compute_costs_euros=1,
+        compute_cost_euro_millicents=2 * 1000 * 100,
+        payment_type=PaymentTypeChoices.PREPAID,
+        payment_status=Invoice.PaymentStatusChoices.PAID,
+    )
+    with pytest.raises(InsufficientBudgetError):
+        challenge.active_invoice
+
+
+@pytest.mark.django_db
+def test_active_invoice_raises_on_zero_balance():
+    challenge = ChallengeFactory()
+    InvoiceFactory(
+        challenge=challenge,
+        compute_costs_euros=1,
+        compute_cost_euro_millicents=1 * 1000 * 100,
+        payment_type=PaymentTypeChoices.PREPAID,
+        payment_status=Invoice.PaymentStatusChoices.PAID,
+    )
+    with pytest.raises(InsufficientBudgetError):
+        challenge.active_invoice
+
+
+@pytest.mark.django_db
+def test_active_invoice_orders_by_expiry():
+    challenge = ChallengeFactory()
+
+    _fixed_now = now()
+
+    invoice0 = InvoiceFactory(
+        challenge=challenge,
+        compute_costs_euros=1,
+        compute_cost_euro_millicents=0,
+        payment_type=PaymentTypeChoices.PREPAID,
+        payment_status=Invoice.PaymentStatusChoices.PAID,
+        expires_on=_fixed_now + timedelta(10),
+    )
+    invoice1 = InvoiceFactory(
+        challenge=challenge,
+        compute_costs_euros=1,
+        compute_cost_euro_millicents=0,
+        payment_type=PaymentTypeChoices.PREPAID,
+        payment_status=Invoice.PaymentStatusChoices.PAID,
+        expires_on=_fixed_now + timedelta(10),
+    )
+
+    # All things being equal, use created time to determine order, so invoice0 should be active as it was created first
+    assert challenge.active_invoice == invoice0
+
+    invoice1.expires_on = _fixed_now + timedelta(5)
+    invoice1.save()
+    assert invoice1.expires_on < invoice0.expires_on, "Sanity"
+    assert challenge.active_invoice == invoice1
+
+    invoice0.expires_on = _fixed_now + timedelta(4)
+    invoice0.save()
+    assert invoice0.expires_on < invoice1.expires_on, "Sanity"
+    assert challenge.active_invoice == invoice0
+
+
+@pytest.mark.django_db
+def test_active_invoice_ignores_overall_balance():
+    challenge = ChallengeFactory()
+
+    InvoiceFactory(
+        challenge=challenge,
+        compute_costs_euros=1,
+        compute_cost_euro_millicents=0,
+        payment_type=PaymentTypeChoices.PREPAID,
+        payment_status=Invoice.PaymentStatusChoices.PAID,
+    )
+    InvoiceFactory(
+        challenge=challenge,
+        compute_costs_euros=1,
+        compute_cost_euro_millicents=1000 * 1000 * 100,
+        payment_type=PaymentTypeChoices.PREPAID,
+        payment_status=Invoice.PaymentStatusChoices.PAID,
+    )
+
+    challenge.active_invoice

--- a/app/tests/challenges_tests/test_tasks.py
+++ b/app/tests/challenges_tests/test_tasks.py
@@ -80,7 +80,7 @@ def test_challenge_budget_alert_email(settings):
     challenge.add_admin(challenge_admin)
     staff_user = UserFactory(is_staff=True)
     settings.MANAGERS = [(staff_user.last_name, staff_user.email)]
-    InvoiceFactory(
+    invoice = InvoiceFactory(
         challenge=challenge,
         support_costs_euros=0,
         compute_costs_euros=10,
@@ -93,7 +93,8 @@ def test_challenge_budget_alert_email(settings):
         time_limit=60,
     )
 
-    evaluation.utilization.compute_cost_euro_millicents = 500000
+    evaluation.utilization.invoice = invoice
+    evaluation.utilization.compute_cost_euro_millicents = 5 * 1000 * 100
     evaluation.utilization.save()
     update_challenge_compute_costs()
 
@@ -104,7 +105,8 @@ def test_challenge_budget_alert_email(settings):
         submission__phase=phase,
         time_limit=60,
     )
-    evaluation.utilization.compute_cost_euro_millicents = 300000
+    evaluation.utilization.invoice = invoice
+    evaluation.utilization.compute_cost_euro_millicents = 3 * 1000 * 100
     evaluation.utilization.save()
     update_challenge_compute_costs()
 
@@ -134,6 +136,7 @@ def test_challenge_budget_alert_email(settings):
         submission__phase=phase,
         time_limit=60,
     )
+    evaluation.utilization.invoice = invoice
     evaluation.utilization.compute_cost_euro_millicents = 100000
     evaluation.utilization.save()
     update_challenge_compute_costs()
@@ -145,6 +148,7 @@ def test_challenge_budget_alert_email(settings):
         submission__phase=phase,
         time_limit=60,
     )
+    evaluation.utilization.invoice = invoice
     evaluation.utilization.compute_cost_euro_millicents = 1
     evaluation.utilization.save()
     update_challenge_compute_costs()
@@ -169,7 +173,7 @@ def test_challenge_budget_alert_two_thresholds_one_email(settings):
     challenge.add_admin(challenge_admin)
     staff_user = UserFactory(is_staff=True)
     settings.MANAGERS = [(staff_user.last_name, staff_user.email)]
-    InvoiceFactory(
+    invoice = InvoiceFactory(
         challenge=challenge,
         support_costs_euros=0,
         compute_costs_euros=10,
@@ -181,6 +185,7 @@ def test_challenge_budget_alert_two_thresholds_one_email(settings):
         submission__phase=phase,
         time_limit=60,
     )
+    evaluation.utilization.invoice = invoice
     evaluation.utilization.compute_cost_euro_millicents = 950000
     evaluation.utilization.save()
     update_challenge_compute_costs()
@@ -203,10 +208,12 @@ def test_challenge_budget_alert_two_thresholds_one_email(settings):
 def test_challenge_budget_alert_no_budget():
     challenge = ChallengeFactory()
     phase = PhaseFactory(challenge=challenge)
+    invoice = InvoiceFactory(challenge=challenge)
     evaluation = EvaluationFactory(
         submission__phase=phase,
         time_limit=60,
     )
+    evaluation.utilization.invoice = invoice
     evaluation.utilization.compute_cost_euro_millicents = 1
     evaluation.utilization.save()
     assert len(mail.outbox) == 0

--- a/app/tests/challenges_tests/test_tasks.py
+++ b/app/tests/challenges_tests/test_tasks.py
@@ -208,7 +208,7 @@ def test_challenge_budget_alert_two_thresholds_one_email(settings):
 def test_challenge_budget_alert_no_budget():
     challenge = ChallengeFactory()
     phase = PhaseFactory(challenge=challenge)
-    invoice = InvoiceFactory(challenge=challenge)
+    invoice = InvoiceFactory(challenge=challenge, compute_costs_euros=0)
     evaluation = EvaluationFactory(
         submission__phase=phase,
         time_limit=60,

--- a/app/tests/evaluation_tests/test_admin.py
+++ b/app/tests/evaluation_tests/test_admin.py
@@ -19,6 +19,7 @@ from tests.evaluation_tests.factories import (
     SubmissionFactory,
 )
 from tests.factories import ChallengeFactory
+from tests.invoices_tests.factories import InvoiceFactory
 
 
 @pytest.mark.django_db
@@ -66,6 +67,9 @@ def test_selectable_gpu_type_choices_invalid():
 @pytest.mark.django_db
 def test_reevaluate_submission_only_for_evaluations_without_inputs(rf):
     s1, s2 = SubmissionFactory.create_batch(2)
+    InvoiceFactory.create_valid(challenge=s1.phase.challenge)
+    InvoiceFactory.create_valid(challenge=s2.phase.challenge)
+
     s1.phase.additional_evaluation_inputs.add(ComponentInterfaceFactory())
 
     modeladmin = SubmissionAdmin(Submission, AdminSite)
@@ -88,7 +92,7 @@ def test_reevaluate_submission_only_for_evaluations_without_inputs(rf):
     )
 
     messages = [m.message for m in request._messages]
-    assert len(messages) == 1
+    assert len(messages) == 1, messages
     assert (
         messages[0]
         == f"Submission {s1.pk} cannot be reevaluated in the admin because it requires additional inputs. Please reschedule through the challenge UI."
@@ -98,6 +102,7 @@ def test_reevaluate_submission_only_for_evaluations_without_inputs(rf):
 @pytest.mark.django_db
 def test_reevaluate_submission_idempotent(rf):
     submission = SubmissionFactory()
+    InvoiceFactory.create_valid(challenge=submission.phase.challenge)
     MethodFactory(
         phase=submission.phase,
         is_manifest_valid=True,
@@ -160,6 +165,7 @@ def test_rescheduling_external_evaluation_not_possible(rf):
 
     SubmissionFactory(phase=phase_ext)
     SubmissionFactory(phase=phase_int)
+    InvoiceFactory.create_valid(challenge=phase_int.challenge)
 
     modeladmin = SubmissionAdmin(Submission, AdminSite)
     request = rf.get("/foo")
@@ -177,3 +183,52 @@ def test_rescheduling_external_evaluation_not_possible(rf):
     messages = [m.message for m in request._messages]
     assert len(messages) == 1
     assert messages[0] == "External evaluations cannot be requeued."
+
+
+@pytest.mark.django_db
+def test_reevaluate_submission_missing_invoice(rf):
+    submission = SubmissionFactory()
+
+    modeladmin = SubmissionAdmin(Submission, AdminSite)
+    request = rf.get("/foo")
+    # Add session
+    middleware = SessionMiddleware(lambda x: None)
+    middleware.process_request(request)
+    request.session.save()
+    # Add messages storage
+    messages_storage = FallbackStorage(request)
+    request.session["_messages"] = messages_storage
+    request._messages = messages_storage
+
+    reevaluate_submissions(modeladmin, request, Submission.objects.all())
+
+    messages = [m.message for m in request._messages]
+    assert len(messages) == 1
+    assert (
+        messages[0]
+        == f"Submission {submission.pk} cannot be reevaluated. Challenge has insufficient budget."
+    )
+
+
+@pytest.mark.django_db
+def test_reevaluate_submission_assigns_invoice(rf):
+    submission = SubmissionFactory()
+    invoice = InvoiceFactory.create_valid(challenge=submission.phase.challenge)
+    MethodFactory(
+        phase=submission.phase,
+        is_manifest_valid=True,
+        is_in_registry=True,
+        is_desired_version=True,
+    )
+
+    modeladmin = SubmissionAdmin(Submission, AdminSite)
+    request = rf.get("/foo")
+
+    reevaluate_submissions(
+        request=request,
+        modeladmin=modeladmin,
+        queryset=Submission.objects.all(),
+    )
+
+    evaluation = Evaluation.objects.get()
+    assert evaluation.evaluation_utilization.invoice == invoice

--- a/app/tests/evaluation_tests/test_admin.py
+++ b/app/tests/evaluation_tests/test_admin.py
@@ -67,8 +67,8 @@ def test_selectable_gpu_type_choices_invalid():
 @pytest.mark.django_db
 def test_reevaluate_submission_only_for_evaluations_without_inputs(rf):
     s1, s2 = SubmissionFactory.create_batch(2)
-    InvoiceFactory.create_valid(challenge=s1.phase.challenge)
-    InvoiceFactory.create_valid(challenge=s2.phase.challenge)
+    InvoiceFactory(challenge=s1.phase.challenge)
+    InvoiceFactory(challenge=s2.phase.challenge)
 
     s1.phase.additional_evaluation_inputs.add(ComponentInterfaceFactory())
 
@@ -102,7 +102,7 @@ def test_reevaluate_submission_only_for_evaluations_without_inputs(rf):
 @pytest.mark.django_db
 def test_reevaluate_submission_idempotent(rf):
     submission = SubmissionFactory()
-    InvoiceFactory.create_valid(challenge=submission.phase.challenge)
+    InvoiceFactory(challenge=submission.phase.challenge)
     MethodFactory(
         phase=submission.phase,
         is_manifest_valid=True,
@@ -165,7 +165,7 @@ def test_rescheduling_external_evaluation_not_possible(rf):
 
     SubmissionFactory(phase=phase_ext)
     SubmissionFactory(phase=phase_int)
-    InvoiceFactory.create_valid(challenge=phase_int.challenge)
+    InvoiceFactory(challenge=phase_int.challenge)
 
     modeladmin = SubmissionAdmin(Submission, AdminSite)
     request = rf.get("/foo")
@@ -213,7 +213,7 @@ def test_reevaluate_submission_missing_invoice(rf):
 @pytest.mark.django_db
 def test_reevaluate_submission_assigns_invoice(rf):
     submission = SubmissionFactory()
-    invoice = InvoiceFactory.create_valid(challenge=submission.phase.challenge)
+    invoice = InvoiceFactory(challenge=submission.phase.challenge)
     MethodFactory(
         phase=submission.phase,
         is_manifest_valid=True,

--- a/app/tests/evaluation_tests/test_forms.py
+++ b/app/tests/evaluation_tests/test_forms.py
@@ -902,6 +902,78 @@ class TestSubmissionForm:
             in str(form.errors)
         )
 
+    def test_insufficient_funds(self):
+        user = UserFactory()
+        VerificationFactory(user=user, is_verified=True)
+        alg = AlgorithmFactory()
+        alg.add_editor(user=user)
+        ci1 = ComponentInterfaceFactory()
+        ci2 = ComponentInterfaceFactory()
+        interface = AlgorithmInterfaceFactory(inputs=[ci1], outputs=[ci2])
+        alg.interfaces.set([interface])
+        archive = ArchiveFactory()
+        p = PhaseFactory(
+            submission_kind=SubmissionKindChoices.ALGORITHM,
+            submissions_limit_per_user_per_period=10,
+            archive=archive,
+        )
+        p.algorithm_interfaces.set([interface])
+        civ = ComponentInterfaceValueFactory(interface=ci1)
+        i = ArchiveItemFactory(archive=p.archive)
+        i.values.add(civ)
+
+        invoice = InvoiceFactory(
+            challenge=p.challenge,
+            compute_costs_euros=10,
+            payment_type=PaymentTypeChoices.COMPLIMENTARY,
+        )
+
+        # Fetch from the db to get the cost annotations
+        p = Phase.objects.get(pk=p.pk)
+
+        ai = AlgorithmImageFactory(
+            is_manifest_valid=True,
+            is_in_registry=True,
+            is_desired_version=True,
+            algorithm=alg,
+        )
+        AlgorithmJobFactory(
+            algorithm_image=ai,
+            algorithm_interface=interface,
+            status=4,
+            time_limit=ai.algorithm.time_limit,
+        )
+        MethodFactory(
+            is_manifest_valid=True,
+            is_in_registry=True,
+            is_desired_version=True,
+            phase=p,
+        )
+
+        form = SubmissionForm(
+            user=user,
+            phase=p,
+            data={"algorithm": alg, "creator": user, "phase": p},
+        )
+
+        assert form.errors == {}
+        assert form.is_valid()
+
+        # Remove funds
+        invoice.payment_status = PaymentStatusChoices.CANCELLED
+        invoice.save()
+
+        form = SubmissionForm(
+            user=user,
+            phase=p,
+            data={"algorithm": alg, "creator": user, "phase": p},
+        )
+        assert not form.is_valid()
+        assert (
+            "Challenge has insufficient budget. Please contact the challenge organizers."
+            in str(form.errors)
+        )
+
 
 @pytest.mark.django_db
 class TestSubmissionFormOptions:

--- a/app/tests/evaluation_tests/test_models.py
+++ b/app/tests/evaluation_tests/test_models.py
@@ -108,7 +108,7 @@ def test_algorithm_submission_creates_one_job_per_test_set_image(
         phase=algorithm_submission.method.phase,
         algorithm_image=algorithm_submission.algorithm_image,
     )
-    InvoiceFactory.create_valid(challenge=s.phase.challenge)
+    InvoiceFactory(challenge=s.phase.challenge)
 
     eval = EvaluationFactory(
         submission=s,
@@ -141,7 +141,7 @@ def test_create_evaluation_is_idempotent(
         phase=algorithm_submission.method.phase,
         algorithm_image=algorithm_submission.algorithm_image,
     )
-    i = InvoiceFactory.create_valid(challenge=s.phase.challenge)
+    i = InvoiceFactory(challenge=s.phase.challenge)
 
     with django_capture_on_commit_callbacks(execute=True):
         s.create_evaluation(additional_inputs=None, invoice=i)
@@ -168,7 +168,7 @@ def test_create_evaluation_sets_gpu_and_memory():
 
     submission.create_evaluation(
         additional_inputs=None,
-        invoice=InvoiceFactory.create_valid(challenge=method.phase.challenge),
+        invoice=InvoiceFactory(challenge=method.phase.challenge),
     )
 
     evaluation = Evaluation.objects.get()
@@ -248,7 +248,7 @@ def test_create_evaluation_uniqueness_checks(
         phase=algorithm_submission.method.phase,
         algorithm_image=algorithm_submission.algorithm_image,
     )
-    invoice = InvoiceFactory.create_valid(challenge=sub.phase.challenge)
+    invoice = InvoiceFactory(challenge=sub.phase.challenge)
 
     with django_capture_on_commit_callbacks(execute=True):
         sub.create_evaluation(
@@ -350,7 +350,7 @@ def test_create_evaluation_with_invoice(
         phase=algorithm_submission.method.phase,
         algorithm_image=algorithm_submission.algorithm_image,
     )
-    i = InvoiceFactory.create_valid(challenge=s.phase.challenge)
+    i = InvoiceFactory(challenge=s.phase.challenge)
 
     with django_capture_on_commit_callbacks(execute=True):
         s.create_evaluation(additional_inputs=None, invoice=i)
@@ -364,7 +364,7 @@ class TestPhaseLimits:
     def setup_method(self):
         phase = PhaseFactory()
 
-        InvoiceFactory.create_valid(challenge=phase.challenge)
+        InvoiceFactory(challenge=phase.challenge)
 
         # Fetch from the db to get the cost annotations
         self.phase = Phase.objects.get(pk=phase.pk)

--- a/app/tests/evaluation_tests/test_models.py
+++ b/app/tests/evaluation_tests/test_models.py
@@ -108,6 +108,7 @@ def test_algorithm_submission_creates_one_job_per_test_set_image(
         phase=algorithm_submission.method.phase,
         algorithm_image=algorithm_submission.algorithm_image,
     )
+    InvoiceFactory.create_valid(challenge=s.phase.challenge)
 
     eval = EvaluationFactory(
         submission=s,
@@ -140,12 +141,13 @@ def test_create_evaluation_is_idempotent(
         phase=algorithm_submission.method.phase,
         algorithm_image=algorithm_submission.algorithm_image,
     )
+    i = InvoiceFactory.create_valid(challenge=s.phase.challenge)
 
     with django_capture_on_commit_callbacks(execute=True):
-        s.create_evaluation(additional_inputs=None)
+        s.create_evaluation(additional_inputs=None, invoice=i)
 
     with django_capture_on_commit_callbacks(execute=True):
-        s.create_evaluation(additional_inputs=None)
+        s.create_evaluation(additional_inputs=None, invoice=i)
 
     assert Evaluation.objects.count() == 1
     # max_inital_jobs is set to 1, so only one job should be created
@@ -164,7 +166,10 @@ def test_create_evaluation_sets_gpu_and_memory():
 
     submission = SubmissionFactory(phase=method.phase)
 
-    submission.create_evaluation(additional_inputs=None)
+    submission.create_evaluation(
+        additional_inputs=None,
+        invoice=InvoiceFactory.create_valid(challenge=method.phase.challenge),
+    )
 
     evaluation = Evaluation.objects.get()
 
@@ -243,9 +248,13 @@ def test_create_evaluation_uniqueness_checks(
         phase=algorithm_submission.method.phase,
         algorithm_image=algorithm_submission.algorithm_image,
     )
+    invoice = InvoiceFactory.create_valid(challenge=sub.phase.challenge)
 
     with django_capture_on_commit_callbacks(execute=True):
-        sub.create_evaluation(additional_inputs=None)
+        sub.create_evaluation(
+            additional_inputs=None,
+            invoice=invoice,
+        )
 
     assert Evaluation.objects.count() == 1
 
@@ -254,7 +263,10 @@ def test_create_evaluation_uniqueness_checks(
     assert sub.phase.active_ground_truth == gt
 
     with django_capture_on_commit_callbacks(execute=True):
-        sub.create_evaluation(additional_inputs=None)
+        sub.create_evaluation(
+            additional_inputs=None,
+            invoice=invoice,
+        )
 
     assert Evaluation.objects.count() == 2
 
@@ -266,7 +278,10 @@ def test_create_evaluation_uniqueness_checks(
     assert sub.phase.active_image == m
 
     with django_capture_on_commit_callbacks(execute=True):
-        sub.create_evaluation(additional_inputs=None)
+        sub.create_evaluation(
+            additional_inputs=None,
+            invoice=invoice,
+        )
 
     assert Evaluation.objects.count() == 3
 
@@ -274,7 +289,10 @@ def test_create_evaluation_uniqueness_checks(
     sub.phase.save()
 
     with django_capture_on_commit_callbacks(execute=True):
-        sub.create_evaluation(additional_inputs=None)
+        sub.create_evaluation(
+            additional_inputs=None,
+            invoice=invoice,
+        )
 
     assert Evaluation.objects.count() == 4
 
@@ -282,7 +300,7 @@ def test_create_evaluation_uniqueness_checks(
     sub.phase.save()
 
     with django_capture_on_commit_callbacks(execute=True):
-        sub.create_evaluation(additional_inputs=None)
+        sub.create_evaluation(additional_inputs=None, invoice=invoice)
 
     assert Evaluation.objects.count() == 5
 
@@ -290,12 +308,12 @@ def test_create_evaluation_uniqueness_checks(
     sub.phase.save()
 
     with django_capture_on_commit_callbacks(execute=True):
-        sub.create_evaluation(additional_inputs=None)
+        sub.create_evaluation(additional_inputs=None, invoice=invoice)
 
     assert Evaluation.objects.count() == 6
 
     with django_capture_on_commit_callbacks(execute=True):
-        sub.create_evaluation(additional_inputs=None)
+        sub.create_evaluation(additional_inputs=None, invoice=invoice)
 
     assert Evaluation.objects.count() == 6
 
@@ -304,17 +322,41 @@ def test_create_evaluation_uniqueness_checks(
     ComponentInterfaceValueFactory(interface=ci, value="foo")
     with django_capture_on_commit_callbacks(execute=True):
         sub.create_evaluation(
-            additional_inputs=[CIVData(interface_slug=ci.slug, value="foo")]
+            additional_inputs=[CIVData(interface_slug=ci.slug, value="foo")],
+            invoice=invoice,
         )
 
     assert Evaluation.objects.count() == 7
 
     with django_capture_on_commit_callbacks(execute=True):
         sub.create_evaluation(
-            additional_inputs=[CIVData(interface_slug=ci.slug, value="foo")]
+            additional_inputs=[CIVData(interface_slug=ci.slug, value="foo")],
+            invoice=invoice,
         )
 
     assert Evaluation.objects.count() == 7
+
+
+@pytest.mark.django_db
+def test_create_evaluation_with_invoice(
+    django_capture_on_commit_callbacks, settings, algorithm_submission
+):
+    settings.LAMBDA_TASKS_EAGER = True
+
+    settings.CELERY_TASK_ALWAYS_EAGER = True
+    settings.CELERY_TASK_EAGER_PROPAGATES = True
+
+    s = SubmissionFactory(
+        phase=algorithm_submission.method.phase,
+        algorithm_image=algorithm_submission.algorithm_image,
+    )
+    i = InvoiceFactory.create_valid(challenge=s.phase.challenge)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        s.create_evaluation(additional_inputs=None, invoice=i)
+
+    evaluation = Evaluation.objects.get()
+    assert evaluation.evaluation_utilization.invoice == i
 
 
 @pytest.mark.django_db
@@ -322,11 +364,7 @@ class TestPhaseLimits:
     def setup_method(self):
         phase = PhaseFactory()
 
-        InvoiceFactory(
-            challenge=phase.challenge,
-            compute_costs_euros=10,
-            payment_type=PaymentTypeChoices.COMPLIMENTARY,
-        )
+        InvoiceFactory.create_valid(challenge=phase.challenge)
 
         # Fetch from the db to get the cost annotations
         self.phase = Phase.objects.get(pk=phase.pk)

--- a/app/tests/evaluation_tests/test_tasks.py
+++ b/app/tests/evaluation_tests/test_tasks.py
@@ -1086,7 +1086,7 @@ def test_create_algorithm_jobs_for_evaluation_invoice_workflow():
     archive = ArchiveFactory()
     submission = SubmissionFactory(phase__archive=archive, algorithm_image=ai)
     challenge = submission.phase.challenge
-    invoice = InvoiceFactory.create_valid(challenge=challenge)
+    invoice = InvoiceFactory(challenge=challenge)
     evaluation = EvaluationFactory(
         submission=submission,
         time_limit=ai.algorithm.time_limit,

--- a/app/tests/evaluation_tests/test_tasks.py
+++ b/app/tests/evaluation_tests/test_tasks.py
@@ -47,6 +47,7 @@ from tests.evaluation_tests.factories import (
     EvaluationFactory,
     MethodFactory,
     PhaseFactory,
+    SubmissionFactory,
 )
 from tests.factories import ChallengeFactory, UserFactory
 from tests.invoices_tests.factories import InvoiceFactory
@@ -1077,3 +1078,36 @@ def test_evaluation_order_without_title():
     expected_civ = civs[0]
 
     assert {*job.inputs.all()} == {expected_civ}
+
+
+@pytest.mark.django_db
+def test_create_algorithm_jobs_for_evaluation_invoice_workflow():
+    ai = AlgorithmImageFactory()
+    archive = ArchiveFactory()
+    submission = SubmissionFactory(phase__archive=archive, algorithm_image=ai)
+    challenge = submission.phase.challenge
+    invoice = InvoiceFactory.create_valid(challenge=challenge)
+    evaluation = EvaluationFactory(
+        submission=submission,
+        time_limit=ai.algorithm.time_limit,
+        status=Evaluation.PENDING,
+    )
+    evaluation.utilization.invoice = invoice
+    evaluation.utilization.save()
+    input_ci = ComponentInterfaceFactory(kind=InterfaceKindChoices.BOOL)
+    interface = AlgorithmInterfaceFactory(inputs=[input_ci])
+    ai.algorithm.interfaces.set([interface])
+
+    evaluation.submission.phase.algorithm_interfaces.set([interface])
+
+    archive_item = ArchiveItemFactory(archive=archive)
+    archive_item.values.add(ComponentInterfaceValueFactory(interface=input_ci))
+
+    create_algorithm_jobs_for_evaluation(
+        evaluation_pk=evaluation.pk, first_run=True
+    )
+
+    assert Job.objects.count() == 1, "Sanity: creates jobs"
+    job = Job.objects.get()
+    assert job.utilization.invoice == invoice
+    assert job.status == Job.PENDING

--- a/app/tests/evaluation_tests/test_views.py
+++ b/app/tests/evaluation_tests/test_views.py
@@ -2828,7 +2828,7 @@ def test_reschedule_evaluation_with_additional_inputs(
 
     user = UserFactory()
     phase.challenge.add_admin(user)
-    InvoiceFactory(
+    invoice = InvoiceFactory(
         challenge=phase.challenge,
         support_costs_euros=0,
         compute_costs_euros=10,
@@ -2892,6 +2892,7 @@ def test_reschedule_evaluation_with_additional_inputs(
     assert civ_bool not in eval2.inputs.all()
     assert eval2.inputs.get(interface=ci_str).value == "Bar"
     assert not eval2.inputs.get(interface=ci_bool).value
+    assert eval2.evaluation_utilization.invoice == invoice
 
     # mark eval2 as successful
     eval2.status = Evaluation.SUCCESS
@@ -2922,6 +2923,38 @@ def test_reschedule_evaluation_with_additional_inputs(
     assert response.status_code == 200
     assert (
         "A result for these inputs with the current method and ground truth already exists."
+        in str(response.content)
+    )
+    assert Evaluation.objects.count() == evaluation_count
+
+    # try rerunning without a valid invoice, that should fail
+    invoice.payment_status = PaymentStatusChoices.CANCELLED
+    invoice.save()
+
+    with django_capture_on_commit_callbacks(execute=True):
+        response = get_view_for_user(
+            viewname="evaluation:evaluation-create",
+            client=client,
+            method=client.post,
+            user=user,
+            reverse_kwargs={
+                "challenge_short_name": phase.challenge.short_name,
+                "slug": phase.slug,
+                "pk": submission.pk,
+            },
+            data={
+                **get_interface_form_data(
+                    interface_slug=ci_str.slug, data="FooBar"
+                ),
+                **get_interface_form_data(
+                    interface_slug=ci_bool.slug, data=False
+                ),
+            },
+        )
+
+    assert response.status_code == 200
+    assert (
+        "Challenge has insufficient budget. Please contact support to add more funds."
         in str(response.content)
     )
     assert Evaluation.objects.count() == evaluation_count
@@ -2960,7 +2993,7 @@ def test_create_evaluation_requires_matching_algorithm_interfaces(
 
     user = UserFactory()
     phase.challenge.add_admin(user)
-    InvoiceFactory(
+    invoice = InvoiceFactory(
         challenge=phase.challenge,
         support_costs_euros=0,
         compute_costs_euros=10,
@@ -2989,7 +3022,7 @@ def test_create_evaluation_requires_matching_algorithm_interfaces(
         time_limit=10,
     )
 
-    submission.create_evaluation(additional_inputs=None)
+    submission.create_evaluation(additional_inputs=None, invoice=invoice)
 
     eval = Evaluation.objects.order_by("created").last()
 
@@ -3033,7 +3066,7 @@ def test_create_evaluation_blocked_if_failed_jobs_exist(
 
     user = UserFactory()
     phase.challenge.add_admin(user)
-    InvoiceFactory(
+    invoice = InvoiceFactory(
         challenge=phase.challenge,
         support_costs_euros=0,
         compute_costs_euros=10,
@@ -3083,7 +3116,9 @@ def test_create_evaluation_blocked_if_failed_jobs_exist(
     ) as mocked_execute_eval:
         mocked_execute_eval.return_value = None
         with django_capture_on_commit_callbacks(execute=True):
-            submission.create_evaluation(additional_inputs=None)
+            submission.create_evaluation(
+                additional_inputs=None, invoice=invoice
+            )
 
     eval = Evaluation.objects.order_by("created").last()
     assert eval.status == status
@@ -3113,7 +3148,7 @@ def test_reschedule_evaluation_blocked_if_failed_jobs_with_complete_inputs_exist
 
     user = UserFactory()
     phase.challenge.add_admin(user)
-    InvoiceFactory(
+    invoice = InvoiceFactory(
         challenge=phase.challenge,
         support_costs_euros=0,
         compute_costs_euros=10,
@@ -3186,7 +3221,9 @@ def test_reschedule_evaluation_blocked_if_failed_jobs_with_complete_inputs_exist
     ) as mocked_execute_eval:
         mocked_execute_eval.return_value = None
         with django_capture_on_commit_callbacks(execute=True):
-            submission.create_evaluation(additional_inputs=None)
+            submission.create_evaluation(
+                additional_inputs=None, invoice=invoice
+            )
 
     eval = Evaluation.objects.order_by("created").last()
     assert eval.status == Evaluation.VALIDATING_INPUTS

--- a/app/tests/invoices_tests/factories.py
+++ b/app/tests/invoices_tests/factories.py
@@ -10,9 +10,10 @@ from tests.factories import ChallengeFactory
 class InvoiceFactory(factory.django.DjangoModelFactory):
     challenge = factory.SubFactory(ChallengeFactory)
     payment_type = Invoice.PaymentTypeChoices.PREPAID
-    support_costs_euros = 0
-    compute_costs_euros = 0
-    storage_costs_euros = 0
+    payment_status = Invoice.PaymentStatusChoices.PAID
+    support_costs_euros = 100
+    compute_costs_euros = 100
+    storage_costs_euros = 100
     issued_on = factory.Faker("past_date")
     paid_on = factory.Faker("past_date")
     internal_invoice_number = factory.Faker("numerify", text="#########")
@@ -29,20 +30,6 @@ class InvoiceFactory(factory.django.DjangoModelFactory):
             else None
         )
     )
-
-    @classmethod
-    def create_valid(cls, **kwargs):
-        if "support_costs_euros" not in kwargs:
-            kwargs["support_costs_euros"] = 100
-        if "compute_costs_euros" not in kwargs:
-            kwargs["compute_costs_euros"] = 100
-        if "storage_costs_euros" not in kwargs:
-            kwargs["storage_costs_euros"] = 100
-        if "payment_type" not in kwargs:
-            kwargs["payment_type"] = Invoice.PaymentTypeChoices.PREPAID
-        if "payment_status" not in kwargs:
-            kwargs["payment_status"] = Invoice.PaymentStatusChoices.PAID
-        return cls.create(**kwargs)
 
     class Meta:
         model = Invoice

--- a/app/tests/invoices_tests/factories.py
+++ b/app/tests/invoices_tests/factories.py
@@ -30,5 +30,19 @@ class InvoiceFactory(factory.django.DjangoModelFactory):
         )
     )
 
+    @classmethod
+    def create_valid(cls, **kwargs):
+        if "support_costs_euros" not in kwargs:
+            kwargs["support_costs_euros"] = 100
+        if "compute_costs_euros" not in kwargs:
+            kwargs["compute_costs_euros"] = 100
+        if "storage_costs_euros" not in kwargs:
+            kwargs["storage_costs_euros"] = 100
+        if "payment_type" not in kwargs:
+            kwargs["payment_type"] = Invoice.PaymentTypeChoices.PREPAID
+        if "payment_status" not in kwargs:
+            kwargs["payment_status"] = Invoice.PaymentStatusChoices.PAID
+        return cls.create(**kwargs)
+
     class Meta:
         model = Invoice


### PR DESCRIPTION
Related to pitch:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/475#issuecomment-4175366634

Largely a re-do of: https://github.com/DIAGNijmegen/rse-roadmap/issues/475

With the exception that the base is way different and that we ignore any negative balances on other invoices in the challenge.

In short: this change set adds an `Challenge.active_invoice` which is used via `Submission.create_evaluation` to have it assigned to the `EvaluationUtilization` and subsequently all related jobs.

Note: this involves quite some tests suddenly needing a valid invoice.