### PR TITLE
Refactor utilization priority of invoices

### DIFF
--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -816,9 +816,16 @@ class Challenge(ChallengeBase, FieldChangeMixin):
 
     @property
     def active_invoice(self):
-        for invoice in self.invoices.order_by("expires_on", "created").all():
+        prioritized_invoices = (
+            self.invoices.with_utilization_priority_per_challenge().order_by(
+                "utilization_priority"
+            )
+        )
+
+        for invoice in prioritized_invoices:
             if invoice.available_compute_cost_euro_millicents > 0:
                 return invoice
+
         raise InsufficientBudgetError
 
     @cached_property

--- a/app/grandchallenge/invoices/admin.py
+++ b/app/grandchallenge/invoices/admin.py
@@ -95,6 +95,7 @@ class InvoiceAdmin(admin.ModelAdmin):
                     "challenge",
                     "payment_type",
                     "payment_status",
+                    "utilization_priority",
                     "total_amount_euros",
                     "internal_comments",
                     "internal_invoice_number",

--- a/app/grandchallenge/invoices/admin.py
+++ b/app/grandchallenge/invoices/admin.py
@@ -180,7 +180,9 @@ class InvoiceAdmin(admin.ModelAdmin):
     def internal_invoice_number_display(self, obj):
         return obj.internal_invoice_number
 
-    @admin.display(boolean=True)
+    @admin.display(
+        boolean=True, ordering="expires_on", description="Not expired"
+    )
     def is_not_expired(self, obj):
         return not obj.is_expired
 

--- a/app/grandchallenge/invoices/admin.py
+++ b/app/grandchallenge/invoices/admin.py
@@ -167,7 +167,7 @@ class InvoiceAdmin(admin.ModelAdmin):
         "utilization_priority",
     ]
 
-    ordering = ["expires_on", "created"]
+    ordering = ["created"]
 
     @admin.display(description="Total")
     def total_amount_euros(self, obj):

--- a/app/grandchallenge/invoices/admin.py
+++ b/app/grandchallenge/invoices/admin.py
@@ -75,6 +75,7 @@ class InvoiceAdmin(admin.ModelAdmin):
         "expires_on",
         "last_checked_on",
         "is_not_expired",
+        "utilization_priority",
         "internal_comments",
     )
     list_filter = (
@@ -163,6 +164,7 @@ class InvoiceAdmin(admin.ModelAdmin):
         "write_off_compute_cost",
         "total_amount_euros",
         "is_not_expired",
+        "utilization_priority",
     ]
 
     ordering = ["expires_on", "created"]
@@ -193,6 +195,10 @@ class InvoiceAdmin(admin.ModelAdmin):
 
     def write_off_compute_cost(self, obj):
         return millicents_to_euro(obj.write_off_compute_cost_euro_millicents)
+
+    @admin.display(ordering="utilization_priority")
+    def utilization_priority(self, obj):
+        return obj.utilization_priority
 
     @admin.display(description="Consumed budget")
     def percent_budget_consumed_display(self, obj):
@@ -246,6 +252,7 @@ class InvoiceAdmin(admin.ModelAdmin):
             .get_queryset(request)
             .with_overdue_status()
             .with_budget_authorization()
+            .with_utilization_priority_per_challenge()
         )
 
 

--- a/app/grandchallenge/invoices/models.py
+++ b/app/grandchallenge/invoices/models.py
@@ -6,8 +6,16 @@ from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Count, Exists, ExpressionWrapper, F, OuterRef, Q
-from django.db.models.functions import Cast, Now
+from django.db.models import (
+    Count,
+    Exists,
+    ExpressionWrapper,
+    F,
+    OuterRef,
+    Q,
+    Window,
+)
+from django.db.models.functions import Cast, Now, RowNumber
 from django.utils.html import format_html
 from django.utils.timezone import now
 from guardian.shortcuts import assign_perm
@@ -136,6 +144,17 @@ class InvoiceQuerySet(models.QuerySet):
                 payment_type=Invoice.PaymentTypeChoices.POSTPAID,
                 payment_status=Invoice.PaymentStatusChoices.INITIALIZED,
                 follow_up_on__lte=now().date(),
+            )
+        )
+
+    def with_utilization_priority_per_challenge(self):
+        return self.annotate(
+            is_paid=Q(payment_status=Invoice.PaymentStatusChoices.PAID)
+        ).annotate(
+            utilization_priority=Window(
+                expression=RowNumber(),
+                partition_by=[F("challenge_id")],
+                order_by=["-is_paid", "expires_on", "created"],
             )
         )
 

