### PR TITLE
Structured `descriptions_map_safe` for case texts.

### DIFF
--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -26,6 +26,7 @@ from django.db.models.functions import Coalesce
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.utils.functional import cached_property
+from django.utils.safestring import SafeString
 from django_extensions.db.models import TitleSlugDescriptionModel
 from guardian.shortcuts import assign_perm, remove_perm
 from pictures.models import PictureField
@@ -1104,22 +1105,20 @@ class DisplaySet(
             return ""
 
     @property
-    def descriptions_map_safe(self) -> dict[str]:
+    def descriptions_map_safe(self) -> dict[str, SafeString]:
         case_text = self.reader_study.case_text
+        if not case_text:
+            return {}
+
         result = {}
-        if case_text:
-            seen_names = set()
-            output = ""
+        for val in self.values.all():
+            try:
+                name = val.image.name
+            except AttributeError:
+                continue
 
-            for val in self.values.all():
-                try:
-                    name = val.image.name
-                except AttributeError:
-                    continue
-
-                if name in case_text and name not in seen_names:
-                    seen_names.add(name)
-                    result[name] = md2html(case_text[name])
+            if name in case_text and name not in result:
+                result[name] = md2html(case_text[name])
         return result
 
     @property

--- a/app/grandchallenge/reader_studies/models.py
+++ b/app/grandchallenge/reader_studies/models.py
@@ -1104,6 +1104,25 @@ class DisplaySet(
             return ""
 
     @property
+    def descriptions_map_safe(self) -> dict[str]:
+        case_text = self.reader_study.case_text
+        result = {}
+        if case_text:
+            seen_names = set()
+            output = ""
+
+            for val in self.values.all():
+                try:
+                    name = val.image.name
+                except AttributeError:
+                    continue
+
+                if name in case_text and name not in seen_names:
+                    seen_names.add(name)
+                    result[name] = md2html(case_text[name])
+        return result
+
+    @property
     def standard_index(self) -> int:
         return [*self.reader_study.display_sets.all()].index(self)
 

--- a/app/grandchallenge/reader_studies/serializers.py
+++ b/app/grandchallenge/reader_studies/serializers.py
@@ -178,6 +178,7 @@ class DisplaySetSerializer(HyperlinkedModelSerializer):
             "optional_hanging_protocols",
             "view_content",
             "description",
+            "descriptions_map_safe",
             "index",
         )
 

--- a/app/grandchallenge/reader_studies/serializers.py
+++ b/app/grandchallenge/reader_studies/serializers.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db.models import Prefetch
+from drf_spectacular.utils import extend_schema_field
 from rest_framework.fields import (
     BooleanField,
     CharField,
@@ -151,6 +152,7 @@ class DisplaySetSerializer(HyperlinkedModelSerializer):
     )
     index = SerializerMethodField()
     title_safe = SerializerMethodField()
+    descriptions_map_safe = SerializerMethodField()
 
     def get_index(self, obj) -> int | None:
         if obj.reader_study.shuffle_hanging_list:
@@ -164,6 +166,15 @@ class DisplaySetSerializer(HyperlinkedModelSerializer):
 
     def get_title_safe(self, obj) -> str:
         return clean(obj.title, no_tags=True)
+
+    @extend_schema_field(
+        {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+        }
+    )
+    def get_descriptions_map_safe(self, obj) -> dict[str, str]:
+        return obj.descriptions_map_safe
 
     class Meta:
         model = DisplaySet

--- a/app/tests/reader_studies_tests/test_models.py
+++ b/app/tests/reader_studies_tests/test_models.py
@@ -5,6 +5,7 @@ import pytest
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models import ProtectedError
 from django.db.utils import IntegrityError
+from django.utils.safestring import SafeString
 
 from grandchallenge.components.models import (
     ComponentInterface,
@@ -675,6 +676,10 @@ def test_display_set_description():
 
     for ds in rs.display_sets.all():
         assert ds.description == result[ds.pk]
+
+        assert len(ds.descriptions_map_safe) > 0
+        for v in ds.descriptions_map_safe.values():
+            assert isinstance(v, SafeString)
 
 
 @pytest.fixture(scope="function")

--- a/app/tests/reader_studies_tests/test_serializers.py
+++ b/app/tests/reader_studies_tests/test_serializers.py
@@ -5,7 +5,8 @@ from grandchallenge.reader_studies.interactive_algorithms import (
 )
 from grandchallenge.reader_studies.models import QuestionWidgetKindChoices
 from grandchallenge.reader_studies.serializers import QuestionSerializer
-from tests.factories import UserFactory
+from tests.components_tests.factories import ComponentInterfaceValueFactory
+from tests.factories import ImageFactory, UserFactory
 from tests.reader_studies_tests.factories import (
     DisplaySetFactory,
     QuestionFactory,
@@ -110,6 +111,38 @@ def test_display_set_title_tags_scrubbed(client):
 
     rendered_text = response.json()["title_safe"]
     assert rendered_text == "No tags allowedalert('XSS')"
+
+
+@pytest.mark.django_db
+def test_display_view_content_scrubbed(client):
+    image = ImageFactory(name="display-image")
+    image2 = ImageFactory(name="display-image-2")
+    rs = ReaderStudyFactory(
+        case_text={
+            image.name: "<b>My Help Text</b><script>naughty</script>",
+            image2.name: "<b>Another Help Text</b><script>naughty</script>",
+            "not-an-image": "Should not appear",
+        }
+    )
+    ds = DisplaySetFactory(reader_study=rs, title="empty")
+    ds.values.add(ComponentInterfaceValueFactory(image=image))
+    ds.values.add(ComponentInterfaceValueFactory(image=image2))
+
+    # Ensure duplicate values do not duplicate output.
+    ds.values.add(ComponentInterfaceValueFactory(image=image))
+
+    u = UserFactory()
+    rs.add_reader(u)
+
+    response = get_view_for_user(client=client, url=ds.api_url, user=u)
+    assert response.status_code == 200
+
+    rendered = response.json()
+    assert rendered["description"] == "<p><b>My Help Text</b>naughty</p>"
+    assert rendered["descriptions_map_safe"] == {
+        image.name: "<p><b>My Help Text</b>naughty</p>",
+        image2.name: "<p><b>Another Help Text</b>naughty</p>",
+    }
 
 
 @pytest.mark.parametrize(

--- a/app/tests/reader_studies_tests/test_serializers.py
+++ b/app/tests/reader_studies_tests/test_serializers.py
@@ -138,7 +138,10 @@ def test_display_view_content_scrubbed(client):
     assert response.status_code == 200
 
     rendered = response.json()
-    assert rendered["description"] == "<p><b>My Help Text</b>naughty</p>"
+    assert (
+        rendered["description"]
+        == "<p><b>My Help Text</b>naughty</p><p><b>Another Help Text</b>naughty</p>"
+    )
     assert rendered["descriptions_map_safe"] == {
         image.name: "<p><b>My Help Text</b>naughty</p>",
         image2.name: "<p><b>Another Help Text</b>naughty</p>",


### PR DESCRIPTION
Same as #4866 but with a structured map instead of a concatenated string. Opened this because of James' comment about the concatenation being messy/potentially unsafe. This avoids this because it serializes everything as a mapping, so that we get the safe strings as values inside the map.