### PR TITLE
Split consumed and write_off budget

### DIFF
--- a/app/grandchallenge/challenges/admin.py
+++ b/app/grandchallenge/challenges/admin.py
@@ -59,7 +59,12 @@ class ChallengeAdmin(ModelAdmin):
     search_fields = ("short_name",)
 
     def get_queryset(self, *args, **kwargs):
-        return super().get_queryset(*args, **kwargs).with_available_compute()
+        return (
+            super()
+            .get_queryset(*args, **kwargs)
+            .with_available_compute()
+            .with_invoices_with_budget_authorization()
+        )
 
     def available_compute_euros(self, obj):
         return millicents_to_euro(obj.available_compute_euro_millicents)

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -154,14 +154,6 @@ class ChallengeQuerySet(models.QuerySet):
             ),
         )
 
-    def with_invoices_with_budget_authorization(self):
-        return self.prefetch_related(
-            Prefetch(
-                "invoices",
-                queryset=Invoice.objects.with_budget_authorization(),
-            )
-        )
-
     def with_user_roles(self, *, user):
         User = get_user_model()  # noqa: N806
         return self.annotate(
@@ -177,6 +169,16 @@ class ChallengeQuerySet(models.QuerySet):
                     pk=user.pk,
                 )
             ),
+        )
+
+    def with_only_active_invoices(self):
+        return self.prefetch_related(
+            Prefetch(
+                "invoices",
+                queryset=Invoice.objects.with_budget_authorization().filter(
+                    is_budget_authorized=True, expires_on__gt=now().date()
+                ),
+            )
         )
 
 
@@ -842,35 +844,31 @@ class Challenge(ChallengeBase, FieldChangeMixin):
         )
 
     @cached_property
-    def active_invoices(self):
-        return self.invoices.with_is_active().filter(is_active=True)
-
-    @cached_property
     def approved_compute_cost_euro_millicents(self):
         return sum(
             invoice.approved_compute_cost_euro_millicents
-            for invoice in self.active_invoices
+            for invoice in self.invoices.all()
         )
 
     @cached_property
     def available_compute_cost_euro_millicents(self):
         return sum(
             invoice.available_compute_cost_euro_millicents
-            for invoice in self.active_invoices
+            for invoice in self.invoices.all()
         )
 
     @cached_property
     def consumed_compute_cost_euro_millicents(self):
         return sum(
             invoice.consumed_compute_cost_euro_millicents
-            for invoice in self.active_invoices
+            for invoice in self.invoices.all()
         )
 
     @cached_property
     def write_off_compute_cost_euro_millicents(self):
         return sum(
             invoice.write_off_compute_cost_euro_millicents
-            for invoice in self.active_invoices
+            for invoice in self.invoices.all()
         )
 
     @cached_property
@@ -889,7 +887,7 @@ class Challenge(ChallengeBase, FieldChangeMixin):
 
     @property
     def active_invoice(self):
-        for invoice in self.active_invoices.order_by("expires_on", "created"):
+        for invoice in self.invoices.order_by("expires_on", "created"):
             if invoice.available_compute_cost_euro_millicents > 0:
                 return invoice
         raise InsufficientBudgetError

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -835,7 +835,7 @@ class Challenge(ChallengeBase, FieldChangeMixin):
 
     @cached_property
     def should_be_open_but_is_over_budget(self):
-        return self.available_compute_euro_millicents <= 0 and any(
+        return self.available_compute_cost_euro_millicents <= 0 and any(
             phase.submission_period_is_open_now
             and phase.submissions_limit_per_user_per_period > 0
             for phase in self.phase_set.all()
@@ -843,41 +843,49 @@ class Challenge(ChallengeBase, FieldChangeMixin):
 
     @cached_property
     def percent_budget_consumed(self):
-        if self.approved_compute_costs_euro_millicents:
+        if self.approved_compute_cost_euro_millicents:
             return int(
                 100
-                * self.compute_cost_euro_millicents
-                / self.approved_compute_costs_euro_millicents
+                * self.available_compute_cost_euro_millicents
+                / self.approved_compute_cost_euro_millicents
             )
         else:
             return None
 
     @cached_property
-    def available_compute_euro_millicents_via_invoices(self):
+    def approved_compute_cost_euro_millicents(self):
+        total_compute_costs_euros = (
+            self.invoices.with_is_active()
+            .filter(is_active=True)
+            .aggregate(
+                total=Sum(
+                    "compute_costs_euros",
+                    output_field=models.PositiveBigIntegerField(),
+                )
+            )["total"]
+        )
+
+        return (total_compute_costs_euros or 0) * 1000 * 100
+
+    @cached_property
+    def available_compute_cost_euro_millicents(self):
         return sum(
-            invoice.available_compute_cost_euro_millicents
-            for invoice in self.get_available_invoices()
+            max(invoice.available_compute_cost_euro_millicents, 0)
+            for invoice in self.invoices.with_is_active().filter(
+                is_active=True
+            )
         )
 
     @property
     def active_invoice(self):
-        available_invoices = self.get_available_invoices()
-        if available_invoices:
-            return available_invoices[0]
-        else:
-            raise InsufficientBudgetError
-
-    def get_available_invoices(self):
-        invoices = (
-            self.invoices.with_budget_authorization()
+        for invoice in (
+            self.invoices.with_is_active()
+            .filter(is_active=True)
             .order_by("expires_on", "created")
-            .all()
-        )
-        return [
-            invoice
-            for invoice in invoices
-            if invoice.available_compute_cost_euro_millicents > 0
-        ]
+        ):
+            if invoice.available_compute_cost_euro_millicents > 0:
+                return invoice
+        raise InsufficientBudgetError
 
     def send_alert_if_budget_consumed_warning_threshold_exceeded(self):
         for percent_threshold in sorted(
@@ -885,7 +893,7 @@ class Challenge(ChallengeBase, FieldChangeMixin):
         ):
             previous_cost = self.initial_value("compute_cost_euro_millicents")
             threshold = (
-                self.approved_compute_costs_euro_millicents
+                self.approved_compute_cost_euro_millicents
                 * percent_threshold
                 / 100
             )

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -842,47 +842,54 @@ class Challenge(ChallengeBase, FieldChangeMixin):
         )
 
     @cached_property
+    def active_invoices(self):
+        return self.invoices.with_is_active().filter(is_active=True)
+
+    @cached_property
+    def approved_compute_cost_euro_millicents(self):
+        return sum(
+            invoice.approved_compute_cost_euro_millicents
+            for invoice in self.active_invoices
+        )
+
+    @cached_property
+    def available_compute_cost_euro_millicents(self):
+        return sum(
+            invoice.available_compute_cost_euro_millicents
+            for invoice in self.active_invoices
+        )
+
+    @cached_property
+    def consumed_compute_cost_euro_millicents(self):
+        return sum(
+            invoice.consumed_compute_cost_euro_millicents
+            for invoice in self.active_invoices
+        )
+
+    @cached_property
+    def write_off_compute_cost_euro_millicents(self):
+        return sum(
+            invoice.write_off_compute_cost_euro_millicents
+            for invoice in self.active_invoices
+        )
+
+    @cached_property
     def percent_budget_consumed(self):
-        if self.approved_compute_cost_euro_millicents:
+        if self.approved_compute_cost_euro_millicents > 0:
             return int(
                 100
-                * self.available_compute_cost_euro_millicents
+                * (
+                    self.consumed_compute_cost_euro_millicents
+                    + self.write_off_compute_cost_euro_millicents
+                )
                 / self.approved_compute_cost_euro_millicents
             )
         else:
             return None
 
-    @cached_property
-    def approved_compute_cost_euro_millicents(self):
-        total_compute_costs_euros = (
-            self.invoices.with_is_active()
-            .filter(is_active=True)
-            .aggregate(
-                total=Sum(
-                    "compute_costs_euros",
-                    output_field=models.PositiveBigIntegerField(),
-                )
-            )["total"]
-        )
-
-        return (total_compute_costs_euros or 0) * 1000 * 100
-
-    @cached_property
-    def available_compute_cost_euro_millicents(self):
-        return sum(
-            max(invoice.available_compute_cost_euro_millicents, 0)
-            for invoice in self.invoices.with_is_active().filter(
-                is_active=True
-            )
-        )
-
     @property
     def active_invoice(self):
-        for invoice in (
-            self.invoices.with_is_active()
-            .filter(is_active=True)
-            .order_by("expires_on", "created")
-        ):
+        for invoice in self.active_invoices.order_by("expires_on", "created"):
             if invoice.available_compute_cost_euro_millicents > 0:
                 return invoice
         raise InsufficientBudgetError

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -171,13 +171,11 @@ class ChallengeQuerySet(models.QuerySet):
             ),
         )
 
-    def with_only_active_invoices(self):
+    def with_invoices_with_budget_authorization(self):
         return self.prefetch_related(
             Prefetch(
                 "invoices",
-                queryset=Invoice.objects.with_budget_authorization().filter(
-                    is_budget_authorized=True, expires_on__gt=now().date()
-                ),
+                queryset=Invoice.objects.with_budget_authorization(),
             )
         )
 
@@ -872,22 +870,29 @@ class Challenge(ChallengeBase, FieldChangeMixin):
         )
 
     @cached_property
-    def percent_budget_consumed(self):
-        if self.approved_compute_cost_euro_millicents > 0:
-            return int(
-                100
-                * (
-                    self.consumed_compute_cost_euro_millicents
-                    + self.write_off_compute_cost_euro_millicents
-                )
-                / self.approved_compute_cost_euro_millicents
-            )
+    def percent_active_budget_consumed(self):
+        active_invoices = [
+            invoice
+            for invoice in self.invoices.all()
+            if not invoice.is_expired
+        ]
+
+        consumed = sum(
+            invoice.consumed_compute_cost_euro_millicents
+            for invoice in active_invoices
+        )
+        approved = sum(
+            invoice.approved_compute_cost_euro_millicents
+            for invoice in active_invoices
+        )
+        if approved > 0:
+            return int(100 * consumed / approved)
         else:
             return None
 
     @property
     def active_invoice(self):
-        for invoice in self.invoices.order_by("expires_on", "created"):
+        for invoice in self.invoices.order_by("expires_on", "created").all():
             if invoice.available_compute_cost_euro_millicents > 0:
                 return invoice
         raise InsufficientBudgetError

