### PR TITLE
Fix admin pages for models, gt and component images

### DIFF
--- a/app/grandchallenge/algorithms/admin.py
+++ b/app/grandchallenge/algorithms/admin.py
@@ -267,6 +267,7 @@ class AlgorithmPermissionRequestAdmin(admin.ModelAdmin):
 @admin.register(AlgorithmModel)
 class AlgorithmModelAdmin(admin.ModelAdmin):
     ordering = ("-created",)
+    exclude = ("model",)
     list_display = (
         "algorithm",
         "created",

--- a/app/grandchallenge/components/admin.py
+++ b/app/grandchallenge/components/admin.py
@@ -37,11 +37,11 @@ def cancel_image_imports(modeladmin, request, queryset):
 
 class ComponentImageAdmin(admin.ModelAdmin):
     ordering = ("-created",)
+    exclude = ("image",)
     readonly_fields = (
         "creator",
         "user_upload",
         "import_status",
-        "image",
     )
     list_display = (
         "pk",

--- a/app/grandchallenge/evaluation/admin.py
+++ b/app/grandchallenge/evaluation/admin.py
@@ -278,6 +278,7 @@ class EvaluationAdmin(admin.ModelAdmin):
 
 @admin.register(EvaluationGroundTruth)
 class EvaluationGroundTruthAdmin(admin.ModelAdmin):
+    exclude = ("ground_truth",)
     list_display = ("phase", "created", "is_desired_version", "comment")
     list_filter = ("is_desired_version",)
     search_fields = ("phase__slug", "comment")
@@ -286,7 +287,6 @@ class EvaluationGroundTruthAdmin(admin.ModelAdmin):
         "phase",
         "checksum",
         "size_in_storage",
-        "ground_truth",
     )
 
 


### PR DESCRIPTION
The admin pages for component images, models and ground truths were inaccessible because including the image calls the `url` property on the file field to generate a clickable link. Direct links to files in protected storage are not allowed though, making the admin pages inaccessible. 

I don't think we ever need these links, so just excluding them from those pages seems good enough. 

https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/873#issuecomment-5060032863