### PR TITLE
Chain output job output parsing

### DIFF
--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1045,10 +1045,7 @@ def handle_event(*, event: dict, backend: str):
 
 
 @lambda_task(
-    queue=LambdaTaskQueueChoices.MEM8G,
-    retry_on=(LockNotAcquiredException,),
-    soft_timeout=LONG_TASK_SOFT_TIMEOUT,
-    hard_timeout=LONG_TASK_HARD_TIMEOUT,
+    queue=LambdaTaskQueueChoices.MEM8G, retry_on=(LockNotAcquiredException,)
 )
 def parse_job_outputs(
     *,
@@ -1062,32 +1059,95 @@ def parse_job_outputs(
     with check_lock_acquired():
         job = model.objects.select_for_update(nowait=True).get(pk=job_pk)
 
-    executor = job.get_executor(backend=backend)
-
     if job.status != job.EXECUTED:
         raise RuntimeError("Job is not ready for output parsing")
 
     if job.outputs.exists():
         raise RuntimeError("Job already has outputs")
 
-    try:
-        outputs = executor.get_outputs(
-            output_interfaces=job.output_interfaces.all()
+    interface_pks = list(
+        job.output_interfaces.order_by("pk").values_list("pk", flat=True)
+    )
+
+    if not interface_pks:
+        job.update_status(status=job.SUCCESS)
+    else:
+        job.update_status(status=job.PARSING)
+
+        # Kick off the parsing chain
+        parse_job_output_interface.execute_on_commit(
+            job_pk=job_pk,
+            job_app_label=job_app_label,
+            job_model_name=job_model_name,
+            backend=backend,
+            interface_pks=interface_pks,
         )
+
+
+@lambda_task(
+    queue=LambdaTaskQueueChoices.MEM8G, retry_on=(LockNotAcquiredException,)
+)
+def parse_job_output_interface(
+    *,
+    job_pk: str | UUID,
+    job_app_label: str,
+    job_model_name: str,
+    backend: str,
+    interface_pks: list[int],
+):
+    model = apps.get_model(app_label=job_app_label, model_name=job_model_name)
+
+    with check_lock_acquired():
+        job = model.objects.select_for_update(nowait=True).get(pk=job_pk)
+
+    if job.status != job.PARSING:
+        # Check for changes in status
+        raise RuntimeError("Job is not in parsing state")
+
+    executor = job.get_executor(backend=backend)
+
+    # Defensive copy to avoid mutating the original list
+    remaining_pks = list(interface_pks)
+    interface_pk = remaining_pks.pop(0)
+
+    interface_model = job.output_interfaces.model
+    try:
+        interface = interface_model.objects.get(pk=interface_pk)
+    except interface_model.DoesNotExist:
+        job.update_status(
+            status=job.FAILURE,
+            error_message=f"Output interface with pk={interface_pk} does not exist",
+        )
+        return
+
+    try:
+        outputs = executor.get_outputs(output_interfaces=[interface])
     except ComponentException as e:
         job.update_status(
             status=job.FAILURE,
             error_message=str(e),
             detailed_error_message=e.message_details,
         )
+        return
     except Exception:
         job.update_status(
             status=job.FAILURE,
             error_message=SystemErrorMessages.UNEXPECTED_ERROR,
         )
         task_logger.error("Could not parse outputs", exc_info=True)
+        return
     else:
         job.outputs.add(*outputs)
+
+    if remaining_pks:
+        parse_job_output_interface.execute_on_commit(
+            job_pk=job_pk,
+            job_app_label=job_app_label,
+            job_model_name=job_model_name,
+            backend=backend,
+            interface_pks=remaining_pks,
+        )
+    else:
         job.update_status(status=job.SUCCESS)
 
 

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1106,9 +1106,7 @@ def parse_job_output_interface(
 
     executor = job.get_executor(backend=backend)
 
-    # Defensive copy to avoid mutating the original list
-    remaining_pks = list(interface_pks)
-    interface_pk = remaining_pks.pop(0)
+    interface_pk = interface_pks.pop(0)
 
     interface_model = job.output_interfaces.model
     try:
@@ -1128,27 +1126,24 @@ def parse_job_output_interface(
             error_message=str(e),
             detailed_error_message=e.message_details,
         )
-        return
     except Exception:
         job.update_status(
             status=job.FAILURE,
             error_message=SystemErrorMessages.UNEXPECTED_ERROR,
         )
         task_logger.error("Could not parse outputs", exc_info=True)
-        return
     else:
         job.outputs.add(*outputs)
-
-    if remaining_pks:
-        parse_job_output_interface.execute_on_commit(
-            job_pk=job_pk,
-            job_app_label=job_app_label,
-            job_model_name=job_model_name,
-            backend=backend,
-            interface_pks=remaining_pks,
-        )
-    else:
-        job.update_status(status=job.SUCCESS)
+        if interface_pks:
+            parse_job_output_interface.execute_on_commit(
+                job_pk=job_pk,
+                job_app_label=job_app_label,
+                job_model_name=job_model_name,
+                backend=backend,
+                interface_pks=interface_pks,
+            )
+        else:
+            job.update_status(status=job.SUCCESS)
 
 
 @lambda_task(retry_on=(RetryStep,))

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1067,19 +1067,16 @@ def parse_job_outputs(
         job.output_interfaces.order_by("pk").values_list("pk", flat=True)
     )
 
-    if not interface_pks:
-        job.update_status(status=job.SUCCESS)
-    else:
-        job.update_status(status=job.PARSING)
+    job.update_status(status=job.PARSING)
 
-        # Kick off the parsing chain
-        parse_singular_job_output.execute_on_commit(
-            job_pk=job_pk,
-            job_app_label=job_app_label,
-            job_model_name=job_model_name,
-            backend=backend,
-            interface_pks=interface_pks,
-        )
+    # Kick off the parsing chain
+    parse_singular_job_output.execute_on_commit(
+        job_pk=job_pk,
+        job_app_label=job_app_label,
+        job_model_name=job_model_name,
+        backend=backend,
+        interface_pks=interface_pks,
+    )
 
 
 @lambda_task(
@@ -1098,8 +1095,10 @@ def parse_singular_job_output(
     with check_lock_acquired():
         job = model.objects.select_for_update(nowait=True).get(pk=job_pk)
 
+    if not interface_pks:
+        raise RuntimeError("No output interfaces to parse")
+
     if job.status != job.PARSING:
-        # Check for changes in status
         raise RuntimeError("Job is not in parsing state")
 
     executor = job.get_executor(backend=backend)

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1044,9 +1044,7 @@ def handle_event(*, event: dict, backend: str):
         parse_job_outputs.execute_on_commit(**job.task_kwargs)
 
 
-@lambda_task(
-    queue=LambdaTaskQueueChoices.MEM8G, retry_on=(LockNotAcquiredException,)
-)
+@lambda_task(retry_on=(LockNotAcquiredException,))
 def parse_job_outputs(
     *,
     job_pk: str | UUID,
@@ -1075,7 +1073,7 @@ def parse_job_outputs(
         job.update_status(status=job.PARSING)
 
         # Kick off the parsing chain
-        parse_job_output_interface.execute_on_commit(
+        parse_singular_job_output.execute_on_commit(
             job_pk=job_pk,
             job_app_label=job_app_label,
             job_model_name=job_model_name,
@@ -1087,7 +1085,7 @@ def parse_job_outputs(
 @lambda_task(
     queue=LambdaTaskQueueChoices.MEM8G, retry_on=(LockNotAcquiredException,)
 )
-def parse_job_output_interface(
+def parse_singular_job_output(
     *,
     job_pk: str | UUID,
     job_app_label: str,
@@ -1135,7 +1133,7 @@ def parse_job_output_interface(
     else:
         job.outputs.add(*outputs)
         if interface_pks:
-            parse_job_output_interface.execute_on_commit(
+            parse_singular_job_output.execute_on_commit(
                 job_pk=job_pk,
                 job_app_label=job_app_label,
                 job_model_name=job_model_name,

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -35,6 +35,7 @@ from grandchallenge.components.backends.base import (
     InferenceResult,
     RuntimeSetupResult,
 )
+from grandchallenge.components.backends.exceptions import ComponentException
 from grandchallenge.components.models import (
     APIMethodChoices,
     ComponentInterfaceValue,
@@ -55,6 +56,8 @@ from grandchallenge.components.tasks import (
     handle_endpoint_status_event,
     invoke_endpoint,
     parse_endpoint_invocation_outputs,
+    parse_job_outputs,
+    parse_singular_job_output,
     preload_interactive_algorithms,
     remove_container_image_from_registry,
     remove_inactive_container_images,
@@ -77,6 +80,7 @@ from grandchallenge.workstations.models import WorkstationImage
 from tests.algorithms_tests.factories import (
     AlgorithmFactory,
     AlgorithmImageFactory,
+    AlgorithmInterfaceFactory,
     AlgorithmJobFactory,
     AlgorithmModelFactory,
     EndpointFactory,
@@ -88,7 +92,10 @@ from tests.cases_tests.factories import (
     DICOMImageSetUploadFactory,
     RawImageUploadSessionFactory,
 )
-from tests.components_tests.factories import ComponentInterfaceFactory
+from tests.components_tests.factories import (
+    ComponentInterfaceFactory,
+    ComponentInterfaceValueFactory,
+)
 from tests.evaluation_tests.factories import (
     EvaluationFactory,
     EvaluationGroundTruthFactory,
@@ -2071,3 +2078,281 @@ def test_invoke_endpoint_skips_keep_alive_for_reader_study_endpoint(mocker):
     invoke_endpoint(**invocation.task_kwargs)
 
     spy_keep_alive.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_parse_job_outputs(
+    settings, django_capture_on_commit_callbacks, mocker
+):
+    settings.LAMBDA_TASKS_EAGER = True
+
+    ai = AlgorithmImageFactory(
+        is_manifest_valid=True, is_in_registry=True, is_desired_version=True
+    )
+
+    int_socket_0, int_socket_1, int_socket_2, int_socket_3 = (
+        ComponentInterfaceFactory.create_batch(
+            4, kind=InterfaceKindChoices.INTEGER
+        )
+    )
+
+    interface = AlgorithmInterfaceFactory(
+        inputs=[int_socket_0],
+        outputs=[int_socket_1, int_socket_2, int_socket_3],
+    )
+    ai.algorithm.interfaces.add(interface)
+
+    job = AlgorithmJobFactory(
+        algorithm_image=ai,
+        algorithm_interface=interface,
+        status=Job.EXECUTED,
+        time_limit=60,
+    )
+
+    class TestExecutor:
+        def get_outputs(self, output_interfaces):
+            return [
+                ComponentInterfaceValueFactory(interface=interface, value=42)
+                for interface in output_interfaces
+            ]
+
+    mocker.patch(
+        "grandchallenge.algorithms.models.Job.get_executor",
+        return_value=TestExecutor(),
+    )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        parse_job_outputs(**job.task_kwargs)
+
+    job.refresh_from_db()
+    assert job.error_message == ""
+    assert job.status == Job.SUCCESS
+    assert job.outputs.count() == 3
+
+
+@pytest.mark.django_db
+def test_parse_job_outputs_incorrect_state(
+    settings, django_capture_on_commit_callbacks, mocker
+):
+    settings.LAMBDA_TASKS_EAGER = True
+
+    ai = AlgorithmImageFactory(
+        is_manifest_valid=True, is_in_registry=True, is_desired_version=True
+    )
+
+    job = AlgorithmJobFactory(
+        algorithm_image=ai,
+        status=Job.CANCELLED,
+        time_limit=60,
+    )
+
+    with pytest.raises(
+        RuntimeError, match="Job is not ready for output parsing"
+    ):
+        with django_capture_on_commit_callbacks(execute=True):
+            parse_job_outputs(**job.task_kwargs)
+
+    job.status = job.EXECUTED
+    job.save()
+
+    job.outputs.add(ComponentInterfaceValueFactory())
+
+    with pytest.raises(RuntimeError, match="Job already has outputs"):
+        with django_capture_on_commit_callbacks(execute=True):
+            parse_job_outputs(**job.task_kwargs)
+
+
+@pytest.mark.django_db
+def test_parse_singular_job_output(
+    settings, django_capture_on_commit_callbacks, mocker
+):
+    settings.LAMBDA_TASKS_EAGER = True
+
+    ai = AlgorithmImageFactory(
+        is_manifest_valid=True, is_in_registry=True, is_desired_version=True
+    )
+
+    int_socket_0, int_socket_1, int_socket_2, int_socket_3 = (
+        ComponentInterfaceFactory.create_batch(
+            4, kind=InterfaceKindChoices.INTEGER
+        )
+    )
+
+    interface = AlgorithmInterfaceFactory(
+        inputs=[int_socket_0],
+        outputs=[int_socket_1, int_socket_2, int_socket_3],
+    )
+    ai.algorithm.interfaces.add(interface)
+
+    job = AlgorithmJobFactory(
+        algorithm_image=ai,
+        algorithm_interface=interface,
+        status=Job.PARSING,
+        time_limit=60,
+    )
+
+    class TestExecutor:
+        def get_outputs(self, output_interfaces):
+            return [
+                ComponentInterfaceValueFactory(interface=interface, value=42)
+                for interface in output_interfaces
+            ]
+
+    mocker.patch(
+        "grandchallenge.algorithms.models.Job.get_executor",
+        return_value=TestExecutor(),
+    )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        parse_singular_job_output(
+            **job.task_kwargs,
+            interface_pks=[int_socket_1.pk, int_socket_2.pk, int_socket_3.pk],
+        )
+
+    job.refresh_from_db()
+    assert job.error_message == ""
+    assert job.status == Job.SUCCESS
+    assert job.outputs.count() == 3
+
+
+@pytest.mark.django_db
+def test_parse_singular_job_output_incorrect_state(
+    settings, django_capture_on_commit_callbacks
+):
+    settings.LAMBDA_TASKS_EAGER = True
+
+    ai = AlgorithmImageFactory(
+        is_manifest_valid=True, is_in_registry=True, is_desired_version=True
+    )
+
+    job = AlgorithmJobFactory(
+        algorithm_image=ai,
+        status=Job.CANCELLED,
+        time_limit=60,
+    )
+
+    with pytest.raises(RuntimeError, match="Job is not in parsing state"):
+        with django_capture_on_commit_callbacks(execute=True):
+            parse_singular_job_output(**job.task_kwargs, interface_pks=[42])
+
+
+@pytest.mark.django_db
+def test_parse_singular_job_output_nonexistent_interface(
+    settings, django_capture_on_commit_callbacks
+):
+    settings.LAMBDA_TASKS_EAGER = True
+
+    ai = AlgorithmImageFactory(
+        is_manifest_valid=True, is_in_registry=True, is_desired_version=True
+    )
+
+    job = AlgorithmJobFactory(
+        algorithm_image=ai,
+        status=Job.PARSING,
+        time_limit=60,
+    )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        parse_singular_job_output(**job.task_kwargs, interface_pks=[42])
+
+    job.refresh_from_db()
+    assert job.status == Job.FAILURE
+    assert job.error_message == "Output interface with pk=42 does not exist"
+
+
+@pytest.mark.django_db
+def test_parse_singular_job_output_executor_exception(
+    settings, django_capture_on_commit_callbacks, mocker
+):
+    settings.LAMBDA_TASKS_EAGER = True
+
+    ai = AlgorithmImageFactory(
+        is_manifest_valid=True, is_in_registry=True, is_desired_version=True
+    )
+
+    int_socket_0, int_socket_1, int_socket_2, int_socket_3 = (
+        ComponentInterfaceFactory.create_batch(
+            4, kind=InterfaceKindChoices.INTEGER
+        )
+    )
+
+    interface = AlgorithmInterfaceFactory(
+        inputs=[int_socket_0],
+        outputs=[int_socket_1, int_socket_2, int_socket_3],
+    )
+    ai.algorithm.interfaces.add(interface)
+
+    job = AlgorithmJobFactory(
+        algorithm_image=ai,
+        algorithm_interface=interface,
+        status=Job.PARSING,
+        time_limit=60,
+    )
+
+    class TestExecutor:
+        def get_outputs(self, *_, **__):
+            raise Exception("Test execution that should not be passed to user")
+
+    mocker.patch(
+        "grandchallenge.algorithms.models.Job.get_executor",
+        return_value=TestExecutor(),
+    )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        parse_singular_job_output(
+            **job.task_kwargs, interface_pks=[int_socket_1.pk]
+        )
+
+    job.refresh_from_db()
+    assert job.status == Job.FAILURE
+    assert job.error_message == "An unexpected error occurred"
+
+
+@pytest.mark.django_db
+def test_parse_singular_job_output_executor_component_exception(
+    settings, django_capture_on_commit_callbacks, mocker
+):
+    settings.LAMBDA_TASKS_EAGER = True
+
+    ai = AlgorithmImageFactory(
+        is_manifest_valid=True, is_in_registry=True, is_desired_version=True
+    )
+
+    int_socket_0, int_socket_1, int_socket_2, int_socket_3 = (
+        ComponentInterfaceFactory.create_batch(
+            4, kind=InterfaceKindChoices.INTEGER
+        )
+    )
+
+    interface = AlgorithmInterfaceFactory(
+        inputs=[int_socket_0],
+        outputs=[int_socket_1, int_socket_2, int_socket_3],
+    )
+    ai.algorithm.interfaces.add(interface)
+
+    job = AlgorithmJobFactory(
+        algorithm_image=ai,
+        algorithm_interface=interface,
+        status=Job.PARSING,
+        time_limit=60,
+    )
+
+    class TestExecutor:
+        def get_outputs(self, *_, **__):
+            raise ComponentException(
+                "Test execution that should be passed to user"
+            )
+
+    mocker.patch(
+        "grandchallenge.algorithms.models.Job.get_executor",
+        return_value=TestExecutor(),
+    )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        parse_singular_job_output(
+            **job.task_kwargs, interface_pks=[int_socket_1.pk]
+        )
+
+    job.refresh_from_db()
+    assert job.status == Job.FAILURE
+    assert job.error_message == "Test execution that should be passed to user"


### PR DESCRIPTION
Closes: https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/868

The increase from 4 minutes to 14 minutes runtime was insufficient. Logs indicate that each output files takes around 1m42s to process.

This PR, in the most safe way possible, splits the processing of job outputs from one task, to a chain of tasks.