--- a/app/grandchallenge/utilization/management/commands/route_challenge_utilizations_to_invoices.py
+++ b/app/grandchallenge/utilization/management/commands/route_challenge_utilizations_to_invoices.py
@@ -35,7 +35,8 @@ def get_invoice_map():
     for invoice in (
         Invoice.objects.with_budget_authorization()
         .exclude(is_budget_authorized=False)
-        .order_by("expires_on", "created")
+        .with_utilization_priority_per_challenge()
+        .order_by("utilization_priority")
     ):
         invoices[invoice.challenge_id].append(invoice)
         invoice._original_compute_cost_euro_millicents = (

--- a/app/tests/challenges_tests/test_models.py
+++ b/app/tests/challenges_tests/test_models.py
@@ -876,60 +876,6 @@ def test_active_invoice_raises_on_zero_balance():
 
 
 @pytest.mark.django_db
-def test_active_invoice_orders_by_expiry():
-    challenge = ChallengeFactory()
-
-    _fixed_now = now()
-
-    invoice0 = InvoiceFactory(
-        challenge=challenge,
-        compute_costs_euros=1,
-        compute_cost_euro_millicents=0,
-        payment_type=PaymentTypeChoices.PREPAID,
-        payment_status=Invoice.PaymentStatusChoices.PAID,
-        expires_on=_fixed_now + timedelta(10),
-    )
-    invoice1 = InvoiceFactory(
-        challenge=challenge,
-        compute_costs_euros=1,
-        compute_cost_euro_millicents=0,
-        payment_type=PaymentTypeChoices.PREPAID,
-        payment_status=Invoice.PaymentStatusChoices.PAID,
-        expires_on=_fixed_now + timedelta(10),
-    )
-
-    challenge = (
-        Challenge.objects.with_invoices_with_budget_authorization().get(
-            pk=challenge.pk
-        )
-    )
-    # All things being equal, use created time to determine order, so invoice0 should be active as it was created first
-    assert challenge.active_invoice == invoice0
-
-    invoice1.expires_on = _fixed_now + timedelta(5)
-    invoice1.save()
-    assert invoice1.expires_on < invoice0.expires_on, "Sanity"
-
-    challenge = (
-        Challenge.objects.with_invoices_with_budget_authorization().get(
-            pk=challenge.pk
-        )
-    )
-    assert challenge.active_invoice == invoice1
-
-    invoice0.expires_on = _fixed_now + timedelta(4)
-    invoice0.save()
-    assert invoice0.expires_on < invoice1.expires_on, "Sanity"
-
-    challenge = (
-        Challenge.objects.with_invoices_with_budget_authorization().get(
-            pk=challenge.pk
-        )
-    )
-    assert challenge.active_invoice == invoice0
-
-
-@pytest.mark.django_db
 def test_active_invoice_ignores_invoices_with_negative_balance():
     challenge = ChallengeFactory()
 

--- a/app/tests/invoices_tests/test_models.py
+++ b/app/tests/invoices_tests/test_models.py
@@ -12,6 +12,7 @@ from grandchallenge.invoices.models import (
     PaymentStatusChoices,
     PaymentTypeChoices,
 )
+from tests.factories import ChallengeFactory
 from tests.invoices_tests.factories import InvoiceFactory
 
 
@@ -446,3 +447,147 @@ def test_complimentary_invoice_status_badge(invoice_kwargs, badge):
     )
     invoice = Invoice.objects.with_is_expired().get(pk=invoice.pk)
     assert invoice.get_status_badge() == badge
