### PR TITLE
Add new field to display set data "description_safe"

### DIFF
--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1083,6 +1083,11 @@ class DisplaySet(
 
     @property
     def description(self) -> str:
+        # Note: Remove this after August 2026
+        return self.description_safe
+
+    @property
+    def description_safe(self) -> str:
         case_text = self.reader_study.case_text
 
         if case_text:

--- a/app/grandchallenge/reader_studies/serializers.py
+++ b/app/grandchallenge/reader_studies/serializers.py
@@ -178,6 +178,7 @@ class DisplaySetSerializer(HyperlinkedModelSerializer):
             "optional_hanging_protocols",
             "view_content",
             "description",
+            "description_safe",
             "index",
         )
 

--- a/app/tests/reader_studies_tests/test_serializers.py
+++ b/app/tests/reader_studies_tests/test_serializers.py
@@ -5,7 +5,8 @@ from grandchallenge.reader_studies.interactive_algorithms import (
 )
 from grandchallenge.reader_studies.models import QuestionWidgetKindChoices
 from grandchallenge.reader_studies.serializers import QuestionSerializer
-from tests.factories import UserFactory
+from tests.components_tests.factories import ComponentInterfaceValueFactory
+from tests.factories import ImageFactory, UserFactory
 from tests.reader_studies_tests.factories import (
     DisplaySetFactory,
     QuestionFactory,
@@ -110,6 +111,41 @@ def test_display_set_title_tags_scrubbed(client):
 
     rendered_text = response.json()["title_safe"]
     assert rendered_text == "No tags allowedalert('XSS')"
+
+
+@pytest.mark.django_db
+def test_display_view_content_scrubbed(client):
+    image = ImageFactory(name="display-image")
+    image2 = ImageFactory(name="display-image-2")
+    rs = ReaderStudyFactory(
+        case_text={
+            image.name: "<b>My Help Text</b><script>naughty</script>",
+            image2.name: "<b>Another Help Text</b><script>naughty</script>",
+            "not-an-image": "Should not appear",
+        }
+    )
+    ds = DisplaySetFactory(reader_study=rs, title="empty")
+    ds.values.add(ComponentInterfaceValueFactory(image=image))
+    ds.values.add(ComponentInterfaceValueFactory(image=image2))
+
+    # Ensure duplicate values do not duplicate output.
+    ds.values.add(ComponentInterfaceValueFactory(image=image))
+
+    u = UserFactory()
+    rs.add_reader(u)
+
+    response = get_view_for_user(client=client, url=ds.api_url, user=u)
+    assert response.status_code == 200
+
+    rendered = response.json()
+    assert (
+        rendered["description"]
+        == "<p><b>My Help Text</b>naughty</p><p><b>Another Help Text</b>naughty</p>"
+    )
+    assert (
+        rendered["description_safe"]
+        == "<p><b>My Help Text</b>naughty</p><p><b>Another Help Text</b>naughty</p>"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
See CIRRUS bug `#3991`.

We are trying to clearly mark fields that are "safely escaped html" with the `_safe` postfix in our json structures. This was not done for the description field, so this is fixing this problem.

Needs to be a two-step removal - in two months we can remove the old `description` field, when CIRRUS was updated twice.