### PR TITLE
Refactor SaveFormInitMixin

### DIFF
--- a/app/grandchallenge/core/forms.py
+++ b/app/grandchallenge/core/forms.py
@@ -28,7 +28,7 @@ class SaveFormHelper(FormHelper):
     """
     - Sets the gc-disable-after-submit attribute on the form element
     - Generates a default layout lazily at render time
-      (rather than snapshotting fields are construction time)
+      (rather than snapshotting fields at construction time)
     """
 
     def __init__(self, form=None):

--- a/app/grandchallenge/core/forms.py
+++ b/app/grandchallenge/core/forms.py
@@ -26,14 +26,9 @@ class PhaseMixin:
 
 class SaveFormHelper(FormHelper):
     """
-    A FormHelper subclass that:
-      - Sets the gc-disable-after-submit attribute on the form element
-      - Generates a default layout (Fieldset + Save button) lazily at
-        render time from the form's current fields
-
-    The lazy layout means field ordering and dynamic field addition
-    work seamlessly — whatever fields exist when the form is rendered
-    will be included.
+    - Sets the gc-disable-after-submit attribute on the form element
+    - Generates a default layout lazily at render time
+      (rather than snapshotting fields are construction time)
     """
 
     def __init__(self, form=None):
@@ -67,17 +62,6 @@ class SaveFormHelper(FormHelper):
 
 
 class SaveFormInitMixin:
-    """
-    Mixin that sets up a SaveFormHelper on the form.
-
-    The helper uses lazy layout generation, so MRO ordering does not
-    matter — fields added by any mixin (before or after this one)
-    will be included in the rendered form.
-
-    Forms that need a custom layout can set self.helper.layout in
-    their __init__ after calling super().
-    """
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = SaveFormHelper(self)

--- a/app/grandchallenge/core/forms.py
+++ b/app/grandchallenge/core/forms.py
@@ -24,38 +24,68 @@ class PhaseMixin:
         super().__init__(*args, **kwargs)
 
 
+class SaveFormHelper(FormHelper):
+    """
+    A FormHelper subclass that:
+      - Sets the gc-disable-after-submit attribute on the form element
+      - Generates a default layout (Fieldset + Save button) lazily at
+        render time from the form's current fields
+
+    The lazy layout means field ordering and dynamic field addition
+    don't matter — whatever fields exist when the form is rendered
+    will be included.
+
+    If a custom layout is set via `self.helper.layout = Layout(...)`,
+    the gc-disable-after-submit attribute is still preserved (it lives
+    on helper.attrs, not in the layout).
+    """
+
+    def __init__(self, form=None):
+        # Skip super().__init__(form) to avoid eagerly snapshotting fields
+        super().__init__()
+        self.form = form
+        self.attrs["gc-disable-after-submit"] = True
+        self._custom_layout = None
+
+    @property
+    def layout(self):
+        if self._custom_layout is not None:
+            return self._custom_layout
+
+        if self.form is not None:
+            return Layout(
+                Fieldset(None, *self.form.fields.keys()),
+                StrictButton(
+                    "Save",
+                    css_class="btn-primary",
+                    type="submit",
+                    css_id="submit-id-save",
+                ),
+            )
+
+        return Layout()
+
+    @layout.setter
+    def layout(self, value):
+        self._custom_layout = value
+
+
 class SaveFormInitMixin:
     """
-    Mixin that adds some save features to a form via init:
-      - a 'Save' button
-      - disabling fieldsets after the form is submitted
+    Mixin that sets up a SaveFormHelper on the form.
 
-    When used in a form with dynamically created fields,
-    this mixin needs to be placed before any other mixins.
+    The helper uses lazy layout generation, so MRO ordering does not
+    matter — fields added by any mixin (before or after this one)
+    will be included in the rendered form.
+
+    Forms that need a custom layout can set self.helper.layout in
+    their __init__ after calling super(). The gc-disable-after-submit
+    attribute is always preserved.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.init_form_helper()
-
-    def init_form_helper(self):
-        self.helper = FormHelper(self)
-        self.helper.attrs["gc-disable-after-submit"] = True
-        self.helper.layout = Layout(
-            Fieldset(
-                None,  # Legend
-                self.helper.layout,
-            ),
-            StrictButton(
-                "Save",
-                css_class="btn-primary",
-                type="submit",
-                css_id="submit-id-save",
-            ),
-        )
-
-    class Media:
-        js = ["js/disable_after_submit.mjs"]
+        self.helper = SaveFormHelper(self)
 
 
 class WorkstationUserFilterMixin(UserMixin):

--- a/app/grandchallenge/core/forms.py
+++ b/app/grandchallenge/core/forms.py
@@ -32,12 +32,8 @@ class SaveFormHelper(FormHelper):
         render time from the form's current fields
 
     The lazy layout means field ordering and dynamic field addition
-    don't matter — whatever fields exist when the form is rendered
+    work seamlessly — whatever fields exist when the form is rendered
     will be included.
-
-    If a custom layout is set via `self.helper.layout = Layout(...)`,
-    the gc-disable-after-submit attribute is still preserved (it lives
-    on helper.attrs, not in the layout).
     """
 
     def __init__(self, form=None):
@@ -79,8 +75,7 @@ class SaveFormInitMixin:
     will be included in the rendered form.
 
     Forms that need a custom layout can set self.helper.layout in
