### PR TITLE
Add a copy button for image pks

### DIFF
--- a/app/grandchallenge/components/templates/components/partials/civ/dicom_image_set.html
+++ b/app/grandchallenge/components/templates/components/partials/civ/dicom_image_set.html
@@ -1,13 +1,17 @@
 {% load pathlib %}
+{% load copy_button %}
 
-<div class="badge badge-primary"
-    title="{{ civ.interface.title }}"
->
-    {% if display_inline %}
-        {{ civ.interface.title|truncatechars:64 }}:
-        {{ civ.image.name|stem|truncatechars:32 }}
-    {% else %}
-        {{ civ.interface.title }}:
-        {{ civ.image.name|stem }}
-    {% endif %}
-</div>
+<span>
+    <div class="badge badge-primary"
+        title="{{ civ.interface.title }}"
+    >
+        {% if display_inline %}
+            {{ civ.interface.title|truncatechars:64 }}:
+            {{ civ.image.name|stem|truncatechars:32 }}
+        {% else %}
+            {{ civ.interface.title }}:
+            {{ civ.image.name|stem }}
+        {% endif %}
+    </div>
+    {% copy_button_only value=civ.image.pk title="Copy image pk to clipboard" %}
+</span>

--- a/app/grandchallenge/components/templates/components/partials/civ/panimg_image.html
+++ b/app/grandchallenge/components/templates/components/partials/civ/panimg_image.html
@@ -1,22 +1,26 @@
 {% load pathlib %}
+{% load copy_button %}
 
 <ul class="list-unstyled mb-0">
   {% for file in civ.image.files.all %}
     <li>
-        <a class="badge badge-primary"
-            href="{{ file.file.url }}"
-            title="{{ civ.interface.title }}"
-        >
-        <i class="fas fa-fw fa-download"></i>
-        {% if display_inline %}
-            {{ civ.interface.title|truncatechars:64 }}:
-            {{ civ.image.name|stem|truncatechars:32 }}
-        {% else %}
-            {{ civ.interface.title }}:
-            {{ civ.image.name|stem }}
-        {% endif %}
-        ({{ file.file|suffix }})
-        </a>
+        <span>
+            <a class="badge badge-primary"
+                href="{{ file.file.url }}"
+                title="{{ civ.interface.title }}"
+            >
+            <i class="fas fa-fw fa-download"></i>
+            {% if display_inline %}
+                {{ civ.interface.title|truncatechars:64 }}:
+                {{ civ.image.name|stem|truncatechars:32 }}
+            {% else %}
+                {{ civ.interface.title }}:
+                {{ civ.image.name|stem }}
+            {% endif %}
+            ({{ file.file|suffix }})
+            </a>
+            {% copy_button_only value=civ.image.pk title="Copy image pk to clipboard" %}
+        </span>
     </li>
   {% endfor %}
 </ul>

--- a/app/grandchallenge/core/templates/grandchallenge/partials/copy_button.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/copy_button.html
@@ -1,0 +1,10 @@
+<span>
+    {% if link %}
+        <a href="{{ link }}">
+    {% endif %}
+            {{ display_value }}
+    {% if link %}
+        </a>
+    {% endif %}
+    {{ button }}
+</span>

--- a/app/grandchallenge/core/templatetags/copy_button.py
+++ b/app/grandchallenge/core/templatetags/copy_button.py
@@ -1,35 +1,35 @@
 from django import template
 from django.template.defaultfilters import stringfilter
+from django.template.loader import render_to_string
 from django.utils.html import format_html
 
 register = template.Library()
 
 
-@register.filter
-@stringfilter
-def copy_button(value, link=None):
-    button = format_html(
+@register.simple_tag
+def copy_button_only(value, title="Copy to clipboard"):
+    return format_html(
         "<button "
         'type="button" '
         'class="btn btn-link text-dark p-0 mt-0 mb-1 mx-1 copy-btn shadow-none" '
         'data-copy="{value}" '
         'data-placement="left" '
-        'title="Copy to clipboard">'
+        'title="{title}">'
         '<i class="far fa-copy"></i>'
         "</button>",
         value=value,
+        title=title,
     )
 
-    shortened = str(value).split("-", 1)[0]
 
-    if link:
-        return (
-            format_html(
-                '<a href="{link}">{display_value}</a>',
-                link=link,
-                display_value=shortened,
-            )
-            + button
-        )
-    else:
-        return format_html("{display_value}", display_value=shortened) + button
+@register.filter
+@stringfilter
+def copy_button(value, link=None):
+    return render_to_string(
+        "grandchallenge/partials/copy_button.html",
+        context={
+            "button": copy_button_only(value=value),
+            "display_value": str(value).split("-", 1)[0],
+            "link": link,
+        },
+    )

--- a/app/tests/core_tests/test_copy_button.py
+++ b/app/tests/core_tests/test_copy_button.py
@@ -1,0 +1,45 @@
+from grandchallenge.core.templatetags.copy_button import (
+    copy_button,
+    copy_button_only,
+)
+
+
+class TestCopyButtonOnly:
+    def test_renders_button_with_value(self):
+        result = copy_button_only(value="test-value")
+        assert 'data-copy="test-value"' in result
+
+    def test_default_title(self):
+        result = copy_button_only(value="x")
+        assert 'title="Copy to clipboard"' in result
+
+    def test_custom_title(self):
+        result = copy_button_only(value="x", title="Custom title")
+        assert 'title="Custom title"' in result
+
+    def test_escapes_html_in_value(self):
+        result = copy_button_only(value='<script>alert("xss")</script>')
+        assert "<script>" not in result
+        assert "&lt;script&gt;" in result
+
+    def test_escapes_html_in_title(self):
+        result = copy_button_only(value="x", title='<img src="x">')
+        assert "<img" not in result
+
+
+class TestCopyButton:
+    def test_contains_copy_button(self):
+        result = copy_button("abc-def-ghi")
+        assert 'data-copy="abc-def-ghi"' in result
+
+    def test_display_value_is_prefix_before_first_dash(self):
+        result = copy_button("abc-def-ghi")
+        assert "abc" in result
+
+    def test_no_link_by_default(self):
+        result = copy_button("abc-def")
+        assert "<a" not in result
+
+    def test_with_link(self):
+        result = copy_button("abc-def", "/some/url/")
+        assert 'href="/some/url/"' in result


### PR DESCRIPTION
Separates out the button from the rendered link, and moves that to a Django template partial as the format_html was getting a bit complex. Adds a span so the links and buttons do not line break.

Examples:

<img width="290" height="54" alt="Screenshot 2026-06-09 at 16 23 16" src="https://github.com/user-attachments/assets/9a0ff946-6073-4298-8d1f-5f354d46238f" />

<img width="1149" height="314" alt="Screenshot 2026-06-09 at 16 23 00" src="https://github.com/user-attachments/assets/5af7d424-9cff-44a5-908d-3c8c6d0a47e5" />


Closes https://github.com/DIAGNijmegen/rse-roadmap/issues/491