--- a/app/grandchallenge/challenges/tasks.py
+++ b/app/grandchallenge/challenges/tasks.py
@@ -105,8 +105,10 @@ def retry_with_backoff(exceptions, max_attempts=5, base_delay=1, max_delay=10):
 @acks_late_2xlarge_task
 def update_challenge_compute_costs():
     # TODO: remove the loop and do this live once the challenge.compute_cost_euro_millicents field is removed or deprecated
-    for challenge in Challenge.objects.with_available_compute().iterator(
-        chunk_size=1000
+    for challenge in (
+        Challenge.objects.with_available_compute()
+        .with_invoices_with_budget_authorization()
+        .iterator(chunk_size=1000)
     ):
         with transaction.atomic():
             annotate_challenge_compute_costs(challenge=challenge)

--- a/app/grandchallenge/challenges/templates/challenges/challenge_costs_overview.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_costs_overview.html
@@ -14,12 +14,12 @@
                 href="{% url 'challenges:list' %}">Challenges</a>
         </li>
         <li class="breadcrumb-item active"
-            aria-current="page">Cost Overview</li>
+            aria-current="page">Active Cost Overview</li>
     </ol>
 {% endblock %}
 
 {% block content %}
-    <h3 class="mb-3">Challenge Cost Overview</h3>
+    <h3 class="mb-3">Challenge Active Cost Overview</h3>
 
     <div class="table-responsive">
         <table
@@ -35,11 +35,11 @@
                     <th>Status</th>
                     <th>Should be Open</th>
                     <th>Most Recent Submission</th>
-                    <th>Percentage Budget Consumed</th>
-                    <th>Approved Compute Costs</th>
-                    <th>Total Compute Costs Incurred</th>
+                    <th>% Active Budget Consumed</th>
                     <th>Available Compute Costs</th>
-                     <th>Available Compute Costs (via Invoices)</th>
+                    <th>Total Approved Compute Costs</th>
+                    <th>Total Consumed Compute Costs </th>
+                    <th>Total Write-Off Compute Costs</th>
                     <th>Object Storage Costs per Year</th>
                     <th>Registry Storage Costs per Year</th>
                 </tr>
@@ -53,11 +53,11 @@
                         </td>
                         <td>{% if challenge.should_be_open_but_is_over_budget %}<i class="fa fa-exclamation-triangle text-danger"></i>{% endif %}</td>
                         <td data-order="{% if challenge.cached_latest_result %}{{ challenge.cached_latest_result|date:"c" }}{% else %}-1{% endif %}">{% if challenge.cached_latest_result %}{{ challenge.cached_latest_result|date }}{% endif %}</td>
-                        <td data-order="{% if challenge.percent_budget_consumed is None %}-1{% else %}{{ challenge.percent_budget_consumed }}{% endif %}" class="{% if challenge.percent_budget_consumed >= 100 %}text-danger{% elif challenge.percent_budget_consumed >= 70 %}text-warning{% else %}text-success{% endif %}">{% if challenge.percent_budget_consumed is not None %}{{ challenge.percent_budget_consumed }}&nbsp;%{% endif %}</td>
+                        <td data-order="{% if challenge.percent_active_budget_consumed is None %}-1{% else %}{{ challenge.percent_active_budget_consumed }}{% endif %}" class="{% if challenge.percent_active_budget_consumed >= 100 %}text-danger{% elif challenge.percent_active_budget_consumed >= 70 %}text-warning{% else %}text-success{% endif %}">{% if challenge.percent_active_budget_consumed is not None %}{{ challenge.percent_active_budget_consumed }}&nbsp;%{% endif %}</td>
+                        <td class="{% if challenge.available_compute_cost_euro_millicents <= 0 %}text-danger{% endif %}">{{ challenge.available_compute_cost_euro_millicents|millicents_to_euro }}</td>
                         <td>{{ challenge.approved_compute_costs_euro_millicents|millicents_to_euro }}</td>
-                        <td>{{ challenge.compute_cost_euro_millicents|millicents_to_euro }}</td>
-                        <td class="{% if challenge.available_compute_euro_millicents <= 0 %}text-danger{% endif %}">{{ challenge.available_compute_euro_millicents|millicents_to_euro }}</td>
-                        <td>{{ challenge.available_compute_euro_millicents_via_invoices|millicents_to_euro }}</td>
+                        <td>{{ challenge.consumed_compute_cost_euro_millicents|millicents_to_euro }}</td>
+                        <td class="{% if challenge.write_off_compute_cost_euro_millicents > 0 %}text-danger{% endif %}">{{ challenge.write_off_compute_cost_euro_millicents|millicents_to_euro }}</td>
                         <td>{{ challenge.size_in_storage|storage_bytes_to_euro_per_year }}</td>
                         <td>{{ challenge.size_in_registry|registry_bytes_to_euro_per_year }}</td>
                     </tr>

--- a/app/grandchallenge/challenges/templates/challenges/challenge_costs_overview.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_costs_overview.html
@@ -54,12 +54,12 @@
                         <td>{% if challenge.should_be_open_but_is_over_budget %}<i class="fa fa-exclamation-triangle text-danger"></i>{% endif %}</td>
                         <td data-order="{% if challenge.cached_latest_result %}{{ challenge.cached_latest_result|date:"c" }}{% else %}-1{% endif %}">{% if challenge.cached_latest_result %}{{ challenge.cached_latest_result|date }}{% endif %}</td>
                         <td data-order="{% if challenge.percent_active_budget_consumed is None %}-1{% else %}{{ challenge.percent_active_budget_consumed }}{% endif %}" class="{% if challenge.percent_active_budget_consumed >= 100 %}text-danger{% elif challenge.percent_active_budget_consumed >= 70 %}text-warning{% else %}text-success{% endif %}">{% if challenge.percent_active_budget_consumed is not None %}{{ challenge.percent_active_budget_consumed }}&nbsp;%{% endif %}</td>
-                        <td class="{% if challenge.available_compute_cost_euro_millicents <= 0 %}text-danger{% endif %}">{{ challenge.available_compute_cost_euro_millicents|millicents_to_euro }}</td>
-                        <td>{{ challenge.approved_compute_costs_euro_millicents|millicents_to_euro }}</td>
-                        <td>{{ challenge.consumed_compute_cost_euro_millicents|millicents_to_euro }}</td>
-                        <td class="{% if challenge.write_off_compute_cost_euro_millicents > 0 %}text-danger{% endif %}">{{ challenge.write_off_compute_cost_euro_millicents|millicents_to_euro }}</td>
-                        <td>{{ challenge.size_in_storage|storage_bytes_to_euro_per_year }}</td>
-                        <td>{{ challenge.size_in_registry|registry_bytes_to_euro_per_year }}</td>
+                        <td data-order="{{ challenge.available_compute_cost_euro_millicents}}" class="{% if challenge.available_compute_cost_euro_millicents <= 0 %}text-danger{% endif %}">{{ challenge.available_compute_cost_euro_millicents|millicents_to_euro }}</td>
+                        <td data-order="{{ challenge.approved_compute_costs_euro_millicents }}">{{ challenge.approved_compute_costs_euro_millicents|millicents_to_euro }}</td>
+                        <td data-order="{{ challenge.consumed_compute_cost_euro_millicents }}">{{ challenge.consumed_compute_cost_euro_millicents|millicents_to_euro }}</td>
+                        <td data-order="{{ challenge.write_off_compute_cost_euro_millicents }}" class="{% if challenge.write_off_compute_cost_euro_millicents > 0 %}text-danger{% endif %}">{{ challenge.write_off_compute_cost_euro_millicents|millicents_to_euro }}</td>
+                        <td data-order="{{ challenge.size_in_storage }}">{{ challenge.size_in_storage|storage_bytes_to_euro_per_year }}</td>
+                        <td data-order="{{ challenge.size_in_registry }}">{{ challenge.size_in_registry|registry_bytes_to_euro_per_year }}</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/app/grandchallenge/challenges/templates/challenges/challenge_costs_overview.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_costs_overview.html
@@ -38,7 +38,7 @@
                     <th>
                         % Active Budget Consumed
                         <span data-toggle="tooltip" data-placement="right"
-                              title="Consumed costs as a percentage of the approved costs of the currently active invoices."
+                              title="Consumed costs as a percentage of the approved costs of the currently active (i.e., non-expired) invoices."
                               class="text-muted">
                             <i class="fas fa-question-circle"></i>
                         </span>
@@ -46,7 +46,7 @@
                     <th>
                         Available Compute Costs
                         <span data-toggle="tooltip" data-placement="right"
-                              title="Approved budget minus consumed costs of currently active invoices."
+                              title="Total approved budget - total consumed costs of currently active invoices."
                               class="text-muted">
                             <i class="fas fa-question-circle"></i>
                         </span>
@@ -54,7 +54,7 @@
                     <th>
                         Total Approved Compute Costs
                         <span data-toggle="tooltip" data-placement="right"
-                              title="Sum of  approved compute budget in all the invoices."
+                              title="Sum of approved compute budget of all invoices."
                               class="text-muted">
                             <i class="fas fa-question-circle"></i>
                         </span>
@@ -62,7 +62,7 @@
                     <th>
                         Total Consumed Compute Costs
                         <span data-toggle="tooltip" data-placement="right"
-                              title="Total compute costs billed against all the invoices."
+                              title="Total compute costs billed against all the invoices, capped at total approved."
                               class="text-muted">
                             <i class="fas fa-question-circle"></i>
                         </span>

--- a/app/grandchallenge/challenges/templates/challenges/challenge_costs_overview.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_costs_overview.html
@@ -38,7 +38,7 @@
                     <th>% Active Budget Consumed</th>
                     <th>Available Compute Costs</th>
                     <th>Total Approved Compute Costs</th>
-                    <th>Total Consumed Compute Costs </th>
+                    <th>Total Consumed Compute Costs</th>
                     <th>Total Write-Off Compute Costs</th>
                     <th>Object Storage Costs per Year</th>
                     <th>Registry Storage Costs per Year</th>

--- a/app/grandchallenge/challenges/templates/challenges/challenge_costs_overview.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_costs_overview.html
@@ -14,12 +14,12 @@
                 href="{% url 'challenges:list' %}">Challenges</a>
         </li>
         <li class="breadcrumb-item active"
-            aria-current="page">Active Cost Overview</li>
+            aria-current="page">Cost Overview</li>
     </ol>
 {% endblock %}
 
 {% block content %}
-    <h3 class="mb-3">Challenge Active Cost Overview</h3>
+    <h3 class="mb-3">Challenge Cost Overview</h3>
 
     <div class="table-responsive">
         <table

--- a/app/grandchallenge/challenges/templates/challenges/challenge_costs_overview.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_costs_overview.html
@@ -35,13 +35,62 @@
                     <th>Status</th>
                     <th>Should be Open</th>
                     <th>Most Recent Submission</th>
-                    <th>% Active Budget Consumed</th>
-                    <th>Available Compute Costs</th>
-                    <th>Total Approved Compute Costs</th>
-                    <th>Total Consumed Compute Costs</th>
-                    <th>Total Write-Off Compute Costs</th>
-                    <th>Object Storage Costs per Year</th>
-                    <th>Registry Storage Costs per Year</th>
+                    <th>
+                        % Active Budget Consumed
+                        <span data-toggle="tooltip" data-placement="right"
+                              title="Consumed costs as a percentage of the approved costs of the currently active invoices."
+                              class="text-muted">
+                            <i class="fas fa-question-circle"></i>
+                        </span>
+                    </th>
+                    <th>
+                        Available Compute Costs
+                        <span data-toggle="tooltip" data-placement="right"
+                              title="Approved budget minus consumed costs of currently active invoices."
+                              class="text-muted">
+                            <i class="fas fa-question-circle"></i>
+                        </span>
+                    </th>
+                    <th>
+                        Total Approved Compute Costs
+                        <span data-toggle="tooltip" data-placement="right"
+                              title="Sum of  approved compute budget in all the invoices."
+                              class="text-muted">
+                            <i class="fas fa-question-circle"></i>
+                        </span>
+                    </th>
+                    <th>
+                        Total Consumed Compute Costs
+                        <span data-toggle="tooltip" data-placement="right"
+                              title="Total compute costs billed against all the invoices."
+                              class="text-muted">
+                            <i class="fas fa-question-circle"></i>
+                        </span>
+                    </th>
+                    <th>
+                        Total Write-Off Compute Costs
+                        <span data-toggle="tooltip" data-placement="right"
+                              title="Costs written off and not charged to any budget."
+                              class="text-muted">
+                            <i class="fas fa-question-circle"></i>
+                        </span>
+                    </th>
+                    <th>
+                        Object Storage Costs per Year
+                        <span data-toggle="tooltip" data-placement="right"
+                              title="Estimated annual cost for storing challenge data in object storage."
+                              class="text-muted">
+                            <i class="fas fa-question-circle"></i>
+                        </span>
+                    </th>
+                    <th>
+                        Registry Storage Costs per Year
+                        <span data-toggle="tooltip" data-placement="right"
+                              title="Estimated annual cost for storing container images in the registry."
+                              class="text-muted">
+                            <i class="fas fa-question-circle"></i>
+                        </span>
+                    </th>
                 </tr>
             </thead>
             <tbody>
@@ -65,4 +114,9 @@
             </tbody>
         </table>
     </div>
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    <script type="text/javascript" src="{% static "js/tooltips.js" %}"></script>
 {% endblock %}

--- a/app/grandchallenge/challenges/views.py
+++ b/app/grandchallenge/challenges/views.py
@@ -393,7 +393,7 @@ class ChallengeCostOverview(
             super()
             .get_queryset()
             .with_available_compute()
-            .with_invoices_with_budget_authorization()
+            .with_only_active_invoices()
             .prefetch_related("phase_set")
         )
 

--- a/app/grandchallenge/challenges/views.py
+++ b/app/grandchallenge/challenges/views.py
@@ -393,7 +393,7 @@ class ChallengeCostOverview(
             super()
             .get_queryset()
             .with_available_compute()
-            .with_only_active_invoices()
+            .with_invoices_with_budget_authorization()
             .prefetch_related("phase_set")
         )
 

--- a/app/grandchallenge/evaluation/admin.py
+++ b/app/grandchallenge/evaluation/admin.py
@@ -4,6 +4,7 @@ from django.forms import ModelForm
 from django.utils.html import format_html
 
 from grandchallenge.challenges.exceptions import InsufficientBudgetError
+from grandchallenge.challenges.models import Challenge
 from grandchallenge.components.admin import (
     ComponentImageAdmin,
     cancel_jobs,
@@ -170,8 +171,11 @@ def reevaluate_submissions(modeladmin, request, queryset):
                 messages.WARNING,
             )
         else:
+            challenge = Challenge.objects.with_invoices_with_budget_authorization().get(
+                pk=submission.phase.challenge.pk
+            )
             try:
-                invoice = submission.phase.challenge.active_invoice
+                invoice = challenge.active_invoice
             except InsufficientBudgetError:
                 modeladmin.message_user(
                     request,

--- a/app/grandchallenge/evaluation/forms.py
+++ b/app/grandchallenge/evaluation/forms.py
@@ -24,6 +24,7 @@ from django.utils.text import format_lazy
 from grandchallenge.algorithms.forms import UserAlgorithmsForPhaseMixin
 from grandchallenge.algorithms.models import Job
 from grandchallenge.challenges.exceptions import InsufficientBudgetError
+from grandchallenge.challenges.models import Challenge
 from grandchallenge.components.forms import (
     AdditionalInputsMixin,
     ContainerImageForm,
@@ -750,8 +751,14 @@ class EvaluationForm(SaveFormInitMixin, AdditionalInputsMixin, forms.Form):
                     "Please wait for the other evaluation to complete."
                 )
 
+        challenge = (
+            Challenge.objects.with_invoices_with_budget_authorization().get(
+                pk=cleaned_data["submission"].phase.challenge.pk
+            )
+        )
+
         try:
-            invoice = cleaned_data["submission"].phase.challenge.active_invoice
+            invoice = challenge.active_invoice
         except InsufficientBudgetError:
             raise ValidationError(
                 "Challenge has insufficient budget. Please contact support to add more funds."

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -237,7 +237,7 @@ class PhaseManager(models.Manager):
                 # to use a custom model manager with select_related
                 models.Prefetch(
                     "challenge",
-                    queryset=Challenge.objects.with_available_compute(),
+                    queryset=Challenge.objects.with_available_compute().with_invoices_with_budget_authorization(),
                 )
             )
         )

--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -1110,7 +1110,7 @@ class Phase(FieldChangeMixin, HangingProtocolMixin, UUIDModel):
             self.public
             and self.submission_period_is_open_now
             and self.submissions_limit_per_user_per_period > 0
-            and self.challenge.available_compute_euro_millicents > 0
+            and self.challenge.available_compute_cost_euro_millicents > 0
         )
 
     @property

