### PR TITLE
Cancel active invocations when stopping endpoint

### DIFF
--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1794,7 +1794,7 @@ def stop_endpoint(*, pk: str | UUID, app_label: str, model_name: str):
 
     endpoint.orchestrator.deprovision()
     endpoint.update_status(status=endpoint.StatusChoices.STOPPED)
-    cancel_related_invocations.execute_on_commit(
+    cancel_active_invocations.execute_on_commit(
         endpoint_pk=endpoint.pk, _delay=300
     )
 
@@ -1819,7 +1819,7 @@ def stop_expired_endpoints(*, app_label: str, model_name: str):
 
 
 @lambda_task
-def cancel_related_invocations(*, endpoint_pk: str | UUID):
+def cancel_active_invocations(*, endpoint_pk: str | UUID):
     from grandchallenge.algorithms.models import Invocation
 
     invocations = list(

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1818,7 +1818,7 @@ def stop_expired_endpoints(*, app_label: str, model_name: str):
         stop_endpoint.execute_on_commit(**endpoint.task_kwargs)
 
 
-@lambda_task(retry_on=(LockNotAcquiredException,))
+@lambda_task
 def cancel_related_invocations(*, endpoint_pk: str | UUID):
     from grandchallenge.algorithms.models import Invocation
 
@@ -1833,7 +1833,7 @@ def cancel_related_invocations(*, endpoint_pk: str | UUID):
     )
 
     if Invocation.objects.active().filter(endpoint=endpoint_pk).exists():
-        raise LockNotAcquiredException(
+        task_logger.error(
             "Some invocations were locked and could not be cancelled"
         )
 

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1818,7 +1818,7 @@ def stop_expired_endpoints(*, app_label: str, model_name: str):
         stop_endpoint.execute_on_commit(**endpoint.task_kwargs)
 
 
-@lambda_task
+@lambda_task(retry_on=(LockNotAcquiredException,))
 def cancel_active_invocations(*, endpoint_pk: str | UUID):
     from grandchallenge.algorithms.models import Invocation
 
@@ -1833,7 +1833,7 @@ def cancel_active_invocations(*, endpoint_pk: str | UUID):
     )
 
     if Invocation.objects.active().filter(endpoint=endpoint_pk).exists():
-        task_logger.error(
+        raise LockNotAcquiredException(
             "Some invocations were locked and could not be cancelled"
         )
 

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1822,20 +1822,17 @@ def stop_expired_endpoints(*, app_label: str, model_name: str):
 def cancel_active_invocations(*, endpoint_pk: str | UUID):
     from grandchallenge.algorithms.models import Invocation
 
-    invocations = list(
-        Invocation.objects.active()
-        .select_for_update(skip_locked=True)
-        .filter(endpoint=endpoint_pk)
-        .values_list("pk", flat=True)
-    )
+    with check_lock_acquired():
+        invocations = list(
+            Invocation.objects.active()
+            .select_for_update(nowait=True)
+            .filter(endpoint=endpoint_pk)
+            .values_list("pk", flat=True)
+        )
+
     Invocation.objects.filter(pk__in=invocations).update(
         status=Invocation.StatusChoices.CANCELLED
     )
-
-    if Invocation.objects.active().filter(endpoint=endpoint_pk).exists():
-        raise LockNotAcquiredException(
-            "Some invocations were locked and could not be cancelled"
-        )
 
 
 @lambda_task(retry_on=(LockNotAcquiredException,))

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1794,6 +1794,9 @@ def stop_endpoint(*, pk: str | UUID, app_label: str, model_name: str):
 
     endpoint.orchestrator.deprovision()
     endpoint.update_status(status=endpoint.StatusChoices.STOPPED)
+    cancel_related_invocations.execute_on_commit(
+        endpoint_pk=endpoint.pk, _delay=300
+    )
 
 
 @lambda_task
@@ -1813,6 +1816,26 @@ def stop_expired_endpoints(*, app_label: str, model_name: str):
 
     for endpoint in endpoints_to_stop:
         stop_endpoint.execute_on_commit(**endpoint.task_kwargs)
+
+
+@lambda_task(retry_on=(LockNotAcquiredException,))
+def cancel_related_invocations(*, endpoint_pk: str | UUID):
+    from grandchallenge.algorithms.models import Invocation
+
+    invocations = list(
+        Invocation.objects.active()
+        .select_for_update(skip_locked=True)
+        .filter(endpoint=endpoint_pk)
+        .values_list("pk", flat=True)
+    )
+    Invocation.objects.filter(pk__in=invocations).update(
+        status=Invocation.StatusChoices.CANCELLED
+    )
+
+    if Invocation.objects.active().filter(endpoint=endpoint_pk).exists():
+        raise LockNotAcquiredException(
+            "Some invocations were locked and could not be cancelled"
+        )
 
 
 @lambda_task(retry_on=(LockNotAcquiredException,))

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1794,9 +1794,7 @@ def stop_endpoint(*, pk: str | UUID, app_label: str, model_name: str):
 
     endpoint.orchestrator.deprovision()
     endpoint.update_status(status=endpoint.StatusChoices.STOPPED)
-    cancel_active_invocations.execute_on_commit(
-        endpoint_pk=endpoint.pk, _delay=300
-    )
+    cancel_active_invocations.execute_on_commit(endpoint_pk=endpoint.pk)
 
 
 @lambda_task

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -20,6 +20,7 @@ from grandchallenge.algorithms.models import (
     AlgorithmImage,
     Endpoint,
     EndpointStatusChoices,
+    Invocation,
     InvocationStatusChoices,
     Job,
 )
@@ -1686,6 +1687,29 @@ def test_stop_endpoint_wrong_state_raises(mocker):
 
     assert endpoint.status == initial_status
     mock_update_status_method.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_stop_endpoint_cancels_active_invocations(
+    mocker, settings, django_capture_on_commit_callbacks
+):
+    settings.LAMBDA_TASKS_EAGER = True
+    endpoint = EndpointFactory.create(status=EndpointStatusChoices.RUNNING)
+    for status in InvocationStatusChoices.get_active_choices():
+        InvocationFactory.create(endpoint=endpoint, status=status)
+        InvocationFactory.create(status=status)
+    mocker.patch.object(
+        EndpointOrchestrator,
+        "deprovision",
+    )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        stop_endpoint(**endpoint.task_kwargs)
+
+    for invocation in Invocation.objects.filter(endpoint=endpoint):
+        assert invocation.status == InvocationStatusChoices.CANCELLED
+    for invocation in Invocation.objects.exclude(endpoint=endpoint):
+        assert invocation.status != InvocationStatusChoices.CANCELLED
 
 
 @pytest.mark.django_db

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -1732,12 +1732,11 @@ def test_stop_expired_endpoints(
         "deprovision",
     )
 
-    with django_capture_on_commit_callbacks(execute=True) as callbacks:
+    with django_capture_on_commit_callbacks(execute=True):
         stop_expired_endpoints(app_label="algorithms", model_name="endpoint")
 
     endpoint_to_stop.refresh_from_db()
 
-    assert len(callbacks) == 1
     mock_deprovision.assert_called_once()
     assert endpoint_to_stop.status == EndpointStatusChoices.STOPPED
 

--- a/app/tests/workstations_tests/test_models.py
+++ b/app/tests/workstations_tests/test_models.py
@@ -328,11 +328,9 @@ def test_session_stopped_schedules_stop_for_correct_endpoints(
         "deprovision",
     )
 
-    with django_capture_on_commit_callbacks(execute=True) as callbacks:
+    with django_capture_on_commit_callbacks(execute=True):
         session.status = Session.STOPPED
         session.save()
-
-    assert len(callbacks) == 1
 
     user_implementation_endpoint.refresh_from_db()
     other_user_implementation_endpoint.refresh_from_db()


### PR DESCRIPTION
Endpoints will stop regardless of any active invocations. Mark those invocations as cancelled. 

See https://github.com/DIAGNijmegen/rse-roadmap/issues/484