### PR TITLE
Show budget consumption in `Invoice` admin

### DIFF
--- a/app/grandchallenge/core/templatetags/costs.py
+++ b/app/grandchallenge/core/templatetags/costs.py
@@ -9,16 +9,13 @@ register = template.Library()
 def euro(value, decimal_places=2):
     try:
         return format_html("€&nbsp;{}", f"{value:,.{decimal_places}f}")
-    except ValueError:
-        return ""
+    except (TypeError, ValueError):
+        return "-"
 
 
 @register.filter
 def millicents_to_euro(millicents):
-    try:
-        return euro(millicents / 1000 / 100)
-    except TypeError:
-        return "-"
+    return euro(millicents / 1000 / 100)
 
 
 @register.filter

--- a/app/grandchallenge/core/templatetags/costs.py
+++ b/app/grandchallenge/core/templatetags/costs.py
@@ -5,17 +5,19 @@ from django.utils.html import format_html
 register = template.Library()
 
 
-@register.filter
 def euro(value, decimal_places=2):
     try:
         return format_html("€&nbsp;{}", f"{value:,.{decimal_places}f}")
-    except (TypeError, ValueError):
-        return "-"
+    except ValueError:
+        return ""
 
 
 @register.filter
 def millicents_to_euro(millicents):
-    return euro(millicents / 1000 / 100)
+    try:
+        return euro(millicents / 1000 / 100)
+    except TypeError:
+        return "-"
 
 
 @register.filter

--- a/app/grandchallenge/core/templatetags/costs.py
+++ b/app/grandchallenge/core/templatetags/costs.py
@@ -5,6 +5,7 @@ from django.utils.html import format_html
 register = template.Library()
 
 
+@register.filter
 def euro(value, decimal_places=2):
     try:
         return format_html("€&nbsp;{}", f"{value:,.{decimal_places}f}")

--- a/app/grandchallenge/invoices/admin.py
+++ b/app/grandchallenge/invoices/admin.py
@@ -47,18 +47,18 @@ class ToCheckFilter(admin.SimpleListFilter):
         return queryset
 
 
-class IsActiveFilter(admin.SimpleListFilter):
-    title = "is active"
-    parameter_name = "is_active"
+class IsExpiredFilter(admin.SimpleListFilter):
+    title = "is expired"
+    parameter_name = "is_expired"
 
     def lookups(self, request, model_admin):
         return [("1", "Yes"), ("0", "No")]
 
     def queryset(self, request, queryset):
         if self.value() == "1":
-            return queryset.exclude(is_expired=True)
+            return queryset.filter(is_expired=True)
         elif self.value() == "0":
-            return queryset.exclude(is_expired=False)
+            return queryset.filter(is_expired=False)
         return queryset
 
 
@@ -74,13 +74,13 @@ class InvoiceAdmin(admin.ModelAdmin):
         "issued_on",
         "expires_on",
         "last_checked_on",
-        "is_active",
+        "is_not_expired",
         "internal_comments",
     )
     list_filter = (
         OverdueListFilter,
         ToCheckFilter,
-        IsActiveFilter,
+        IsExpiredFilter,
         "payment_status",
         "payment_type",
         "challenge__short_name",
@@ -111,7 +111,7 @@ class InvoiceAdmin(admin.ModelAdmin):
                     "follow_up_on",
                     (
                         "expires_on",
-                        "is_active",
+                        "is_not_expired",
                     ),
                 ]
             },
@@ -162,7 +162,7 @@ class InvoiceAdmin(admin.ModelAdmin):
         "consumed_compute_cost",
         "write_off_compute_cost",
         "total_amount_euros",
-        "is_active",
+        "is_not_expired",
     ]
 
     ordering = ["expires_on", "created"]
@@ -179,7 +179,7 @@ class InvoiceAdmin(admin.ModelAdmin):
         return obj.internal_invoice_number
 
     @admin.display(boolean=True)
-    def is_active(self, obj):
+    def is_not_expired(self, obj):
         return not obj.is_expired
 
     def available_compute_cost(self, obj):