--- a/app/grandchallenge/invoices/models.py
+++ b/app/grandchallenge/invoices/models.py
@@ -405,6 +405,20 @@ class Invoice(models.Model, FieldChangeMixin):
         )
         return abs(min(balance, 0))
 
+    @cached_property
+    def percent_budget_consumed(self):
+        if self.approved_compute_cost_euro_millicents > 0:
+            return int(
+                100
+                * (
+                    self.consumed_compute_cost_euro_millicents
+                    + self.write_off_compute_cost_euro_millicents
+                )
+                / self.approved_compute_cost_euro_millicents
+            )
+        else:
+            return None
+
     def clean(self):
         if (
             not self._state.adding

--- a/app/grandchallenge/invoices/models.py
+++ b/app/grandchallenge/invoices/models.py
@@ -47,17 +47,6 @@ class InvoiceQuerySet(models.QuerySet):
             ),
         )
 
-    def with_is_active(self):
-        return self.with_budget_authorization().annotate(
-            is_active=ExpressionWrapper(
-                Q(is_budget_authorized=True)
-                & Q(
-                    expires_on__gt=now().date(),
-                ),
-                output_field=models.BooleanField(),
-            )
-        )
-
     def with_overdue_status(self):
         today = now().date()
 

--- a/app/grandchallenge/invoices/models.py
+++ b/app/grandchallenge/invoices/models.py
@@ -47,6 +47,17 @@ class InvoiceQuerySet(models.QuerySet):
             ),
         )
 
+    def with_is_active(self):
+        return self.with_budget_authorization().annotate(
+            is_active=ExpressionWrapper(
+                Q(is_budget_authorized=True)
+                & Q(
+                    expires_on__gt=now().date(),
+                ),
+                output_field=models.BooleanField(),
+            )
+        )
+
     def with_overdue_status(self):
         today = now().date()
 

--- a/app/grandchallenge/invoices/models.py
+++ b/app/grandchallenge/invoices/models.py
@@ -395,7 +395,7 @@ class Invoice(models.Model, FieldChangeMixin):
         return abs(min(balance, 0))
 
     @cached_property
