### PR TITLE
Show challenge budget utilization to challenge organizers

### DIFF
--- a/app/grandchallenge/challenges/emails.py
+++ b/app/grandchallenge/challenges/emails.py
@@ -117,7 +117,7 @@ def send_challenge_request_processed_update_email(
 def send_email_percent_budget_consumed_alert(*, invoice, percent_threshold):
     challenge = invoice.challenge
     subject = format_html(
-        "[{challenge_name}] over {percent_threshold}% Budget Consumed Alert",
+        "[{challenge_name}] over {percent_threshold}% Compute Budget Consumed Alert",
         challenge_name=challenge.short_name,
         percent_threshold=percent_threshold,
     )

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -766,10 +766,21 @@ class Challenge(ChallengeBase, FieldChangeMixin):
         )
 
     @cached_property
+    def active_invoices(self):
+        return self.invoices.filter(is_expired=False)
+
+    @cached_property
     def approved_compute_cost_euro_millicents(self):
         return sum(
             invoice.approved_compute_cost_euro_millicents
             for invoice in self.invoices.all()
+        )
+
+    @cached_property
+    def active_approved_compute_cost_euro_millicents(self):
+        return sum(
+            invoice.approved_compute_cost_euro_millicents
+            for invoice in self.active_invoices
         )
 
     @cached_property
@@ -780,6 +791,13 @@ class Challenge(ChallengeBase, FieldChangeMixin):
         )
 
     @cached_property
+    def active_approved_storage_cost_euro_millicents(self):
+        return sum(
+            invoice.approved_storage_cost_euro_millicents
+            for invoice in self.active_invoices
+        )
+
+    @cached_property
     def available_compute_cost_euro_millicents(self):
         return sum(
             invoice.available_compute_cost_euro_millicents
@@ -787,10 +805,24 @@ class Challenge(ChallengeBase, FieldChangeMixin):
         )
 
     @cached_property
+    def active_available_compute_cost_euro_millicents(self):
+        return sum(
+            invoice.available_compute_cost_euro_millicents
+            for invoice in self.active_invoices
+        )
+
+    @cached_property
     def consumed_compute_cost_euro_millicents(self):
         return sum(
             invoice.consumed_compute_cost_euro_millicents
             for invoice in self.invoices.all()
+        )
+
+    @cached_property
+    def active_consumed_compute_cost_euro_millicents(self):
+        return sum(
+            invoice.consumed_compute_cost_euro_millicents
+            for invoice in self.active_invoices
         )
 
     @cached_property
@@ -802,27 +834,16 @@ class Challenge(ChallengeBase, FieldChangeMixin):
 
     @cached_property
     def percent_active_compute_budget_consumed(self):
-        active_invoices = [
-            invoice
-            for invoice in self.invoices.all()
-            if not invoice.is_expired
-        ]
+        consumed = self.active_consumed_compute_cost_euro_millicents
+        approved = self.active_approved_compute_cost_euro_millicents
 
-        consumed = sum(
-            invoice.consumed_compute_cost_euro_millicents
-            for invoice in active_invoices
-        )
-        approved = sum(
-            invoice.approved_compute_cost_euro_millicents
-            for invoice in active_invoices
-        )
         if approved > 0:
             return int(100 * consumed / approved)
         else:
             return None
 
     @property
