### PR TITLE
Extend endpoint maximum duration on invocation

### DIFF
--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -1740,6 +1740,10 @@ class Endpoint(FieldChangeMixin, UUIDModel):
     def orchestrator(self):
         return EndpointOrchestrator(**self.orchestrator_kwargs)
 
+    @property
+    def is_linked_to_reader_study(self):
+        return self.endpoint_utilization.reader_studies.exists()
+
     def get_remaining_lifetime(self):
         if self.status in EndpointStatusChoices.get_active_choices():
             return self.created + self.maximum_duration - now()
@@ -1792,6 +1796,12 @@ class Endpoint(FieldChangeMixin, UUIDModel):
         return duration_limit
 
     def keep_alive(self, *, seconds):
+        if self.is_linked_to_reader_study:
+            raise RuntimeError(
+                "This method should only be used for endpoints that are not "
+                "linked to a reader study"
+            )
+
         self.update_utilization()
         new_duration = self.endpoint_utilization.duration + timedelta(
             seconds=seconds

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -1795,7 +1795,7 @@ class Endpoint(FieldChangeMixin, UUIDModel):
         )
         return duration_limit
 
-    def keep_alive(self, *, seconds):
+    def keep_alive(self, *, duration):
         if self.is_linked_to_reader_study:
             raise RuntimeError(
                 "This method should only be used for endpoints that are not "
@@ -1803,9 +1803,7 @@ class Endpoint(FieldChangeMixin, UUIDModel):
             )
 
         self.update_utilization()
-        new_duration = self.endpoint_utilization.duration + timedelta(
-            seconds=seconds
-        )
+        new_duration = self.endpoint_utilization.duration + duration
         duration_limit = self._get_duration_limit()
 
         limit_reached = new_duration >= duration_limit

--- a/app/grandchallenge/algorithms/serializers.py
+++ b/app/grandchallenge/algorithms/serializers.py
@@ -510,6 +510,11 @@ class InvocationPostSerializer(serializers.ModelSerializer):
             status=InvocationStatusChoices.VALIDATING_INPUTS,
         )
 
+        if not invocation.endpoint.is_linked_to_reader_study:
+            invocation.endpoint.keep_alive(
+                seconds=invocation.orchestrator.time_limit.total_seconds()
+            )
+
         try:
             invocation.process_civ_data_objects_and_execute_linked_task(
                 civ_data_objects=civ_data_objects,

--- a/app/grandchallenge/algorithms/serializers.py
+++ b/app/grandchallenge/algorithms/serializers.py
@@ -512,7 +512,7 @@ class InvocationPostSerializer(serializers.ModelSerializer):
 
         if not invocation.endpoint.is_linked_to_reader_study:
             invocation.endpoint.keep_alive(
-                seconds=invocation.orchestrator.time_limit.total_seconds()
+                duration=invocation.orchestrator.time_limit
             )
 
         try:

--- a/app/grandchallenge/algorithms/serializers.py
+++ b/app/grandchallenge/algorithms/serializers.py
@@ -510,11 +510,6 @@ class InvocationPostSerializer(serializers.ModelSerializer):
             status=InvocationStatusChoices.VALIDATING_INPUTS,
         )
 
-        if not invocation.endpoint.is_linked_to_reader_study:
-            invocation.endpoint.keep_alive(
-                duration=invocation.orchestrator.time_limit
-            )
-
         try:
             invocation.process_civ_data_objects_and_execute_linked_task(
                 civ_data_objects=civ_data_objects,
@@ -532,5 +527,10 @@ class InvocationPostSerializer(serializers.ModelSerializer):
                     error_message=SystemErrorMessages.UNEXPECTED_ERROR,
                 )
                 logger.error(e, exc_info=True)
+
+        if not invocation.endpoint.is_linked_to_reader_study:
+            invocation.endpoint.keep_alive(
+                duration=invocation.orchestrator.time_limit
+            )
 
         return invocation

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -1,5 +1,6 @@
 import io
 import logging
