### PR TITLE
Allow uploading of failure result on invocation timeout

### DIFF
--- a/app/grandchallenge/components/backends/amazon_sagemaker_endpoint.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_endpoint.py
@@ -316,7 +316,9 @@ class EndpointOrchestrator:
             ContentType="application/json",
             InputLocation=self._invocation_s3_uri,
             InferenceId=inference_id,
-            InvocationTimeoutSeconds=int(self._time_limit.total_seconds()),
+            InvocationTimeoutSeconds=int(
+                self._time_limit.total_seconds() + 10
+            ),  # Add buffer time to upload invocation result
         )
 
     @staticmethod

--- a/app/tests/components_tests/test_amazon_sagemaker_endpoint_backend.py
+++ b/app/tests/components_tests/test_amazon_sagemaker_endpoint_backend.py
@@ -622,7 +622,7 @@ def test_invocation_invoke_endpoint(settings):
                 "ContentType": "application/json",
                 "InputLocation": orchestrator._invocation_s3_uri,
                 "InferenceId": invocation.inference_id,
-                "InvocationTimeoutSeconds": 42,
+                "InvocationTimeoutSeconds": 52,  # 10 seconds added buffer time
             },
         )
 


### PR DESCRIPTION
If the timeout of the invocation is equal to the `InvocationMaximumTimeout` seconds, there will not be any time to upload the result, and the invocation state will be failed without a clear explanation. Add buffer time for the uploading to complete. 