### PR TITLE
Link directly through to the evaluation logs

### DIFF
--- a/app/grandchallenge/evaluation/models.py
+++ b/app/grandchallenge/evaluation/models.py
@@ -2015,8 +2015,14 @@ class EvaluationActionMessageBuilder:
     @property
     def evaluation_logs_message(self):
         return format_html(
-            "<a href={url}#logs>inspect the evaluation logs</a>",
-            url=self.evaluation.get_absolute_url(),
+            "<a href={url}>inspect the evaluation logs</a>",
+            url=reverse(
+                viewname="evaluation:evaluation-logs-detail",
+                kwargs={
+                    "pk": self.evaluation.pk,
+                    "challenge_short_name": self.phase.challenge.short_name,
+                },
+            ),
         )
 
     @property


### PR DESCRIPTION
There is a link in the evaluation admin section but may as well take them straight through to the dedicated logs page.

See #4816