### PR TITLE
Fix task errors for add_image_to_answer

### DIFF
--- a/app/grandchallenge/reader_studies/tasks.py
+++ b/app/grandchallenge/reader_studies/tasks.py
@@ -118,7 +118,7 @@ def create_display_sets_for_upload_session(
             ds.values.add(civ)
 
 
-@lambda_task
+@lambda_task(queue=LambdaTaskQueueChoices.MEM8G)
 def add_image_to_answer(
     *, upload_session_pk: str | UUID, answer_pk: str | UUID
 ):

--- a/app/grandchallenge/reader_studies/tasks.py
+++ b/app/grandchallenge/reader_studies/tasks.py
@@ -142,13 +142,17 @@ def add_image_to_answer(
                 error=e
             )
             upload_session.save()
+            return {"status": "Voxel values for answer are invalid"}
         else:
             answer.answer_image = image
             answer.save()
             image.assign_view_perm_to_creator()
             image.update_viewer_groups_permissions()
+            return {"status": "Answer successfully updated"}
     else:
-        raise ValueError("Upload session for answer does not match")
+        return {
+            "status": f"Upload session for answer ({answer.answer}) does not match {upload_session_pk}"
+        }
 
 
 @lambda_task(queue=LambdaTaskQueueChoices.MEM8G)


### PR DESCRIPTION
`add_image_to_answer` would raise an error if the answer upload session and the requested upload session that has just finished processing did not match. This happens when a user saves an annotation answer in rapid succession.

This should not be a task error as the task behaved correctly, so now we return a status object with what happened, which can be seen in the Django admin.