+from datetime import timedelta
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -934,7 +935,7 @@ class EndpointViewSet(
     @action(detail=True, methods=["patch"])
     def keep_alive(self, request, *args, **kwargs):
         endpoint = self.get_object()
-        result = endpoint.keep_alive(seconds=300)
+        result = endpoint.keep_alive(duration=timedelta(seconds=300))
 
         if result.limit_reached:
             return Response(

--- a/app/grandchallenge/components/backends/amazon_sagemaker_endpoint.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_endpoint.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import NamedTuple
 from uuid import UUID
 
@@ -178,8 +178,9 @@ class EndpointOrchestrator:
             return 30
 
     @property
-    def _time_limit(self):
-        return self._executor._time_limit
+    def time_limit(self):
+        # Add buffer time to upload invocation result
+        return self._executor._time_limit + timedelta(seconds=10)
 
     @property
     def runtime_setup_result_key(self):
@@ -336,9 +337,7 @@ class EndpointOrchestrator:
             ContentType="application/json",
             InputLocation=self._invocation_s3_uri,
             InferenceId=inference_id,
-            InvocationTimeoutSeconds=int(
-                self._time_limit.total_seconds() + 10
-            ),  # Add buffer time to upload invocation result
+            InvocationTimeoutSeconds=int(self.time_limit.total_seconds()),
         )
 
     @staticmethod

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1865,7 +1865,11 @@ def invoke_endpoint(*, pk: str | UUID, app_label: str, model_name: str):
     model = apps.get_model(app_label=app_label, model_name=model_name)
 
     with check_lock_acquired():
-        invocation = model.objects.select_for_update(nowait=True).get(pk=pk)
+        invocation = (
+            model.objects.select_for_update(nowait=True)
+            .select_related("endpoint")
+            .get(pk=pk)
+        )
 
     if invocation.status == invocation.StatusChoices.CANCELLED:
         # Nothing to do
@@ -1879,6 +1883,11 @@ def invoke_endpoint(*, pk: str | UUID, app_label: str, model_name: str):
         raise RuntimeError("Endpoint is not running")
 
     orchestrator = invocation.orchestrator
+
+    if not invocation.endpoint.is_linked_to_reader_study:
+        invocation.endpoint.keep_alive(
+            seconds=orchestrator.time_limit.total_seconds()
+        )
 
     try:
         orchestrator.invoke_endpoint(inference_id=invocation.inference_id)

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1885,9 +1885,7 @@ def invoke_endpoint(*, pk: str | UUID, app_label: str, model_name: str):
     orchestrator = invocation.orchestrator
 
     if not invocation.endpoint.is_linked_to_reader_study:
-        invocation.endpoint.keep_alive(
-            seconds=orchestrator.time_limit.total_seconds()
-        )
+        invocation.endpoint.keep_alive(duration=orchestrator.time_limit)
 
     try:
         orchestrator.invoke_endpoint(inference_id=invocation.inference_id)

--- a/app/tests/algorithms_tests/test_api.py
+++ b/app/tests/algorithms_tests/test_api.py
@@ -47,6 +47,7 @@ from tests.components_tests.factories import (
     ComponentInterfaceValueFactory,
 )
 from tests.factories import ImageFactory, UserFactory
+from tests.reader_studies_tests.factories import ReaderStudyFactory
 from tests.uploads_tests.factories import (
     UserUploadFactory,
     create_upload_from_file,
@@ -1427,6 +1428,68 @@ class TestInvocationCreate:
                 "please try again after they have completed"
             ]
         }
+
+    def test_create_invocation_extends_maximum_duration(self, client):
+        user = UserFactory()
+        endpoint = EndpointFactory.create(
+            creator=user,
+            status=EndpointStatusChoices.RUNNING,
+            maximum_duration=timedelta(seconds=0),
+        )
+        ci_string = ComponentInterfaceFactory(
+            kind=ComponentInterface.Kind.STRING
+        )
+        interface = AlgorithmInterfaceFactory(inputs=[ci_string])
+        endpoint.algorithm_image.algorithm.interfaces.add(interface)
+
+        client.force_login(user=user)
+        response = client.post(
+            self.url,
+            content_type="application/json",
+            data={
+                "endpoint": endpoint.api_url,
+                "inputs": [
+                    {"interface": ci_string.slug, "value": "foo"},
+                ],
+            },
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        endpoint.refresh_from_db()
+        assert endpoint.maximum_duration.total_seconds() > 0
+
+    def test_create_invocation_retains_maximum_duration_for_reader_study_endpoint(
+        self, client
+    ):
+        user = UserFactory()
+        endpoint = EndpointFactory.create(
+            creator=user,
+            status=EndpointStatusChoices.RUNNING,
+            maximum_duration=timedelta(seconds=0),
+        )
+        reader_study = ReaderStudyFactory.create()
+        endpoint.endpoint_utilization.reader_studies.add(reader_study)
+        ci_string = ComponentInterfaceFactory(
+            kind=ComponentInterface.Kind.STRING
+        )
+        interface = AlgorithmInterfaceFactory(inputs=[ci_string])
+        endpoint.algorithm_image.algorithm.interfaces.add(interface)
+
+        client.force_login(user=user)
+        response = client.post(
+            self.url,
+            content_type="application/json",
+            data={
+                "endpoint": endpoint.api_url,
+                "inputs": [
+                    {"interface": ci_string.slug, "value": "foo"},
+                ],
+            },
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        endpoint.refresh_from_db()
+        assert endpoint.maximum_duration.total_seconds() == 0
 
 
 @pytest.mark.django_db

--- a/app/tests/algorithms_tests/test_models.py
+++ b/app/tests/algorithms_tests/test_models.py
@@ -1773,7 +1773,7 @@ class TestEndpointProperties:
 def test_endpoint_keep_alive_limit_reached():
     endpoint = EndpointFactory.create()
 
-    result = endpoint.keep_alive(seconds=60)
+    result = endpoint.keep_alive(duration=timedelta(seconds=60))
 
     assert result.limit_reached
     endpoint.refresh_from_db()
@@ -1792,7 +1792,7 @@ def test_endpoint_keep_alive():
         comment="test",
     )
 
-    result = endpoint.keep_alive(seconds=60)
+    result = endpoint.keep_alive(duration=timedelta(seconds=60))
 
     assert not result.limit_reached
     endpoint.refresh_from_db()
@@ -1814,7 +1814,7 @@ def test_endpoint_keep_alive_raises_for_reader_study_endpoint():
     )
 
     with pytest.raises(RuntimeError, match=expected_error_message):