+
+
+@pytest.mark.django_db
+def test_utilization_priority_per_challenge():
+    challenge_0 = ChallengeFactory()
+    challenge_1 = ChallengeFactory()
+
+    invoice_0_0 = InvoiceFactory(challenge=challenge_0)
+    invoice_0_1 = InvoiceFactory(challenge=challenge_0)
+    invoice_1_0 = InvoiceFactory(challenge=challenge_1)
+    invoice_1_1 = InvoiceFactory(challenge=challenge_1)
+
+    prioritized_invoices = (
+        Invoice.objects.with_utilization_priority_per_challenge().order_by(
+            "utilization_priority"
+        )
+    )
+
+    challenge_0_prioritized_invoices = prioritized_invoices.filter(
+        challenge=challenge_0
+    )
+    assert list(
+        challenge_0_prioritized_invoices.values_list("pk", flat=True)
+    ) == [invoice_0_0.pk, invoice_0_1.pk]
+    assert list(
+        challenge_0_prioritized_invoices.values_list(
+            "utilization_priority", flat=True
+        )
+    ) == [1, 2]
+
+    challenge_1_prioritized_invoices = prioritized_invoices.filter(
+        challenge=challenge_1
+    )
+    assert list(
+        challenge_1_prioritized_invoices.values_list("pk", flat=True)
+    ) == [invoice_1_0.pk, invoice_1_1.pk]
+    assert list(
+        challenge_1_prioritized_invoices.values_list(
+            "utilization_priority", flat=True
+        )
+    ) == [1, 2]
+
+
+@pytest.mark.django_db
+def test_utilization_priority_created():
+    challenge = ChallengeFactory()
+
+    invoice_0 = InvoiceFactory(challenge=challenge)
+    invoice_1 = InvoiceFactory(challenge=challenge)
+
+    prioritized_invoices = (
+        Invoice.objects.with_utilization_priority_per_challenge().order_by(
+            "utilization_priority"
+        )
+    )
+
+    assert list(prioritized_invoices.values_list("pk", flat=True)) == [
+        invoice_0.pk,
+        invoice_1.pk,
+    ]
+
+    invoice_1.created = now() - timedelta(days=7)
+    invoice_1.save()
+
+    prioritized_invoices = (
+        Invoice.objects.with_utilization_priority_per_challenge().order_by(
+            "utilization_priority"
+        )
+    )
+
+    assert list(prioritized_invoices.values_list("pk", flat=True)) == [
+        invoice_1.pk,
+        invoice_0.pk,
+    ]
+
+
+@pytest.mark.django_db
+def test_utilization_priority_expiry_date():
+    challenge = ChallengeFactory()
+
+    invoice_0 = InvoiceFactory(challenge=challenge)
+    invoice_1 = InvoiceFactory(challenge=challenge)
+
+    prioritized_invoices = (
+        Invoice.objects.with_utilization_priority_per_challenge().order_by(
+            "utilization_priority"
+        )
+    )
+
+    assert list(prioritized_invoices.values_list("pk", flat=True)) == [
+        invoice_0.pk,
+        invoice_1.pk,
+    ]
+
+    invoice_1.expires_on = now().date() - timedelta(days=7)
+    invoice_1.save()
+
+    prioritized_invoices = (
+        Invoice.objects.with_utilization_priority_per_challenge().order_by(
+            "utilization_priority"
+        )
+    )
+
+    assert list(prioritized_invoices.values_list("pk", flat=True)) == [
+        invoice_1.pk,
+        invoice_0.pk,
+    ]
+
+
+@pytest.mark.django_db
+def test_utilization_priority_paid_status():
+    challenge = ChallengeFactory()
+
+    invoice_0 = InvoiceFactory(
+        challenge=challenge, payment_status=PaymentStatusChoices.PAID
+    )
+    invoice_1 = InvoiceFactory(
+        challenge=challenge, payment_status=PaymentStatusChoices.PAID
+    )
+
+    prioritized_invoices = (
+        Invoice.objects.with_utilization_priority_per_challenge().order_by(
+            "utilization_priority"
+        )
+    )
+
+    assert list(prioritized_invoices.values_list("pk", flat=True)) == [
+        invoice_0.pk,
+        invoice_1.pk,
+    ]
+
+    invoice_0.payment_status = PaymentStatusChoices.CANCELLED
+    invoice_0.save()
+
+    prioritized_invoices = (
+        Invoice.objects.with_utilization_priority_per_challenge().order_by(
+            "utilization_priority"
+        )
+    )
+
+    assert list(prioritized_invoices.values_list("pk", flat=True)) == [
+        invoice_1.pk,
+        invoice_0.pk,
+    ]


### PR DESCRIPTION
Adds a new annotation to `Invoice` which shows the utilization priority. The lower the number, the sooner it will get utilized (if it has available budget). 

The priority is made such that already `PAID` invoices will have higher priority than those that have available budget but haven't been paid (i.e. postpaid vs prepaid). Priority ignores current incurred costs on the invoice.

See: https://github.com/DIAGNijmegen/rse-roadmap/issues/475#issuecomment-4681336214

In addition, it adds the priority in a sortable manner to the admin invoice list as to make it absolutely obvious in which order existing invoices will be utilized.

<img width="1443" height="443" alt="afbeelding" src="https://github.com/user-attachments/assets/4c411d0d-7f16-4e3e-b6b7-da33f2305037" />
