### PR TITLE
Fix HTML missing attribute quotes in page_detail.html

### DIFF
--- a/app/grandchallenge/pages/templates/pages/page_detail.html
+++ b/app/grandchallenge/pages/templates/pages/page_detail.html
@@ -72,7 +72,7 @@
             </div>
         {% endif %}
 
-        <div id=pageContainer>
+        <div id="pageContainer">
             {{ object.content_markdown|md2html }}
         </div>
 


### PR DESCRIPTION
Missing quotation marks. Randomly found this while looking at some grand-challenge html.