-    def percent_active_budget_consumed(self):
+    def percent_budget_consumed(self):
         if self.approved_compute_cost_euro_millicents > 0:
             return int(
                 100

--- a/app/grandchallenge/invoices/models.py
+++ b/app/grandchallenge/invoices/models.py
@@ -395,14 +395,11 @@ class Invoice(models.Model, FieldChangeMixin):
         return abs(min(balance, 0))
 
     @cached_property
-    def percent_budget_consumed(self):
+    def percent_active_budget_consumed(self):
         if self.approved_compute_cost_euro_millicents > 0:
             return int(
                 100
-                * (
-                    self.consumed_compute_cost_euro_millicents
-                    + self.write_off_compute_cost_euro_millicents
-                )
+                * self.consumed_compute_cost_euro_millicents
                 / self.approved_compute_cost_euro_millicents
             )
         else:

--- a/app/grandchallenge/invoices/models.py
+++ b/app/grandchallenge/invoices/models.py
@@ -374,17 +374,36 @@ class Invoice(models.Model, FieldChangeMixin):
 
     @cached_property
     def available_compute_cost_euro_millicents(self):
-        utilized = self.compute_cost_euro_millicents
-        diff = self.compute_costs_euros * 1000 * 100 - utilized
-
-        if not self.is_budget_authorized:
-            return -utilized
-        elif self.is_expired:
-            # If the invoice is expired we cap the balance at 0 or below.
-            # Meaning the challenge cannot use more compute from this invoice.
-            return min(diff, 0)
+        if self.is_expired:
+            return 0
         else:
-            return diff
+            return (
+                self.approved_compute_cost_euro_millicents
+                - self.consumed_compute_cost_euro_millicents
+            )
+
+    @cached_property
+    def approved_compute_cost_euro_millicents(self):
+        return (
+            self.compute_costs_euros * 1000 * 100
+            if self.is_budget_authorized
+            else 0
+        )
+
+    @cached_property
+    def consumed_compute_cost_euro_millicents(self):
+        return min(
+            self.compute_cost_euro_millicents,
+            self.approved_compute_cost_euro_millicents,  # Cap
+        )
+
+    @cached_property
+    def write_off_compute_cost_euro_millicents(self):
+        balance = (
+            self.approved_compute_cost_euro_millicents
+            - self.compute_cost_euro_millicents
+        )
+        return abs(min(balance, 0))
 
     def clean(self):
         if (

--- a/app/grandchallenge/pages/templates/pages/challenge_statistics.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_statistics.html
@@ -131,7 +131,7 @@
                         <th>% Active Budget Consumed</th>
                         <th>Available Compute Costs</th>
                         <th>Total Approved Compute Costs</th>
-                        <th>Total Consumed Compute Costs </th>
+                        <th>Total Consumed Compute Costs</th>
                         <th>Total Write-Off Compute Costs</th>
                         <th>Object Storage Costs per Year</th>
                         <th>Registry Storage Costs per Year</th>

--- a/app/grandchallenge/pages/templates/pages/challenge_statistics.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_statistics.html
@@ -144,12 +144,12 @@
                         </td>
                         <td>{% if challenge.should_be_open_but_is_over_budget %}<i class="fa fa-exclamation-triangle text-danger"></i>{% endif %}</td>
                         <td data-order="{% if challenge.percent_active_budget_consumed is None %}-1{% else %}{{ challenge.percent_active_budget_consumed }}{% endif %}" class="{% if challenge.percent_active_budget_consumed >= 100 %}text-danger{% elif challenge.percent_active_budget_consumed >= 70 %}text-warning{% else %}text-success{% endif %}">{% if challenge.percent_active_budget_consumed is not None %}{{ challenge.percent_active_budget_consumed }}&nbsp;%{% endif %}</td>
-                        <td class="{% if challenge.available_compute_cost_euro_millicents <= 0 %}text-danger{% endif %}">{{ challenge.available_compute_cost_euro_millicents|millicents_to_euro }}</td>
-                        <td>{{ challenge.approved_compute_costs_euro_millicents|millicents_to_euro }}</td>
-                        <td>{{ challenge.consumed_compute_cost_euro_millicents|millicents_to_euro }}</td>
-                        <td class="{% if challenge.write_off_compute_cost_euro_millicents > 0 %}text-danger{% endif %}">{{ challenge.write_off_compute_cost_euro_millicents|millicents_to_euro }}</td>
-                        <td>{{ challenge.size_in_storage|storage_bytes_to_euro_per_year }}</td>
-                        <td>{{ challenge.size_in_registry|registry_bytes_to_euro_per_year }}</td>
+                        <td data-order="{{ challenge.available_compute_cost_euro_millicents }}" class="{% if challenge.available_compute_cost_euro_millicents <= 0 %}text-danger{% endif %}">{{ challenge.available_compute_cost_euro_millicents|millicents_to_euro }}</td>
+                        <td data-order="{{ challenge.approved_compute_costs_euro_millicents }}">{{ challenge.approved_compute_costs_euro_millicents|millicents_to_euro }}</td>
+                        <td data-order="{{ challenge.consumed_compute_cost_euro_millicents }}">{{ challenge.consumed_compute_cost_euro_millicents|millicents_to_euro }}</td>
+                        <td data-order="{{ challenge.write_off_compute_cost_euro_millicents }}" class="{% if challenge.write_off_compute_cost_euro_millicents > 0 %}text-danger{% endif %}">{{ challenge.write_off_compute_cost_euro_millicents|millicents_to_euro }}</td>
+                        <td data-order="{{ challenge.size_in_storage }}">{{ challenge.size_in_storage|storage_bytes_to_euro_per_year }}</td>
+                        <td data-order="{{ challenge.size_in_registry }}">{{ challenge.size_in_registry|registry_bytes_to_euro_per_year }}</td>
                     </tr>
                 </tbody>
             </table>

--- a/app/grandchallenge/pages/templates/pages/challenge_statistics.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_statistics.html
@@ -137,9 +137,17 @@
                             </span>
                         </th>
                         <th>
-                            Active Available Compute Costs
+                            % Active Budget Consumed
                             <span data-toggle="tooltip" data-placement="right"
-                                title="Approved budget minus consumed costs of currently active invoices."
+                                title="Consumed costs as a percentage of the approved costs of the currently active (i.e., non-expired) invoices."
+                                class="text-muted">
+                                <i class="fas fa-question-circle"></i>
+                            </span>
+                        </th>
+                        <th>
+                            Available Compute Costs
+                            <span data-toggle="tooltip" data-placement="right"
+                                title="Total approved budget - total consumed costs of currently active invoices."
                                 class="text-muted">
                                 <i class="fas fa-question-circle"></i>
                             </span>
@@ -147,7 +155,7 @@
                         <th>
                             Total Approved Compute Costs
                             <span data-toggle="tooltip" data-placement="right"
-                                title="Sum of  approved compute budget in all the invoices."
+                                title="Sum of approved compute budget of all invoices."
                                 class="text-muted">
                                 <i class="fas fa-question-circle"></i>
                             </span>
@@ -155,7 +163,7 @@
                         <th>
                             Total Consumed Compute Costs
                             <span data-toggle="tooltip" data-placement="right"
-                                title="Total compute costs billed against all the invoices."
+                                title="Total compute costs billed against all the invoices, capped at total approved."
                                 class="text-muted">
                                 <i class="fas fa-question-circle"></i>
                             </span>

--- a/app/grandchallenge/pages/templates/pages/challenge_statistics.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_statistics.html
@@ -128,13 +128,62 @@
                     <tr>
                         <th>Challenge Status</th>
                         <th>Should be Open</th>
-                        <th>% Active Budget Consumed</th>
-                        <th>Available Compute Costs</th>
-                        <th>Total Approved Compute Costs</th>
-                        <th>Total Consumed Compute Costs</th>
-                        <th>Total Write-Off Compute Costs</th>
-                        <th>Object Storage Costs per Year</th>
-                        <th>Registry Storage Costs per Year</th>
+                        <th>
+                            % Active Budget Consumed
+                        <span data-toggle="tooltip" data-placement="right"
+                                title="Consumed costs as a percentage of the approved costs of the currently active invoices."
+                                class="text-muted">
+                                <i class="fas fa-question-circle"></i>
+                            </span>
+                        </th>
+                        <th>
+                            Active Available Compute Costs
+                            <span data-toggle="tooltip" data-placement="right"
+                                title="Approved budget minus consumed costs of currently active invoices."
+                                class="text-muted">
+                                <i class="fas fa-question-circle"></i>
+                            </span>
+                        </th>
+                        <th>
+                            Total Approved Compute Costs
+                            <span data-toggle="tooltip" data-placement="right"
+                                title="Sum of  approved compute budget in all the invoices."
+                                class="text-muted">
+                                <i class="fas fa-question-circle"></i>
+                            </span>
+                        </th>
+                        <th>
+                            Total Consumed Compute Costs
+                            <span data-toggle="tooltip" data-placement="right"
+                                title="Total compute costs billed against all the invoices."
+                                class="text-muted">
+                                <i class="fas fa-question-circle"></i>
+                            </span>
+                        </th>
+                        <th>
+                            Total Write-Off Compute Costs
+                            <span data-toggle="tooltip" data-placement="right"
+                                title="Costs written off and not charged to any budget."
+                                class="text-muted">
+                                <i class="fas fa-question-circle"></i>
+                            </span>
+                        </th>
+                        <th>
+                            Object Storage Costs per Year
+                            <span data-toggle="tooltip" data-placement="right"
+                                title="Estimated annual cost for storing challenge data in object storage."
+                                class="text-muted">
+                                <i class="fas fa-question-circle"></i>
+                            </span>
+                        </th>
+                        <th>
+                            Registry Storage Costs per Year
+                            <span data-toggle="tooltip" data-placement="right"
+                                title="Estimated annual cost for storing container images in the registry."
+                                class="text-muted">
+                                <i class="fas fa-question-circle"></i>
+                            </span>
+                        </th>
                     </tr>
                 </thead>
                 <tbody>
@@ -215,6 +264,7 @@
 {% block script %}
     {{ block.super }}
 
+    <script type="text/javascript" src="{% static "js/tooltips.js" %}"></script>
     <script src="{% static 'vendored/vega/vega.min.js' %}"></script>
     <script src="{% static 'vendored/vega-lite/vega-lite.min.js' %}"></script>
     <script src="{% static 'vendored/vega-embed/vega-embed.min.js' %}"></script>

--- a/app/grandchallenge/pages/templates/pages/challenge_statistics.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_statistics.html
@@ -144,12 +144,12 @@
                         </td>
                         <td>{% if challenge.should_be_open_but_is_over_budget %}<i class="fa fa-exclamation-triangle text-danger"></i>{% endif %}</td>
                         <td data-order="{% if challenge.percent_active_budget_consumed is None %}-1{% else %}{{ challenge.percent_active_budget_consumed }}{% endif %}" class="{% if challenge.percent_active_budget_consumed >= 100 %}text-danger{% elif challenge.percent_active_budget_consumed >= 70 %}text-warning{% else %}text-success{% endif %}">{% if challenge.percent_active_budget_consumed is not None %}{{ challenge.percent_active_budget_consumed }}&nbsp;%{% endif %}</td>
-                        <td data-order="{{ challenge.available_compute_cost_euro_millicents }}" class="{% if challenge.available_compute_cost_euro_millicents <= 0 %}text-danger{% endif %}">{{ challenge.available_compute_cost_euro_millicents|millicents_to_euro }}</td>
-                        <td data-order="{{ challenge.approved_compute_costs_euro_millicents }}">{{ challenge.approved_compute_costs_euro_millicents|millicents_to_euro }}</td>
-                        <td data-order="{{ challenge.consumed_compute_cost_euro_millicents }}">{{ challenge.consumed_compute_cost_euro_millicents|millicents_to_euro }}</td>
-                        <td data-order="{{ challenge.write_off_compute_cost_euro_millicents }}" class="{% if challenge.write_off_compute_cost_euro_millicents > 0 %}text-danger{% endif %}">{{ challenge.write_off_compute_cost_euro_millicents|millicents_to_euro }}</td>
-                        <td data-order="{{ challenge.size_in_storage }}">{{ challenge.size_in_storage|storage_bytes_to_euro_per_year }}</td>
-                        <td data-order="{{ challenge.size_in_registry }}">{{ challenge.size_in_registry|registry_bytes_to_euro_per_year }}</td>
+                        <td class="{% if challenge.available_compute_cost_euro_millicents <= 0 %}text-danger{% endif %}">{{ challenge.available_compute_cost_euro_millicents|millicents_to_euro }}</td>
+                        <td>{{ challenge.approved_compute_costs_euro_millicents|millicents_to_euro }}</td>
+                        <td>{{ challenge.consumed_compute_cost_euro_millicents|millicents_to_euro }}</td>
+                        <td class="{% if challenge.write_off_compute_cost_euro_millicents > 0 %}text-danger{% endif %}">{{ challenge.write_off_compute_cost_euro_millicents|millicents_to_euro }}</td>
+                        <td>{{ challenge.size_in_storage|storage_bytes_to_euro_per_year }}</td>
+                        <td>{{ challenge.size_in_registry|registry_bytes_to_euro_per_year }}</td>
                     </tr>
                 </tbody>
             </table>

--- a/app/grandchallenge/pages/templates/pages/challenge_statistics.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_statistics.html
@@ -128,10 +128,11 @@
                     <tr>
                         <th>Challenge Status</th>
                         <th>Should be Open</th>
-                        <th>Percentage Budget Consumed</th>
-                        <th>Approved Compute Costs</th>
-                        <th>Total Compute Costs Incurred</th>
+                        <th>% Active Budget Consumed</th>
                         <th>Available Compute Costs</th>
+                        <th>Total Approved Compute Costs</th>
+                        <th>Total Consumed Compute Costs </th>
+                        <th>Total Write-Off Compute Costs</th>
                         <th>Object Storage Costs per Year</th>
                         <th>Registry Storage Costs per Year</th>
                     </tr>
@@ -142,10 +143,11 @@
                             <span class="badge {% if challenge.status == challenge.StatusChoices.OPEN %}badge-success{% elif challenge.status == challenge.StatusChoices.OPENING_SOON %}badge-warning{% else %}badge-danger{% endif %}">{{ challenge.status.name }}</span>
                         </td>
                         <td>{% if challenge.should_be_open_but_is_over_budget %}<i class="fa fa-exclamation-triangle text-danger"></i>{% endif %}</td>
-                        <td class="{% if challenge.percent_budget_consumed >= 100 %}text-danger{% elif challenge.percent_budget_consumed >= 70 %}text-warning{% else %}text-success{% endif %}">{% if challenge.percent_budget_consumed is not None %}{{ challenge.percent_budget_consumed }}&nbsp;%{% endif %}</td>
+                        <td data-order="{% if challenge.percent_active_budget_consumed is None %}-1{% else %}{{ challenge.percent_active_budget_consumed }}{% endif %}" class="{% if challenge.percent_active_budget_consumed >= 100 %}text-danger{% elif challenge.percent_active_budget_consumed >= 70 %}text-warning{% else %}text-success{% endif %}">{% if challenge.percent_active_budget_consumed is not None %}{{ challenge.percent_active_budget_consumed }}&nbsp;%{% endif %}</td>
+                        <td class="{% if challenge.available_compute_cost_euro_millicents <= 0 %}text-danger{% endif %}">{{ challenge.available_compute_cost_euro_millicents|millicents_to_euro }}</td>
                         <td>{{ challenge.approved_compute_costs_euro_millicents|millicents_to_euro }}</td>
-                        <td>{{ challenge.compute_cost_euro_millicents|millicents_to_euro }}</td>
-                        <td class="{% if challenge.available_compute_euro_millicents <= 0 %}text-danger{% endif %}">{{ challenge.available_compute_euro_millicents|millicents_to_euro }}</td>
+                        <td>{{ challenge.consumed_compute_cost_euro_millicents|millicents_to_euro }}</td>
+                        <td class="{% if challenge.write_off_compute_cost_euro_millicents > 0 %}text-danger{% endif %}">{{ challenge.write_off_compute_cost_euro_millicents|millicents_to_euro }}</td>
                         <td>{{ challenge.size_in_storage|storage_bytes_to_euro_per_year }}</td>
                         <td>{{ challenge.size_in_registry|registry_bytes_to_euro_per_year }}</td>
                     </tr>

--- a/app/grandchallenge/subdomains/middleware.py
+++ b/app/grandchallenge/subdomains/middleware.py
@@ -46,6 +46,7 @@ def challenge_subdomain_middleware(get_response):
         else:
             request.challenge = get_object_or_404(
                 Challenge.objects.with_available_compute()
+                .with_invoices_with_budget_authorization()
                 .select_related("discussion_forum")
                 .prefetch_related("phase_set"),
                 short_name__iexact=subdomain,

--- a/app/tests/challenges_tests/test_models.py
+++ b/app/tests/challenges_tests/test_models.py
@@ -810,9 +810,6 @@ def test_challenge_queryset_with_user_roles_multiple_challenges():
 @pytest.mark.django_db
 def test_active_invoice():
     challenge = ChallengeFactory()
-    challenge = Challenge.objects.with_only_active_invoices().get(
-        pk=challenge.pk
-    )
     invoice = InvoiceFactory(
         challenge=challenge,
         compute_costs_euros=1,
@@ -820,14 +817,21 @@ def test_active_invoice():
         payment_type=PaymentTypeChoices.PREPAID,
         payment_status=Invoice.PaymentStatusChoices.PAID,
     )
+    challenge = (
+        Challenge.objects.with_invoices_with_budget_authorization().get(
+            pk=challenge.pk
+        )
+    )
     assert challenge.active_invoice == invoice
 
 
 @pytest.mark.django_db
 def test_active_invoice_no_invoice():
     challenge = ChallengeFactory()
-    challenge = Challenge.objects.with_only_active_invoices().get(
-        pk=challenge.pk
+    challenge = (
+        Challenge.objects.with_invoices_with_budget_authorization().get(
+            pk=challenge.pk
+        )
     )
     with pytest.raises(InsufficientBudgetError):
         challenge.active_invoice
@@ -836,15 +840,17 @@ def test_active_invoice_no_invoice():
 @pytest.mark.django_db
 def test_active_invoice_raises_on_negative_balance():
     challenge = ChallengeFactory()
-    challenge = Challenge.objects.with_only_active_invoices().get(
-        pk=challenge.pk
-    )
     InvoiceFactory(
         challenge=challenge,
         compute_costs_euros=1,
         compute_cost_euro_millicents=2 * 1000 * 100,
         payment_type=PaymentTypeChoices.PREPAID,
         payment_status=Invoice.PaymentStatusChoices.PAID,
+    )
+    challenge = (
+        Challenge.objects.with_invoices_with_budget_authorization().get(
+            pk=challenge.pk
+        )
     )
     with pytest.raises(InsufficientBudgetError):
         challenge.active_invoice
@@ -853,15 +859,17 @@ def test_active_invoice_raises_on_negative_balance():
 @pytest.mark.django_db
 def test_active_invoice_raises_on_zero_balance():
     challenge = ChallengeFactory()
-    challenge = Challenge.objects.with_only_active_invoices().get(
-        pk=challenge.pk
-    )
     InvoiceFactory(
         challenge=challenge,
         compute_costs_euros=1,
         compute_cost_euro_millicents=1 * 1000 * 100,
         payment_type=PaymentTypeChoices.PREPAID,
         payment_status=Invoice.PaymentStatusChoices.PAID,
+    )
+    challenge = (
+        Challenge.objects.with_invoices_with_budget_authorization().get(
+            pk=challenge.pk
+        )
     )
     with pytest.raises(InsufficientBudgetError):
         challenge.active_invoice
@@ -870,9 +878,6 @@ def test_active_invoice_raises_on_zero_balance():
 @pytest.mark.django_db
 def test_active_invoice_orders_by_expiry():
     challenge = ChallengeFactory()
-    challenge = Challenge.objects.with_only_active_invoices().get(
-        pk=challenge.pk
-    )
 
     _fixed_now = now()
 
@@ -893,26 +898,40 @@ def test_active_invoice_orders_by_expiry():
         expires_on=_fixed_now + timedelta(10),
     )
 
+    challenge = (
+        Challenge.objects.with_invoices_with_budget_authorization().get(
+            pk=challenge.pk
+        )
+    )
     # All things being equal, use created time to determine order, so invoice0 should be active as it was created first
     assert challenge.active_invoice == invoice0
 
     invoice1.expires_on = _fixed_now + timedelta(5)
     invoice1.save()
     assert invoice1.expires_on < invoice0.expires_on, "Sanity"
+
+    challenge = (
+        Challenge.objects.with_invoices_with_budget_authorization().get(
+            pk=challenge.pk
+        )
+    )
     assert challenge.active_invoice == invoice1
 
     invoice0.expires_on = _fixed_now + timedelta(4)
     invoice0.save()
     assert invoice0.expires_on < invoice1.expires_on, "Sanity"
+
+    challenge = (
+        Challenge.objects.with_invoices_with_budget_authorization().get(
+            pk=challenge.pk
+        )
+    )
     assert challenge.active_invoice == invoice0
 
 
 @pytest.mark.django_db
 def test_active_invoice_ignores_invoices_with_negative_balance():
     challenge = ChallengeFactory()
-    challenge = Challenge.objects.with_only_active_invoices().get(
-        pk=challenge.pk
-    )
 
     InvoiceFactory(
         challenge=challenge,
@@ -929,21 +948,28 @@ def test_active_invoice_ignores_invoices_with_negative_balance():
         payment_status=Invoice.PaymentStatusChoices.PAID,
     )
 
+    challenge = (
+        Challenge.objects.with_invoices_with_budget_authorization().get(
+            pk=challenge.pk
+        )
+    )
     challenge.active_invoice
 
 
 @pytest.mark.django_db
 def test_budget_properties():
     challenge = ChallengeFactory()
-    challenge = Challenge.objects.with_only_active_invoices().get(
-        pk=challenge.pk
-    )
 
+    challenge = (
+        Challenge.objects.with_invoices_with_budget_authorization().get(
+            pk=challenge.pk
+        )
+    )
     assert challenge.available_compute_cost_euro_millicents == 0
     assert challenge.approved_compute_cost_euro_millicents == 0
     assert challenge.consumed_compute_cost_euro_millicents == 0
     assert challenge.write_off_compute_cost_euro_millicents == 0
-    assert challenge.percent_budget_consumed is None
+    assert challenge.percent_active_budget_consumed is None
 
     InvoiceFactory(
         challenge=challenge,
@@ -951,55 +977,14 @@ def test_budget_properties():
         compute_cost_euro_millicents=6 * 1000 * 100,
     )
 
-    challenge = Challenge.objects.with_only_active_invoices().get(
-        pk=challenge.pk
+    challenge = (
+        Challenge.objects.with_invoices_with_budget_authorization().get(
+            pk=challenge.pk
+        )
     )
 
     assert challenge.available_compute_cost_euro_millicents == 4 * 1000 * 100
     assert challenge.approved_compute_cost_euro_millicents == 10 * 1000 * 100
     assert challenge.consumed_compute_cost_euro_millicents == 6 * 1000 * 100
     assert challenge.write_off_compute_cost_euro_millicents == 0
-    assert challenge.percent_budget_consumed == 60
-
-
-@pytest.mark.django_db
-def test_budget_properties_ignore_non_active_invoices():
-    challenge = ChallengeFactory()
-    challenge = Challenge.objects.with_only_active_invoices().get(
-        pk=challenge.pk
-    )
-
-    InvoiceFactory(
-        challenge=challenge,
-        compute_costs_euros=100,
-        compute_cost_euro_millicents=200 * 1000 * 100,
-        expires_on=now().date() - timedelta(days=1),
-    )
-    InvoiceFactory(
-        challenge=challenge,
-        compute_costs_euros=100,
-        compute_cost_euro_millicents=200 * 1000 * 100,
-        payment_status=Invoice.PaymentStatusChoices.CANCELLED,
-    )
-
-    assert challenge.approved_compute_cost_euro_millicents == 0
-    assert challenge.available_compute_cost_euro_millicents == 0
-    assert challenge.consumed_compute_cost_euro_millicents == 0
-    assert challenge.percent_budget_consumed is None
-
-    InvoiceFactory(
-        challenge=challenge,
-        compute_costs_euros=10,
-        compute_cost_euro_millicents=6 * 1000 * 100,
-    )
-
-    challenge = Challenge.objects.with_only_active_invoices().get(
-        pk=challenge.pk
-    )
-
-    assert challenge.available_compute_cost_euro_millicents == 4 * 1000 * 100
-    assert challenge.approved_compute_cost_euro_millicents == 10 * 1000 * 100
-    assert challenge.consumed_compute_cost_euro_millicents == 6 * 1000 * 100
-    assert challenge.write_off_compute_cost_euro_millicents == 0
-
-    assert challenge.percent_budget_consumed == 60
+    assert challenge.percent_active_budget_consumed == 60

--- a/app/tests/challenges_tests/test_models.py
+++ b/app/tests/challenges_tests/test_models.py
@@ -808,81 +808,11 @@ def test_challenge_queryset_with_user_roles_multiple_challenges():
 
 
 @pytest.mark.django_db
-def test_challenge_available_compute_euro_millicents():
-    challenge = ChallengeFactory()
-
-    challenge = (
-        Challenge.objects.with_invoices_with_budget_authorization().get(
-            pk=challenge.pk
-        )
-    )
-    assert challenge.available_compute_euro_millicents_via_invoices == 0
-
-    InvoiceFactory(
-        challenge=challenge,
-        payment_status=Invoice.PaymentStatusChoices.PAID,
-        payment_type=Invoice.PaymentTypeChoices.COMPLIMENTARY,
-        compute_costs_euros=1,
-    )
-
-    challenge = (
-        Challenge.objects.with_invoices_with_budget_authorization().get(
-            pk=challenge.pk
-        )
-    )
-    assert (
-        challenge.available_compute_euro_millicents_via_invoices
-        == 1 * 1000 * 100
-    )
-
-    InvoiceFactory(
-        challenge=challenge,
-        payment_status=Invoice.PaymentStatusChoices.PAID,
-        payment_type=Invoice.PaymentTypeChoices.COMPLIMENTARY,
-        compute_costs_euros=2,
-    )
-
-    # All these should be ignored
-    InvoiceFactory(
-        challenge=challenge,
-        payment_status=Invoice.PaymentStatusChoices.CANCELLED,  # Not authorized: should be ignored
-        payment_type=Invoice.PaymentTypeChoices.COMPLIMENTARY,
-        compute_costs_euros=4,
-    )
-
-    InvoiceFactory(
-        challenge=challenge,
-        payment_status=Invoice.PaymentStatusChoices.PAID,
-        payment_type=Invoice.PaymentTypeChoices.COMPLIMENTARY,
-        compute_costs_euros=8,
-        compute_cost_euro_millicents=9
-        * 1000
-        * 1000,  # Note, overcharge: should be ignored
-    )
-
-    InvoiceFactory(
-        challenge=challenge,
-        payment_status=Invoice.PaymentStatusChoices.PAID,
-        payment_type=Invoice.PaymentTypeChoices.COMPLIMENTARY,
-        compute_costs_euros=16,
-        expires_on=now().date()
-        - timedelta(days=1),  # Expired: should be ignored
-    )
-
-    challenge = (
-        Challenge.objects.with_invoices_with_budget_authorization().get(
-            pk=challenge.pk
-        )
-    )
-    assert (
-        challenge.available_compute_euro_millicents_via_invoices
-        == (1 + 2) * 1000 * 100
-    )
-
-
-@pytest.mark.django_db
 def test_active_invoice():
     challenge = ChallengeFactory()
+    challenge = Challenge.objects.with_only_active_invoices().get(
+        pk=challenge.pk
+    )
     invoice = InvoiceFactory(
         challenge=challenge,
         compute_costs_euros=1,
@@ -896,6 +826,9 @@ def test_active_invoice():
 @pytest.mark.django_db
 def test_active_invoice_no_invoice():
     challenge = ChallengeFactory()
+    challenge = Challenge.objects.with_only_active_invoices().get(
+        pk=challenge.pk
+    )
     with pytest.raises(InsufficientBudgetError):
         challenge.active_invoice
 
@@ -903,6 +836,9 @@ def test_active_invoice_no_invoice():
 @pytest.mark.django_db
 def test_active_invoice_raises_on_negative_balance():
     challenge = ChallengeFactory()
+    challenge = Challenge.objects.with_only_active_invoices().get(
+        pk=challenge.pk
+    )
     InvoiceFactory(
         challenge=challenge,
         compute_costs_euros=1,
@@ -917,6 +853,9 @@ def test_active_invoice_raises_on_negative_balance():
 @pytest.mark.django_db
 def test_active_invoice_raises_on_zero_balance():
     challenge = ChallengeFactory()
+    challenge = Challenge.objects.with_only_active_invoices().get(
+        pk=challenge.pk
+    )
     InvoiceFactory(
         challenge=challenge,
         compute_costs_euros=1,
@@ -931,6 +870,9 @@ def test_active_invoice_raises_on_zero_balance():
 @pytest.mark.django_db
 def test_active_invoice_orders_by_expiry():
     challenge = ChallengeFactory()
+    challenge = Challenge.objects.with_only_active_invoices().get(
+        pk=challenge.pk
+    )
 
     _fixed_now = now()
 
@@ -968,6 +910,9 @@ def test_active_invoice_orders_by_expiry():
 @pytest.mark.django_db
 def test_active_invoice_ignores_invoices_with_negative_balance():
     challenge = ChallengeFactory()
+    challenge = Challenge.objects.with_only_active_invoices().get(
+        pk=challenge.pk
+    )
 
     InvoiceFactory(
         challenge=challenge,
@@ -990,6 +935,9 @@ def test_active_invoice_ignores_invoices_with_negative_balance():
 @pytest.mark.django_db
 def test_budget_properties():
     challenge = ChallengeFactory()
+    challenge = Challenge.objects.with_only_active_invoices().get(
+        pk=challenge.pk
+    )
 
     assert challenge.available_compute_cost_euro_millicents == 0
     assert challenge.approved_compute_cost_euro_millicents == 0
@@ -1003,7 +951,9 @@ def test_budget_properties():
         compute_cost_euro_millicents=6 * 1000 * 100,
     )
 
-    challenge = Challenge.objects.get(pk=challenge.pk)
+    challenge = Challenge.objects.with_only_active_invoices().get(
+        pk=challenge.pk
+    )
 
     assert challenge.available_compute_cost_euro_millicents == 4 * 1000 * 100
     assert challenge.approved_compute_cost_euro_millicents == 10 * 1000 * 100
@@ -1015,6 +965,9 @@ def test_budget_properties():
 @pytest.mark.django_db
 def test_budget_properties_ignore_non_active_invoices():
     challenge = ChallengeFactory()
+    challenge = Challenge.objects.with_only_active_invoices().get(
+        pk=challenge.pk
+    )
 
     InvoiceFactory(
         challenge=challenge,
@@ -1040,7 +993,9 @@ def test_budget_properties_ignore_non_active_invoices():
         compute_cost_euro_millicents=6 * 1000 * 100,
     )
 
-    challenge = Challenge.objects.get(pk=challenge.pk)
+    challenge = Challenge.objects.with_only_active_invoices().get(
+        pk=challenge.pk
+    )
 
     assert challenge.available_compute_cost_euro_millicents == 4 * 1000 * 100
     assert challenge.approved_compute_cost_euro_millicents == 10 * 1000 * 100

--- a/app/tests/challenges_tests/test_models.py
+++ b/app/tests/challenges_tests/test_models.py
@@ -985,3 +985,52 @@ def test_active_invoice_ignores_invoices_with_negative_balance():
     )
 
     challenge.active_invoice
+
+
+@pytest.mark.django_db
+def test_budget_properties():
+    challenge = ChallengeFactory()
+
+    assert challenge.approved_compute_cost_euro_millicents == 0
+    assert challenge.available_compute_cost_euro_millicents == 0
+    assert challenge.percent_budget_consumed is None
+
+    InvoiceFactory(
+        challenge=challenge,
+        compute_costs_euros=10,
+        compute_cost_euro_millicents=5 * 1000 * 100,
+    )
+
+    challenge = Challenge.objects.get(pk=challenge.pk)
+
+    assert challenge.approved_compute_cost_euro_millicents == 10 * 1000 * 100
+    assert challenge.available_compute_cost_euro_millicents == 5 * 1000 * 100
+    assert challenge.percent_budget_consumed == 50
+
+
+@pytest.mark.django_db
+def test_budget_properties_with_over_charged_invoices():
+    challenge = ChallengeFactory()
+
+    assert challenge.approved_compute_cost_euro_millicents == 0
+    assert challenge.available_compute_cost_euro_millicents == 0
+    assert challenge.percent_budget_consumed is None
+
+    InvoiceFactory(
+        challenge=challenge,
+        compute_costs_euros=10,
+        compute_cost_euro_millicents=15
+        * 1000
+        * 100,  # Note, overcharge: should be ignored
+    )
+    InvoiceFactory(
+        challenge=challenge,
+        compute_costs_euros=20,
+        compute_cost_euro_millicents=1 * 1000 * 100,
+    )
+
+    challenge = Challenge.objects.get(pk=challenge.pk)
+
+    assert challenge.approved_compute_cost_euro_millicents == 30 * 1000 * 100
+    assert challenge.available_compute_cost_euro_millicents == 19 * 1000 * 100
+    assert challenge.percent_budget_consumed == 63

--- a/app/tests/challenges_tests/test_models.py
+++ b/app/tests/challenges_tests/test_models.py
@@ -991,46 +991,60 @@ def test_active_invoice_ignores_invoices_with_negative_balance():
 def test_budget_properties():
     challenge = ChallengeFactory()
 
-    assert challenge.approved_compute_cost_euro_millicents == 0
     assert challenge.available_compute_cost_euro_millicents == 0
+    assert challenge.approved_compute_cost_euro_millicents == 0
+    assert challenge.consumed_compute_cost_euro_millicents == 0
+    assert challenge.write_off_compute_cost_euro_millicents == 0
     assert challenge.percent_budget_consumed is None
 
     InvoiceFactory(
         challenge=challenge,
         compute_costs_euros=10,
-        compute_cost_euro_millicents=5 * 1000 * 100,
+        compute_cost_euro_millicents=6 * 1000 * 100,
     )
 
     challenge = Challenge.objects.get(pk=challenge.pk)
 
+    assert challenge.available_compute_cost_euro_millicents == 4 * 1000 * 100
     assert challenge.approved_compute_cost_euro_millicents == 10 * 1000 * 100
-    assert challenge.available_compute_cost_euro_millicents == 5 * 1000 * 100
-    assert challenge.percent_budget_consumed == 50
+    assert challenge.consumed_compute_cost_euro_millicents == 6 * 1000 * 100
+    assert challenge.write_off_compute_cost_euro_millicents == 0
+    assert challenge.percent_budget_consumed == 60
 
 
 @pytest.mark.django_db
-def test_budget_properties_with_over_charged_invoices():
+def test_budget_properties_ignore_non_active_invoices():
     challenge = ChallengeFactory()
+
+    InvoiceFactory(
+        challenge=challenge,
+        compute_costs_euros=100,
+        compute_cost_euro_millicents=200 * 1000 * 100,
+        expires_on=now().date() - timedelta(days=1),
+    )
+    InvoiceFactory(
+        challenge=challenge,
+        compute_costs_euros=100,
+        compute_cost_euro_millicents=200 * 1000 * 100,
+        payment_status=Invoice.PaymentStatusChoices.CANCELLED,
+    )
 
     assert challenge.approved_compute_cost_euro_millicents == 0
     assert challenge.available_compute_cost_euro_millicents == 0
+    assert challenge.consumed_compute_cost_euro_millicents == 0
     assert challenge.percent_budget_consumed is None
 
     InvoiceFactory(
         challenge=challenge,
         compute_costs_euros=10,
-        compute_cost_euro_millicents=15
-        * 1000
-        * 100,  # Note, overcharge: should be ignored
-    )
-    InvoiceFactory(
-        challenge=challenge,
-        compute_costs_euros=20,
-        compute_cost_euro_millicents=1 * 1000 * 100,
+        compute_cost_euro_millicents=6 * 1000 * 100,
     )
 
     challenge = Challenge.objects.get(pk=challenge.pk)
 
-    assert challenge.approved_compute_cost_euro_millicents == 30 * 1000 * 100
-    assert challenge.available_compute_cost_euro_millicents == 19 * 1000 * 100
-    assert challenge.percent_budget_consumed == 63
+    assert challenge.available_compute_cost_euro_millicents == 4 * 1000 * 100
+    assert challenge.approved_compute_cost_euro_millicents == 10 * 1000 * 100
+    assert challenge.consumed_compute_cost_euro_millicents == 6 * 1000 * 100
+    assert challenge.write_off_compute_cost_euro_millicents == 0
+
+    assert challenge.percent_budget_consumed == 60

--- a/app/tests/evaluation_tests/test_models.py
+++ b/app/tests/evaluation_tests/test_models.py
@@ -577,12 +577,10 @@ def test_open_for_submission(
     phase.submissions_close_at = submissions_close
     phase.save()
 
-    phase.challenge.compute_cost_euro_millicents = 5 * 1000 * 100
-    phase.challenge.save()
-
     InvoiceFactory(
         challenge=phase.challenge,
         compute_costs_euros=compute_costs_euros,
+        compute_cost_euro_millicents=5 * 1000 * 100,
         payment_type=PaymentTypeChoices.COMPLIMENTARY,
     )
 

--- a/app/tests/evaluation_tests/test_models.py
+++ b/app/tests/evaluation_tests/test_models.py
@@ -648,7 +648,7 @@ def test_combined_leaderboards(
             == f"<bound method Signature.apply_async of grandchallenge.evaluation.tasks.update_combined_leaderboard(pk={leaderboard.pk!r})>"
         )
 
-    with django_assert_max_num_queries(7):
+    with django_assert_max_num_queries(8):
         update_combined_leaderboard(pk=leaderboard.pk)
 
     assert (

--- a/app/tests/invoices_tests/test_compute_cost.py
+++ b/app/tests/invoices_tests/test_compute_cost.py
@@ -12,6 +12,46 @@ from tests.factories import ChallengeFactory
 from tests.invoices_tests.factories import InvoiceFactory
 
 
+@pytest.mark.django_db
+def test_percent_budget_consumed():
+    challenge = ChallengeFactory()
+    invoice = InvoiceFactory(
+        challenge=challenge,
+        compute_costs_euros=2,
+        compute_cost_euro_millicents=1 * 1000 * 100,
+    )
+    invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
+
+    assert invoice.percent_budget_consumed == 50
+
+
+@pytest.mark.django_db
+def test_percent_budget_consumed_over_charge():
+    challenge = ChallengeFactory()
+    invoice = InvoiceFactory(
+        challenge=challenge,
+        compute_costs_euros=2,
+        compute_cost_euro_millicents=3 * 1000 * 100,
+    )
+    invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
+
+    assert invoice.percent_budget_consumed == 150
+
+
+@pytest.mark.django_db
+def test_percent_budget_consumed_unauthorized():
+    challenge = ChallengeFactory()
+    invoice = InvoiceFactory(
+        challenge=challenge,
+        compute_costs_euros=2,
+        compute_cost_euro_millicents=3 * 1000 * 100,
+        payment_status=PaymentStatusChoices.CANCELLED,
+    )
+    invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
+
+    assert invoice.percent_budget_consumed is None
+
+
 ##########
 # PREPAID
 #########

--- a/app/tests/invoices_tests/test_compute_cost.py
+++ b/app/tests/invoices_tests/test_compute_cost.py
@@ -35,7 +35,7 @@ def test_percent_budget_consumed_over_charge():
     )
     invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
 
-    assert invoice.percent_budget_consumed == 150
+    assert invoice.percent_budget_consumed == 100
 
 
 @pytest.mark.django_db

--- a/app/tests/invoices_tests/test_compute_cost.py
+++ b/app/tests/invoices_tests/test_compute_cost.py
@@ -12,22 +12,6 @@ from tests.factories import ChallengeFactory
 from tests.invoices_tests.factories import InvoiceFactory
 
 
-@pytest.mark.django_db
-def test_budget_authorization_errors_out_early():
-    challenge = ChallengeFactory()
-    invoice = InvoiceFactory(
-        challenge=challenge,
-        compute_costs_euros=2,
-        compute_cost_euro_millicents=0,
-        payment_type=PaymentTypeChoices.PREPAID,
-        payment_status=Invoice.PaymentStatusChoices.PAID,
-    )
-    with pytest.raises(
-        AttributeError, match="no attribute 'is_budget_authorized'"
-    ):
-        invoice.available_compute_cost_euro_millicents
-
-
 ##########
 # PREPAID
 #########
@@ -42,7 +26,11 @@ def test_prepaid_no_utilization_positive_balance():
         payment_status=Invoice.PaymentStatusChoices.PAID,
     )
     invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
+
     assert invoice.available_compute_cost_euro_millicents == 2 * 1000 * 100
+    assert invoice.approved_compute_cost_euro_millicents == 2 * 1000 * 100
+    assert invoice.consumed_compute_cost_euro_millicents == 0
+    assert invoice.write_off_compute_cost_euro_millicents == 0
 
 
 @pytest.mark.django_db
@@ -56,7 +44,11 @@ def test_prepaid_utilization_positive_balance():
         payment_status=Invoice.PaymentStatusChoices.PAID,
     )
     invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
+
     assert invoice.available_compute_cost_euro_millicents == 1 * 1000 * 100
+    assert invoice.approved_compute_cost_euro_millicents == 2 * 1000 * 100
+    assert invoice.consumed_compute_cost_euro_millicents == 1 * 1000 * 100
+    assert invoice.write_off_compute_cost_euro_millicents == 0
 
 
 @pytest.mark.django_db
@@ -81,13 +73,17 @@ def test_prepaid_no_utilization_zero_balance(payment_status, expires_on):
     invoice = InvoiceFactory(
         challenge=challenge,
         compute_costs_euros=1,
-        compute_cost_euro_millicents=0,
+        compute_cost_euro_millicents=1,
         payment_type=PaymentTypeChoices.PREPAID,
         payment_status=payment_status,
         expires_on=expires_on,
     )
     invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
+
     assert invoice.available_compute_cost_euro_millicents == 0
+    assert invoice.approved_compute_cost_euro_millicents == 0
+    assert invoice.consumed_compute_cost_euro_millicents == 0
+    assert invoice.write_off_compute_cost_euro_millicents == 1
 
 
 @pytest.mark.django_db
@@ -110,7 +106,11 @@ def test_prepaid_overutilization_negative_balance(payment_status):
         payment_status=payment_status,
     )
     invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
-    assert invoice.available_compute_cost_euro_millicents == -3 * 1000 * 100
+
+    assert invoice.available_compute_cost_euro_millicents == 0
+    assert invoice.approved_compute_cost_euro_millicents == 0
+    assert invoice.consumed_compute_cost_euro_millicents == 0
+    assert invoice.write_off_compute_cost_euro_millicents == 3 * 1000 * 100
 
 
 @pytest.mark.django_db
@@ -125,7 +125,11 @@ def test_prepaid_utilization_expired_zero_balance():
         expires_on=now().date() - timedelta(days=2),
     )
     invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
+
     assert invoice.available_compute_cost_euro_millicents == 0
+    assert invoice.approved_compute_cost_euro_millicents == 4 * 1000 * 100
+    assert invoice.consumed_compute_cost_euro_millicents == 1 * 1000 * 100
+    assert invoice.write_off_compute_cost_euro_millicents == 0
 
 
 @pytest.mark.django_db
@@ -140,7 +144,11 @@ def test_prepaid_overutilization_expired_negative_balance():
         expires_on=now().date() - timedelta(days=2),  # Expired
     )
     invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
-    assert invoice.available_compute_cost_euro_millicents == -2 * 1000 * 100
+
+    assert invoice.available_compute_cost_euro_millicents == 0
+    assert invoice.approved_compute_cost_euro_millicents == 1 * 1000 * 100
+    assert invoice.consumed_compute_cost_euro_millicents == 1 * 1000 * 100
+    assert invoice.write_off_compute_cost_euro_millicents == 2 * 1000 * 100
 
 
 ##########
@@ -183,10 +191,17 @@ def test_postpaid_no_utilization(
     postpaid_invoice = Invoice.objects.with_budget_authorization().get(
         pk=postpaid_invoice.pk
     )
+
     assert (
         postpaid_invoice.available_compute_cost_euro_millicents
         == 2 * 1000 * 100
     )
+    assert (
+        postpaid_invoice.approved_compute_cost_euro_millicents
+        == 2 * 1000 * 100
+    )
+    assert postpaid_invoice.consumed_compute_cost_euro_millicents == 0
+    assert postpaid_invoice.write_off_compute_cost_euro_millicents == 0
 
 
 @pytest.mark.django_db
@@ -287,6 +302,9 @@ def test_postpaid_postpaid_status_interaction_zero_balance(
         pk=postpaid_invoice.pk
     )
     assert postpaid_invoice.available_compute_cost_euro_millicents == 0
+    assert postpaid_invoice.approved_compute_cost_euro_millicents == 0
+    assert postpaid_invoice.consumed_compute_cost_euro_millicents == 0
+    assert postpaid_invoice.write_off_compute_cost_euro_millicents == 0
 
 
 @pytest.mark.django_db
@@ -314,6 +332,12 @@ def test_postpaid_with_expired_paid_prepaid():
         postpaid_invoice.available_compute_cost_euro_millicents
         == 2 * 1000 * 100
     )
+    assert (
+        postpaid_invoice.approved_compute_cost_euro_millicents
+        == 2 * 1000 * 100
+    )
+    assert postpaid_invoice.consumed_compute_cost_euro_millicents == 0
+    assert postpaid_invoice.write_off_compute_cost_euro_millicents == 0
 
 
 @pytest.mark.django_db
@@ -337,10 +361,20 @@ def test_postpaid_utilized():
     postpaid_invoice = Invoice.objects.with_budget_authorization().get(
         pk=postpaid_invoice.pk
     )
+
     assert (
         postpaid_invoice.available_compute_cost_euro_millicents
         == 3 * 1000 * 100
     )
+    assert (
+        postpaid_invoice.approved_compute_cost_euro_millicents
+        == 4 * 1000 * 100
+    )
+    assert (
+        postpaid_invoice.consumed_compute_cost_euro_millicents
+        == 1 * 1000 * 100
+    )
+    assert postpaid_invoice.write_off_compute_cost_euro_millicents == 0
 
 
 @pytest.mark.django_db
@@ -367,6 +401,15 @@ def test_postpaid_utilized_but_expired():
         pk=postpaid_invoice.pk
     )
     assert postpaid_invoice.available_compute_cost_euro_millicents == 0
+    assert (
+        postpaid_invoice.approved_compute_cost_euro_millicents
+        == 4 * 1000 * 100
+    )
+    assert (
+        postpaid_invoice.consumed_compute_cost_euro_millicents
+        == 1 * 1000 * 100
+    )
+    assert postpaid_invoice.write_off_compute_cost_euro_millicents == 0
 
 
 @pytest.mark.django_db
@@ -390,9 +433,18 @@ def test_postpaid_overutilized():
     postpaid_invoice = Invoice.objects.with_budget_authorization().get(
         pk=postpaid_invoice.pk
     )
+    assert postpaid_invoice.available_compute_cost_euro_millicents == 0
     assert (
-        postpaid_invoice.available_compute_cost_euro_millicents
-        == -2 * 1000 * 100
+        postpaid_invoice.approved_compute_cost_euro_millicents
+        == 1 * 1000 * 100
+    )
+    assert (
+        postpaid_invoice.consumed_compute_cost_euro_millicents
+        == 1 * 1000 * 100
+    )
+    assert (
+        postpaid_invoice.write_off_compute_cost_euro_millicents
+        == 2 * 1000 * 100
     )
 
 
@@ -418,9 +470,18 @@ def test_postpaid_overutilized_but_expired():
     postpaid_invoice = Invoice.objects.with_budget_authorization().get(
         pk=postpaid_invoice.pk
     )
+    assert postpaid_invoice.available_compute_cost_euro_millicents == 0
     assert (
-        postpaid_invoice.available_compute_cost_euro_millicents
-        == -2 * 1000 * 100
+        postpaid_invoice.approved_compute_cost_euro_millicents
+        == 1 * 1000 * 100
+    )
+    assert (
+        postpaid_invoice.consumed_compute_cost_euro_millicents
+        == 1 * 1000 * 100
+    )
+    assert (
+        postpaid_invoice.write_off_compute_cost_euro_millicents
+        == 2 * 1000 * 100
     )
 
 
@@ -450,6 +511,9 @@ def test_complimentary_no_utilization_positive_balance(payment_status):
     )
     invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
     assert invoice.available_compute_cost_euro_millicents == 1 * 1000 * 100
