### PR TITLE
Refactor endpoints REST API

### DIFF
--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -1814,6 +1814,11 @@ class Endpoint(FieldChangeMixin, UUIDModel):
         duration_limit = self._get_duration_limit()
 
         limit_reached = new_duration >= duration_limit
+
+        # Update maximum_duration regardless of whether the limit is reached,
+        # because the new duration limit may be shorter than the current value
+        # when available credits have reduced, e.g. due to other running
+        # endpoints.
         self.maximum_duration = min(new_duration, duration_limit)
         self.save(update_fields=["maximum_duration"])
 

--- a/app/grandchallenge/algorithms/models.py
+++ b/app/grandchallenge/algorithms/models.py
@@ -1589,7 +1589,8 @@ class EndpointManager(models.QuerySet):
 
 
 class KeepAliveResult(NamedTuple):
-    limit_reached: bool
+    lifetime_extended: bool
+    message: str = ""
 
 
 class Endpoint(FieldChangeMixin, UUIDModel):
@@ -1802,6 +1803,12 @@ class Endpoint(FieldChangeMixin, UUIDModel):
                 "linked to a reader study"
             )
 
+        if self.status not in EndpointStatusChoices.get_active_choices():
+            return KeepAliveResult(
+                lifetime_extended=False,
+                message="Endpoint no longer active",
+            )
+
         self.update_utilization()
         new_duration = self.endpoint_utilization.duration + duration
         duration_limit = self._get_duration_limit()
@@ -1810,9 +1817,16 @@ class Endpoint(FieldChangeMixin, UUIDModel):
         self.maximum_duration = min(new_duration, duration_limit)
         self.save(update_fields=["maximum_duration"])
 
-        return KeepAliveResult(
-            limit_reached=limit_reached,
-        )
+        if limit_reached:
+            return KeepAliveResult(
+                lifetime_extended=False,
+                message="Endpoint duration limit reached",
+            )
+        else:
+            return KeepAliveResult(
+                lifetime_extended=True,
+                message="Endpoint lifetime extended",
+            )
 
     @property
     def api_url(self) -> str:

--- a/app/grandchallenge/algorithms/serializers.py
+++ b/app/grandchallenge/algorithms/serializers.py
@@ -123,7 +123,7 @@ class AlgorithmModelSerializer(serializers.ModelSerializer):
         fields = ["pk", "algorithm", "created", "import_status", "model"]
 
 
-class HyperlinkedEndpointSerializer(serializers.ModelSerializer):
+class EndpointSerializer(serializers.ModelSerializer):
     algorithm = HyperlinkedRelatedField(
         source="algorithm_image.algorithm",
         view_name="api:algorithm-detail",
@@ -146,7 +146,7 @@ class HyperlinkedEndpointSerializer(serializers.ModelSerializer):
         ]
 
 