-    their __init__ after calling super(). The gc-disable-after-submit
-    attribute is always preserved.
+    their __init__ after calling super().
     """
 
     def __init__(self, *args, **kwargs):

--- a/app/grandchallenge/core/templates/grandchallenge/partials/script.html
+++ b/app/grandchallenge/core/templates/grandchallenge/partials/script.html
@@ -25,3 +25,6 @@
 
 {# Copy button #}
 <script type="module" src="{% static "js/copy_to_clipboard.mjs" %}"></script>
+
+{# Disable-after-submit for all forms with gc-disable-after-submit attribute #}
+<script type="module" src="{% static 'js/disable_after_submit.mjs' %}"></script>

--- a/app/grandchallenge/evaluation/forms.py
+++ b/app/grandchallenge/evaluation/forms.py
@@ -809,8 +809,6 @@ class ConfigureAlgorithmPhasesForm(SaveFormInitMixin, Form):
                     required=False,
                 )
 
-        self.init_form_helper()
-
     def clean(self):
         cleaned_data = super().clean()
         selected_phases = [

--- a/app/grandchallenge/hanging_protocols/forms.py
+++ b/app/grandchallenge/hanging_protocols/forms.py
@@ -1,7 +1,6 @@
 import json
 from typing import NamedTuple
 
-from crispy_forms.helper import FormHelper
 from crispy_forms.layout import ButtonHolder, Div, Layout, Submit
 from django import forms
 from django.conf import settings
@@ -42,7 +41,6 @@ class HangingProtocolForm(SaveFormInitMixin, forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.helper = FormHelper(self)
         self.helper.layout = Layout(
             Div(
                 "title",

--- a/app/grandchallenge/workstation_configs/forms.py
+++ b/app/grandchallenge/workstation_configs/forms.py
@@ -1,4 +1,3 @@
-from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Fieldset, Layout, Submit
 from django.conf import settings
 from django.forms import ModelForm
@@ -72,7 +71,6 @@ class WorkstationConfigForm(SaveFormInitMixin, ModelForm):
     def __init__(self, *args, read_only=False, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.helper = FormHelper(self)
         self.helper.layout = Layout(
             Fieldset("", *GENERAL_FIELDS),
             Fieldset(

--- a/app/tests/core_tests/test_save_form_helper.py
+++ b/app/tests/core_tests/test_save_form_helper.py
@@ -1,0 +1,93 @@
+import pytest
+from crispy_forms.layout import Layout, Submit
+from django.forms import CharField, Form
+
+from grandchallenge.core.forms import SaveFormInitMixin
+
+
+class SimpleForm(SaveFormInitMixin, Form):
+    name = CharField()
+
+
+class DynamicFieldForm(SaveFormInitMixin, Form):
+    """Form that adds fields after super().__init__()."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["dynamic"] = CharField()
+
+
+class DynamicFieldMixin:
+    """Mixin that adds fields, simulating AdditionalInputsMixin."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["from_mixin"] = CharField()
+
+
+class MixinOrderAForm(SaveFormInitMixin, DynamicFieldMixin, Form):
+    """SaveFormInitMixin first in MRO."""
+
+    pass
+
+
+class MixinOrderBForm(DynamicFieldMixin, SaveFormInitMixin, Form):
+    """SaveFormInitMixin second in MRO."""
+
+    pass
+
+
+class CustomLayoutForm(SaveFormInitMixin, Form):
+    name = CharField()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper.layout = Layout(
+            "name",
+            Submit("save", "Go"),
+        )
+
+
+@pytest.mark.parametrize(
+    "form_class",
+    (
+        SimpleForm,
+        DynamicFieldForm,
+        CustomLayoutForm,
+        MixinOrderAForm,
+        MixinOrderBForm,
+    ),
+)
+def test_save_form_helper_always_sets_disable_attribute(form_class):
+    form = form_class(data={})
+    assert form.helper.attrs["gc-disable-after-submit"] is True
+
+
+def test_dynamic_fields_included_in_default_layout():
+    form = DynamicFieldForm(data={})
+    layout = form.helper.layout
+    field_names = [field for field in layout[0].fields]
+    assert "dynamic" in field_names
+
+
+def test_custom_layout_preserves_disable_attribute():
+    form = CustomLayoutForm(data={})
+    assert form.helper.attrs["gc-disable-after-submit"] is True
+    # The custom layout is used, not the default
+    assert len(form.helper.layout.fields) == 2  # "name" + Submit
+
+
+def test_mixin_ordering_does_not_matter():
+    """Fields from DynamicFieldMixin are included regardless of MRO order."""
+    form_a = MixinOrderAForm(data={})
+    form_b = MixinOrderBForm(data={})
+
+    layout_a = form_a.helper.layout
+    layout_b = form_b.helper.layout
+
+    # Both should include from_mixin in their default layout
+    fields_a = [field for field in layout_a[0].fields]
+    fields_b = [field for field in layout_b[0].fields]
+
+    assert "from_mixin" in fields_a
+    assert "from_mixin" in fields_b


### PR DESCRIPTION
Replaces the eager field-snapshotting in `SaveFormInitMixin` with a `SaveFormHelper` class that generates its layout lazily at render time. Dynamic fields added after super().__init__() are now always included regardless of MRO ordering and without having to call `init_form_helper()` again.

Forms with custom layouts now no longer need to create a fresh `FormHelper`, which in turn means that the gc-disabled-after-submit attribute is kept. Moving the js to the base template means it works regardless of form media declarations. 

Closes #4267 

This PR has been implemented iteratively with kiro, all code has been reviewed by me.