### PR TITLE
Set algorithm image import status as cancelled when the build does not succeed

### DIFF
--- a/app/grandchallenge/codebuild/migrations/0002_cancel_images_with_failed_builds.py
+++ b/app/grandchallenge/codebuild/migrations/0002_cancel_images_with_failed_builds.py
@@ -1,0 +1,43 @@
+from django.db import migrations
+
+
+def cancel_initialized_images_with_failed_builds(apps, schema_editor):
+    from grandchallenge.codebuild.models import BuildStatusChoices
+    from grandchallenge.components.models import ImportStatusChoices
+
+    Build = apps.get_model("codebuild", "Build")  # noqa: N806
+    AlgorithmImage = apps.get_model(  # noqa: N806
+        "algorithms", "AlgorithmImage"
+    )
+
+    failed_statuses = {
+        BuildStatusChoices.FAILED,
+        BuildStatusChoices.FAULT,
+        BuildStatusChoices.TIMED_OUT,
+        BuildStatusChoices.STOPPED,
+    }
+
+    algorithm_image_pks = Build.objects.filter(
+        status__in=failed_statuses,
+        algorithm_image__isnull=False,
+        algorithm_image__import_status=ImportStatusChoices.INITIALIZED,
+    ).values_list("algorithm_image_id", flat=True)
+
+    AlgorithmImage.objects.filter(pk__in=algorithm_image_pks).update(
+        import_status=ImportStatusChoices.CANCELLED
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("codebuild", "0001_initial"),
+        ("algorithms", "0102_alter_endpoint_options_alter_job_options"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            cancel_initialized_images_with_failed_builds,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]

--- a/app/grandchallenge/codebuild/tasks.py
+++ b/app/grandchallenge/codebuild/tasks.py
@@ -49,6 +49,11 @@ def handle_completed_build_event(*, build_arn: str, build_status: str):
 
     if build.status == build.BuildStatusChoices.SUCCEEDED:
         add_image_to_algorithm.execute_on_commit(build_pk=build.pk)
+    else:
+        build.algorithm_image.import_status = (
+            build.algorithm_image.ImportStatusChoices.CANCELLED
+        )
+        build.algorithm_image.save()
 
 
 @lambda_task(queue=LambdaTaskQueueChoices.MEM8G)

--- a/app/tests/codebuild_tests/conftest.py
+++ b/app/tests/codebuild_tests/conftest.py
@@ -1,0 +1,60 @@
+import boto3
+import pytest
+from botocore.stub import Stubber
+
+from grandchallenge.codebuild.models import Build
+from tests.algorithms_tests.factories import AlgorithmImageFactory
+from tests.github_tests.factories import GitHubWebhookMessageFactory
+
+
+@pytest.fixture
+def codebuild_stubber():
+    client = boto3.client("codebuild", region_name="us-east-1")
+    with Stubber(client) as stubber:
+        yield client, stubber
+
+
+@pytest.fixture
+def logs_stubber():
+    client = boto3.client("logs", region_name="us-east-1")
+    with Stubber(client) as stubber:
+        yield client, stubber
+
+
+@pytest.fixture
+def s3_stubber():
+    client = boto3.client("s3", region_name="us-east-1")
+    with Stubber(client) as stubber:
+        yield client, stubber
+
+
+@pytest.fixture
+def build(codebuild_stubber, settings):
+    client, stubber = codebuild_stubber
+    settings.CODEBUILD_PROJECT_NAME = "test-project"
+    settings.CODEBUILD_BUILD_LOGS_GROUP_NAME = "test-log-group"
+    settings.CODEBUILD_ARTIFACTS_BUCKET_NAME = "test-artifacts-bucket"
+
+    algorithm_image = AlgorithmImageFactory(image=None)
+    webhook_message = GitHubWebhookMessageFactory(
+        zipfile="github/zips/test.zip"
+    )
+
+    stubber.add_response(
+        method="start_build",
+        service_response={
+            "build": {
+                "id": "test-project:build-123",
+                "buildStatus": "IN_PROGRESS",
+            }
+        },
+    )
+
+    build = Build(
+        webhook_message=webhook_message,
+        algorithm_image=algorithm_image,
+    )
+    build._Build__codebuild_client = client
+    build.save()
+
+    return build

--- a/app/tests/codebuild_tests/test_models.py
+++ b/app/tests/codebuild_tests/test_models.py
@@ -1,0 +1,80 @@
+import pytest
+
+from grandchallenge.codebuild.models import Build, BuildStatusChoices
+from tests.algorithms_tests.factories import AlgorithmImageFactory
+from tests.github_tests.factories import GitHubWebhookMessageFactory
+
+
+@pytest.mark.django_db
+def test_build_number(build):
+    assert build.build_number == "build-123"
+
+
+@pytest.mark.django_db
+def test_animate_when_in_progress(build):
+    assert build.animate is True
+
+
+@pytest.mark.django_db
+def test_not_animate_when_finished(build):
+    build.status = BuildStatusChoices.SUCCEEDED
+    assert build.animate is False
+
+
+@pytest.mark.django_db
+def test_finished_when_not_in_progress(build):
+    build.status = BuildStatusChoices.FAILED
+    assert build.finished is True
+
+
+@pytest.mark.django_db
+def test_not_finished_when_in_progress(build):
+    assert build.finished is False
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "status,expected_context",
+    [
+        (BuildStatusChoices.SUCCEEDED, "success"),
+        (BuildStatusChoices.STOPPED, "warning"),
+        (BuildStatusChoices.FAILED, "danger"),
+        (BuildStatusChoices.FAULT, "danger"),
+        (BuildStatusChoices.TIMED_OUT, "danger"),
+        (BuildStatusChoices.IN_PROGRESS, "info"),
+    ],
+)
+def test_status_context(build, status, expected_context):
+    build.status = status
+    assert build.status_context == expected_context
+
+
+@pytest.mark.django_db
+def test_save_calls_start_build(codebuild_stubber, settings):
+    client, stubber = codebuild_stubber
+    settings.CODEBUILD_PROJECT_NAME = "my-project"
+
+    algorithm_image = AlgorithmImageFactory(image=None)
+    webhook_message = GitHubWebhookMessageFactory(
+        zipfile="github/zips/test.zip"
+    )
+
+    stubber.add_response(
+        method="start_build",
+        service_response={
+            "build": {
+                "id": "my-project:build-999",
+                "buildStatus": "IN_PROGRESS",
+            }
+        },
+    )
+
+    build = Build(
+        webhook_message=webhook_message,
+        algorithm_image=algorithm_image,
+    )
+    build._Build__codebuild_client = client
+    build.save()
+
+    assert build.build_id == "my-project:build-999"
+    assert build.status == BuildStatusChoices.IN_PROGRESS