-    def active_invoice(self):
+    def utilization_invoice(self):
         prioritized_invoices = (
             self.invoices.with_utilization_priority_per_challenge().order_by(
                 "utilization_priority"

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -773,6 +773,13 @@ class Challenge(ChallengeBase, FieldChangeMixin):
         )
 
     @cached_property
+    def approved_storage_cost_euro_millicents(self):
+        return sum(
+            invoice.storage_costs_euros * 1000 * 100
+            for invoice in self.invoices.all()
+        )
+
+    @cached_property
     def available_compute_cost_euro_millicents(self):
         return sum(
             invoice.available_compute_cost_euro_millicents

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -775,7 +775,7 @@ class Challenge(ChallengeBase, FieldChangeMixin):
     @cached_property
     def approved_storage_cost_euro_millicents(self):
         return sum(
-            invoice.storage_costs_euros * 1000 * 100
+            invoice.approved_storage_cost_euro_millicents
             for invoice in self.invoices.all()
         )
 

--- a/app/grandchallenge/challenges/models.py
+++ b/app/grandchallenge/challenges/models.py
@@ -794,7 +794,7 @@ class Challenge(ChallengeBase, FieldChangeMixin):
         )
 
     @cached_property
-    def percent_active_budget_consumed(self):
+    def percent_active_compute_budget_consumed(self):
         active_invoices = [
             invoice
             for invoice in self.invoices.all()

--- a/app/grandchallenge/challenges/templates/challenges/challenge_costs_overview.html
+++ b/app/grandchallenge/challenges/templates/challenges/challenge_costs_overview.html
@@ -36,7 +36,7 @@
                     <th>Should be Open</th>
                     <th>Most Recent Submission</th>
                     <th>
-                        % Active Budget Consumed
+                        % Active Compute Budget Consumed
                         <span data-toggle="tooltip" data-placement="right"
                               title="Consumed costs as a percentage of the approved costs of the currently active (i.e., non-expired) invoices."
                               class="text-muted">
@@ -102,7 +102,7 @@
                         </td>
                         <td>{% if challenge.should_be_open_but_is_over_budget %}<i class="fa fa-exclamation-triangle text-danger"></i>{% endif %}</td>
                         <td data-order="{% if challenge.cached_latest_result %}{{ challenge.cached_latest_result|date:"c" }}{% else %}-1{% endif %}">{% if challenge.cached_latest_result %}{{ challenge.cached_latest_result|date }}{% endif %}</td>
-                        <td data-order="{% if challenge.percent_active_budget_consumed is None %}-1{% else %}{{ challenge.percent_active_budget_consumed }}{% endif %}" class="{% if challenge.percent_active_budget_consumed >= 100 %}text-danger{% elif challenge.percent_active_budget_consumed >= 70 %}text-warning{% else %}text-success{% endif %}">{% if challenge.percent_active_budget_consumed is not None %}{{ challenge.percent_active_budget_consumed }}&nbsp;%{% endif %}</td>
+                        <td data-order="{% if challenge.percent_active_compute_budget_consumed is None %}-1{% else %}{{ challenge.percent_active_compute_budget_consumed }}{% endif %}" class="{% if challenge.percent_active_compute_budget_consumed >= 100 %}text-danger{% elif challenge.percent_active_compute_budget_consumed >= 70 %}text-warning{% else %}text-success{% endif %}">{% if challenge.percent_active_compute_budget_consumed is not None %}{{ challenge.percent_active_compute_budget_consumed }}&nbsp;%{% endif %}</td>
                         <td data-order="{{ challenge.available_compute_cost_euro_millicents}}" class="{% if challenge.available_compute_cost_euro_millicents <= 0 %}text-danger{% endif %}">{{ challenge.available_compute_cost_euro_millicents|millicents_to_euro }}</td>
                         <td data-order="{{ challenge.approved_compute_cost_euro_millicents }}">{{ challenge.approved_compute_cost_euro_millicents|millicents_to_euro }}</td>
                         <td data-order="{{ challenge.consumed_compute_cost_euro_millicents }}">{{ challenge.consumed_compute_cost_euro_millicents|millicents_to_euro }}</td>

--- a/app/grandchallenge/evaluation/admin.py
+++ b/app/grandchallenge/evaluation/admin.py
@@ -175,7 +175,7 @@ def reevaluate_submissions(modeladmin, request, queryset):
                 pk=submission.phase.challenge.pk
             )
             try:
-                invoice = challenge.active_invoice
+                invoice = challenge.utilization_invoice
             except InsufficientBudgetError:
                 modeladmin.message_user(
                     request,

--- a/app/grandchallenge/evaluation/forms.py
+++ b/app/grandchallenge/evaluation/forms.py
@@ -472,7 +472,7 @@ class SubmissionForm(
             )
 
         try:
-            invoice = self._phase.challenge.active_invoice
+            invoice = self._phase.challenge.utilization_invoice
         except InsufficientBudgetError:
             raise ValidationError(
                 "Challenge has insufficient budget. Please contact the challenge organizers."
@@ -758,7 +758,7 @@ class EvaluationForm(SaveFormInitMixin, AdditionalInputsMixin, forms.Form):
         )
 
         try:
-            invoice = challenge.active_invoice
+            invoice = challenge.utilization_invoice
         except InsufficientBudgetError:
             raise ValidationError(
                 "Challenge has insufficient budget. Please contact support to add more funds."

--- a/app/grandchallenge/invoices/admin.py
+++ b/app/grandchallenge/invoices/admin.py
@@ -70,7 +70,7 @@ class InvoiceAdmin(admin.ModelAdmin):
         "payment_type",
         "payment_status",
         "total_amount_euros",
-        "percent_budget_consumed_display",
+        "percent_compute_budget_consumed_display",
         "issued_on",
         "expires_on",
         "last_checked_on",
@@ -130,7 +130,7 @@ class InvoiceAdmin(admin.ModelAdmin):
             "Budget Usage",
             {
                 "fields": [
-                    "percent_budget_consumed_display",
+                    "percent_compute_budget_consumed_display",
                     "available_compute_cost",
                     "approved_compute_cost",
                     "consumed_compute_cost",
@@ -156,7 +156,7 @@ class InvoiceAdmin(admin.ModelAdmin):
     readonly_fields = [
         "created",
         "invoice_request_text",
-        "percent_budget_consumed_display",
+        "percent_compute_budget_consumed_display",
         "available_compute_cost",
         "approved_compute_cost",
         "consumed_compute_cost",
@@ -194,9 +194,9 @@ class InvoiceAdmin(admin.ModelAdmin):
     def write_off_compute_cost(self, obj):
         return millicents_to_euro(obj.write_off_compute_cost_euro_millicents)
 
-    @admin.display(description="Consumed budget")
-    def percent_budget_consumed_display(self, obj):
-        value = obj.percent_budget_consumed
+    @admin.display(description="Consumed compute budget")
+    def percent_compute_budget_consumed_display(self, obj):
+        value = obj.percent_compute_budget_consumed
         if value is None:
             return "-"
         return f"{value}%"

--- a/app/grandchallenge/invoices/models.py
+++ b/app/grandchallenge/invoices/models.py
@@ -450,6 +450,14 @@ class Invoice(models.Model, FieldChangeMixin):
         )
 
     @cached_property
+    def approved_storage_cost_euro_millicents(self):
+        return (
+            self.storage_costs_euros * 1000 * 100
+            if self.is_budget_authorized
+            else 0
+        )
+
+    @cached_property
     def consumed_compute_cost_euro_millicents(self):
         return min(
             self.compute_cost_euro_millicents,

--- a/app/grandchallenge/invoices/models.py
+++ b/app/grandchallenge/invoices/models.py
@@ -465,7 +465,7 @@ class Invoice(models.Model, FieldChangeMixin):
         return abs(min(balance, 0))
 
     @cached_property
-    def percent_budget_consumed(self):
+    def percent_compute_budget_consumed(self):
         if self.approved_compute_cost_euro_millicents > 0:
             return int(
                 100

--- a/app/grandchallenge/invoices/templates/invoices/invoice_detail.html
+++ b/app/grandchallenge/invoices/templates/invoices/invoice_detail.html
@@ -91,7 +91,7 @@
 
     <hr>
 
-    <h3>Compute Costs</h3>
+    <h3 class="mt-3">Compute Costs</h3>
 
 
     {% if not object.is_budget_authorized %}
@@ -100,8 +100,7 @@
         </span>
     {% else %}
 
-
-    <dl class="mt-3 px-3 border-left rounded">
+    <dl class="mt-1">
         <dt>Compute budget spent</dt>
         <dd>
             <div class="progress my-1">

--- a/app/grandchallenge/invoices/templates/invoices/invoice_detail.html
+++ b/app/grandchallenge/invoices/templates/invoices/invoice_detail.html
@@ -81,10 +81,7 @@
                 <dt>Storage capacity reservation</dt>
                 <dd class="mb-0">€&nbsp;{{ object.storage_costs_euros }}</dd>
 
-                <div class="d-flex align-items-center">
-                    <hr class="flex-grow-1 my-0 mr-2" style="width: 100px;">
-                    <span>+</span>
-                </div>
+                <hr class="mt-1 mb-3 ml-0" style="width: 60%">
 
                 <dt>Total Amount</dt>
                 <dd>{{ invoice.total_amount_euros|euro:0 }}</dd>

--- a/app/grandchallenge/invoices/templates/invoices/invoice_detail.html
+++ b/app/grandchallenge/invoices/templates/invoices/invoice_detail.html
@@ -70,7 +70,7 @@
                 {% endif %}
             </dl>
         </div>
-        <div class="col-md-6">
+        <div class="col-md-6 pl-3 border-left rounded">
             <dl>
                 <dt>Base contribution</dt>
                 <dd>€&nbsp;{{ object.support_costs_euros }}</dd>
@@ -81,9 +81,9 @@
                 <dt>Storage capacity reservation</dt>
                 <dd class="mb-0">€&nbsp;{{ object.storage_costs_euros }}</dd>
 
-                <hr class="mt-1 mb-3 ml-0" style="width: 60%">
+                <hr class="mt-3 ml-0" style="width: 44%">
 
-                <dt>Total Amount</dt>
+                <dt>Total amount</dt>
                 <dd>{{ invoice.total_amount_euros|euro:0 }}</dd>
             </dl>
         </div>
@@ -91,7 +91,7 @@
 
     <hr>
 
-    <h3>Compute Budget Consumption</h3>
+    <h3>Compute Costs</h3>
 
 
     {% if not object.is_budget_authorized %}
@@ -100,20 +100,24 @@
         </span>
     {% else %}
 
-    <div class="progress mb-3">
-        <div
-            class="progress-bar {% if object.percent_compute_budget_consumed >= 100 %}bg-danger{% elif object.percent_compute_budget_consumed >= 70 %}bg-warning{% else %}bg-success{% endif %}"
-            style="width: {{ object.percent_compute_budget_consumed }}%"
-        >
-            {{ object.percent_compute_budget_consumed }}%
-        </div>
-    </div>
 
-    <dl>
-        <dt>Used compute capacity</dt>
+    <dl class="mt-3 px-3 border-left rounded">
+        <dt>Compute budget spent</dt>
+        <dd>
+            <div class="progress my-1">
+                <div
+                class="progress-bar {% if object.percent_compute_budget_consumed >= 100 %}bg-danger{% elif object.percent_compute_budget_consumed >= 70 %}bg-warning{% else %}bg-success{% endif %}"
+                style="width: {{ object.percent_compute_budget_consumed }}%"
+                >
+                    {{ object.percent_compute_budget_consumed }}%
+                </div>
+            </div>
+        </dd>
+
+        <dt>Compute budget used</dt>
         <dd>{{ object.consumed_compute_cost_euro_millicents|millicents_to_euro }}</dd>
 
-        <dt>Available compute capacity</dt>
+        <dt>Compute budget remaining</dt>
         <dd>{{ object.available_compute_cost_euro_millicents|millicents_to_euro }}</dd>
 
     </dl>

--- a/app/grandchallenge/invoices/templates/invoices/invoice_detail.html
+++ b/app/grandchallenge/invoices/templates/invoices/invoice_detail.html
@@ -96,31 +96,28 @@
     </div>
 
 
-    <h3>Budget Consumption</h3>
+    <h3>Compute Budget Consumption</h3>
 
     <hr>
 
     {% if not object.is_budget_authorized %}
          <span class="text-muted">
-            When authorized or paid, the budget consumption will be shown here.
+            Any compute budget consumption will be shown here.
         </span>
     {% else %}
     <dl>
 
 
-        <dt>Used budget</dt>
+        <dt>Used compute budget</dt>
         <dd>
             <div class="progress">
                 <div
-                    class="progress-bar {% if object.percent_budget_consumed >= 100 %}bg-danger{% elif object.percent_budget_consumed >= 70 %}bg-warning{% else %}bg-success{% endif %}"
-                    style="width: {{ object.percent_budget_consumed }}%"
+                    class="progress-bar {% if object.percent_compute_budget_consumed >= 100 %}bg-danger{% elif object.percent_compute_budget_consumed >= 70 %}bg-warning{% else %}bg-success{% endif %}"
+                    style="width: {{ object.percent_compute_budget_consumed }}%"
                 >
-                    {{ object.percent_budget_consumed }}%
+                    {{ object.percent_compute_budget_consumed }}%
                 </div>
             </div>
-
-
-
         </dd>
 
         <dt>Used compute capacity</dt>
@@ -130,6 +127,5 @@
         <dd>{{ object.available_compute_cost_euro_millicents|millicents_to_euro }}</dd>
 
     </dl>
-
     {% endif %}
 {% endblock %}

--- a/app/grandchallenge/invoices/templates/invoices/invoice_detail.html
+++ b/app/grandchallenge/invoices/templates/invoices/invoice_detail.html
@@ -19,58 +19,117 @@
         <li class="breadcrumb-item">
             <a href="{% url 'invoices:list' challenge_short_name=challenge.short_name %}">Invoices</a>
         </li>
-        <li class="breadcrumb-item active" aria-current="page">Invoice {% firstof object.internal_invoice_number object.pk %}</li>
+        <li class="breadcrumb-item active" aria-current="page">Invoice {% firstof object.internal_invoice_number object.external_pk %}</li>
     </ol>
 {% endblock %}
 
 {% block content %}
     <h2>Invoice for {{ challenge.short_name }}</h2>
 
-    <dl>
-        <dt>Invoice Number</dt>
-        <dd>{% firstof object.internal_invoice_number '-' %}</dd>
+    <hr>
 
-        <dt>Amount</dt>
-        <dd>{{ invoice.total_amount_euros|euro:0 }}</dd>
+    <div class="row">
+        <div class="col-md-6">
+            <dl>
+                <dt>Invoice Number</dt>
+                <dd>{% firstof object.internal_invoice_number '-' %}</dd>
 
-        <dt>Type</dt>
-        <dd>{{ invoice.get_payment_type_display }}</dd>
+                <dt>Type</dt>
+                <dd>{{ invoice.get_payment_type_display }}</dd>
 
-        <dt>Status</dt>
-        <dd>{{ object.get_status_badge }}</dd>
+                <dt>Status</dt>
+                <dd>{{ object.get_status_badge }}</dd>
 
-         {% if object.payment_status != object.PaymentStatusChoices.CANCELLED %}
+                {% if object.payment_status != object.PaymentStatusChoices.CANCELLED %}
 
-            <dt>Issued on</dt>
-            <dd>{{ invoice.issued_on|default_if_none:"-" }}</dd>
+                    <dt>Issued on</dt>
+                    <dd>{{ invoice.issued_on|default_if_none:"-" }}</dd>
 
-            {% if object.payment_status == object.PaymentStatusChoices.ISSUED %}
-                <dt>Due on</dt>
-                <dd>
-                    {{ object.due_date|default_if_none:"-" }}
-                    {% if object.is_overdue %}
-                        <i class="fas fa-exclamation-triangle text-danger" title="Invoice is overdue."></i>
-                    {% elif object.is_due %}
-                        <i class="fas fa-exclamation-triangle text-warning" title="Invoice is due."></i>
+                    {% if object.payment_status == object.PaymentStatusChoices.ISSUED %}
+                        <dt>Due on</dt>
+                        <dd>
+                            {{ object.due_date|default_if_none:"-" }}
+                            {% if object.is_overdue %}
+                                <i class="fas fa-exclamation-triangle text-danger" title="Invoice is overdue."></i>
+                            {% elif object.is_due %}
+                                <i class="fas fa-exclamation-triangle text-warning" title="Invoice is due."></i>
+                            {% endif %}
+                        </dd>
                     {% endif %}
-                </dd>
-            {% endif %}
 
-            {% if object.payment_type == object.PaymentTypeChoices.POSTPAID %}
-                <dt>Follow-up on</dt>
-                <dd>{{ object.follow_up_on|default_if_none:"-" }}</dd>
-            {% endif %}
+                    {% if object.payment_type == object.PaymentTypeChoices.POSTPAID %}
+                        <dt>Follow-up on</dt>
+                        <dd>{{ object.follow_up_on|default_if_none:"-" }}</dd>
+                    {% endif %}
 
+                    <dt>Expires on</dt>
+                    <dd>
+                        {{ object.expires_on }}
+                        {% if object.is_expired %}
+                            <i class="fas fa-exclamation-triangle text-danger" title="Invoice is expired."></i>
+                        {% endif %}
+                    </dd>
 
-            <dt>Expires on</dt>
-            <dd>
-                {{ object.expires_on }}
-                {% if object.is_expired %}
-                    <i class="fas fa-exclamation-triangle text-danger" title="Invoice is expired."></i>
                 {% endif %}
-            </dd>
+            </dl>
+        </div>
+        <div class="col-md-6">
+            <dl>
+                <dt>Base contribution</dt>
+                <dd>€&nbsp;{{ object.support_costs_euros }}</dd>
 
-        {% endif %}
+                <dt>Compute capacity reservation</dt>
+                <dd>€&nbsp;{{ object.compute_costs_euros }}</dd>
+
+                <dt>Storage capacity reservation</dt>
+                <dd class="mb-0">€&nbsp;{{ object.storage_costs_euros }}</dd>
+
+                <div class="d-flex align-items-center">
+                    <hr class="flex-grow-1 my-0 mr-2" style="width: 100px;">
+                    <span>+</span>
+                </div>
+
+                <dt>Total Amount</dt>
+                <dd>{{ invoice.total_amount_euros|euro:0 }}</dd>
+            </dl>
+        </div>
+    </div>
+
+
+    <h3>Budget Consumption</h3>
+
+    <hr>
+
+    {% if not object.is_budget_authorized %}
+         <span class="text-muted">
+            When authorized or paid, the budget consumption will be shown here.
+        </span>
+    {% else %}
+    <dl>
+
+
+        <dt>Used budget</dt>
+        <dd>
+            <div class="progress">
+                <div
+                    class="progress-bar {% if object.percent_budget_consumed >= 100 %}bg-danger{% elif object.percent_budget_consumed >= 70 %}bg-warning{% else %}bg-success{% endif %}"
+                    style="width: {{ object.percent_budget_consumed }}%"
+                >
+                    {{ object.percent_budget_consumed }}%
+                </div>
+            </div>
+
+
+
+        </dd>
+
+        <dt>Used compute capacity</dt>
+        <dd>{{ object.consumed_compute_cost_euro_millicents|millicents_to_euro }}</dd>
+
+        <dt>Remaining compute capacity</dt>
+        <dd>{{ object.available_compute_cost_euro_millicents|millicents_to_euro }}</dd>
 
     </dl>
+
+    {% endif %}
 {% endblock %}

--- a/app/grandchallenge/invoices/templates/invoices/invoice_detail.html
+++ b/app/grandchallenge/invoices/templates/invoices/invoice_detail.html
@@ -93,8 +93,7 @@
 
     <h3 class="mt-3">Compute Costs</h3>
 
-
-    {% if not object.is_budget_authorized %}
+    {% if not object.approved_compute_cost_euro_millicents %}
          <span class="text-muted">
             Any compute budget consumption will be shown here.
         </span>

--- a/app/grandchallenge/invoices/templates/invoices/invoice_detail.html
+++ b/app/grandchallenge/invoices/templates/invoices/invoice_detail.html
@@ -89,35 +89,37 @@
         </div>
     </div>
 
-    <hr>
+    {% if not object.is_expired %}
+        <hr>
 
-    <h3 class="mt-3">Compute Costs</h3>
+        <h3 class="mt-3">Compute Costs</h3>
 
-    {% if not object.approved_compute_cost_euro_millicents %}
-         <span class="text-muted">
-            Any compute budget consumption will be shown here.
-        </span>
-    {% else %}
+        {% if not object.approved_compute_cost_euro_millicents %}
+            <span class="text-muted">
+                Any compute budget consumption will be shown here.
+            </span>
+        {% else %}
 
-    <dl class="mt-1">
-        <dt>Compute budget spent</dt>
-        <dd>
-            <div class="progress my-1">
-                <div
-                class="progress-bar {% if object.percent_compute_budget_consumed >= 100 %}bg-danger{% elif object.percent_compute_budget_consumed >= 70 %}bg-warning{% else %}bg-success{% endif %}"
-                style="width: {{ object.percent_compute_budget_consumed }}%"
-                >
-                    {{ object.percent_compute_budget_consumed }}%
+        <dl class="mt-1">
+            <dt>Compute budget spent</dt>
+            <dd>
+                <div class="progress my-1">
+                    <div
+                    class="progress-bar {% if object.percent_compute_budget_consumed >= 100 %}bg-danger{% elif object.percent_compute_budget_consumed >= 70 %}bg-warning{% else %}bg-success{% endif %}"
+                    style="width: {{ object.percent_compute_budget_consumed }}%"
+                    >
+                        {{ object.percent_compute_budget_consumed }}%
+                    </div>
                 </div>
-            </div>
-        </dd>
+            </dd>
 
-        <dt>Compute budget used</dt>
-        <dd>{{ object.consumed_compute_cost_euro_millicents|millicents_to_euro }}</dd>
+            <dt>Compute budget used</dt>
+            <dd>{{ object.consumed_compute_cost_euro_millicents|millicents_to_euro }}</dd>
 
-        <dt>Compute budget remaining</dt>
-        <dd>{{ object.available_compute_cost_euro_millicents|millicents_to_euro }}</dd>
+            <dt>Compute budget remaining</dt>
+            <dd>{{ object.available_compute_cost_euro_millicents|millicents_to_euro }}</dd>
 
-    </dl>
+        </dl>
+        {% endif %}
     {% endif %}
 {% endblock %}

--- a/app/grandchallenge/invoices/templates/invoices/invoice_detail.html
+++ b/app/grandchallenge/invoices/templates/invoices/invoice_detail.html
@@ -17,7 +17,7 @@
             <a href="{{ challenge.get_absolute_url }}">{% firstof challenge.title challenge.short_name %}</a>
         </li>
         <li class="breadcrumb-item">
-            <a href="{% url 'invoices:list' challenge_short_name=challenge.short_name %}">Invoices</a>
+            <a href="{% url 'invoices:list' challenge_short_name=challenge.short_name %}">Invoices & Budget</a>
         </li>
         <li class="breadcrumb-item active" aria-current="page">Invoice {% firstof object.internal_invoice_number object.external_pk %}</li>
     </ol>
@@ -25,9 +25,6 @@
 
 {% block content %}
     <h2>Invoice for {{ challenge.short_name }}</h2>
-
-    <hr>
-
     <div class="row">
         <div class="col-md-6">
             <dl>
@@ -95,35 +92,31 @@
         </div>
     </div>
 
+    <hr>
 
     <h3>Compute Budget Consumption</h3>
 
-    <hr>
 
     {% if not object.is_budget_authorized %}
          <span class="text-muted">
             Any compute budget consumption will be shown here.
         </span>
     {% else %}
+
+    <div class="progress mb-3">
+        <div
+            class="progress-bar {% if object.percent_compute_budget_consumed >= 100 %}bg-danger{% elif object.percent_compute_budget_consumed >= 70 %}bg-warning{% else %}bg-success{% endif %}"
+            style="width: {{ object.percent_compute_budget_consumed }}%"
+        >
+            {{ object.percent_compute_budget_consumed }}%
+        </div>
+    </div>
+
     <dl>
-
-
-        <dt>Used compute budget</dt>
-        <dd>
-            <div class="progress">
-                <div
-                    class="progress-bar {% if object.percent_compute_budget_consumed >= 100 %}bg-danger{% elif object.percent_compute_budget_consumed >= 70 %}bg-warning{% else %}bg-success{% endif %}"
-                    style="width: {{ object.percent_compute_budget_consumed }}%"
-                >
-                    {{ object.percent_compute_budget_consumed }}%
-                </div>
-            </div>
-        </dd>
-
         <dt>Used compute capacity</dt>
         <dd>{{ object.consumed_compute_cost_euro_millicents|millicents_to_euro }}</dd>
 
-        <dt>Remaining compute capacity</dt>
+        <dt>Available compute capacity</dt>
         <dd>{{ object.available_compute_cost_euro_millicents|millicents_to_euro }}</dd>
 
     </dl>

--- a/app/grandchallenge/invoices/templates/invoices/invoice_list.html
+++ b/app/grandchallenge/invoices/templates/invoices/invoice_list.html
@@ -78,7 +78,7 @@
                         {% endif %}
                     </td>
                     <td>{{ invoice.total_amount_euros|euro:0 }}</td>
-                    <td data-order="{% if invoice.percent_budget_consumed is None %}-1{% else %}{{ invoice.percent_budget_consumed }}{% endif %}" class="{% if invoice.percent_budget_consumed >= 100 %}text-danger{% elif invoice.percent_budget_consumed >= 70 %}text-warning{% elif invoice.percent_budget_consumed is not None %}text-success{% endif %}">{{ invoice.percent_budget_consumed|default_if_none:"-" }}</td>
+                        <td data-order="{% if invoice.percent_compute_budget_consumed is None %}-1{% else %}{{ invoice.percent_compute_budget_consumed }}{% endif %}" class="{% if invoice.percent_compute_budget_consumed >= 100 %}text-danger{% elif invoice.percent_compute_budget_consumed >= 70 %}text-warning{% elif invoice.percent_compute_budget_consumed is not None %}text-success{% endif %}">{{ invoice.percent_compute_budget_consumed|default_if_none:"-" }}</td>
                     <td>{{ invoice.get_payment_type_display }}</td>
                     <td>{{ invoice.get_status_badge }}</td>
                 </tr>

--- a/app/grandchallenge/invoices/templates/invoices/invoice_list.html
+++ b/app/grandchallenge/invoices/templates/invoices/invoice_list.html
@@ -56,6 +56,7 @@
                 <th>Issued on</th>
                 <th>Due on</th>
                 <th>Amount</th>
+                <th>Used budget</th>
                 <th>Type</th>
                 <th>Status</th>
             </tr>
@@ -77,6 +78,7 @@
                         {% endif %}
                     </td>
                     <td>{{ invoice.total_amount_euros|euro:0 }}</td>
+                    <td data-order="{% if invoice.percent_budget_consumed is None %}-1{% else %}{{ invoice.percent_budget_consumed }}{% endif %}" class="{% if invoice.percent_budget_consumed >= 100 %}text-danger{% elif invoice.percent_budget_consumed >= 70 %}text-warning{% elif invoice.percent_budget_consumed is not None %}text-success{% endif %}">{{ invoice.percent_budget_consumed|default_if_none:"-" }}</td>
                     <td>{{ invoice.get_payment_type_display }}</td>
                     <td>{{ invoice.get_status_badge }}</td>
                 </tr>

--- a/app/grandchallenge/invoices/templates/invoices/invoice_list.html
+++ b/app/grandchallenge/invoices/templates/invoices/invoice_list.html
@@ -58,7 +58,7 @@
                     <th>Issued on</th>
                     <th>Due on</th>
                     <th>Amount</th>
-                    <th>Used compute budget</th>
+                    <th>Compute budget spent</th>
                     <th>Type</th>
                     <th>Status</th>
                 </tr>
@@ -71,7 +71,7 @@
                         </td>
                         <td>{% firstof invoice.internal_invoice_number '-' %}</td>
                         <td data-order="{{ invoice.issued_on|date:"c" }}">{{ invoice.issued_on|default_if_none:"-" }}</td>
-                        <td data-order="{{ invoice.due_date|date:"c" }}">
+                        <td class="text-nowrap" data-order="{{ invoice.due_date|date:"c" }}">
                             {{ invoice.due_date|default_if_none:"-" }}
                             {% if invoice.is_overdue %}
                                 <i class="fas fa-exclamation-triangle text-danger" title="Invoice is overdue."></i>
@@ -91,13 +91,12 @@
         </table>
     </div>
 
-    <hr>
-    <h3>Compute Capacity for {{ challenge.short_name }}</h3>
+    <h3>Total Compute Costs for {{ challenge.short_name }}</h3>
 
-    <dl>
-        <dt>Active budget</dt>
+    <dl class="mt-3 px-3 border-left rounded">
+        <dt>Total compute budget spent</dt>
         <dd>
-            <div class="progress">
+            <div class="progress my-1">
                 <div
                 class="progress-bar {% if challenge.percent_active_compute_budget_consumed >= 100 %}bg-danger{% elif challenge.percent_active_compute_budget_consumed >= 70 %}bg-warning{% else %}bg-success{% endif %}"
                 style="width: {{ challenge.percent_active_compute_budget_consumed }}%"
@@ -107,24 +106,24 @@
             </div>
         </dd>
 
-        <dt>Total used compute capacity</dt>
+        <dt>Total compute budget used</dt>
         <dd>{{ challenge.consumed_compute_cost_euro_millicents|millicents_to_euro }}</dd>
 
-        <dt>Total available compute capacity</dt>
+        <dt>Total compute budget remaining</dt>
          <dd>{{ challenge.available_compute_cost_euro_millicents|millicents_to_euro }}</dd>
     </dl>
 
-    <hr>
-    <h3>Storage Capacity for {{ challenge.short_name }}</h3>
 
-    <dl>
-        <dt>Total available storage capacity</dt>
+    <h3>Total Storage Costs for {{ challenge.short_name }}</h3>
+
+    <dl class="mt-3 px-3 border-left rounded">
+        <dt>Total storage budget available</dt>
         <dd>{{ challenge.approved_storage_cost_euro_millicents|millicents_to_euro }}</dd>
 
-        <dt>Total current object data storage</dt>
+        <dt>Total object data storage</dt>
         <dd>{{ challenge.size_in_storage|filesizeformat }}</dd>
 
-        <dt>Total current container registry storage</dt>
+        <dt>Total container registry storage</dt>
         <dd>{{ challenge.size_in_registry|filesizeformat }}</dd>
     </dl>
 

--- a/app/grandchallenge/invoices/templates/invoices/invoice_list.html
+++ b/app/grandchallenge/invoices/templates/invoices/invoice_list.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% load url %}
 {% load costs %}
+{% load humanize %}
 
 {% block title %}
     Invoices - {% firstof challenge.title challenge.short_name %} - {{ block.super }}
@@ -16,7 +17,7 @@
         <li class="breadcrumb-item"><a
                 href="{{ challenge.get_absolute_url }}">{% firstof challenge.title challenge.short_name %}</a></li>
         <li class="breadcrumb-item active"
-            aria-current="page">Invoices</li>
+            aria-current="page">Invoices & Budget</li>
     </ol>
 {% endblock %}
 
@@ -33,57 +34,98 @@
             <i class="fas fa-exclamation-triangle"></i> There {{ num_is_due|pluralize:"is,are" }} {{ num_is_due }} invoice{{ num_is_due|pluralize }} due.
         </p>
     {% endif %}
+
+
     <p>
         If an invoice has been paid recently, the status will be updated soon.
         For any questions, please <a target="_blank" href="mailto:{{ SUPPORT_EMAIL }}">contact support</a>.
     </p>
 
-
     <div class="table-responsive">
-    <table
-        data-data-table
-        data-paginate="false"
-        data-length-change="false"
-        data-filter="false"
-        data-info="false"
-        data-order='[[1, "asc"]]'
-        class="table table-hover table-borderless table-sm w-100"
-    >
-        <thead class="thead-light">
-            <tr>
-            <th></th>
-                <th class="nonSortable">Invoice Number</th>
-                <th>Issued on</th>
-                <th>Due on</th>
-                <th>Amount</th>
-                <th>Used budget</th>
-                <th>Type</th>
-                <th>Status</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for invoice in object_list %}
+        <table
+            data-data-table
+            data-paginate="false"
+            data-length-change="false"
+            data-filter="false"
+            data-info="false"
+            data-order='[[1, "asc"]]'
+            class="table table-hover table-borderless table-sm w-100"
+        >
+            <thead class="thead-light">
                 <tr>
-                    <td>
-                        <a href="{% url 'invoices:detail' challenge_short_name=invoice.challenge.short_name external_pk=invoice.external_pk %}" title="View invoice details"><i class="fas fa-info-circle"></i></a>
-                    </td>
-                    <td>{% firstof invoice.internal_invoice_number '-' %}</td>
-                    <td data-order="{{ invoice.issued_on|date:"c" }}">{{ invoice.issued_on|default_if_none:"-" }}</td>
-                    <td data-order="{{ invoice.due_date|date:"c" }}">
-                        {{ invoice.due_date|default_if_none:"-" }}
-                        {% if invoice.is_overdue %}
-                            <i class="fas fa-exclamation-triangle text-danger" title="Invoice is overdue."></i>
-                        {% elif invoice.is_due %}
-                            <i class="fas fa-exclamation-triangle text-warning" title="Invoice is due."></i>
-                        {% endif %}
-                    </td>
-                    <td>{{ invoice.total_amount_euros|euro:0 }}</td>
-                        <td data-order="{% if invoice.percent_compute_budget_consumed is None %}-1{% else %}{{ invoice.percent_compute_budget_consumed }}{% endif %}" class="{% if invoice.percent_compute_budget_consumed >= 100 %}text-danger{% elif invoice.percent_compute_budget_consumed >= 70 %}text-warning{% elif invoice.percent_compute_budget_consumed is not None %}text-success{% endif %}">{{ invoice.percent_compute_budget_consumed|default_if_none:"-" }}</td>
-                    <td>{{ invoice.get_payment_type_display }}</td>
-                    <td>{{ invoice.get_status_badge }}</td>
+                <th></th>
+                    <th class="nonSortable">Invoice Number</th>
+                    <th>Issued on</th>
+                    <th>Due on</th>
+                    <th>Amount</th>
+                    <th>Used compute budget</th>
+                    <th>Type</th>
+                    <th>Status</th>
                 </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-</div>
+            </thead>
+            <tbody>
+                {% for invoice in object_list %}
+                    <tr>
+                        <td>
+                            <a href="{% url 'invoices:detail' challenge_short_name=invoice.challenge.short_name external_pk=invoice.external_pk %}" title="View invoice details"><i class="fas fa-info-circle"></i></a>
+                        </td>
+                        <td>{% firstof invoice.internal_invoice_number '-' %}</td>
+                        <td data-order="{{ invoice.issued_on|date:"c" }}">{{ invoice.issued_on|default_if_none:"-" }}</td>
+                        <td data-order="{{ invoice.due_date|date:"c" }}">
+                            {{ invoice.due_date|default_if_none:"-" }}
+                            {% if invoice.is_overdue %}
+                                <i class="fas fa-exclamation-triangle text-danger" title="Invoice is overdue."></i>
+                            {% elif invoice.is_due %}
+                                <i class="fas fa-exclamation-triangle text-warning" title="Invoice is due."></i>
+                            {% endif %}
+                        </td>
+                        <td>{{ invoice.total_amount_euros|euro:0 }}</td>
+                        <td data-order="{% if invoice.percent_compute_budget_consumed is None %}-1{% else %}{{ invoice.percent_compute_budget_consumed }}{% endif %}" class="{% if invoice.percent_compute_budget_consumed >= 100 %}text-danger{% elif invoice.percent_compute_budget_consumed >= 70 %}text-warning{% elif invoice.percent_compute_budget_consumed is not None %}text-success{% endif %}">
+                            {% if invoice.percent_compute_budget_consumed is not None %} {{ invoice.percent_compute_budget_consumed }}% {% else %} - {% endif %}
+                        </td>
+                        <td>{{ invoice.get_payment_type_display }}</td>
+                        <td>{{ invoice.get_status_badge }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <hr>
+    <h3>Compute Capacity for {{ challenge.short_name }}</h3>
+
+    <dl>
+        <dt>Active budget</dt>
+        <dd>
+            <div class="progress">
+                <div
+                class="progress-bar {% if challenge.percent_active_compute_budget_consumed >= 100 %}bg-danger{% elif challenge.percent_active_compute_budget_consumed >= 70 %}bg-warning{% else %}bg-success{% endif %}"
+                style="width: {{ challenge.percent_active_compute_budget_consumed }}%"
+                >
+                {{ challenge.percent_active_compute_budget_consumed }}%
+                </div>
+            </div>
+        </dd>
+
+        <dt>Total used compute capacity</dt>
+        <dd>{{ challenge.consumed_compute_cost_euro_millicents|millicents_to_euro }}</dd>
+
+        <dt>Total available compute capacity</dt>
+         <dd>{{ challenge.available_compute_cost_euro_millicents|millicents_to_euro }}</dd>
+    </dl>
+
+    <hr>
+    <h3>Storage Capacity for {{ challenge.short_name }}</h3>
+
+    <dl>
+        <dt>Total available storage capacity</dt>
+        <dd>{{ challenge.approved_storage_cost_euro_millicents|millicents_to_euro }}</dd>
+
+        <dt>Total current object data storage</dt>
+        <dd>{{ challenge.size_in_storage|filesizeformat }}</dd>
+
+        <dt>Total current container registry storage</dt>
+        <dd>{{ challenge.size_in_registry|filesizeformat }}</dd>
+    </dl>
+
 {% endblock %}

--- a/app/grandchallenge/invoices/templates/invoices/invoice_list.html
+++ b/app/grandchallenge/invoices/templates/invoices/invoice_list.html
@@ -80,9 +80,13 @@
                             {% endif %}
                         </td>
                         <td>{{ invoice.total_amount_euros|euro:0 }}</td>
-                        <td data-order="{% if invoice.percent_compute_budget_consumed is None %}-1{% else %}{{ invoice.percent_compute_budget_consumed }}{% endif %}" class="{% if invoice.percent_compute_budget_consumed >= 100 %}text-danger{% elif invoice.percent_compute_budget_consumed >= 70 %}text-warning{% elif invoice.percent_compute_budget_consumed is not None %}text-success{% endif %}">
-                            {% if invoice.percent_compute_budget_consumed is not None %} {{ invoice.percent_compute_budget_consumed }}% {% else %} - {% endif %}
-                        </td>
+                        {% if not invoice.is_expired %}
+                            <td data-order="{% if invoice.percent_compute_budget_consumed is None %}-1{% else %}{{ invoice.percent_compute_budget_consumed }}{% endif %}" class="{% if invoice.percent_compute_budget_consumed >= 100 %}text-danger{% elif invoice.percent_compute_budget_consumed >= 70 %}text-warning{% elif invoice.percent_compute_budget_consumed is not None %}text-success{% endif %}">
+                                {% if invoice.percent_compute_budget_consumed is not None %} {{ invoice.percent_compute_budget_consumed }}% {% else %} - {% endif %}
+                            </td>
+                        {% else %}
+                            <td data-order="-1">-</td>
+                        {% endif %}
                         <td>{{ invoice.get_payment_type_display }}</td>
                         <td>{{ invoice.get_status_badge }}</td>
                     </tr>
@@ -91,16 +95,16 @@
         </table>
     </div>
 
-    <h3 class="mt-3">Challenge Compute Costs</h3>
+    <h3 class="mt-3">Challenge Active Compute Costs</h3>
 
-    {% if not challenge.approved_compute_cost_euro_millicents %}
+    {% if not challenge.active_approved_compute_cost_euro_millicents %}
          <span class="text-muted">
             Any compute budget consumption will be shown here.
         </span>
     {% else %}
 
     <dl class="mt-1">
-        <dt>Total compute budget spent</dt>
+        <dt>Total active compute budget spent</dt>
         <dd>
             <div class="progress my-1">
                 <div
@@ -112,26 +116,26 @@
             </div>
         </dd>
 
-        <dt>Total compute budget used</dt>
-        <dd>{{ challenge.consumed_compute_cost_euro_millicents|millicents_to_euro }}</dd>
+        <dt>Total active compute budget used</dt>
+        <dd>{{ challenge.active_consumed_compute_cost_euro_millicents|millicents_to_euro }}</dd>
 
-        <dt>Total compute budget remaining</dt>
-         <dd>{{ challenge.available_compute_cost_euro_millicents|millicents_to_euro }}</dd>
+        <dt>Total active compute budget remaining</dt>
+        <dd>{{ challenge.active_available_compute_cost_euro_millicents|millicents_to_euro }}</dd>
+
     </dl>
 
     {% endif %}
 
-    <h3 class="mt-3">Challenge Storage Usage</h3>
+    <h3 class="mt-3">Challenge Active Storage Usage</h3>
 
-    {% if not challenge.approved_storage_cost_euro_millicents %}
+    {% if not challenge.active_approved_storage_cost_euro_millicents %}
          <span class="text-muted">
-            Any storage costs and usage will be shown here.
+            Any storage usage will be shown here.
         </span>
     {% else %}
-
     <dl class="mt-1">
         <dt>Total storage budget available</dt>
-        <dd>{{ challenge.approved_storage_cost_euro_millicents|millicents_to_euro }}</dd>
+        <dd>{{ challenge.active_approved_storage_cost_euro_millicents|millicents_to_euro }}</dd>
 
         <dt>Total object data storage</dt>
         <dd>{{ challenge.size_in_storage|filesizeformat }}</dd>
@@ -139,7 +143,5 @@
         <dt>Total container registry storage</dt>
         <dd>{{ challenge.size_in_registry|filesizeformat }}</dd>
     </dl>
-
     {% endif %}
-
 {% endblock %}

--- a/app/grandchallenge/invoices/templates/invoices/invoice_list.html
+++ b/app/grandchallenge/invoices/templates/invoices/invoice_list.html
@@ -93,6 +93,12 @@
 
     <h3 class="mt-3">Challenge Compute Costs</h3>
 
+    {% if not challenge.approved_compute_cost_euro_millicents %}
+         <span class="text-muted">
+            Any compute budget consumption will be shown here.
+        </span>
+    {% else %}
+
     <dl class="mt-1">
         <dt>Total compute budget spent</dt>
         <dd>
@@ -113,8 +119,15 @@
          <dd>{{ challenge.available_compute_cost_euro_millicents|millicents_to_euro }}</dd>
     </dl>
 
+    {% endif %}
 
-    <h3 class="mt-3">Challenge Storage Costs</h3>
+    <h3 class="mt-3">Challenge Storage Usage</h3>
+
+    {% if not challenge.approved_storage_cost_euro_millicents %}
+         <span class="text-muted">
+            Any storage costs and usage will be shown here.
+        </span>
+    {% else %}
 
     <dl class="mt-1">
         <dt>Total storage budget available</dt>
@@ -126,5 +139,7 @@
         <dt>Total container registry storage</dt>
         <dd>{{ challenge.size_in_registry|filesizeformat }}</dd>
     </dl>
+
+    {% endif %}
 
 {% endblock %}

--- a/app/grandchallenge/invoices/templates/invoices/invoice_list.html
+++ b/app/grandchallenge/invoices/templates/invoices/invoice_list.html
@@ -91,9 +91,9 @@
         </table>
     </div>
 
-    <h3>Total Compute Costs for {{ challenge.short_name }}</h3>
+    <h3 class="mt-3">Challenge Compute Costs</h3>
 
-    <dl class="mt-3 px-3 border-left rounded">
+    <dl class="mt-1">
         <dt>Total compute budget spent</dt>
         <dd>
             <div class="progress my-1">
@@ -114,9 +114,9 @@
     </dl>
 
 
-    <h3>Total Storage Costs for {{ challenge.short_name }}</h3>
+    <h3 class="mt-3">Challenge Storage Costs</h3>
 
-    <dl class="mt-3 px-3 border-left rounded">
+    <dl class="mt-1">
         <dt>Total storage budget available</dt>
         <dd>{{ challenge.approved_storage_cost_euro_millicents|millicents_to_euro }}</dd>
 

--- a/app/grandchallenge/invoices/views.py
+++ b/app/grandchallenge/invoices/views.py
@@ -34,7 +34,7 @@ class InvoiceList(
         return (
             queryset.filter(challenge=self.request.challenge)
             .with_overdue_status()
-            .with_is_expired()
+            .with_budget_authorization()
         )
 
 
@@ -54,4 +54,4 @@ class InvoiceDetail(
 
     def get_queryset(self):
         queryset = super().get_queryset()
-        return queryset.with_overdue_status().with_is_expired()
+        return queryset.with_overdue_status().with_budget_authorization()

--- a/app/grandchallenge/pages/templates/pages/challenge_settings_base.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_settings_base.html
@@ -37,7 +37,7 @@
               <li class="nav-item">
                   <a class="nav-link px-4 py-1 mb-1 {% if request.resolver_match.view_name == 'invoices:list' %} active {% endif %}"
                     href="{% url 'invoices:list' challenge_short_name=challenge.short_name %}">
-                      <i class="fas fa-file-invoice-dollar fa-fw"></i>&nbsp;Invoices&nbsp;
+                      <i class="fas fa-file-invoice-dollar fa-fw"></i>&nbsp;Invoices&nbsp;&&nbsp;Budget&nbsp;
                       {% if invoice_aggregates.num_is_overdue %}
                             <span class="badge badge-pill badge-danger align-middle" title="Invoices overdue">
                                 {{ invoice_aggregates.num_is_overdue }}
@@ -53,7 +53,7 @@
               <li class="nav-item">
                 <a class="nav-link px-4 py-1 mb-1 {% if request.resolver_match.view_name == 'participants:registration-question-list' or request.resolver_match.view_name == 'participants:registration-question-create' or request.resolver_match.view_name == 'participants:registration-question-delete'  %}active{% endif %}"
                   href="{% url 'participants:registration-question-list' challenge_short_name=challenge.short_name %}">
-                    <i class="fas fa-question-circle fa-fw"></i>&nbsp;Registration Questions </a>
+                    <i class="fas fa-question-circle fa-fw"></i>&nbsp;Registration Questions</a>
               </li>
               <li class="nav-item">
                   <a class="nav-link px-4 py-1 mb-1 {% if request.resolver_match.view_name in 'pages:list,pages:create,pages:content-update,pages:metadata-update,pages:delete' %}active{% endif %}"

--- a/app/grandchallenge/pages/templates/pages/challenge_statistics.html
+++ b/app/grandchallenge/pages/templates/pages/challenge_statistics.html
@@ -66,7 +66,7 @@
                         <th>Challenge Status</th>
                         <th>Should be Open</th>
                         <th>
-                            % Active Budget Consumed
+                            % Active Compute Budget Consumed
                             <span data-toggle="tooltip" data-placement="right"
                                 title="Consumed costs as a percentage of the approved costs of the currently active (i.e., non-expired) invoices."
                                 class="text-muted">
@@ -129,7 +129,7 @@
                             <span class="badge {% if challenge.status == challenge.StatusChoices.OPEN %}badge-success{% elif challenge.status == challenge.StatusChoices.OPENING_SOON %}badge-warning{% else %}badge-danger{% endif %}">{{ challenge.status.name }}</span>
                         </td>
                         <td>{% if challenge.should_be_open_but_is_over_budget %}<i class="fa fa-exclamation-triangle text-danger"></i>{% endif %}</td>
-                        <td data-order="{% if challenge.percent_active_budget_consumed is None %}-1{% else %}{{ challenge.percent_active_budget_consumed }}{% endif %}" class="{% if challenge.percent_active_budget_consumed >= 100 %}text-danger{% elif challenge.percent_active_budget_consumed >= 70 %}text-warning{% else %}text-success{% endif %}">{% if challenge.percent_active_budget_consumed is not None %}{{ challenge.percent_active_budget_consumed }}&nbsp;%{% endif %}</td>
+                        <td data-order="{% if challenge.percent_active_compute_budget_consumed is None %}-1{% else %}{{ challenge.percent_active_compute_budget_consumed }}{% endif %}" class="{% if challenge.percent_active_compute_budget_consumed >= 100 %}text-danger{% elif challenge.percent_active_compute_budget_consumed >= 70 %}text-warning{% else %}text-success{% endif %}">{% if challenge.percent_active_compute_budget_consumed is not None %}{{ challenge.percent_active_compute_budget_consumed }}&nbsp;%{% endif %}</td>
                         <td class="{% if challenge.available_compute_cost_euro_millicents <= 0 %}text-danger{% endif %}">{{ challenge.available_compute_cost_euro_millicents|millicents_to_euro }}</td>
                         <td>{{ challenge.approved_compute_cost_euro_millicents|millicents_to_euro }}</td>
                         <td>{{ challenge.consumed_compute_cost_euro_millicents|millicents_to_euro }}</td>

--- a/app/tests/challenges_tests/test_models.py
+++ b/app/tests/challenges_tests/test_models.py
@@ -808,7 +808,7 @@ def test_challenge_queryset_with_user_roles_multiple_challenges():
 
 
 @pytest.mark.django_db
-def test_active_invoice():
+def test_utilization_invoice():
     challenge = ChallengeFactory()
     invoice = InvoiceFactory(
         challenge=challenge,
@@ -822,11 +822,11 @@ def test_active_invoice():
             pk=challenge.pk
         )
     )
-    assert challenge.active_invoice == invoice
+    assert challenge.utilization_invoice == invoice
 
 
 @pytest.mark.django_db
-def test_active_invoice_no_invoice():
+def test_utilization_invoice_no_invoice():
     challenge = ChallengeFactory()
     challenge = (
         Challenge.objects.with_invoices_with_budget_authorization().get(
@@ -834,11 +834,11 @@ def test_active_invoice_no_invoice():
         )
     )
     with pytest.raises(InsufficientBudgetError):
-        challenge.active_invoice
+        challenge.utilization_invoice
 
 
 @pytest.mark.django_db
-def test_active_invoice_raises_on_negative_balance():
+def test_utilization_invoice_raises_on_negative_balance():
     challenge = ChallengeFactory()
     InvoiceFactory(
         challenge=challenge,
@@ -853,11 +853,11 @@ def test_active_invoice_raises_on_negative_balance():
         )
     )
     with pytest.raises(InsufficientBudgetError):
-        challenge.active_invoice
+        challenge.utilization_invoice
 
 
 @pytest.mark.django_db
-def test_active_invoice_raises_on_zero_balance():
+def test_utilization_invoice_raises_on_zero_balance():
     challenge = ChallengeFactory()
     InvoiceFactory(
         challenge=challenge,
@@ -872,11 +872,11 @@ def test_active_invoice_raises_on_zero_balance():
         )
     )
     with pytest.raises(InsufficientBudgetError):
-        challenge.active_invoice
+        challenge.utilization_invoice
 
 
 @pytest.mark.django_db
-def test_active_invoice_ignores_invoices_with_negative_balance():
+def test_utilization_invoice_ignores_invoices_with_negative_balance():
     challenge = ChallengeFactory()
 
     InvoiceFactory(
@@ -899,7 +899,7 @@ def test_active_invoice_ignores_invoices_with_negative_balance():
             pk=challenge.pk
         )
     )
-    challenge.active_invoice
+    challenge.utilization_invoice
 
 
 @pytest.mark.django_db
@@ -934,3 +934,73 @@ def test_budget_properties():
     assert challenge.consumed_compute_cost_euro_millicents == 6 * 1000 * 100
     assert challenge.write_off_compute_cost_euro_millicents == 0
     assert challenge.percent_active_compute_budget_consumed == 60
+
+
+@pytest.mark.django_db
+def test_active_budget_properties():
+    challenge = ChallengeFactory()
+
+    challenge = (
+        Challenge.objects.with_invoices_with_budget_authorization().get(
+            pk=challenge.pk
+        )
+    )
+    assert challenge.active_available_compute_cost_euro_millicents == 0
+    assert challenge.active_approved_compute_cost_euro_millicents == 0
+    assert challenge.active_consumed_compute_cost_euro_millicents == 0
+
+    InvoiceFactory(  # Active invoice
+        challenge=challenge,
+        compute_costs_euros=10,
+        compute_cost_euro_millicents=6 * 1000 * 100,
+    )
+
+    challenge = (
+        Challenge.objects.with_invoices_with_budget_authorization().get(
+            pk=challenge.pk
+        )
+    )
+
+    assert (
+        challenge.active_available_compute_cost_euro_millicents
+        == 4 * 1000 * 100
+    )
+    assert (
+        challenge.active_approved_compute_cost_euro_millicents
+        == 10 * 1000 * 100
+    )
+    assert (
+        challenge.active_consumed_compute_cost_euro_millicents
+        == 6 * 1000 * 100
+    )
+
+    InvoiceFactory(  # Active invoice, should not be ignored in active budget properties
+        challenge=challenge,
+        compute_costs_euros=10,
+        compute_cost_euro_millicents=6 * 1000 * 100,
+    )
+    InvoiceFactory(  # Expired invoice, should be ignored in active budget properties
+        challenge=challenge,
+        compute_costs_euros=10,
+        compute_cost_euro_millicents=6 * 1000 * 100,
+        expires_on=now() - timedelta(days=1),
+    )
+
+    challenge = (
+        Challenge.objects.with_invoices_with_budget_authorization().get(
+            pk=challenge.pk
+        )
+    )
+
+    assert (
+        challenge.active_available_compute_cost_euro_millicents
+        == 4 * 2 * 1000 * 100
+    )
+    assert (
+        challenge.active_approved_compute_cost_euro_millicents
+        == 10 * 2 * 1000 * 100
+    )
+    assert (
+        challenge.active_consumed_compute_cost_euro_millicents
+        == 6 * 2 * 1000 * 100
+    )

--- a/app/tests/challenges_tests/test_models.py
+++ b/app/tests/challenges_tests/test_models.py
@@ -969,7 +969,7 @@ def test_budget_properties():
     assert challenge.approved_compute_cost_euro_millicents == 0
     assert challenge.consumed_compute_cost_euro_millicents == 0
     assert challenge.write_off_compute_cost_euro_millicents == 0
-    assert challenge.percent_active_budget_consumed is None
+    assert challenge.percent_active_compute_budget_consumed is None
 
     InvoiceFactory(
         challenge=challenge,
@@ -987,4 +987,4 @@ def test_budget_properties():
     assert challenge.approved_compute_cost_euro_millicents == 10 * 1000 * 100
     assert challenge.consumed_compute_cost_euro_millicents == 6 * 1000 * 100
     assert challenge.write_off_compute_cost_euro_millicents == 0
-    assert challenge.percent_active_budget_consumed == 60
+    assert challenge.percent_active_compute_budget_consumed == 60

--- a/app/tests/invoices_tests/test_compute_cost.py
+++ b/app/tests/invoices_tests/test_compute_cost.py
@@ -52,6 +52,32 @@ def test_percent_compute_budget_consumed_unauthorized():
     assert invoice.percent_compute_budget_consumed is None
 
 
+@pytest.mark.django_db
+def test_approved_storage_costs_authorized():
+    challenge = ChallengeFactory()
+    invoice = InvoiceFactory(
+        challenge=challenge,
+        storage_costs_euros=2,
+        payment_status=PaymentStatusChoices.PAID,
+    )
+    invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
+
+    assert invoice.approved_storage_cost_euro_millicents == 2 * 1000 * 100
+
+
+@pytest.mark.django_db
+def test_approved_storage_costs_unauthorized():
+    challenge = ChallengeFactory()
+    invoice = InvoiceFactory(
+        challenge=challenge,
+        storage_costs_euros=2,
+        payment_status=PaymentStatusChoices.CANCELLED,
+    )
+    invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
+
+    assert invoice.approved_storage_cost_euro_millicents == 0
+
+
 ##########
 # PREPAID
 #########

--- a/app/tests/invoices_tests/test_compute_cost.py
+++ b/app/tests/invoices_tests/test_compute_cost.py
@@ -13,7 +13,7 @@ from tests.invoices_tests.factories import InvoiceFactory
 
 
 @pytest.mark.django_db
-def test_percent_budget_consumed():
+def test_percent_compute_budget_consumed():
     challenge = ChallengeFactory()
     invoice = InvoiceFactory(
         challenge=challenge,
@@ -22,11 +22,11 @@ def test_percent_budget_consumed():
     )
     invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
 
-    assert invoice.percent_budget_consumed == 50
+    assert invoice.percent_compute_budget_consumed == 50
 
 
 @pytest.mark.django_db
-def test_percent_budget_consumed_over_charge():
+def test_percent_compute_budget_consumed_over_charge():
     challenge = ChallengeFactory()
     invoice = InvoiceFactory(
         challenge=challenge,
@@ -35,11 +35,11 @@ def test_percent_budget_consumed_over_charge():
     )
     invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
 
-    assert invoice.percent_budget_consumed == 100
+    assert invoice.percent_compute_budget_consumed == 100
 
 
 @pytest.mark.django_db
-def test_percent_budget_consumed_unauthorized():
+def test_percent_compute_budget_consumed_unauthorized():
     challenge = ChallengeFactory()
     invoice = InvoiceFactory(
         challenge=challenge,
@@ -49,7 +49,7 @@ def test_percent_budget_consumed_unauthorized():
     )
     invoice = Invoice.objects.with_budget_authorization().get(pk=invoice.pk)
 
-    assert invoice.percent_budget_consumed is None
+    assert invoice.percent_compute_budget_consumed is None
 
 
 ##########

--- a/app/tests/invoices_tests/test_tasks.py
+++ b/app/tests/invoices_tests/test_tasks.py
@@ -638,7 +638,7 @@ def test_invoice_budget_alert_email(
     ]
     assert (
         challenge_admin_email[0].subject
-        == "[testserver] [test] over 70% Budget Consumed Alert"
+        == "[testserver] [test] over 70% Compute Budget Consumed Alert"
     )
     assert (
         "We would like to inform you that more than 70% of the compute budget "
@@ -676,7 +676,7 @@ def test_invoice_budget_alert_email(
     assert len(mail.outbox) != 0
     assert (
         mail.outbox[0].subject
-        == "[testserver] [test] over 90% Budget Consumed Alert"
+        == "[testserver] [test] over 90% Compute Budget Consumed Alert"
     )
 
 
@@ -727,7 +727,7 @@ def test_invoice_budget_alert_two_thresholds_one_email(
     }
     assert (
         mail.outbox[0].subject
-        == "[testserver] [test] over 90% Budget Consumed Alert"
+        == "[testserver] [test] over 90% Compute Budget Consumed Alert"
     )
 
 

--- a/app/tests/invoices_tests/test_views.py
+++ b/app/tests/invoices_tests/test_views.py
@@ -1,4 +1,5 @@
 import pytest
+from django.utils.timezone import now, timedelta
 
 from tests.factories import ChallengeFactory, UserFactory
 from tests.invoices_tests.factories import InvoiceFactory
@@ -88,3 +89,38 @@ def test_invoice_list_view_num_invoices_shown(client):
         )
         assert response.status_code == 200
         assert len(response.context_data["object_list"]) == num_invoices
+
+
+@pytest.mark.django_db
+def test_invoice_detail_hide_compute_when_expired(client):
+    challenge = ChallengeFactory()
+
+    user = UserFactory()
+    challenge.add_admin(user)
+
+    invoice = InvoiceFactory(challenge=challenge)
+
+    response = get_view_for_user(
+        viewname="invoices:detail",
+        client=client,
+        reverse_kwargs={"external_pk": invoice.external_pk},
+        challenge=challenge,
+        user=user,
+    )
+    assert response.status_code == 200
+
+    assert "Compute Costs" in response.rendered_content
+
+    invoice.expires_on = now().date() - timedelta(days=1)
+    invoice.save()
+
+    response = get_view_for_user(
+        viewname="invoices:detail",
+        client=client,
+        reverse_kwargs={"external_pk": invoice.external_pk},
+        challenge=challenge,
+        user=user,
+    )
+    assert response.status_code == 200
+
+    assert "Compute Costs" not in response.rendered_content


### PR DESCRIPTION
Part of pitch:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/465#event-25960017666

In addition of adding the utilization markup:
- Renamed `percent_budget_consumed` to `percent_compute_budget_consumed` to better match the content.
- Added an approved variant of the storage costs that is bound by budget authorization.
 
## Showcase
<img width="50%" height="1048" alt="afbeelding" src="https://github.com/user-attachments/assets/8d0bc08a-1862-4eb2-aa56-4f05eb639c7c" />

<img width="50%" height="1048" alt="afbeelding" src="https://github.com/user-attachments/assets/864bab1e-fa87-4ae1-b4c9-8a0e2210e1bc" />

<img width="50%" height="1048" alt="afbeelding" src="https://github.com/user-attachments/assets/4f85dbca-8210-47fe-84a8-e6ba6de2cbeb" />

