### PR TITLE
Fix flaky display-set index test

### DIFF
--- a/app/tests/reader_studies_tests/test_api.py
+++ b/app/tests/reader_studies_tests/test_api.py
@@ -2088,13 +2088,16 @@ def test_display_sets_shuffled_per_user(client):
     ]
 
 
-@pytest.mark.flaky(reruns=3)
 @pytest.mark.django_db
 def test_display_set_index(client):
     n_display_sets = 10
     reader_study = ReaderStudyFactory()
     user = UserFactory()
     reader_study.add_reader(user)
+
+    assert not DisplaySet.objects.filter(
+        reader_study=reader_study
+    ).exists(), "Sanity DisplaySets should not exist yet"
 
     DisplaySetFactory.create_batch(n_display_sets, reader_study=reader_study)
 
@@ -2154,8 +2157,14 @@ def test_display_set_index(client):
 
     # determine shuffled index of first Displayset
     set_seed(1 / int(user.pk))
-    queryset = list(DisplaySet.objects.all().order_by("?"))
-    new_index = queryset.index(DisplaySet.objects.first())
+    distinct_pks = (
+        DisplaySet.objects.filter(reader_study=reader_study)
+        .values_list("pk", flat=True)
+        .distinct()
+    )
+    queryset = DisplaySet.objects.filter(pk__in=distinct_pks).order_by("?")
+    queryset_list = list(queryset)
+    new_index = queryset_list.index(DisplaySet.objects.first())
 
     assert response.json()["index"] == new_index
 

--- a/app/tests/reader_studies_tests/test_api.py
+++ b/app/tests/reader_studies_tests/test_api.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 
 from grandchallenge.cases.models import RawImageUploadSession
 from grandchallenge.components.models import InterfaceKindChoices
+from grandchallenge.core.utils.query import set_seed
 from grandchallenge.reader_studies.models import (
     Answer,
     AnswerType,
@@ -2088,7 +2089,7 @@ def test_display_sets_shuffled_per_user(client):
 
 
 @pytest.mark.django_db
-def test_display_set_index(client):
+def test_display_set_index(client, mocker):
     n_display_sets = 10
     reader_study = ReaderStudyFactory()
     user = UserFactory()
@@ -2111,9 +2112,8 @@ def test_display_set_index(client):
     assert [x["index"] for x in response.json()["results"]] == [
         *range(n_display_sets)
     ]
-    assert [x["order"] for x in response.json()["results"]] == [
-        *range(10, 10 * (n_display_sets + 1), 10)
-    ]
+    unshuffled_order = [x["order"] for x in response.json()["results"]]
+    assert unshuffled_order == [*range(10, 10 * (n_display_sets + 1), 10)]
 
     response = get_view_for_user(
         viewname="api:reader-studies-display-set-detail",
@@ -2124,6 +2124,11 @@ def test_display_set_index(client):
     )
 
     assert response.json()["index"] == 0
+
+    # Ensure fixed randomness for shuffling so that we can test the order is different when shuffling is enabled
+    mocker.patch(
+        "grandchallenge.reader_studies.views.set_seed", lambda *_: set_seed(1)
+    )
 
     reader_study.shuffle_hanging_list = True
     reader_study.save()
@@ -2150,6 +2155,9 @@ def test_display_set_index(client):
         *range(n_display_sets)
     ]
     shuffled_order = [x["order"] for x in response.json()["results"]]
+    assert (
+        unshuffled_order != shuffled_order
+    ), "The order should be different when shuffling is enabled"
 
     response = get_view_for_user(
         viewname="api:reader-studies-display-set-detail",

--- a/app/tests/reader_studies_tests/test_api.py
+++ b/app/tests/reader_studies_tests/test_api.py
@@ -7,7 +7,6 @@ from django.urls import reverse
 
 from grandchallenge.cases.models import RawImageUploadSession
 from grandchallenge.components.models import InterfaceKindChoices
-from grandchallenge.core.utils.query import set_seed
 from grandchallenge.reader_studies.models import (
     Answer,
     AnswerType,
@@ -2142,6 +2141,11 @@ def test_display_set_index(client):
         for x in response.json()["results"]
         if x["pk"] == str(DisplaySet.objects.last().pk)
     ][0]
+    first = [
+        x
+        for x in response.json()["results"]
+        if x["pk"] == str(DisplaySet.objects.first().pk)
+    ][0]
     assert [x["index"] for x in response.json()["results"]] == [
         *range(n_display_sets)
     ]
@@ -2155,18 +2159,9 @@ def test_display_set_index(client):
         method=client.get,
     )
 
-    # determine shuffled index of first Displayset
-    set_seed(1 / int(user.pk))
-    distinct_pks = (
-        DisplaySet.objects.filter(reader_study=reader_study)
-        .values_list("pk", flat=True)
-        .distinct()
-    )
-    queryset = DisplaySet.objects.filter(pk__in=distinct_pks).order_by("?")
-    queryset_list = list(queryset)
-    new_index = queryset_list.index(DisplaySet.objects.first())
-
-    assert response.json()["index"] == new_index
+    assert (
+        response.json()["index"] == first["index"]
+    ), "Index of first display set should be the same as in the list view"
 
     reader_study.shuffle_hanging_list = False
     reader_study.save()


### PR DESCRIPTION
Closes: #4903

In short: because of _subtle_ differences between the randomization implementation and the test implementation of the shuffeling differed the execution plan (theory) sometimes switched. Subtle in that adding a filter on reader_study has influence. Perhaps a better approach is extracting the shuffeling and re-use it in the test. 

There are cons to that though, and because I want to do other things I think it is fine to leave it as is?