+    assert invoice.approved_compute_cost_euro_millicents == 1 * 1000 * 100
+    assert invoice.consumed_compute_cost_euro_millicents == 0
+    assert invoice.write_off_compute_cost_euro_millicents == 0
 
 
 @pytest.mark.django_db
@@ -464,6 +528,9 @@ def test_complimentary_cancelled():
     )
     invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
     assert invoice.available_compute_cost_euro_millicents == 0
+    assert invoice.approved_compute_cost_euro_millicents == 0
+    assert invoice.consumed_compute_cost_euro_millicents == 0
+    assert invoice.write_off_compute_cost_euro_millicents == 0
 
 
 @pytest.mark.django_db
@@ -487,6 +554,9 @@ def test_complimentary_utilized(payment_status):
     )
     invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
     assert invoice.available_compute_cost_euro_millicents == 3 * 1000 * 100
+    assert invoice.approved_compute_cost_euro_millicents == 4 * 1000 * 100
+    assert invoice.consumed_compute_cost_euro_millicents == 1 * 1000 * 100
+    assert invoice.write_off_compute_cost_euro_millicents == 0
 
 
 @pytest.mark.django_db
@@ -511,6 +581,9 @@ def test_complimentary_utilized_but_expired(payment_status):
     )
     invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
     assert invoice.available_compute_cost_euro_millicents == 0