--- a/app/grandchallenge/invoices/admin.py
+++ b/app/grandchallenge/invoices/admin.py
@@ -58,6 +58,7 @@ class InvoiceAdmin(admin.ModelAdmin):
         "percent_budget_consumed_display",
         "issued_on",
         "follow_up_on",
+        "is_active",
         "internal_comments",
     )
     list_filter = (
@@ -90,7 +91,10 @@ class InvoiceAdmin(admin.ModelAdmin):
                     "paid_on",
                     "last_checked_on",
                     "follow_up_on",
-                    "expires_on",
+                    (
+                        "expires_on",
+                        "is_active",
+                    ),
                 ]
             },
         ),
@@ -139,6 +143,7 @@ class InvoiceAdmin(admin.ModelAdmin):
         "consumed_compute_cost",
         "write_off_compute_cost",
         "total_amount_euros",
+        "is_active",
     ]
 
     @admin.display(description="Total")
@@ -148,6 +153,10 @@ class InvoiceAdmin(admin.ModelAdmin):
     @admin.display(description="Number")
     def internal_invoice_number_display(self, obj):
         return obj.internal_invoice_number
+
+    @admin.display(boolean=True)
+    def is_active(self, obj):
+        return not obj.is_expired
 
     def available_compute_cost(self, obj):
         return millicents_to_euro(obj.available_compute_cost_euro_millicents)

--- a/app/grandchallenge/invoices/admin.py
+++ b/app/grandchallenge/invoices/admin.py
@@ -150,7 +150,7 @@ class InvoiceAdmin(admin.ModelAdmin):
     def total_amount_euros(self, obj):
         return euro(obj.total_amount_euros, decimal_places=0)
 
-    @admin.display(description="Number")
+    @admin.display(description="Number")  # Reduce column width
     def internal_invoice_number_display(self, obj):
         return obj.internal_invoice_number
 

--- a/app/grandchallenge/invoices/admin.py
+++ b/app/grandchallenge/invoices/admin.py
@@ -6,6 +6,7 @@ from grandchallenge.core.admin import (
     UserObjectPermissionAdmin,
 )
 from grandchallenge.core.templatetags.bleach import md2html