-class EndpointPostSerializer(HyperlinkedEndpointSerializer):
+class EndpointPostSerializer(EndpointSerializer):
     algorithm = HyperlinkedRelatedField(
         source="algorithm_image.algorithm",
         queryset=Algorithm.objects.none(),
@@ -417,7 +417,7 @@ class JobPostSerializer(JobSerializer):
         return job
 
 
-class HyperlinkedInvocationSerializer(serializers.ModelSerializer):
+class InvocationSerializer(serializers.ModelSerializer):
     """Serializer with hyperlinks for use in public API"""
 
     endpoint = HyperlinkedRelatedField(

--- a/app/grandchallenge/algorithms/serializers.py
+++ b/app/grandchallenge/algorithms/serializers.py
@@ -123,7 +123,7 @@ class AlgorithmModelSerializer(serializers.ModelSerializer):
         fields = ["pk", "algorithm", "created", "import_status", "model"]
 
 
-class EndpointSerializer(serializers.ModelSerializer):
+class HyperlinkedEndpointSerializer(serializers.ModelSerializer):
     algorithm = HyperlinkedRelatedField(
         source="algorithm_image.algorithm",
         view_name="api:algorithm-detail",
@@ -146,17 +146,12 @@ class EndpointSerializer(serializers.ModelSerializer):
         ]
 
 
-class EndpointPostSerializer(serializers.ModelSerializer):
+class EndpointPostSerializer(HyperlinkedEndpointSerializer):
     algorithm = HyperlinkedRelatedField(
+        source="algorithm_image.algorithm",
         queryset=Algorithm.objects.none(),
         view_name="api:algorithm-detail",
-        write_only=True,
     )
-    status = CharField(source="get_status_display", read_only=True)
-
-    class Meta:
-        model = Endpoint
-        fields = ["pk", "algorithm", "status"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -171,7 +166,7 @@ class EndpointPostSerializer(serializers.ModelSerializer):
             )
 
     def validate(self, data):
-        algorithm = data.pop("algorithm")
+        algorithm = data["algorithm_image"]["algorithm"]
         user = self.context["request"].user
 
         if not algorithm.active_image:

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -83,7 +83,7 @@ from grandchallenge.algorithms.serializers import (
     AlgorithmImageSerializer,
     AlgorithmSerializer,
     EndpointPostSerializer,
-    EndpointSerializer,
+    HyperlinkedEndpointSerializer,
     HyperlinkedInvocationSerializer,
     HyperlinkedJobSerializer,
     InvocationPostSerializer,
@@ -930,7 +930,7 @@ class EndpointViewSet(
         if self.action == "create":
             return EndpointPostSerializer
         else:
-            return EndpointSerializer
+            return HyperlinkedEndpointSerializer
 
     @action(detail=True, methods=["patch"])
     def keep_alive(self, request, *args, **kwargs):

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -83,10 +83,10 @@ from grandchallenge.algorithms.serializers import (
     AlgorithmImageSerializer,
     AlgorithmSerializer,
     EndpointPostSerializer,
-    HyperlinkedEndpointSerializer,
-    HyperlinkedInvocationSerializer,
+    EndpointSerializer,
     HyperlinkedJobSerializer,
     InvocationPostSerializer,
+    InvocationSerializer,
     JobPostSerializer,
 )
 from grandchallenge.components.backends.exceptions import (
@@ -930,7 +930,7 @@ class EndpointViewSet(
         if self.action == "create":
             return EndpointPostSerializer
         else:
-            return HyperlinkedEndpointSerializer
+            return EndpointSerializer
 
     @action(detail=True, methods=["patch"])
     def keep_alive(self, request, *args, **kwargs):
@@ -958,7 +958,7 @@ class InvocationViewSet(
         if self.action == "create":
             return InvocationPostSerializer
         else:
-            return HyperlinkedInvocationSerializer
+            return InvocationSerializer
 
 
 class AlgorithmPermissionRequestCreate(

--- a/app/grandchallenge/algorithms/views.py
+++ b/app/grandchallenge/algorithms/views.py
@@ -937,13 +937,13 @@ class EndpointViewSet(
         endpoint = self.get_object()
         result = endpoint.keep_alive(duration=timedelta(seconds=300))
 
-        if result.limit_reached:
+        if result.lifetime_extended:
+            return Response({"status": result.message})
+        else:
             return Response(
-                {"status": "Endpoint duration limit reached"},
+                {"status": result.message},
                 status=HTTP_400_BAD_REQUEST,
             )
-        else:
-            return Response({"status": "Endpoint lifetime extended"})
 
 
 class InvocationViewSet(

--- a/app/tests/algorithms_tests/test_api.py
+++ b/app/tests/algorithms_tests/test_api.py
@@ -1044,6 +1044,39 @@ class TestEndpointCreate:
 
         assert response.status_code == status.HTTP_201_CREATED, response.data
 
+    def test_created_endpoint_response_fields(self, client):
+        user = UserFactory()
+        assign_perm("algorithms.add_endpoint", user)
+        algorithm = AlgorithmFactory()
+        algorithm.add_user(user)
+        AlgorithmImageFactory(
+            algorithm=algorithm,
+            api_method=APIMethodChoices.INVOKE,
+            is_desired_version=True,
+            is_manifest_valid=True,
+            is_in_registry=True,
+        )
+        AlgorithmUserCreditFactory(
+            algorithm=algorithm,
+            user=user,
+            credits=1000,
+            valid_from=now().date(),
+            valid_until=now().date(),
+            comment="test",
+        )
+
+        client.force_login(user=user)
+        response = client.post(self.url, data={"algorithm": algorithm.api_url})
+
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        assert response.data.keys() == {
+            "algorithm",
+            "api_url",
+            "pk",
+            "remaining_lifetime",
+            "status",
+        }
+
 
 @pytest.mark.django_db
 class TestEndpointCreateReadUpdateOnly:

--- a/app/tests/algorithms_tests/test_api.py
+++ b/app/tests/algorithms_tests/test_api.py
@@ -1165,6 +1165,62 @@ class TestEndpointKeepAlive:
             == endpoint.endpoint_utilization.duration + timedelta(seconds=300)
         )
 
+    @pytest.mark.parametrize(
+        "endpoint_status", EndpointStatusChoices.get_active_choices()
+    )
+    def test_ok_for_active_status(self, client, endpoint_status):
+        endpoint = EndpointFactory.create(
+            maximum_duration=timedelta(seconds=1),
+            status=endpoint_status,
+        )
+        AlgorithmUserCreditFactory(
+            user=endpoint.creator,
+            algorithm=endpoint.algorithm_image.algorithm,
+            credits=1000,
+            valid_from=now().date(),
+            valid_until=now().date(),
+            comment="test",
+        )
+        client.force_login(user=endpoint.creator)
+
+        response = client.patch(self.get_url(endpoint.pk))
+
+        assert response.status_code == 200, response.data
+        assert response.json() == {"status": "Endpoint lifetime extended"}
+        endpoint.refresh_from_db()
+        assert (
+            endpoint.maximum_duration
+            == endpoint.endpoint_utilization.duration + timedelta(seconds=300)
+        )
+
+    @pytest.mark.parametrize(
+        "endpoint_status",
+        set(EndpointStatusChoices).difference(
+            EndpointStatusChoices.get_active_choices()
+        ),
+    )
+    def test_response_for_nonactive_status(self, client, endpoint_status):
+        endpoint = EndpointFactory.create(
+            maximum_duration=timedelta(seconds=0),
+            status=endpoint_status,
+        )
+        AlgorithmUserCreditFactory(
+            user=endpoint.creator,
+            algorithm=endpoint.algorithm_image.algorithm,
+            credits=1000,
+            valid_from=now().date(),
+            valid_until=now().date(),
+            comment="test",
+        )
+        client.force_login(user=endpoint.creator)
+
+        response = client.patch(self.get_url(endpoint.pk))
+
+        assert response.status_code == 400, response.data
+        assert response.json() == {"status": "Endpoint no longer active"}
+        endpoint.refresh_from_db()
+        assert endpoint.maximum_duration == timedelta(seconds=0)
+
 
 @pytest.mark.django_db
 class TestInvocationList:

--- a/app/tests/algorithms_tests/test_models.py
+++ b/app/tests/algorithms_tests/test_models.py
@@ -1775,7 +1775,8 @@ def test_endpoint_keep_alive_limit_reached():
 
     result = endpoint.keep_alive(duration=timedelta(seconds=60))
 
-    assert result.limit_reached
+    assert not result.lifetime_extended
+    assert "Endpoint duration limit reached" in result.message
     endpoint.refresh_from_db()
     assert endpoint.maximum_duration < timedelta(seconds=60)
 
@@ -1794,7 +1795,7 @@ def test_endpoint_keep_alive():
 
     result = endpoint.keep_alive(duration=timedelta(seconds=60))
 
-    assert not result.limit_reached
+    assert result.lifetime_extended
     endpoint.refresh_from_db()
     assert (
         endpoint.maximum_duration

--- a/app/tests/algorithms_tests/test_serializers.py
+++ b/app/tests/algorithms_tests/test_serializers.py
@@ -6,9 +6,9 @@ from rest_framework.exceptions import ErrorDetail
 
 from grandchallenge.algorithms.models import Endpoint, Invocation, Job
 from grandchallenge.algorithms.serializers import (
-    HyperlinkedInvocationSerializer,
     HyperlinkedJobSerializer,
     InvocationPostSerializer,
+    InvocationSerializer,
     JobPostSerializer,
 )
 from grandchallenge.cases.models import RawImageUploadSession
@@ -598,7 +598,7 @@ def test_hyperlinked_invocation_serializer(rf):
         interface__kind=InterfaceKindChoices.PANIMG_IMAGE, image=ImageFactory()
     )
     invocation.inputs.set([civ])
-    serializer = HyperlinkedInvocationSerializer(
+    serializer = InvocationSerializer(
         invocation, context={"request": rf.get("/foo", secure=True)}
     )
     assert serializer.data["status"] == invocation.get_status_display()


### PR DESCRIPTION
Include the api_url in the response after creating an Endpoint for convenience and clarify the reponse for the keep_alive action when the endpoint is no longer active. 