--- a/app/tests/codebuild_tests/test_tasks.py
+++ b/app/tests/codebuild_tests/test_tasks.py
@@ -1,0 +1,67 @@
+import pytest
+
+from grandchallenge.codebuild.models import Build, BuildStatusChoices
+from grandchallenge.components.models import ImportStatusChoices
+from tests.algorithms_tests.factories import AlgorithmImageFactory
+from tests.github_tests.factories import GitHubWebhookMessageFactory
+
+
+@pytest.fixture
+def build(mocker):
+    algorithm_image = AlgorithmImageFactory(image=None)
+    webhook_message = GitHubWebhookMessageFactory()
+    mocker.patch.object(Build, "_create_build")
+    build = Build.objects.create(
+        webhook_message=webhook_message,
+        algorithm_image=algorithm_image,
+        build_config={"projectName": "test-project"},
+        build_id="project:build-123",
+        status=BuildStatusChoices.IN_PROGRESS,
+    )
+    return build
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "build_status",
+    [
+        BuildStatusChoices.FAILED,
+        BuildStatusChoices.FAULT,
+        BuildStatusChoices.TIMED_OUT,
+        BuildStatusChoices.STOPPED,
+    ],
+)
+def test_handle_completed_build_event_cancels_image_on_failure(
+    build, build_status, mocker
+):
+    from grandchallenge.codebuild.tasks import handle_completed_build_event
+
+    mocker.patch.object(Build, "refresh_logs")
+
+    handle_completed_build_event(
+        build_arn=f"arn:aws:codebuild:us-east-1:123456789:build/{build.build_id}",
+        build_status=build_status,
+    )
+
+    build.algorithm_image.refresh_from_db()
+    assert build.algorithm_image.import_status == ImportStatusChoices.CANCELLED
+
+
+@pytest.mark.django_db
+def test_handle_completed_build_event_does_not_cancel_image_on_success(
+    build, mocker, django_capture_on_commit_callbacks
+):
+    from grandchallenge.codebuild.tasks import handle_completed_build_event
+
+    mocker.patch.object(Build, "refresh_logs")
+
+    with django_capture_on_commit_callbacks():
+        handle_completed_build_event(
+            build_arn=f"arn:aws:codebuild:us-east-1:123456789:build/{build.build_id}",
+            build_status=BuildStatusChoices.SUCCEEDED,
+        )
+
+    build.algorithm_image.refresh_from_db()
+    assert (
+        build.algorithm_image.import_status == ImportStatusChoices.INITIALIZED
+    )

