### PR TITLE
Run lambda tasks in background for the development server

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -981,6 +981,9 @@ else:
 LAMBDA_TASKS_QUEUES = {
     "default": os.environ.get("LAMBDA_TASKS_DEFAULT_QUEUE_URL"),
 }
+LAMBDA_TASKS_LOCAL_WORKERS = int(
+    os.environ.get("LAMBDA_TASKS_LOCAL_WORKERS", "0")
+)
 
 COMPONENTS_DEFAULT_BACKEND = os.environ.get(
     "COMPONENTS_DEFAULT_BACKEND",
@@ -1476,3 +1479,8 @@ if DEBUG:
             "SHOW_TOOLBAR_CALLBACK": "config.toolbar_callback",
             "RESULTS_CACHE_SIZE": 100,
         }
+else:
+    if LAMBDA_TASKS_LOCAL_WORKERS:
+        raise ImproperlyConfigured(
+            "LAMBDA_TASKS_LOCAL_WORKERS should only be set in development"
+        )

--- a/app/tests/settings.py
+++ b/app/tests/settings.py
@@ -30,6 +30,9 @@ ROOT_URLCONF = "tests.urls.root"
 CELERY_BROKER = "memory"
 CELERY_BROKER_URL = "memory://"
 
+# Never use local workers in tests, use eager mode per-test if necessary
+LAMBDA_TASKS_LOCAL_WORKERS = 0
+
 # Disable image resizing
 PICTURES["PROCESSOR"] = "pictures.tasks.noop"  # noqa 405
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ x-django-env: &django-env
     COMPONENTS_REGISTRY_INSECURE: "true"
     COMPONENTS_DEFAULT_BACKEND: "tests.components_tests.resources.backends.IOCopyExecutor"
     CSP_REPORT_ONLY: "true"
+    LAMBDA_TASKS_LOCAL_WORKERS: 2
 
 services:
     postgres:

--- a/uv.lock
+++ b/uv.lock
@@ -919,7 +919,7 @@ wheels = [
 
 [[package]]
 name = "django-lambda-tasks"
-version = "0.4.8"
+version = "0.4.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "awslambdaric" },
@@ -928,9 +928,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "redis" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/d9/b5e5b72afd8b599a719c029fd6f2c888dabd16c470f5ab2a8ee9d927bf5f/django_lambda_tasks-0.4.8.tar.gz", hash = "sha256:66e206c0e0ca863048a686474ad04f8f384e1ffc3b28f207095c402057c65e82", size = 154460, upload-time = "2026-06-03T10:28:33.028Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/7a/8147ca6bb01a93c49b4ebd871951341cdee5d94471a34e26f83987342cf8/django_lambda_tasks-0.4.9.tar.gz", hash = "sha256:1c9136dda86fcc4712a7820cbbff3b0abab9999ca886902cbea7478cb063009e", size = 158114, upload-time = "2026-06-03T12:40:08.525Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/a2/d080af7b9326af9143b9458a5dac86b65ad8e69f4f0e83fbe7e7c7e5e577/django_lambda_tasks-0.4.8-py3-none-any.whl", hash = "sha256:cfa9660d62d7cfc3b4001a0bf3de26a78e0a8b24c7a5be79414f726002cc38e3", size = 31578, upload-time = "2026-06-03T10:28:31.964Z" },
+    { url = "https://files.pythonhosted.org/packages/80/77/6353e9ae6cce3094ab077205e4dc61b740087ce8f441f888bd2863dec8e4/django_lambda_tasks-0.4.9-py3-none-any.whl", hash = "sha256:dc4db85130ef4976b5d6c084a8c361ee51f2609231d4b22036695461091960d4", size = 33033, upload-time = "2026-06-03T12:40:07.2Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -919,7 +919,7 @@ wheels = [
 
 [[package]]
 name = "django-lambda-tasks"
-version = "0.4.5"
+version = "0.4.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "awslambdaric" },
@@ -928,9 +928,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "redis" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/5d/a0bf3ec63f6442fb57300bcf8037541db0c363d21a55ade842da31751ffd/django_lambda_tasks-0.4.5.tar.gz", hash = "sha256:b4ed70a89a4db10e321f1b9994559926fccb38152898ce4e7ce5290e4b88b250", size = 154101, upload-time = "2026-06-03T09:14:14.782Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/d9/b5e5b72afd8b599a719c029fd6f2c888dabd16c470f5ab2a8ee9d927bf5f/django_lambda_tasks-0.4.8.tar.gz", hash = "sha256:66e206c0e0ca863048a686474ad04f8f384e1ffc3b28f207095c402057c65e82", size = 154460, upload-time = "2026-06-03T10:28:33.028Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/7f/a52e510df9a322a13ffd8a12f688f596ab8ea2c7cb3a7801e4d5bd1cf1c8/django_lambda_tasks-0.4.5-py3-none-any.whl", hash = "sha256:23dcd3c05e567fbadb96a5c3f1166683d55af8a5563ac88e14aa3e3e458b6aa6", size = 31349, upload-time = "2026-06-03T09:14:13.468Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a2/d080af7b9326af9143b9458a5dac86b65ad8e69f4f0e83fbe7e7c7e5e577/django_lambda_tasks-0.4.8-py3-none-any.whl", hash = "sha256:cfa9660d62d7cfc3b4001a0bf3de26a78e0a8b24c7a5be79414f726002cc38e3", size = 31578, upload-time = "2026-06-03T10:28:31.964Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Users who run without Docker will need to set LAMBDA_TASKS_LOCAL_WORKERS in their environment.

See #4408