### PR TITLE
Make job output parsing idempotent

### DIFF
--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1080,7 +1080,7 @@ def parse_job_outputs(
     queue=LambdaTaskQueueChoices.MEM8G,
     retry_on=(LockNotAcquiredException,),
 )
-def parse_singular_job_output(  # noqa: C901
+def parse_singular_job_output(
     *,
     job_pk: str | UUID,
     job_app_label: str,

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1057,14 +1057,14 @@ def parse_job_outputs(
     with check_lock_acquired():
         job = model.objects.select_for_update(nowait=True).get(pk=job_pk)
 
-    if job.status != job.PARSING:
-        if job.status not in (job.EXECUTED, job.SUCCESS):
-            raise RuntimeError("Job is not ready for output parsing")
-        else:
-            task_logger.info(
-                f"Job with pk={job_pk} already marked as completely parsed: reparsing"
-            )
-        job.update_status(status=job.PARSING)
+    if job.status in (job.SUCCESS, job.FAILURE, job.PARSING):
+        # Nothing to do
+        return
+
+    if job.status != job.EXECUTED:
+        raise RuntimeError("Job is not ready for output parsing")
+
+    job.update_status(status=job.PARSING)
 
     interface_pks = list(
         job.output_interfaces.order_by("pk").values_list("pk", flat=True)
@@ -1084,7 +1084,7 @@ def parse_job_outputs(
     queue=LambdaTaskQueueChoices.MEM8G,
     retry_on=(LockNotAcquiredException,),
 )
-def parse_singular_job_output(
+def parse_singular_job_output(  # noqa: C901
     *,
     job_pk: str | UUID,
     job_app_label: str,
@@ -1099,8 +1099,9 @@ def parse_singular_job_output(
     with check_lock_acquired():
         job = model.objects.select_for_update(nowait=True).get(pk=job_pk)
 
-    if job.status == job.SUCCESS:
-        return  # Nothing to do
+    if job.status in (job.SUCCESS, job.FAILURE):
+        return  # Nothing to do: reached a terminal point
+
     if job.status != job.PARSING:
         raise RuntimeError("Job is not in parsing state")
 
@@ -1121,27 +1122,7 @@ def parse_singular_job_output(
         task_logger.info(
             f"Output interface with pk={interface_pk} already parsed for job with pk={job_pk}"
         )
-    else:
-        if not _parse_output_interface(
-            job=job, backend=backend, interface=interface
-        ):
-            return  # marked as failed, stop here
-
-    if remaining_interface_pks:
-        parse_singular_job_output.execute_on_commit(
-            job_pk=job_pk,
-            job_app_label=job_app_label,
-            job_model_name=job_model_name,
-            backend=backend,
-            interface_pks=remaining_interface_pks,
-        )
-    else:
-        job.update_status(status=job.SUCCESS)
-
-
-def _parse_output_interface(*, job, backend, interface) -> bool:
-    """Parse a single output interface. Returns False if the job was
-    marked as failed (caller should stop), True otherwise."""
+        return  # Nothing to do here
 
     executor = job.get_executor(backend=backend)
 
@@ -1153,17 +1134,27 @@ def _parse_output_interface(*, job, backend, interface) -> bool:
             error_message=str(e),
             detailed_error_message=e.message_details,
         )
-        return False
+        return
     except Exception:
         job.update_status(
             status=job.FAILURE,
             error_message=SystemErrorMessages.UNEXPECTED_ERROR,
         )
         task_logger.error("Could not parse outputs", exc_info=True)
-        return False
+        return
+
+    job.outputs.add(*outputs)
+
+    if remaining_interface_pks:
+        parse_singular_job_output.execute_on_commit(
+            job_pk=job_pk,
+            job_app_label=job_app_label,
+            job_model_name=job_model_name,
+            backend=backend,
+            interface_pks=remaining_interface_pks,
+        )
     else:
-        job.outputs.add(*outputs)
-        return True
+        job.update_status(status=job.SUCCESS)
 
 
 @lambda_task(retry_on=(RetryStep,))

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1105,8 +1105,7 @@ def parse_singular_job_output(  # noqa: C901
     if job.status != job.PARSING:
         raise RuntimeError("Job is not in parsing state")
 
-    interface_pk = interface_pks[0]
-    remaining_interface_pks = interface_pks[1:]
+    interface_pk, *remaining_interface_pks = interface_pks
 
     interface_model = job.output_interfaces.model
     try:

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1057,17 +1057,18 @@ def parse_job_outputs(
     with check_lock_acquired():
         job = model.objects.select_for_update(nowait=True).get(pk=job_pk)
 
-    if job.status != job.EXECUTED:
-        raise RuntimeError("Job is not ready for output parsing")
-
-    if job.outputs.exists():
-        raise RuntimeError("Job already has outputs")
+    if job.status != job.PARSING:
+        if job.status not in (job.EXECUTED, job.SUCCESS):
+            raise RuntimeError("Job is not ready for output parsing")
+        else:
+            task_logger.info(
+                f"Job with pk={job_pk} already marked as completely parsed: reparsing"
+            )
+        job.update_status(status=job.PARSING)
 
     interface_pks = list(
         job.output_interfaces.order_by("pk").values_list("pk", flat=True)
     )
-
-    job.update_status(status=job.PARSING)
 
     # Kick off the parsing chain
     parse_singular_job_output.execute_on_commit(
@@ -1080,7 +1081,8 @@ def parse_job_outputs(
 
 
 @lambda_task(
-    queue=LambdaTaskQueueChoices.MEM8G, retry_on=(LockNotAcquiredException,)
+    queue=LambdaTaskQueueChoices.MEM8G,
+    retry_on=(LockNotAcquiredException,),
 )
 def parse_singular_job_output(
     *,
@@ -1090,20 +1092,20 @@ def parse_singular_job_output(
     backend: str,
     interface_pks: list[int],
 ):
-    model = apps.get_model(app_label=job_app_label, model_name=job_model_name)
-
-    with check_lock_acquired():
-        job = model.objects.select_for_update(nowait=True).get(pk=job_pk)
-
     if not interface_pks:
         raise RuntimeError("No output interfaces to parse")
 
+    model = apps.get_model(app_label=job_app_label, model_name=job_model_name)
+    with check_lock_acquired():
+        job = model.objects.select_for_update(nowait=True).get(pk=job_pk)
+
+    if job.status == job.SUCCESS:
+        return  # Nothing to do
     if job.status != job.PARSING:
         raise RuntimeError("Job is not in parsing state")
 
-    executor = job.get_executor(backend=backend)
-
-    interface_pk = interface_pks.pop(0)
+    interface_pk = interface_pks[0]
+    remaining_interface_pks = interface_pks[1:]
 
     interface_model = job.output_interfaces.model
     try:
@@ -1115,6 +1117,34 @@ def parse_singular_job_output(
         )
         return
 
+    if job.outputs.filter(interface=interface_pk).exists():
+        task_logger.info(
+            f"Output interface with pk={interface_pk} already parsed for job with pk={job_pk}"
+        )
+    else:
+        if not _parse_output_interface(
+            job=job, backend=backend, interface=interface
+        ):
+            return  # marked as failed, stop here
+
+    if remaining_interface_pks:
+        parse_singular_job_output.execute_on_commit(
+            job_pk=job_pk,
+            job_app_label=job_app_label,
+            job_model_name=job_model_name,
+            backend=backend,
+            interface_pks=remaining_interface_pks,
+        )
+    else:
+        job.update_status(status=job.SUCCESS)
+
+
+def _parse_output_interface(*, job, backend, interface) -> bool:
+    """Parse a single output interface. Returns False if the job was
+    marked as failed (caller should stop), True otherwise."""
+
+    executor = job.get_executor(backend=backend)
+
     try:
         outputs = executor.get_outputs(output_interfaces=[interface])
     except ComponentException as e:
@@ -1123,24 +1153,17 @@ def parse_singular_job_output(
             error_message=str(e),
             detailed_error_message=e.message_details,
         )
+        return False
     except Exception:
         job.update_status(
             status=job.FAILURE,
             error_message=SystemErrorMessages.UNEXPECTED_ERROR,
         )
         task_logger.error("Could not parse outputs", exc_info=True)
+        return False
     else:
         job.outputs.add(*outputs)
-        if interface_pks:
-            parse_singular_job_output.execute_on_commit(
-                job_pk=job_pk,
-                job_app_label=job_app_label,
-                job_model_name=job_model_name,
-                backend=backend,
-                interface_pks=interface_pks,
-            )
-        else:
-            job.update_status(status=job.SUCCESS)
+        return True
 
 
 @lambda_task(retry_on=(RetryStep,))

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1057,10 +1057,6 @@ def parse_job_outputs(
     with check_lock_acquired():
         job = model.objects.select_for_update(nowait=True).get(pk=job_pk)
 
-    if job.status in (job.SUCCESS, job.FAILURE, job.PARSING):
-        # Nothing to do
-        return
-
     if job.status != job.EXECUTED:
         raise RuntimeError("Job is not ready for output parsing")
 
@@ -1098,9 +1094,6 @@ def parse_singular_job_output(  # noqa: C901
     model = apps.get_model(app_label=job_app_label, model_name=job_model_name)
     with check_lock_acquired():
         job = model.objects.select_for_update(nowait=True).get(pk=job_pk)
-
-    if job.status in (job.SUCCESS, job.FAILURE):
-        return  # Nothing to do: reached a terminal point
 
     if job.status != job.PARSING:
         raise RuntimeError("Job is not in parsing state")

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1060,6 +1060,9 @@ def parse_job_outputs(
     if job.status != job.EXECUTED:
         raise RuntimeError("Job is not ready for output parsing")
 
+    if job.outputs.exists():
+        raise RuntimeError("Job already has outputs")
+
     job.update_status(status=job.PARSING)
 
     interface_pks = list(

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -2215,6 +2215,15 @@ def test_parse_job_outputs_incorrect_state(
         with django_capture_on_commit_callbacks(execute=True):
             parse_job_outputs(**job.task_kwargs)
 
+    job.status = job.EXECUTED
+    job.save()
+
+    job.outputs.add(ComponentInterfaceValueFactory())
+
+    with pytest.raises(RuntimeError, match="Job already has outputs"):
+        with django_capture_on_commit_callbacks(execute=True):
+            parse_job_outputs(**job.task_kwargs)
+
 
 @pytest.mark.django_db
 def test_parse_singular_job_output(

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -2081,9 +2081,8 @@ def test_invoke_endpoint_skips_keep_alive_for_reader_study_endpoint(mocker):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("test_idempotent", [True, False])
 def test_parse_job_outputs(
-    settings, django_capture_on_commit_callbacks, mocker, test_idempotent
+    settings, django_capture_on_commit_callbacks, mocker
 ):
     settings.LAMBDA_TASKS_EAGER = True
 
@@ -2125,9 +2124,63 @@ def test_parse_job_outputs(
     with django_capture_on_commit_callbacks(execute=True):
         parse_job_outputs(**job.task_kwargs)
 
-    if test_idempotent:
-        with django_capture_on_commit_callbacks(execute=True):
-            parse_job_outputs(**job.task_kwargs)
+    job.refresh_from_db()
+    assert job.error_message == ""
+    assert job.status == Job.SUCCESS
+    assert job.outputs.count() == 3
+
+
+@pytest.mark.django_db
+def test_parse_job_outputs_idempotent(
+    settings, django_capture_on_commit_callbacks, mocker
+):
+    settings.LAMBDA_TASKS_EAGER = True
+
+    ai = AlgorithmImageFactory(
+        is_manifest_valid=True, is_in_registry=True, is_desired_version=True
+    )
+
+    int_socket_0, int_socket_1, int_socket_2, int_socket_3 = (
+        ComponentInterfaceFactory.create_batch(
+            4, kind=InterfaceKindChoices.INTEGER
+        )
+    )
+
+    interface = AlgorithmInterfaceFactory(
+        inputs=[int_socket_0],
+        outputs=[int_socket_1, int_socket_2, int_socket_3],
+    )
+    ai.algorithm.interfaces.add(interface)
+
+    job = AlgorithmJobFactory(
+        algorithm_image=ai,
+        algorithm_interface=interface,
+        status=Job.EXECUTED,
+        time_limit=60,
+    )
+
+    class TestExecutor:
+        def get_outputs(self, output_interfaces):
+            return [
+                ComponentInterfaceValueFactory(interface=interface, value=42)
+                for interface in output_interfaces
+            ]
+
+    mocker.patch(
+        "grandchallenge.algorithms.models.Job.get_executor",
+        return_value=TestExecutor(),
+    )
+
+    ComponentInterfaceValue.objects.all().delete()
+    assert ComponentInterfaceValue.objects.count() == 0
+
+    with django_capture_on_commit_callbacks(execute=True):
+        parse_job_outputs(**job.task_kwargs)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        parse_job_outputs(**job.task_kwargs)
+
+    assert ComponentInterfaceValue.objects.count() == 3
 
     job.refresh_from_db()
     assert job.error_message == ""
@@ -2159,9 +2212,8 @@ def test_parse_job_outputs_incorrect_state(
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("test_idempotent", [True, False])
 def test_parse_singular_job_output(
-    settings, django_capture_on_commit_callbacks, mocker, test_idempotent
+    settings, django_capture_on_commit_callbacks, mocker
 ):
     settings.LAMBDA_TASKS_EAGER = True
 
@@ -2206,16 +2258,69 @@ def test_parse_singular_job_output(
             interface_pks=[int_socket_1.pk, int_socket_2.pk, int_socket_3.pk],
         )
 
-    if test_idempotent:
-        with django_capture_on_commit_callbacks(execute=True):
-            parse_singular_job_output(
-                **job.task_kwargs,
-                interface_pks=[
-                    int_socket_1.pk,
-                    int_socket_2.pk,
-                    int_socket_3.pk,
-                ],
-            )
+    job.refresh_from_db()
+    assert job.error_message == ""
+    assert job.status == Job.SUCCESS
+    assert job.outputs.count() == 3
+
+
+@pytest.mark.django_db
+def test_parse_singular_job_output_idempotent(
+    settings, django_capture_on_commit_callbacks, mocker
+):
+    settings.LAMBDA_TASKS_EAGER = True
+
+    ai = AlgorithmImageFactory(
+        is_manifest_valid=True, is_in_registry=True, is_desired_version=True
+    )
+
+    int_socket_0, int_socket_1, int_socket_2, int_socket_3 = (
+        ComponentInterfaceFactory.create_batch(
+            4, kind=InterfaceKindChoices.INTEGER
+        )
+    )
+
+    interface = AlgorithmInterfaceFactory(
+        inputs=[int_socket_0],
+        outputs=[int_socket_1, int_socket_2, int_socket_3],
+    )
+    ai.algorithm.interfaces.add(interface)
+
+    job = AlgorithmJobFactory(
+        algorithm_image=ai,
+        algorithm_interface=interface,
+        status=Job.PARSING,
+        time_limit=60,
+    )
+
+    class TestExecutor:
+        def get_outputs(self, output_interfaces):
+            return [
+                ComponentInterfaceValueFactory(interface=interface, value=42)
+                for interface in output_interfaces
+            ]
+
+    mocker.patch(
+        "grandchallenge.algorithms.models.Job.get_executor",
+        return_value=TestExecutor(),
+    )
+
+    ComponentInterfaceValue.objects.all().delete()
+    assert ComponentInterfaceValue.objects.count() == 0
+
+    with django_capture_on_commit_callbacks(execute=True):
+        parse_singular_job_output(
+            **job.task_kwargs,
+            interface_pks=[int_socket_1.pk, int_socket_2.pk, int_socket_3.pk],
+        )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        parse_singular_job_output(
+            **job.task_kwargs,
+            interface_pks=[int_socket_1.pk, int_socket_2.pk, int_socket_3.pk],
+        )
+
+    assert ComponentInterfaceValue.objects.count() == 3
 
     job.refresh_from_db()
     assert job.error_message == ""

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -2187,6 +2187,16 @@ def test_parse_job_outputs_idempotent(
     assert job.status == Job.SUCCESS
     assert job.outputs.count() == 3
 
+    # Test idempotency (i.e. no errors) when the job is in a failure state
+    job.status = Job.FAILURE
+    job.save()
+
+    with django_capture_on_commit_callbacks(execute=True):
+        parse_job_outputs(**job.task_kwargs)
+
+    job.refresh_from_db()
+    assert job.status == Job.FAILURE
+
 
 @pytest.mark.django_db
 def test_parse_job_outputs_incorrect_state(
@@ -2365,6 +2375,10 @@ def test_parse_singular_job_output_nonexistent_interface(
         time_limit=60,
     )
 
+    with django_capture_on_commit_callbacks(execute=True):
+        parse_singular_job_output(**job.task_kwargs, interface_pks=[42])
+
+    # Idempotent
     with django_capture_on_commit_callbacks(execute=True):
         parse_singular_job_output(**job.task_kwargs, interface_pks=[42])
 

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -2081,8 +2081,9 @@ def test_invoke_endpoint_skips_keep_alive_for_reader_study_endpoint(mocker):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("test_idempotent", [True, False])
 def test_parse_job_outputs(
-    settings, django_capture_on_commit_callbacks, mocker
+    settings, django_capture_on_commit_callbacks, mocker, test_idempotent
 ):
     settings.LAMBDA_TASKS_EAGER = True
 
@@ -2124,6 +2125,10 @@ def test_parse_job_outputs(
     with django_capture_on_commit_callbacks(execute=True):
         parse_job_outputs(**job.task_kwargs)
 
+    if test_idempotent:
+        with django_capture_on_commit_callbacks(execute=True):
+            parse_job_outputs(**job.task_kwargs)
+
     job.refresh_from_db()
     assert job.error_message == ""
     assert job.status == Job.SUCCESS
@@ -2152,19 +2157,11 @@ def test_parse_job_outputs_incorrect_state(
         with django_capture_on_commit_callbacks(execute=True):
             parse_job_outputs(**job.task_kwargs)
 
-    job.status = job.EXECUTED
-    job.save()
-
-    job.outputs.add(ComponentInterfaceValueFactory())
-
-    with pytest.raises(RuntimeError, match="Job already has outputs"):
-        with django_capture_on_commit_callbacks(execute=True):
-            parse_job_outputs(**job.task_kwargs)
-
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("test_idempotent", [True, False])
 def test_parse_singular_job_output(
-    settings, django_capture_on_commit_callbacks, mocker
+    settings, django_capture_on_commit_callbacks, mocker, test_idempotent
 ):
     settings.LAMBDA_TASKS_EAGER = True
 
@@ -2208,6 +2205,17 @@ def test_parse_singular_job_output(
             **job.task_kwargs,
             interface_pks=[int_socket_1.pk, int_socket_2.pk, int_socket_3.pk],
         )
+
+    if test_idempotent:
+        with django_capture_on_commit_callbacks(execute=True):
+            parse_singular_job_output(
+                **job.task_kwargs,
+                interface_pks=[
+                    int_socket_1.pk,
+                    int_socket_2.pk,
+                    int_socket_3.pk,
+                ],
+            )
 
     job.refresh_from_db()
     assert job.error_message == ""

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -2177,8 +2177,13 @@ def test_parse_job_outputs_idempotent(
     with django_capture_on_commit_callbacks(execute=True):
         parse_job_outputs(**job.task_kwargs)
 
-    with django_capture_on_commit_callbacks(execute=True):
-        parse_job_outputs(**job.task_kwargs)
+    assert ComponentInterfaceValue.objects.count() == 3
+
+    with pytest.raises(
+        RuntimeError, match="Job is not ready for output parsing"
+    ):
+        with django_capture_on_commit_callbacks(execute=True):
+            parse_job_outputs(**job.task_kwargs)
 
     assert ComponentInterfaceValue.objects.count() == 3
 
@@ -2186,16 +2191,6 @@ def test_parse_job_outputs_idempotent(
     assert job.error_message == ""
     assert job.status == Job.SUCCESS
     assert job.outputs.count() == 3
-
-    # Test idempotency (i.e. no errors) when the job is in a failure state
-    job.status = Job.FAILURE
-    job.save()
-
-    with django_capture_on_commit_callbacks(execute=True):
-        parse_job_outputs(**job.task_kwargs)
-
-    job.refresh_from_db()
-    assert job.status == Job.FAILURE
 
 
 @pytest.mark.django_db
@@ -2324,13 +2319,22 @@ def test_parse_singular_job_output_idempotent(
             interface_pks=[int_socket_1.pk, int_socket_2.pk, int_socket_3.pk],
         )
 
-    with django_capture_on_commit_callbacks(execute=True):
-        parse_singular_job_output(
-            **job.task_kwargs,
-            interface_pks=[int_socket_1.pk, int_socket_2.pk, int_socket_3.pk],
-        )
-
     assert ComponentInterfaceValue.objects.count() == 3
+
+    with pytest.raises(RuntimeError, match="Job is not in parsing state"):
+        with django_capture_on_commit_callbacks(execute=True):
+            parse_singular_job_output(
+                **job.task_kwargs,
+                interface_pks=[
+                    int_socket_1.pk,
+                    int_socket_2.pk,
+                    int_socket_3.pk,
+                ],
+            )
+
+    assert (
+        ComponentInterfaceValue.objects.count() == 3
+    )  # Still only created 3 outputs
 
     job.refresh_from_db()
     assert job.error_message == ""
@@ -2375,10 +2379,6 @@ def test_parse_singular_job_output_nonexistent_interface(
         time_limit=60,
     )
 
-    with django_capture_on_commit_callbacks(execute=True):
-        parse_singular_job_output(**job.task_kwargs, interface_pks=[42])
-
-    # Idempotent
     with django_capture_on_commit_callbacks(execute=True):
         parse_singular_job_output(**job.task_kwargs, interface_pks=[42])
 


### PR DESCRIPTION
Slight rework of the tasks involved. Should now be idempotent in that calling it multiple times will not mess things up.

Related: https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/868