### PR TITLE
Add client tokens for idempotent AWS calls

### DIFF
--- a/app/grandchallenge/cases/models.py
+++ b/app/grandchallenge/cases/models.py
@@ -1187,6 +1187,7 @@ class DICOMImageSetUpload(UUIDModel):
 
     def start_dicom_import_job(self):
         return self._health_imaging_client.start_dicom_import_job(
+            clientToken=f"{self._meta.app_label}-{self._meta.model_name}-{self.pk}",
             jobName=self._import_job_name,
             datastoreId=settings.AWS_HEALTH_IMAGING_DATASTORE_ID,
             dataAccessRoleArn=settings.AWS_HEALTH_IMAGING_IMPORT_ROLE_ARN,

--- a/app/grandchallenge/codebuild/models.py
+++ b/app/grandchallenge/codebuild/models.py
@@ -130,6 +130,7 @@ class Build(UUIDModel):
     def _create_build(self):
         self.build_config = {
             "projectName": settings.CODEBUILD_PROJECT_NAME,
+            "idempotencyToken": f"{self._meta.app_label}-{self._meta.model_name}-{self.pk}",
             "sourceLocationOverride": f"{settings.PRIVATE_S3_STORAGE_KWARGS['bucket_name']}/{self.webhook_message.zipfile.name}",
             "sourceTypeOverride": "S3",
             "environmentVariablesOverride": [

--- a/app/grandchallenge/components/backends/amazon_ecs.py
+++ b/app/grandchallenge/components/backends/amazon_ecs.py
@@ -46,11 +46,13 @@ class ECSTaskOrchestrator:
     def start(
         self,
         environment: dict,
+        client_token: str,
     ):
         task_definition_arn = self._register_task_definition()
 
         try:
             response = self._ecs_client.run_task(
+                clientToken=client_token,
                 cluster=settings.COMPONENTS_SERVICE_CLUSTER_NAME,
                 count=1,
                 enableExecuteCommand=False,

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1177,8 +1177,13 @@ def start_service(*, pk: str | UUID, app_label: str, model_name: str):
 
     orchestrator = ECSTaskOrchestrator(**service.orchestrator_kwargs)
 
+    client_token = f"{app_label}-{model_name}-{pk}"
+
     try:
-        service.task_arn = orchestrator.start(environment=service.environment)
+        service.task_arn = orchestrator.start(
+            environment=service.environment,
+            client_token=client_token,
+        )
     except Exception as error:
         task_logger.error(error, exc_info=True)
 

--- a/app/tests/cases_tests/test_models.py
+++ b/app/tests/cases_tests/test_models.py
@@ -114,6 +114,7 @@ def test_start_dicom_import_job(settings):
                 "submittedAt": "2025-08-27T12:00:00Z",
             },
             expected_params={
+                "clientToken": f"cases-dicomimagesetupload-{di_upload.pk}",
                 "datastoreId": settings.AWS_HEALTH_IMAGING_DATASTORE_ID,
                 "inputS3Uri": di_upload._import_input_s3_uri,
                 "outputS3Uri": di_upload._import_output_s3_uri,

--- a/app/tests/workstations_tests/test_tasks.py
+++ b/app/tests/workstations_tests/test_tasks.py
@@ -140,6 +140,7 @@ def test_start_service(mocker, settings, django_capture_on_commit_callbacks):
             method="run_task",
             service_response={"tasks": [{"taskArn": "test-task-arn"}]},
             expected_params={
+                "clientToken": f"workstations-session-{session.pk}",
                 "cluster": "test-cluster-name",
                 "count": 1,
                 "enableECSManagedTags": True,


### PR DESCRIPTION
For idempotent calls to AWS services. These are the only ones that support them, for many other calls they are not necessary, but if they are supported they should be set.

Closes #4843 