### PR TITLE
Add long_task limits to task that parses job outputs

### DIFF
--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1045,7 +1045,10 @@ def handle_event(*, event: dict, backend: str):
 
 
 @lambda_task(
-    queue=LambdaTaskQueueChoices.MEM8G, retry_on=(LockNotAcquiredException,)
+    queue=LambdaTaskQueueChoices.MEM8G,
+    retry_on=(LockNotAcquiredException,),
+    soft_timeout=LONG_TASK_SOFT_TIMEOUT,
+    hard_timeout=LONG_TASK_HARD_TIMEOUT,
 )
 def parse_job_outputs(
     *,


### PR DESCRIPTION
Fixes timeouts on parsing outputs of jobs.

Closes: https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/868