-        endpoint.keep_alive(seconds=60)
+        endpoint.keep_alive(duration=timedelta(seconds=60))
 
     endpoint.refresh_from_db()
     assert endpoint.modified == modified

--- a/app/tests/algorithms_tests/test_models.py
+++ b/app/tests/algorithms_tests/test_models.py
@@ -1803,6 +1803,24 @@ def test_endpoint_keep_alive():
 
 
 @pytest.mark.django_db
+def test_endpoint_keep_alive_raises_for_reader_study_endpoint():
+    endpoint = EndpointFactory.create()
+    modified = endpoint.modified
+    reader_study = ReaderStudyFactory.create()
+    endpoint.endpoint_utilization.reader_studies.add(reader_study)
+    expected_error_message = (
+        "This method should only be used for endpoints that are not "
+        "linked to a reader study"
+    )
+
+    with pytest.raises(RuntimeError, match=expected_error_message):
+        endpoint.keep_alive(seconds=60)
+
+    endpoint.refresh_from_db()
+    assert endpoint.modified == modified
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "algorithm_editor",
     (True, False),

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -52,6 +52,7 @@ from grandchallenge.components.tasks import (
     encode_b64j,
     handle_endpoint_invocation_event,
     handle_endpoint_status_event,
+    invoke_endpoint,
     parse_endpoint_invocation_outputs,
     preload_interactive_algorithms,
     remove_container_image_from_registry,
@@ -2015,3 +2016,35 @@ def test_parse_endpoint_invocation_outputs_cancelled_skipped(mocker):
     mock_get_outputs.assert_not_called()
     assert invocation.status == InvocationStatusChoices.CANCELLED
     assert invocation.outputs.count() == 0
+
+
+@pytest.mark.django_db
+def test_invoke_endpoint_calls_keep_alive(mocker):
+    invocation = InvocationFactory.create(
+        status=InvocationStatusChoices.PROVISIONED,
+    )
+    mock_keep_alive = mocker.patch.object(
+        Endpoint,
+        "keep_alive",
+    )
+
+    invoke_endpoint(**invocation.task_kwargs)
+
+    mock_keep_alive.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_invoke_endpoint_skips_keep_alive_for_reader_study_endpoint(mocker):
+    invocation = InvocationFactory.create(
+        status=InvocationStatusChoices.PROVISIONED,
+    )
+    reader_study = ReaderStudyFactory.create()
+    invocation.endpoint.endpoint_utilization.reader_studies.add(reader_study)
+    mock_keep_alive = mocker.patch.object(
+        Endpoint,
+        "keep_alive",
+    )
+
+    invoke_endpoint(**invocation.task_kwargs)
+
+    mock_keep_alive.assert_not_called()

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -2023,14 +2023,14 @@ def test_invoke_endpoint_calls_keep_alive(mocker):
     invocation = InvocationFactory.create(
         status=InvocationStatusChoices.PROVISIONED,
     )
-    mock_keep_alive = mocker.patch.object(
+    spy_keep_alive = mocker.spy(
         Endpoint,
         "keep_alive",
     )
 
     invoke_endpoint(**invocation.task_kwargs)
 
-    mock_keep_alive.assert_called_once()
+    spy_keep_alive.assert_called_once()
 
 
 @pytest.mark.django_db
@@ -2040,11 +2040,11 @@ def test_invoke_endpoint_skips_keep_alive_for_reader_study_endpoint(mocker):
     )
     reader_study = ReaderStudyFactory.create()
     invocation.endpoint.endpoint_utilization.reader_studies.add(reader_study)
-    mock_keep_alive = mocker.patch.object(
+    spy_keep_alive = mocker.spy(
         Endpoint,
         "keep_alive",
     )
 
     invoke_endpoint(**invocation.task_kwargs)
 
-    mock_keep_alive.assert_not_called()
+    spy_keep_alive.assert_not_called()


### PR DESCRIPTION
Extend the maximum duration for an endpoint:
- when using the InvocationCreate REST API
- again when invoking the algorithm endpoint (to adjust for any time passed during provisioning)

If an endpoint is linked to a reader study, the maximum duration is not extended; lifetime management for these endpoints is linked to the workstation session. 