--- a/app/tests/codebuild_tests/test_tasks.py
+++ b/app/tests/codebuild_tests/test_tasks.py
@@ -1,67 +1,337 @@
 import pytest
 
+from grandchallenge.algorithms.models import AlgorithmImage
 from grandchallenge.codebuild.models import Build, BuildStatusChoices
+from grandchallenge.codebuild.tasks import (
+    add_image_to_algorithm,
+    create_codebuild_build,
+    handle_completed_build_event,
+)
 from grandchallenge.components.models import ImportStatusChoices
-from tests.algorithms_tests.factories import AlgorithmImageFactory
+from tests.algorithms_tests.factories import AlgorithmFactory
 from tests.github_tests.factories import GitHubWebhookMessageFactory
 
 
-@pytest.fixture
-def build(mocker):
-    algorithm_image = AlgorithmImageFactory(image=None)
-    webhook_message = GitHubWebhookMessageFactory()
-    mocker.patch.object(Build, "_create_build")
-    build = Build.objects.create(
-        webhook_message=webhook_message,
-        algorithm_image=algorithm_image,
-        build_config={"projectName": "test-project"},
-        build_id="project:build-123",
-        status=BuildStatusChoices.IN_PROGRESS,
-    )
-    return build
+class TestCreateCodebuildBuild:
+    @pytest.mark.django_db
+    def test_creates_algorithm_image_and_build(
+        self, codebuild_stubber, settings
+    ):
+        client, stubber = codebuild_stubber
+        settings.CODEBUILD_PROJECT_NAME = "my-project"
 
