### PR TITLE
Move follow creation from notifications to discussion_forums

### DIFF
--- a/app/grandchallenge/discussion_forums/models.py
+++ b/app/grandchallenge/discussion_forums/models.py
@@ -51,6 +51,13 @@ class Forum(UUIDModel):
             kwargs={"challenge_short_name": self.parent_object.short_name},
         )
 
+    @property
+    def follow_create_url(self):
+        return reverse(
+            "discussion-forums:forum-follow-create",
+            kwargs={"challenge_short_name": self.parent_object.short_name},
+        )
+
 
 class ForumTopic(FieldChangeMixin, UUIDModel):
     forum = models.ForeignKey(
@@ -187,6 +194,16 @@ class ForumTopic(FieldChangeMixin, UUIDModel):
     def get_absolute_url(self):
         return reverse(
             "discussion-forums:topic-post-list",
+            kwargs={
+                "challenge_short_name": self.forum.parent_object.short_name,
+                "slug": self.slug,
+            },
+        )
+
+    @property
+    def follow_create_url(self):
+        return reverse(
+            "discussion-forums:topic-follow-create",
             kwargs={
                 "challenge_short_name": self.forum.parent_object.short_name,
                 "slug": self.slug,

--- a/app/grandchallenge/discussion_forums/templates/discussion_forums/forum_base.html
+++ b/app/grandchallenge/discussion_forums/templates/discussion_forums/forum_base.html
@@ -25,7 +25,7 @@
         {% if 'view_forum' in user_perms %}
             <div class="col-12 col-md-6">
                 <div class="float-right controls-link-wrapper">
-                    {% include 'actstream/partials/follow_unfollow_links.html' with object=forum %}
+                    {% include 'discussion_forums/partials/follow_unfollow_links.html' with object=forum %}
                     <a href="{% url 'notifications:follow-list' %}" class="btn btn-primary btn-sm"><i class="fas fa-bookmark mr-1"></i>My Subscriptions</a>
                 </div>
             </div>

--- a/app/grandchallenge/discussion_forums/templates/discussion_forums/forumpost_list.html
+++ b/app/grandchallenge/discussion_forums/templates/discussion_forums/forumpost_list.html
@@ -76,7 +76,7 @@
                 {% endif %}
             </div>
             <div class="col-12 col-md-4 text-left text-md-right">
-                {% include 'actstream/partials/follow_unfollow_links.html' with object=topic %}
+                {% include 'discussion_forums/partials/follow_unfollow_links.html' with object=topic %}
             </div>
         </div>
     {% endif %}

--- a/app/grandchallenge/discussion_forums/templates/discussion_forums/partials/follow_unfollow_links.html
+++ b/app/grandchallenge/discussion_forums/templates/discussion_forums/partials/follow_unfollow_links.html
@@ -1,7 +1,6 @@
 {% load follow_extras %}
 {% load activity_tags %}
 {% load meta_attr %}
-{% load crispy_forms_tags %}
 {% load url %}
 
 
@@ -16,11 +15,10 @@
         </form>
     {% endif %}
 {% else %}
-    {% get_content_type object as object_ct %}
-    {% follow_form user=request.user content_type=object_ct object_id=object.id as follow_form %}
-    <form class="d-inline" method="post" action="{% url 'notifications:follow-create' %}">
+    {% follow_form user=request.user follow_object=object as follow_form %}
+    <form class="d-inline" method="post" action="{{ object.follow_create_url }}">
         {% csrf_token %}
-        {{ follow_form|crispy }}
+        {{ follow_form }}
         <button type="submit" class="btn btn-primary btn-sm"><i class="fas fa-bell mr-1"></i>Subscribe
             to {{ object|verbose_name }}
         </button>

--- a/app/grandchallenge/discussion_forums/urls.py
+++ b/app/grandchallenge/discussion_forums/urls.py
@@ -1,11 +1,13 @@
 from django.urls import path
 
 from grandchallenge.discussion_forums.views import (
+    ForumFollowCreate,
     ForumPostCreate,
     ForumPostDelete,
     ForumPostUpdate,
     ForumTopicCreate,
     ForumTopicDelete,
+    ForumTopicFollowCreate,
     ForumTopicListView,
     ForumTopicLockUpdate,
     ForumTopicPostList,
@@ -16,8 +18,13 @@ app_name = "discussion_forums"
 
 
 urlpatterns = [
-    path("topics/", ForumTopicListView.as_view(), name="topic-list"),
     path("posts/mine/", MyForumPosts.as_view(), name="my-posts"),
+    path(
+        "follow/",
+        ForumFollowCreate.as_view(),
+        name="forum-follow-create",
+    ),
+    path("topics/", ForumTopicListView.as_view(), name="topic-list"),
     path(
         "topics/create/",
         ForumTopicCreate.as_view(),
@@ -37,6 +44,11 @@ urlpatterns = [
         "topics/<slug:slug>/",
         ForumTopicPostList.as_view(),
         name="topic-post-list",
+    ),
+    path(
+        "topics/<slug:slug>/follow/",
+        ForumTopicFollowCreate.as_view(),
+        name="topic-follow-create",
     ),
     path(
         "topics/<slug:slug>/posts/create/",

--- a/app/grandchallenge/discussion_forums/views.py
+++ b/app/grandchallenge/discussion_forums/views.py
@@ -1,8 +1,11 @@
+from actstream.models import Follow
+from django.contrib.messages.views import SuccessMessageMixin
 from django.db.models import Prefetch
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
 from django.views.generic import CreateView, DeleteView, ListView, UpdateView
+from guardian.mixins import LoginRequiredMixin
 
 from grandchallenge.core.guardian import (
     ObjectPermissionRequiredMixin,
@@ -20,6 +23,7 @@ from grandchallenge.discussion_forums.models import (
     ForumTopicKindChoices,
     TopicReadRecord,
 )
+from grandchallenge.notifications.forms import FollowForm
 from grandchallenge.subdomains.utils import reverse
 
 
@@ -358,3 +362,77 @@ class MyForumPosts(ViewObjectPermissionListMixin, ListView):
         context = super().get_context_data()
         context.update({"forum": self.forum, "topic": None})
         return context
+
+
+class ForumFollowCreate(
+    LoginRequiredMixin,
+    ObjectPermissionRequiredMixin,
+    SuccessMessageMixin,
+    CreateView,
+):
+    model = Follow
+    form_class = FollowForm
+    permission_required = "view_forum"
+    raise_exception = True
+    success_message = "Subscription successfully added"
+
+    @cached_property
+    def forum(self):
+        return self.request.challenge.discussion_forum
+
+    def get_permission_object(self):
+        return self.forum
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs.update(
+            {
+                "user": self.request.user,
+                "follow_object": self.forum,
+            }
+        )
+        return kwargs
+
+    def get_success_url(self):
+        return self.forum.get_absolute_url()
+
+
+class ForumTopicFollowCreate(
+    LoginRequiredMixin,
+    ObjectPermissionRequiredMixin,
+    SuccessMessageMixin,
+    CreateView,
+):
+    model = Follow
+    form_class = FollowForm
+    permission_required = "view_forumtopic"
+    raise_exception = True
+    success_message = "Subscription successfully added"
+
+    @cached_property
+    def forum(self):
+        return self.request.challenge.discussion_forum
+
+    @cached_property
+    def topic(self):
+        return get_object_or_404(
+            ForumTopic,
+            forum=self.forum,
+            slug=self.kwargs["slug"],
+        )
+
+    def get_permission_object(self):
+        return self.topic
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs.update(
+            {
+                "user": self.request.user,
+                "follow_object": self.topic,
+            }
+        )
+        return kwargs
+
+    def get_success_url(self):
+        return self.topic.get_absolute_url()

--- a/app/grandchallenge/notifications/forms.py
+++ b/app/grandchallenge/notifications/forms.py
@@ -1,23 +1,24 @@
 from actstream.models import Follow
-from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
+from django.forms import HiddenInput, ModelForm
 from guardian.utils import get_anonymous_user
 
-from grandchallenge.core.forms import SaveFormInitMixin
-from grandchallenge.discussion_forums.models import Forum, ForumTopic
 
+class FollowForm(ModelForm):
+    def __init__(self, *, user, follow_object, **kwargs):
+        super().__init__(**kwargs)
 
-class FollowForm(SaveFormInitMixin, forms.ModelForm):
-    def __init__(self, *args, user, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.user = user
         self.fields["user"].queryset = get_user_model().objects.filter(
-            pk=self.user.pk
+            pk=user.pk
         )
-        self.fields["user"].initial = self.user
+        self.fields["user"].initial = user.pk
+        self.fields["content_type"].initial = (
+            ContentType.objects.get_for_model(follow_object).pk
+        )
+        self.fields["object_id"].initial = follow_object.pk
+        self.fields["actor_only"].initial = False
 
     def clean_user(self):
         user = self.cleaned_data["user"]
@@ -27,39 +28,12 @@ class FollowForm(SaveFormInitMixin, forms.ModelForm):
             )
         return user
 
-    def clean(self):
-        cleaned_data = super().clean()
-
-        try:
-            obj_id = cleaned_data["object_id"]
-        except KeyError:
-            raise ValidationError("You cannot create this subscription!")
-
-        if cleaned_data["content_type"] == ContentType.objects.get(
-            app_label="discussion_forums", model="forum"
-        ):
-            perm = self.user.has_perm(
-                "view_forum", Forum.objects.filter(pk=obj_id).get()
-            )
-        elif cleaned_data["content_type"] == ContentType.objects.get(
-            app_label="discussion_forums", model="forumtopic"
-        ):
-            perm = self.user.has_perm(
-                "view_forumtopic",
-                ForumTopic.objects.filter(pk=obj_id).get(),
-            )
-
-        if not perm:
-            raise ValidationError("You cannot create this subscription!")
-
-        return cleaned_data
-
     class Meta:
         model = Follow
         fields = ("user", "content_type", "object_id", "actor_only")
         widgets = {
-            "user": forms.HiddenInput(),
-            "content_type": forms.HiddenInput(),
-            "object_id": forms.HiddenInput(),
-            "actor_only": forms.HiddenInput(),
+            "user": HiddenInput(),
+            "content_type": HiddenInput(),
+            "object_id": HiddenInput(),
+            "actor_only": HiddenInput(),
         }

--- a/app/grandchallenge/notifications/templatetags/follow_extras.py
+++ b/app/grandchallenge/notifications/templatetags/follow_extras.py
@@ -30,27 +30,8 @@ def get_follow_object_pk(user, follow_object):
 
 
 @register.simple_tag
-def follow_form(*, user, object_id, content_type):
-    return FollowForm(
-        user=user,
-        initial={
-            "object_id": object_id,
-            "content_type": content_type,
-            "actor_only": False,
-        },
-    )
-
-
-@register.simple_tag()
-def get_content_type(follow_object):
-    try:
-        ct = ContentType.objects.get(
-            app_label=follow_object._meta.app_label,
-            model=follow_object._meta.model_name,
-        )
-    except AttributeError:
-        ct = None
-    return ct
+def follow_form(*, user, follow_object):
+    return FollowForm(user=user, follow_object=follow_object)
 
 
 @register.simple_tag()

--- a/app/grandchallenge/notifications/urls.py
+++ b/app/grandchallenge/notifications/urls.py
@@ -1,7 +1,6 @@
 from django.urls import path
 
 from grandchallenge.notifications.views import (
-    FollowCreate,
     FollowDelete,
     FollowList,
     NotificationList,
@@ -16,8 +15,5 @@ urlpatterns = [
         "subscriptions/<int:pk>/delete/",
         FollowDelete.as_view(),
         name="follow-delete",
-    ),
-    path(
-        "subscriptions/create/", FollowCreate.as_view(), name="follow-create"
     ),
 ]

--- a/app/grandchallenge/notifications/views.py
+++ b/app/grandchallenge/notifications/views.py
@@ -2,7 +2,7 @@ from actstream.models import Follow
 from django.contrib import messages
 from django.contrib.messages.views import SuccessMessageMixin
 from django.db.models import Q
-from django.views.generic import CreateView, DeleteView, ListView
+from django.views.generic import DeleteView, ListView
 from guardian.mixins import LoginRequiredMixin
 from rest_framework import mixins, viewsets
 from rest_framework.permissions import DjangoObjectPermissions
@@ -18,7 +18,6 @@ from grandchallenge.notifications.filters import (
     FollowFilter,
     NotificationFilter,
 )
-from grandchallenge.notifications.forms import FollowForm
 from grandchallenge.notifications.models import Notification
 from grandchallenge.notifications.serializers import (
     FollowSerializer,
@@ -183,20 +182,6 @@ class FollowDelete(
 
     def get_permission_object(self):
         return self.get_object()
-
-    def get_success_url(self):
-        return reverse("notifications:follow-list")
-
-
-class FollowCreate(LoginRequiredMixin, SuccessMessageMixin, CreateView):
-    model = Follow
-    form_class = FollowForm
-    success_message = "Subscription successfully added"
-
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs.update({"user": self.request.user})
-        return kwargs
 
     def get_success_url(self):
         return reverse("notifications:follow-list")

--- a/app/tests/discussion_forums_tests/test_views.py
+++ b/app/tests/discussion_forums_tests/test_views.py
@@ -1,4 +1,6 @@
 import pytest
+from actstream.actions import is_following, unfollow
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
@@ -706,3 +708,198 @@ def test_queries_on_topic_list_view(client, django_assert_max_num_queries):
                 "challenge_short_name": forum.linked_challenge.short_name,
             },
         )
+
+
+@pytest.mark.django_db
+def test_forum_follow_create_requires_login(client):
+    forum = ForumFactory()
+
+    response = get_view_for_user(
+        viewname="discussion-forums:forum-follow-create",
+        client=client,
+        method=client.post,
+        reverse_kwargs={
+            "challenge_short_name": forum.linked_challenge.short_name,
+        },
+        user=None,
+    )
+    assert response.status_code == 302
+    assert "/accounts/login/" in response.url
+
+
+@pytest.mark.django_db
+def test_forum_topic_follow_create_requires_login(
+    client, settings, django_capture_on_commit_callbacks
+):
+    settings.LAMBDA_TASKS_EAGER = True
+
+    forum = ForumFactory()
+    admin = UserFactory()
+    forum.linked_challenge.add_admin(admin)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        topic = ForumTopicFactory(forum=forum, creator=admin)
+
+    response = get_view_for_user(
+        viewname="discussion-forums:topic-follow-create",
+        client=client,
+        method=client.post,
+        reverse_kwargs={
+            "challenge_short_name": forum.linked_challenge.short_name,
+            "slug": topic.slug,
+        },
+        user=None,
+    )
+    assert response.status_code == 302
+    assert "/accounts/login/" in response.url
+
+
+@pytest.mark.django_db
+def test_forum_follow_create(client):
+    admin = UserFactory()
+    forum = ForumFactory()
+    forum.linked_challenge.add_admin(admin)
+
+    # Admin auto-follows, so unfollow first
+    unfollow(admin, forum)
+    assert not is_following(admin, forum)
+
+    response = get_view_for_user(
+        viewname="discussion-forums:forum-follow-create",
+        client=client,
+        method=client.post,
+        reverse_kwargs={
+            "challenge_short_name": forum.linked_challenge.short_name,
+        },
+        user=admin,
+        data={
+            "user": admin.pk,
+            "content_type": ContentType.objects.get_for_model(forum).pk,
+            "object_id": str(forum.pk),
+            "actor_only": False,
+        },
+    )
+    assert response.status_code == 302
+    assert is_following(admin, forum)
+
+
+@pytest.mark.django_db
+def test_forum_follow_create_permission(client):
+    user = UserFactory()
+    participant = UserFactory()
+    forum = ForumFactory()
+    forum.linked_challenge.add_participant(participant)
+
+    # User without view_forum permission cannot subscribe
+    response = get_view_for_user(
+        viewname="discussion-forums:forum-follow-create",
+        client=client,
+        method=client.post,
+        reverse_kwargs={
+            "challenge_short_name": forum.linked_challenge.short_name,
+        },
+        user=user,
+        data={
+            "user": user.pk,
+            "content_type": ContentType.objects.get_for_model(forum).pk,
+            "object_id": str(forum.pk),
+            "actor_only": False,
+        },
+    )
+    assert response.status_code == 403
+    assert not is_following(user, forum)
+
+    # Participant with view_forum permission can subscribe
+    unfollow(participant, forum)
+    assert not is_following(participant, forum)
+
+    response = get_view_for_user(
+        viewname="discussion-forums:forum-follow-create",
+        client=client,
+        method=client.post,
+        reverse_kwargs={
+            "challenge_short_name": forum.linked_challenge.short_name,
+        },
+        user=participant,
+        data={
+            "user": participant.pk,
+            "content_type": ContentType.objects.get_for_model(forum).pk,
+            "object_id": str(forum.pk),
+            "actor_only": False,
+        },
+    )
+    assert response.status_code == 302
+    assert is_following(participant, forum)
+
+
+@pytest.mark.django_db
+def test_forum_topic_follow_create(
+    client, settings, django_capture_on_commit_callbacks
+):
+    settings.LAMBDA_TASKS_EAGER = True
+
+    admin = UserFactory()
+    participant = UserFactory()
+    forum = ForumFactory()
+    forum.linked_challenge.add_admin(admin)
+    forum.linked_challenge.add_participant(participant)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        topic = ForumTopicFactory(forum=forum, creator=admin)
+
+    # Participant does not auto-follow topics
+    assert not is_following(participant, topic)
+
+    response = get_view_for_user(
+        viewname="discussion-forums:topic-follow-create",
+        client=client,
+        method=client.post,
+        reverse_kwargs={
+            "challenge_short_name": forum.linked_challenge.short_name,
+            "slug": topic.slug,
+        },
+        user=participant,
+        data={
+            "user": participant.pk,
+            "content_type": ContentType.objects.get_for_model(topic).pk,
+            "object_id": str(topic.pk),
+            "actor_only": False,
+        },
+    )
+    assert response.status_code == 302
+    assert is_following(participant, topic)
+
+
+@pytest.mark.django_db
+def test_forum_topic_follow_create_permission(
+    client, settings, django_capture_on_commit_callbacks
+):
+    settings.LAMBDA_TASKS_EAGER = True
+
+    user = UserFactory()
+    forum = ForumFactory()
+    admin = UserFactory()
+    forum.linked_challenge.add_admin(admin)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        topic = ForumTopicFactory(forum=forum, creator=admin)
+
+    # User without view_forumtopic permission cannot subscribe
+    response = get_view_for_user(
+        viewname="discussion-forums:topic-follow-create",
+        client=client,
+        method=client.post,
+        reverse_kwargs={
+            "challenge_short_name": forum.linked_challenge.short_name,
+            "slug": topic.slug,
+        },
+        user=user,
+        data={
+            "user": user.pk,
+            "content_type": ContentType.objects.get_for_model(topic).pk,
+            "object_id": str(topic.pk),
+            "actor_only": False,
+        },
+    )
+    assert response.status_code == 403
+    assert not is_following(user, topic)

--- a/app/tests/notifications_tests/test_views.py
+++ b/app/tests/notifications_tests/test_views.py
@@ -200,18 +200,19 @@ def test_forum_subscribe_and_unsubscribe(client):
     assert not is_following(admin, f)
 
     response = get_view_for_user(
-        viewname="notifications:follow-create",
+        viewname="discussion-forums:forum-follow-create",
         client=client,
         method=client.post,
-        data={
-            "user": admin.id,
-            "content_type": ContentType.objects.get(
-                app_label=f._meta.app_label, model=f._meta.model_name
-            ).id,
-            "object_id": f.id,
-            "actor_only": False,
+        reverse_kwargs={
+            "challenge_short_name": f.linked_challenge.short_name,
         },
         user=admin,
+        data={
+            "user": admin.pk,
+            "content_type": ContentType.objects.get_for_model(f).pk,
+            "object_id": str(f.pk),
+            "actor_only": False,
+        },
     )
     assert response.status_code == 302
     assert is_following(admin, f)
@@ -236,18 +237,20 @@ def test_topic_subscribe_and_unsubscribe(
     assert not is_following(user, t)
 
     response = get_view_for_user(
-        viewname="notifications:follow-create",
+        viewname="discussion-forums:topic-follow-create",
         client=client,
         method=client.post,
-        data={
-            "user": user.id,
-            "content_type": ContentType.objects.get(
-                app_label=t._meta.app_label, model=t._meta.model_name
-            ).id,
-            "object_id": t.id,
-            "actor_only": False,
+        reverse_kwargs={
+            "challenge_short_name": f.linked_challenge.short_name,
+            "slug": t.slug,
         },
         user=user,
+        data={
+            "user": user.pk,
+            "content_type": ContentType.objects.get_for_model(t).pk,
+            "object_id": str(t.pk),
+            "actor_only": False,
+        },
     )
     assert response.status_code == 302
     assert is_following(user, t)
@@ -313,20 +316,21 @@ def test_follow_create_permission(client):
 
     # not a participant, so cannot subscribe
     response = get_view_for_user(
-        viewname="notifications:follow-create",
+        viewname="discussion-forums:forum-follow-create",
         client=client,
         method=client.post,
-        data={
-            "user": user.id,
-            "content_type": ContentType.objects.get(
-                app_label=f._meta.app_label, model=f._meta.model_name
-            ).id,
-            "object_id": f.id,
-            "actor_only": False,
+        reverse_kwargs={
+            "challenge_short_name": f.linked_challenge.short_name,
         },
         user=user,
+        data={
+            "user": user.pk,
+            "content_type": ContentType.objects.get_for_model(f).pk,
+            "object_id": str(f.pk),
+            "actor_only": False,
+        },
     )
-    assert "You cannot create this subscription" in str(response.content)
+    assert response.status_code == 403
     assert len(Follow.objects.all()) == old_num_follows
 
     # Remove follows
@@ -335,18 +339,19 @@ def test_follow_create_permission(client):
 
     for u in [admin, participant]:
         response = get_view_for_user(
-            viewname="notifications:follow-create",
+            viewname="discussion-forums:forum-follow-create",
             client=client,
             method=client.post,
-            data={
-                "user": u.id,
-                "content_type": ContentType.objects.get(
-                    app_label=f._meta.app_label, model=f._meta.model_name
-                ).id,
-                "object_id": f.id,
-                "actor_only": False,
+            reverse_kwargs={
+                "challenge_short_name": f.linked_challenge.short_name,
             },
             user=u,
+            data={
+                "user": u.pk,
+                "content_type": ContentType.objects.get_for_model(f).pk,
+                "object_id": str(f.pk),
+                "actor_only": False,
+            },
         )
         assert response.status_code == 302
         assert is_following(u, f)


### PR DESCRIPTION
Replace the generic FollowCreate view and FollowForm in the notifications app with two specific views in discussion_forums: ForumFollowCreate and ForumTopicFollowCreate.

Permission checks (view_forum, view_forumtopic) are now enforced by ObjectPermissionRequiredMixin on the view rather than in form validation.

This PR has been implemented iteratively with kiro, all code has been pre-reviewed by me.

Closes #4058