+from grandchallenge.core.templatetags.costs import euro, millicents_to_euro
 from grandchallenge.invoices.models import (
     Invoice,
     InvoiceGroupObjectPermission,
@@ -50,17 +51,13 @@ class ToCheckFilter(admin.SimpleListFilter):
 class InvoiceAdmin(admin.ModelAdmin):
     list_display = (
         "challenge",
-        "issued_on",
-        "expires_on",
-        "follow_up_on",
-        "internal_invoice_number",
-        "internal_client_number",
-        "contact_email",
-        "total_amount_euros",
+        "internal_invoice_number_display",
         "payment_type",
         "payment_status",
-        "paid_on",
-        "last_checked_on",
+        "total_amount_euros",
+        "percent_budget_consumed_display",
+        "issued_on",
+        "follow_up_on",
         "internal_comments",
     )
     list_filter = (
@@ -70,8 +67,106 @@ class InvoiceAdmin(admin.ModelAdmin):
         "payment_type",
         "challenge__short_name",
     )
+    fieldsets = [
+        (
+            None,
+            {
+                "fields": [
+                    "challenge",
+                    "payment_type",
+                    "payment_status",
+                    "total_amount_euros",
+                    "internal_comments",
+                    "internal_invoice_number",
+                    "internal_client_number",
+                ]
+            },
+        ),
+        (
+            "Budget Costs",
+            {
+                "fields": [
+                    "support_costs_euros",
+                    "compute_costs_euros",
+                    "storage_costs_euros",
+                ]
+            },
+        ),
+        (
+            "Budget Usage",
+            {
+                "fields": [
+                    "percent_budget_consumed_display",
+                    "available_compute_cost",
+                    "approved_compute_cost",
+                    "consumed_compute_cost",
+                    "write_off_compute_cost",
+                ]
+            },
+        ),
+        (
+            "Dates",
+            {
+                "fields": [
+                    "issued_on",
+                    "paid_on",
+                    "last_checked_on",
+                    "follow_up_on",
+                    "expires_on",
+                ]
+            },
+        ),
+        (
+            "Billing details",
+            {
+                "fields": [
+                    "external_reference",
+                    "billing_address",
+                    "contact_name",
+                    "contact_email",
+                    "vat_number",
+                    "invoice_request_text",
+                ]
+            },
+        ),
+    ]
     autocomplete_fields = ("challenge",)
-    readonly_fields = ["invoice_request_text", "compute_cost_euro_millicents"]
+    readonly_fields = [
+        "invoice_request_text",
+        "percent_budget_consumed_display",
+        "available_compute_cost",
+        "approved_compute_cost",
+        "consumed_compute_cost",
+        "write_off_compute_cost",
+        "total_amount_euros",
+    ]
+
+    @admin.display(description="Total")
+    def total_amount_euros(self, obj):
+        return euro(obj.total_amount_euros, decimal_places=0)
+
+    @admin.display(description="Number")
+    def internal_invoice_number_display(self, obj):
+        return obj.internal_invoice_number
+
+    def available_compute_cost(self, obj):
+        return millicents_to_euro(obj.available_compute_cost_euro_millicents)
+
+    def approved_compute_cost(self, obj):
+        return millicents_to_euro(obj.approved_compute_cost_euro_millicents)
+
+    def consumed_compute_cost(self, obj):
+        return millicents_to_euro(obj.consumed_compute_cost_euro_millicents)
+
+    def write_off_compute_cost(self, obj):
+        return millicents_to_euro(obj.write_off_compute_cost_euro_millicents)
+
+    @admin.display(description="Consumed budget")
+    def percent_budget_consumed_display(self, obj):
+        value = obj.percent_budget_consumed
+        if value is None:
+            return "-"
+        return f"{value}%"
 
     def has_delete_permission(self, request, obj=None):
         # invoices cannot be deleted
@@ -113,7 +208,12 @@ class InvoiceAdmin(admin.ModelAdmin):
         return md2html(warning_text + invoice_request_details)
 
     def get_queryset(self, request):
-        return super().get_queryset(request).with_overdue_status()
+        return (
+            super()
+            .get_queryset(request)
+            .with_overdue_status()
+            .with_budget_authorization()
+        )
 
 
 admin.site.register(InvoiceUserObjectPermission, UserObjectPermissionAdmin)

--- a/app/grandchallenge/invoices/admin.py
+++ b/app/grandchallenge/invoices/admin.py
@@ -83,6 +83,18 @@ class InvoiceAdmin(admin.ModelAdmin):
             },
         ),
         (
+            "Dates",
+            {
+                "fields": [
+                    "issued_on",
+                    "paid_on",
+                    "last_checked_on",
+                    "follow_up_on",
+                    "expires_on",
+                ]
+            },
+        ),
+        (
             "Budget Costs",
             {
                 "fields": [
@@ -101,18 +113,6 @@ class InvoiceAdmin(admin.ModelAdmin):
                     "approved_compute_cost",
                     "consumed_compute_cost",
                     "write_off_compute_cost",
-                ]
-            },
-        ),
-        (
-            "Dates",
-            {
-                "fields": [
-                    "issued_on",
-                    "paid_on",
-                    "last_checked_on",
-                    "follow_up_on",
-                    "expires_on",
                 ]
             },
         ),

--- a/app/grandchallenge/invoices/admin.py
+++ b/app/grandchallenge/invoices/admin.py
@@ -57,7 +57,8 @@ class InvoiceAdmin(admin.ModelAdmin):
         "total_amount_euros",
         "percent_budget_consumed_display",
         "issued_on",
-        "follow_up_on",
+        "expires_on",
+        "last_checked_on",
         "is_active",
         "internal_comments",
     )