-
-@pytest.mark.django_db
-@pytest.mark.parametrize(
-    "build_status",
-    [
-        BuildStatusChoices.FAILED,
-        BuildStatusChoices.FAULT,
-        BuildStatusChoices.TIMED_OUT,
-        BuildStatusChoices.STOPPED,
-    ],
-)
-def test_handle_completed_build_event_cancels_image_on_failure(
-    build, build_status, mocker
-):
-    from grandchallenge.codebuild.tasks import handle_completed_build_event
-
-    mocker.patch.object(Build, "refresh_logs")
-
-    handle_completed_build_event(
-        build_arn=f"arn:aws:codebuild:us-east-1:123456789:build/{build.build_id}",
-        build_status=build_status,
-    )
-
-    build.algorithm_image.refresh_from_db()
-    assert build.algorithm_image.import_status == ImportStatusChoices.CANCELLED
-
-
-@pytest.mark.django_db
-def test_handle_completed_build_event_does_not_cancel_image_on_success(
-    build, mocker, django_capture_on_commit_callbacks
-):
-    from grandchallenge.codebuild.tasks import handle_completed_build_event
-
-    mocker.patch.object(Build, "refresh_logs")
-
-    with django_capture_on_commit_callbacks():
-        handle_completed_build_event(
-            build_arn=f"arn:aws:codebuild:us-east-1:123456789:build/{build.build_id}",
-            build_status=BuildStatusChoices.SUCCEEDED,
+        algorithm = AlgorithmFactory(repo_name="DIAGNijmegen/rse-panimg")
+        webhook_message = GitHubWebhookMessageFactory(
+            zipfile="github/zips/test.zip"
         )
 
-    build.algorithm_image.refresh_from_db()
-    assert (
-        build.algorithm_image.import_status == ImportStatusChoices.INITIALIZED
+        stubber.add_response(
+            method="start_build",
+            service_response={
+                "build": {
+                    "id": "my-project:build-456",
+                    "buildStatus": "IN_PROGRESS",
+                }
+            },
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("boto3.client", lambda *args, **kwargs: client)
+            create_codebuild_build(pk=webhook_message.pk)
+
+        build = Build.objects.get(webhook_message=webhook_message)
+        assert build.algorithm_image is not None
+        assert build.algorithm_image.algorithm == algorithm
+        assert build.build_id == "my-project:build-456"
+        assert build.status == BuildStatusChoices.IN_PROGRESS
+
+    @pytest.mark.django_db
+    def test_skips_if_build_already_exists(self, codebuild_stubber, settings):
+        client, stubber = codebuild_stubber
+        settings.CODEBUILD_PROJECT_NAME = "my-project"
+
+        AlgorithmFactory(repo_name="DIAGNijmegen/rse-panimg")
+        webhook_message = GitHubWebhookMessageFactory(
+            zipfile="github/zips/test.zip"
+        )
+
+        stubber.add_response(
+            method="start_build",
+            service_response={
+                "build": {
+                    "id": "my-project:build-456",
+                    "buildStatus": "IN_PROGRESS",
+                }
+            },
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("boto3.client", lambda *args, **kwargs: client)
+            create_codebuild_build(pk=webhook_message.pk)
+            create_codebuild_build(pk=webhook_message.pk)
+
+        assert (
+            Build.objects.filter(webhook_message=webhook_message).count() == 1
+        )
+
+    @pytest.mark.django_db
+    def test_skips_if_repo_not_linked(self, codebuild_stubber):
+        client, stubber = codebuild_stubber
+        webhook_message = GitHubWebhookMessageFactory()
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("boto3.client", lambda *args, **kwargs: client)
+            create_codebuild_build(pk=webhook_message.pk)
+
+        assert not Build.objects.exists()
+
+    @pytest.mark.django_db
+    def test_algorithm_image_has_no_image_file(
+        self, codebuild_stubber, settings
+    ):
+        client, stubber = codebuild_stubber
+        settings.CODEBUILD_PROJECT_NAME = "my-project"
+
+        AlgorithmFactory(repo_name="DIAGNijmegen/rse-panimg")
+        webhook_message = GitHubWebhookMessageFactory(
+            zipfile="github/zips/test.zip"
+        )
+
+        stubber.add_response(
+            method="start_build",
+            service_response={
+                "build": {
+                    "id": "my-project:build-789",
+                    "buildStatus": "IN_PROGRESS",
+                }
+            },
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("boto3.client", lambda *args, **kwargs: client)
+            create_codebuild_build(pk=webhook_message.pk)
+
+        build = Build.objects.get(webhook_message=webhook_message)
+        assert not build.algorithm_image.image
+
+
+class TestHandleCompletedBuildEvent:
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "build_status",
+        [
+            BuildStatusChoices.FAILED,
+            BuildStatusChoices.FAULT,
+            BuildStatusChoices.TIMED_OUT,
+            BuildStatusChoices.STOPPED,
+        ],
     )
+    def test_cancels_image_on_failure(self, build, build_status, logs_stubber):
+        client, stubber = logs_stubber
+        stubber.add_response(
+            method="get_log_events",
+            service_response={
+                "events": [],
+                "nextForwardToken": "f/0",
+                "nextBackwardToken": "b/0",
+            },
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("boto3.client", lambda *args, **kwargs: client)
+            handle_completed_build_event(
+                build_arn=f"arn:aws:codebuild:us-east-1:123456789:build/{build.build_id}",
+                build_status=build_status,
+            )
+
+        build.algorithm_image.refresh_from_db()
+        assert (
+            build.algorithm_image.import_status
+            == ImportStatusChoices.CANCELLED
+        )
+
+    @pytest.mark.django_db
+    def test_does_not_cancel_image_on_success(
+        self, build, logs_stubber, django_capture_on_commit_callbacks
+    ):
+        client, stubber = logs_stubber
+        stubber.add_response(
+            method="get_log_events",
+            service_response={
+                "events": [],
+                "nextForwardToken": "f/0",
+                "nextBackwardToken": "b/0",
+            },
+        )
+
+        with (
+            pytest.MonkeyPatch.context() as mp,
+            django_capture_on_commit_callbacks(),
+        ):
+            mp.setattr("boto3.client", lambda *args, **kwargs: client)
+            handle_completed_build_event(
+                build_arn=f"arn:aws:codebuild:us-east-1:123456789:build/{build.build_id}",
+                build_status=BuildStatusChoices.SUCCEEDED,
+            )
+
+        build.algorithm_image.refresh_from_db()
+        assert (
+            build.algorithm_image.import_status
+            == ImportStatusChoices.INITIALIZED
+        )
+
+    @pytest.mark.django_db
+    def test_updates_build_status(self, build, logs_stubber):
+        client, stubber = logs_stubber
+        stubber.add_response(
+            method="get_log_events",
+            service_response={
+                "events": [],
+                "nextForwardToken": "f/0",
+                "nextBackwardToken": "b/0",
+            },
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("boto3.client", lambda *args, **kwargs: client)
+            handle_completed_build_event(
+                build_arn=f"arn:aws:codebuild:us-east-1:123456789:build/{build.build_id}",
+                build_status=BuildStatusChoices.FAILED,
+            )
+
+        build.refresh_from_db()
+        assert build.status == BuildStatusChoices.FAILED
+
+    @pytest.mark.django_db
+    def test_stores_build_log(self, build, logs_stubber):
+        client, stubber = logs_stubber
+        stubber.add_response(
+            method="get_log_events",
+            service_response={
+                "events": [
+                    {"message": "[Container] skipped\n"},
+                    {"message": "Step 1: Building image\n"},
+                    {"message": "Step 2: Pushing image\n"},
+                ],
+                "nextForwardToken": "f/0",
+                "nextBackwardToken": "b/0",
+            },
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("boto3.client", lambda *args, **kwargs: client)
+            handle_completed_build_event(
+                build_arn=f"arn:aws:codebuild:us-east-1:123456789:build/{build.build_id}",
+                build_status=BuildStatusChoices.FAILED,
+            )
+
+        build.refresh_from_db()
+        assert (
+            build.build_log
+            == "Step 1: Building image\nStep 2: Pushing image\n"
+        )
+
+    @pytest.mark.django_db
+    def test_is_idempotent(self, build, logs_stubber):
+        client, stubber = logs_stubber
+        stubber.add_response(
+            method="get_log_events",
+            service_response={
+                "events": [],
+                "nextForwardToken": "f/0",
+                "nextBackwardToken": "b/0",
+            },
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("boto3.client", lambda *args, **kwargs: client)
+            handle_completed_build_event(
+                build_arn=f"arn:aws:codebuild:us-east-1:123456789:build/{build.build_id}",
+                build_status=BuildStatusChoices.FAILED,
+            )
+
+            # Calling again is a no-op since status is no longer IN_PROGRESS
+            handle_completed_build_event(
+                build_arn=f"arn:aws:codebuild:us-east-1:123456789:build/{build.build_id}",
+                build_status=BuildStatusChoices.SUCCEEDED,
+            )
+
+        build.refresh_from_db()
+        assert build.status == BuildStatusChoices.FAILED
+
+
+class TestAddImageToAlgorithm:
+    @pytest.mark.django_db
+    def test_copies_image_and_deletes_artifacts(
+        self, build, s3_stubber, monkeypatch
+    ):
+        client, stubber = s3_stubber
+
+        copy_called = False
+
+        def fake_copy_s3_object(**kwargs):
+            nonlocal copy_called
+            copy_called = True
+
+        monkeypatch.setattr(
+            "grandchallenge.codebuild.models.copy_s3_object",
+            fake_copy_s3_object,
+        )
+
+        stubber.add_response(
+            method="list_objects_v2",
+            service_response={
+                "IsTruncated": False,
+                "Contents": [
+                    {
+                        "Key": "codebuild/artifacts/build-123/test-project/container-image.tar.gz"
+                    }
+                ],
+            },
+        )
+        stubber.add_response(
+            method="delete_objects",
+            service_response={
+                "Deleted": [
+                    {
+                        "Key": "codebuild/artifacts/build-123/test-project/container-image.tar.gz"
+                    }
+                ]
+            },
+        )
+
+        monkeypatch.setattr("boto3.client", lambda *args, **kwargs: client)
+        add_image_to_algorithm(build_pk=build.pk)
+
+        assert copy_called
+
+    @pytest.mark.django_db
+    def test_skips_copy_if_image_already_set(
+        self, build, s3_stubber, monkeypatch
+    ):
+        # Set image directly via queryset to avoid triggering validation
+        AlgorithmImage.objects.filter(pk=build.algorithm_image.pk).update(
+            image="some/path.tar.gz"
+        )
+
+        copy_called = False
+
+        def fake_copy_s3_object(**kwargs):
+            nonlocal copy_called
+            copy_called = True
+
+        monkeypatch.setattr(
+            "grandchallenge.codebuild.models.copy_s3_object",
+            fake_copy_s3_object,
+        )
+
+        client, stubber = s3_stubber
+        stubber.add_response(
+            method="list_objects_v2",
+            service_response={"IsTruncated": False},
+        )
+
+        monkeypatch.setattr("boto3.client", lambda *args, **kwargs: client)
+        add_image_to_algorithm(build_pk=build.pk)
+
+        assert not copy_called


### PR DESCRIPTION
Algorithm image imports would be left in an initialized state if the codebuild build fails. This marks them as cancelled, and also performs a data migration to update the existing ones.

There were no tests for the entire codebuild app, so new ones have been added.

This PR has been generated interactively with Kiro and all code has been reviewed by me.

Closes #4068