### PR TITLE
Remove atomic blocks

### DIFF
--- a/app/grandchallenge/components/backends/base.py
+++ b/app/grandchallenge/components/backends/base.py
@@ -28,7 +28,6 @@ from botocore.auth import SigV4Auth
 from botocore.config import Config
 from django.conf import settings
 from django.core.exceptions import SuspiciousFileOperation, ValidationError
-from django.db import transaction
 from django.utils._os import safe_join
 from django.utils.functional import cached_property
 from panimg_models import ImageBuilderOptions
@@ -379,18 +378,15 @@ class Executor(ABC):
         """Create ComponentInterfaceValues from the output interfaces"""
         outputs = []
 
-        with transaction.atomic():
-            # Atomic block required as create_instance needs to
-            # create interfaces in order to store the files
-            for interface in output_interfaces:
-                if interface.is_image_kind:
-                    res = self._create_images_result(interface=interface)
-                elif interface.is_json_kind:
-                    res = self._create_json_result(interface=interface)
-                else:
-                    res = self._create_file_result(interface=interface)
+        for interface in output_interfaces:
+            if interface.is_image_kind:
+                res = self._create_images_result(interface=interface)
+            elif interface.is_json_kind:
+                res = self._create_json_result(interface=interface)
+            else:
+                res = self._create_file_result(interface=interface)
 
-                outputs.append(res)
+            outputs.append(res)
 
         return outputs
 

--- a/app/grandchallenge/components/models.py
+++ b/app/grandchallenge/components/models.py
@@ -22,7 +22,7 @@ from django.core.validators import (
     MinValueValidator,
     RegexValidator,
 )
-from django.db import models, transaction
+from django.db import models
 from django.db.models import IntegerChoices, QuerySet, TextChoices
 from django.forms import ModelChoiceField
 from django.template.defaultfilters import truncatewords
@@ -2248,7 +2248,6 @@ class ComponentImage(FieldChangeMixin, models.Model):
     def get_peer_images(self):
         raise NotImplementedError
 
-    @transaction.atomic
     def mark_desired_version(self):
         self.clear_can_execute_cache()
         if self.is_manifest_valid and self.can_execute:
@@ -2913,7 +2912,6 @@ class Tarball(UUIDModel):
     def linked_file(self):
         raise NotImplementedError
 
-    @transaction.atomic
     def mark_desired_version(self, peer_tarballs=None):
         peer_tarballs = list(peer_tarballs or self.get_peer_tarballs())
         for tb in peer_tarballs:

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -17,7 +17,6 @@ from dateutil.relativedelta import relativedelta
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db import transaction
 from django.db.models import Count, DateTimeField, ExpressionWrapper, F, Q
 from django.utils.module_loading import import_string
 from django.utils.timezone import now
@@ -96,9 +95,8 @@ def assign_docker_image_from_upload(
     model = apps.get_model(app_label=app_label, model_name=model_name)
     instance = model.objects.get(pk=pk)
 
-    with transaction.atomic():
-        instance.user_upload.copy_object(to_field=instance.image)
-        instance.user_upload.delete()
+    instance.user_upload.copy_object(to_field=instance.image)
+    instance.user_upload.delete()
 
 
 @lambda_task(

--- a/app/tests/algorithms_tests/test_models.py
+++ b/app/tests/algorithms_tests/test_models.py
@@ -6,7 +6,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.files.base import ContentFile
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError
 from django.db.models import ProtectedError
 from django.utils.timezone import now
 
@@ -1437,10 +1437,9 @@ def test_algorithmalgorithminterface_unique_constraints():
 
     # cannot add a second time the same interface for the same algorithm
     with pytest.raises(IntegrityError):
-        with transaction.atomic():
-            AlgorithmAlgorithmInterface.objects.create(
-                interface=interface1, algorithm=algorithm
-            )
+        AlgorithmAlgorithmInterface.objects.create(
+            interface=interface1, algorithm=algorithm
+        )
 
 
 @pytest.mark.parametrize(

--- a/app/tests/archives_tests/test_models.py
+++ b/app/tests/archives_tests/test_models.py
@@ -93,13 +93,15 @@ def test_archive_item_set_title():
 
     # Duplication attempt via edit
     ai1.title = ai0.title
-    with transaction.atomic():
-        with pytest.raises(IntegrityError):
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            # Atomic block required for later db queries in this test
             ai1.save()
 
     # Duplication attempt via save
-    with transaction.atomic():
-        with pytest.raises(IntegrityError):
+    with pytest.raises(IntegrityError):
+        with transaction.atomic():
+            # Atomic block required for later db queries in this test
             ArchiveItemFactory(
                 archive=archive,
                 title=ai1.title,

--- a/app/tests/reader_studies_tests/test_signals.py
+++ b/app/tests/reader_studies_tests/test_signals.py
@@ -41,6 +41,7 @@ def test_assert_modification_allowed():
 
     with pytest.raises(ValidationError):
         with transaction.atomic():
+            # Atomic block required for later db queries in this test
             ds.values.remove(civ2)
 
     assert ds.values.count() == 1


### PR DESCRIPTION
Atomic blocks are no longer required as all requests, migrations and tasks are wrapped in atomic blocks.

Management commands, the command line, and scripts are NOT wrapped in atomic blocks, so that still needs to be managed manually.