@@ -73,6 +74,7 @@ class InvoiceAdmin(admin.ModelAdmin):
             None,
             {
                 "fields": [
+                    "created",
                     "challenge",
                     "payment_type",
                     "payment_status",
@@ -136,6 +138,7 @@ class InvoiceAdmin(admin.ModelAdmin):
     ]
     autocomplete_fields = ("challenge",)
     readonly_fields = [
+        "created",
         "invoice_request_text",
         "percent_budget_consumed_display",
         "available_compute_cost",
@@ -145,6 +148,8 @@ class InvoiceAdmin(admin.ModelAdmin):
         "total_amount_euros",
         "is_active",
     ]
+
+    ordering = ["expires_on", "created"]
 
     @admin.display(description="Total")
     def total_amount_euros(self, obj):

--- a/app/grandchallenge/invoices/admin.py
+++ b/app/grandchallenge/invoices/admin.py
@@ -148,7 +148,10 @@ class InvoiceAdmin(admin.ModelAdmin):
 
     @admin.display(description="Total")
     def total_amount_euros(self, obj):
-        return euro(obj.total_amount_euros, decimal_places=0)
+        if obj.total_amount_euros:
+            return euro(obj.total_amount_euros, decimal_places=0)
+        else:
+            return ""
 
     @admin.display(description="Number")  # Reduce column width
     def internal_invoice_number_display(self, obj):

--- a/app/grandchallenge/invoices/admin.py
+++ b/app/grandchallenge/invoices/admin.py
@@ -47,6 +47,21 @@ class ToCheckFilter(admin.SimpleListFilter):
         return queryset
 
 
+class IsActiveFilter(admin.SimpleListFilter):
+    title = "is active"
+    parameter_name = "is_active"
+
+    def lookups(self, request, model_admin):
+        return [("1", "Yes"), ("0", "No")]
+
+    def queryset(self, request, queryset):
+        if self.value() == "1":
+            return queryset.exclude(is_expired=True)
+        elif self.value() == "0":
+            return queryset.exclude(is_expired=False)
+        return queryset
+
+
 @admin.register(Invoice)
 class InvoiceAdmin(admin.ModelAdmin):
     list_display = (
@@ -65,6 +80,7 @@ class InvoiceAdmin(admin.ModelAdmin):
     list_filter = (
         OverdueListFilter,
         ToCheckFilter,
+        IsActiveFilter,
         "payment_status",
         "payment_type",
         "challenge__short_name",

--- a/app/grandchallenge/invoices/models.py
+++ b/app/grandchallenge/invoices/models.py
@@ -100,7 +100,7 @@ class InvoiceQuerySet(models.QuerySet):
             )
         )
 
-        return self.annotate(
+        return self.with_is_expired().annotate(
             is_budget_authorized=ExpressionWrapper(
                 ~Q(payment_status=PaymentStatusChoices.CANCELLED)
                 & (
@@ -120,6 +120,9 @@ class InvoiceQuerySet(models.QuerySet):
                 output_field=models.BooleanField(),
             )
         )
+
+    def with_is_expired(self):
+        return self.annotate(is_expired=Q(expires_on__lt=Now()))
 
     def to_check(self):
         return self.filter(
@@ -427,10 +430,6 @@ class Invoice(models.Model, FieldChangeMixin):
             return "success"
         else:
             return "info"
-
-    @cached_property
-    def is_expired(self):
-        return self.expires_on < now().date()
 
     @cached_property
     def available_compute_cost_euro_millicents(self):

--- a/app/grandchallenge/invoices/views.py
+++ b/app/grandchallenge/invoices/views.py
@@ -31,9 +31,11 @@ class InvoiceList(
 
     def get_queryset(self):
         queryset = super().get_queryset()
-        return queryset.filter(
-            challenge=self.request.challenge
-        ).with_overdue_status()
+        return (
+            queryset.filter(challenge=self.request.challenge)
+            .with_overdue_status()
+            .with_is_expired()
+        )
 
 
 class InvoiceDetail(
@@ -52,4 +54,4 @@ class InvoiceDetail(
 
     def get_queryset(self):
         queryset = super().get_queryset()
-        return queryset.with_overdue_status()
+        return queryset.with_overdue_status().with_is_expired()

--- a/app/tests/invoices_tests/test_models.py
+++ b/app/tests/invoices_tests/test_models.py
@@ -305,6 +305,7 @@ def test_follow_up_on_required_for_initialized_postpaid():
     invoice2.full_clean()
 
 
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "invoice_kwargs, badge",
     (
@@ -350,13 +351,15 @@ def test_follow_up_on_required_for_initialized_postpaid():
     ),
 )
 def test_prepaid_invoice_status_badge(invoice_kwargs, badge):
-    invoice = InvoiceFactory.build(
+    invoice = InvoiceFactory(
         payment_type=Invoice.PaymentTypeChoices.PREPAID,
         **invoice_kwargs,
     )
+    invoice = Invoice.objects.with_is_expired().get(pk=invoice.pk)
     assert invoice.get_status_badge() == badge
 
 
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "invoice_kwargs, badge",
     (
@@ -402,13 +405,15 @@ def test_prepaid_invoice_status_badge(invoice_kwargs, badge):
     ),
 )
 def test_postpaid_invoice_status_badge(invoice_kwargs, badge):
-    invoice = InvoiceFactory.build(
+    invoice = InvoiceFactory(
         payment_type=Invoice.PaymentTypeChoices.POSTPAID,
         **invoice_kwargs,
     )
+    invoice = Invoice.objects.with_is_expired().get(pk=invoice.pk)
     assert invoice.get_status_badge() == badge
 
 
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "invoice_kwargs, badge",
     (
@@ -426,7 +431,7 @@ def test_postpaid_invoice_status_badge(invoice_kwargs, badge):
         ),
         (
             dict(
-                payment_status=Invoice.PaymentStatusChoices.INITIALIZED,
+                payment_status=Invoice.PaymentStatusChoices.PAID,
                 expires_on=now().date() - timedelta(days=7),
                 follow_up_on=now().date() - timedelta(days=30),
             ),
@@ -435,8 +440,9 @@ def test_postpaid_invoice_status_badge(invoice_kwargs, badge):
     ),
 )
 def test_complimentary_invoice_status_badge(invoice_kwargs, badge):
-    invoice = InvoiceFactory.build(
+    invoice = InvoiceFactory(
         payment_type=Invoice.PaymentTypeChoices.COMPLIMENTARY,
         **invoice_kwargs,
     )
+    invoice = Invoice.objects.with_is_expired().get(pk=invoice.pk)
     assert invoice.get_status_badge() == badge


### PR DESCRIPTION
Part of pitch (sort of):
- https://github.com/DIAGNijmegen/rse-roadmap/issues/465#event-25960017666

Since the invoice detail page is meant for challenge organizers, the site admins need to rely on the backend display of information on `Invoice` objects. This includes current usage and status.

This change set re-arranges shown fields in the admin into field sets (plenty of fields to show) and adds these fields:
- `Is active` (i.e. not expired)
- `Consumed budget` (% consumed)
- `Available Compute Cost` (Euros)
- `Approved Compute Cost` (Euros)
- `Consumed Compute Cost` (Euros)
- `Write Off Compute Cost` (Euros)

It also removes some fields from the list view to make it more compact, leaving the most essential (IMO).


## Showcase

<details>
<summary>A few screenshots</summary>

### List View 

<img width="1708" height="703" alt="afbeelding" src="https://github.com/user-attachments/assets/5f934433-d723-469e-acc2-dbfa96e12508" />


### Detail View

(split over three screenshots)

<img width="1708" height="984" alt="afbeelding" src="https://github.com/user-attachments/assets/d9dc1803-4ccb-4ee0-a5b1-41279ff2b3cf" />


<img width="1708" height="503" alt="afbeelding" src="https://github.com/user-attachments/assets/ee813b8f-c1e2-4045-bcf5-9dee89a0b357" />

<img width="1708" height="1008" alt="afbeelding" src="https://github.com/user-attachments/assets/df8adbe2-1b96-4977-801b-de9733d68f3b" />


</details>