+    assert invoice.approved_compute_cost_euro_millicents == 4 * 1000 * 100
+    assert invoice.consumed_compute_cost_euro_millicents == 1 * 1000 * 100
+    assert invoice.write_off_compute_cost_euro_millicents == 0
 
 
 @pytest.mark.django_db
@@ -525,7 +598,10 @@ def test_complimentary_overutilized_but_expired():
         expires_on=now().date() - timedelta(days=2),
     )
     invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
-    assert invoice.available_compute_cost_euro_millicents == -2 * 1000 * 100
+    assert invoice.available_compute_cost_euro_millicents == 0
+    assert invoice.approved_compute_cost_euro_millicents == 1 * 1000 * 100
+    assert invoice.consumed_compute_cost_euro_millicents == 1 * 1000 * 100
+    assert invoice.write_off_compute_cost_euro_millicents == 2 * 1000 * 100
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Part of pitch:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/475#issuecomment-4175366634

and partially:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/465#event-25960017666

While toying on updating the cost overviews on a challenge level I realized that getting a total overview is impossible (or very, very messy) without splitting the write_off (i.e. overcharge) on invoices.

This change set simplifies things a bit and ensures there are 5 properties on the `Invoice` AND `Challenge` level:

- `available_compute_cost_euro_millicents`: how much can still be utilized
- `approved_compute_cost_euro_millicents`: how much budget is authorized 
- `consumed_compute_cost_euro_millicents`: how much of approved is actually used with the notion that you can't consume what is not there
- `write_off_compute_cost_euro_millicents`: the overcharge, what we eat in costs
- `Invoice.percent_budget_consumed` / `Challenge.percent_active_budget_consumed`: capped at 100%

The `consumed_compute_cost_euro_millicents` + `write_off_compute_cost_euro_millicents` is total utilization sum.


### Warning for potential confusion

`Challenge.available_compute_cost_euro_millicents` is not the same as the annotation via `ChallengeQuerySet.with_available_compute`: `available_compute_euro_millicents`. The latter is still based on the whole `Challenge` utilization.