### PR TITLE
Show description when visualizing Vega charts

### DIFF
--- a/app/grandchallenge/components/schemas.py
+++ b/app/grandchallenge/components/schemas.py
@@ -636,6 +636,7 @@ ANSWER_TYPE_SCHEMA = {
 
 VEGA_LITE_SCHEMA = {
     "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+    "$ref": "https://vega.github.io/schema/vega-lite/v5.json",
 }
 
 AFFINE_TRANSFORM_REGISTRATION_SCHEMA = {

--- a/app/grandchallenge/components/schemas.py
+++ b/app/grandchallenge/components/schemas.py
@@ -636,7 +636,6 @@ ANSWER_TYPE_SCHEMA = {
 
 VEGA_LITE_SCHEMA = {
     "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
-    "$ref": "https://vega.github.io/schema/vega-lite/v5.json",
 }
 
 AFFINE_TRANSFORM_REGISTRATION_SCHEMA = {

--- a/app/grandchallenge/components/templates/components/partials/civ/value_chart.html
+++ b/app/grandchallenge/components/templates/components/partials/civ/value_chart.html
@@ -8,4 +8,9 @@
             <span class="sr-only">Loading...</span>
         </div>
     </div>
+    {% if civ.interface.description %}
+        <div class="text-muted">
+            Description: {{ civ.interface.description }}
+        </div>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
A request came from PRISMA challenge organizers: to add a description when showing Vega charts.

Adding a description in the chart itself is tedious: If it becomes longer than just a subtitle you have to manually cut lines and put it as marks. Instead, I opted to add a simple HTML tag instead to the civ rendering.


### Before

<img width="1080" height="727" alt="Screenshot 2026-07-20 at 16 56 45" src="https://github.com/user-attachments/assets/55e73819-5a4f-49ea-84e2-bede680d30a6" />

### After
<img width="1080" height="727" alt="Screenshot 2026-07-20 at 17 00 16" src="https://github.com/user-attachments/assets/80f95229-f17d-463a-b6b2-1ea20616d495" />
