### PR TITLE
Fix invoice due count

### DIFF
--- a/app/grandchallenge/invoices/models.py
+++ b/app/grandchallenge/invoices/models.py
@@ -93,9 +93,9 @@ class InvoiceQuerySet(models.QuerySet):
     def status_aggregates(self):
         return self.aggregate(
             num_is_overdue=Count(
-                "is_overdue", filter=Q(is_overdue=True), distinct=True
+                "pk", filter=Q(is_overdue=True), distinct=True
             ),
-            num_is_due=Count("is_due", filter=Q(is_due=True), distinct=True),
+            num_is_due=Count("pk", filter=Q(is_due=True), distinct=True),
         )
 
     def with_budget_authorization(self):

--- a/app/tests/invoices_tests/test_models.py
+++ b/app/tests/invoices_tests/test_models.py
@@ -806,3 +806,49 @@ def test_utilization_priority_paid_status():
         invoice_1.pk,
         invoice_0.pk,
     ]
+
+
+@pytest.mark.django_db
+def test_status_aggregates(settings):
+    challenge = ChallengeFactory()
+    today = now().date()
+    cutoff = settings.CHALLENGE_INVOICE_OVERDUE_CUTOFF  # 4 weeks (28 days)
+
+    common_settings = {
+        "challenge": challenge,
+        "payment_status": PaymentStatusChoices.ISSUED,
+        "billing_address": "foo",
+        "contact_name": "bar",
+        "contact_email": "fake@email.com",
+        "vat_number": "123",
+        "internal_client_number": "456",
+        "internal_invoice_number": "789",
+        "support_costs_euros": 10,
+        "compute_costs_euros": 10,
+        "storage_costs_euros": 10,
+    }
+    # 2 OVERDUE
+    overdue_issued_on = today - cutoff - timedelta(days=7)
+    InvoiceFactory(
+        payment_type=Invoice.PaymentTypeChoices.PREPAID,
+        issued_on=overdue_issued_on,
+        **common_settings,
+    )
+    InvoiceFactory(
+        payment_type=Invoice.PaymentTypeChoices.POSTPAID,
+        issued_on=overdue_issued_on,
+        **common_settings,
+    )
+
+    # 1 DUE
+    due_issued_on = today - cutoff + timedelta(days=10)
+    InvoiceFactory(
+        payment_type=Invoice.PaymentTypeChoices.PREPAID,
+        issued_on=due_issued_on,
+        **common_settings,
+    )
+
+    aggregates = Invoice.objects.with_overdue_status().status_aggregates
+
+    assert aggregates["num_is_overdue"] == 2
+    assert aggregates["num_is_due"] == 1


### PR DESCRIPTION
This fixes the due and overdue count annotation for invoices. 

The previous code counted distinct values of the is_overdue/is_due boolean field among the filtered rows — since every row passing the filter already has that field set to True, there's only ever one distinct value, so the count collapsed to 1 (or 0 if no rows matched) instead of reflecting the actual number of matching invoices.

Closes #4691 