### PR TITLE
Add metric for Endpoints count on SageMaker

### DIFF
--- a/app/grandchallenge/core/tasks.py
+++ b/app/grandchallenge/core/tasks.py
@@ -118,7 +118,7 @@ def _get_metrics():
 
     metric_data.append(
         {
-            "MetricName": "EndpointsSagemaker",
+            "MetricName": "EndpointsOnSagemaker",
             "Dimensions": [{"Name": "Model", "Value": Endpoint.__name__}],
             "Value": _get_endpoints_count_from_sagemaker(),
             "Unit": "Count",

--- a/app/grandchallenge/core/tasks.py
+++ b/app/grandchallenge/core/tasks.py
@@ -116,7 +116,31 @@ def _get_metrics():
             }
         )
 
+    metric_data.append(
+        {
+            "MetricName": "EndpointsSagemaker",
+            "Dimensions": [{"Name": "Model", "Value": Endpoint.__name__}],
+            "Value": _get_endpoints_count_from_sagemaker(),
+            "Unit": "Count",
+        }
+    )
+
     return metric_data
+
+
+def _get_endpoints_count_from_sagemaker():
+    count = 0
+    sagemaker_client = boto3.client(
+        "sagemaker",
+        region_name=settings.COMPONENTS_AMAZON_ECR_REGION,
+    )
+
+    paginator = sagemaker_client.get_paginator("list_endpoints")
+
+    for page in paginator.paginate():
+        count += len(page["Endpoints"])
+
+    return count
 
 
 def schedule_process_picture(

--- a/app/tests/core_tests/test_tasks.py
+++ b/app/tests/core_tests/test_tasks.py
@@ -12,7 +12,7 @@ from tests.factories import SessionFactory, UploadSessionFactory
 
 
 @pytest.mark.django_db
-def test_get_metrics():
+def test_get_metrics(mocker):
     ai = AlgorithmImageFactory(
         import_status=AlgorithmImage.ImportStatusChoices.COMPLETED
     )
@@ -36,6 +36,9 @@ def test_get_metrics():
     s = UploadSessionFactory()
     s.status = s.SUCCESS
     s.save()
+
+    client = mocker.MagicMock()
+    mocker.patch("grandchallenge.core.tasks.boto3.client", return_value=client)
 
     # Note, this is the format expected by CloudWatch,
     # consult the API when changing this
@@ -367,4 +370,10 @@ def test_get_metrics():
         },
         {"MetricName": "OldestActiveSession", "Value": 0, "Unit": "Seconds"},
         {"MetricName": "OldestActiveEndpoint", "Value": 0, "Unit": "Seconds"},
+        {
+            "MetricName": "EndpointsSagemaker",
+            "Dimensions": [{"Name": "Model", "Value": "Endpoint"}],
+            "Value": 0,
+            "Unit": "Count",
+        },
     ]

--- a/app/tests/core_tests/test_tasks.py
+++ b/app/tests/core_tests/test_tasks.py
@@ -371,7 +371,7 @@ def test_get_metrics(mocker):
         {"MetricName": "OldestActiveSession", "Value": 0, "Unit": "Seconds"},
         {"MetricName": "OldestActiveEndpoint", "Value": 0, "Unit": "Seconds"},
         {
-            "MetricName": "EndpointsSagemaker",
+            "MetricName": "EndpointsOnSagemaker",
             "Dimensions": [{"Name": "Model", "Value": "Endpoint"}],
             "Value": 0,
             "Unit": "Count",


### PR DESCRIPTION
Push count of listed endpoints on SageMaker to cloudwatch for use in an alarm.

Related to https://github.com/DIAGNijmegen/rse-grand-challenge/issues/4880