### PR TITLE
Fix Django admin css in non-debug mode

### DIFF
--- a/app/grandchallenge/django_admin/static/css/django_admin/django_admin.css
+++ b/app/grandchallenge/django_admin/static/css/django_admin/django_admin.css
@@ -1,8 +1,11 @@
 html,
 :root,
-html[data-theme="light"] {
+html[data-theme="dark"],
+html[data-theme="light"],
+html[data-theme="auto"] {
     --primary: #c44133;
     --secondary: #e74c3c;
+    --breadcrumbs-bg: var(--primary);
 }
 
 div.invoice-example-text {

--- a/app/grandchallenge/django_admin/static/css/django_admin/django_admin.css
+++ b/app/grandchallenge/django_admin/static/css/django_admin/django_admin.css
@@ -1,5 +1,6 @@
 html,
-:root {
+:root,
+html[data-theme="light"] {
     --primary: #c44133;
     --secondary: #e74c3c;
 }

--- a/app/grandchallenge/django_admin/static/css/django_admin/django_admin.css
+++ b/app/grandchallenge/django_admin/static/css/django_admin/django_admin.css
@@ -1,8 +1,4 @@
-html,
-:root,
-html[data-theme="dark"],
-html[data-theme="light"],
-html[data-theme="auto"] {
+html[data-theme] {
     --primary: #c44133;
     --secondary: #e74c3c;
     --breadcrumbs-bg: var(--primary);

--- a/app/tests/core_tests/integration_tests.py
+++ b/app/tests/core_tests/integration_tests.py
@@ -1,6 +1,7 @@
 import datetime
 import re
 
+import pytest
 from allauth.account.models import EmailAddress
 from django.contrib.auth import get_user_model
 from django.core import mail
@@ -406,6 +407,7 @@ class ViewsTest(GrandChallengeFrameworkTestCase):
             % (page_url, response.status_code),
         )
 
+    @pytest.mark.flaky(reruns=3)
     def test_non_exitant_project_gives_404(self):
         """Reproduces https://github.com/DIAGNijmegen/rse-grand-challenge/issues/219."""
         non_existant_url = reverse(


### PR DESCRIPTION
Confirmed that cycling through works:

<img width="298" height="181" alt="Screenshot 2026-07-01 at 12 02 42" src="https://github.com/user-attachments/assets/0d09545c-af70-408d-b23d-b91a34be1421" />
<img width="299" height="178" alt="Screenshot 2026-07-01 at 12 02 46" src="https://github.com/user-attachments/assets/3dcdb633-0234-4918-9530-36a5f82aa2e7" />

Closes #3901