### PR TITLE
Skip intermediate `parse_job_outputs`

### DIFF
--- a/app/grandchallenge/components/backends/amazon_sagemaker_endpoint.py
+++ b/app/grandchallenge/components/backends/amazon_sagemaker_endpoint.py
@@ -392,5 +392,5 @@ class EndpointOrchestrator:
         task_logger.error("Endpoint invocation failed")
         raise ComponentException(SystemErrorMessages.UNEXPECTED_ERROR)
 
-    def get_outputs(self, *, output_interfaces):
-        return self._executor.get_outputs(output_interfaces=output_interfaces)
+    def create_value_for_output(self, *, interface):
+        return self._executor.create_value_for_output(interface=interface)

--- a/app/grandchallenge/components/backends/base.py
+++ b/app/grandchallenge/components/backends/base.py
@@ -392,21 +392,13 @@ class Executor(ABC):
     @abstractmethod
     def handle_event(self, *, event): ...
 
-    def get_outputs(self, *, output_interfaces):
-        """Create ComponentInterfaceValues from the output interfaces"""
-        outputs = []
-
-        for interface in output_interfaces:
-            if interface.is_image_kind:
-                res = self._create_images_result(interface=interface)
-            elif interface.is_json_kind:
-                res = self._create_json_result(interface=interface)
-            else:
-                res = self._create_file_result(interface=interface)
-
-            outputs.append(res)
-
-        return outputs
+    def create_value_for_output(self, *, interface):
+        if interface.is_image_kind:
+            return self._create_images_result(interface=interface)
+        elif interface.is_json_kind:
+            return self._create_json_result(interface=interface)
+        else:
+            return self._create_file_result(interface=interface)
 
     def deprovision(self):
         self._delete_objects(

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1117,25 +1117,33 @@ def parse_singular_job_output(
     except ComponentInterface.DoesNotExist:
         job.update_status(
             status=job.FAILURE,
-            error_message=f"Output interface with pk={interface_pk} does not exist",
+            error_message=SystemErrorMessages.UNEXPECTED_ERROR,
+        )
+        task_logger.error(
+            "Could not parse outputs - interface does not exist", exc_info=True
         )
         return
 
     if job.outputs.filter(interface=interface_pk).exists():
-        task_logger.info(
-            f"Output interface with pk={interface_pk} already parsed for job with pk={job_pk}"
+        job.update_status(
+            status=job.FAILURE,
+            error_message=SystemErrorMessages.UNEXPECTED_ERROR,
         )
-        return  # Nothing to do here
+        task_logger.error(
+            "Could not parse outputs - interface already parsed", exc_info=True
+        )
+        return
 
     executor = job.get_executor(backend=backend)
 
     try:
-        outputs = executor.get_outputs(output_interfaces=[interface])
-    except ComponentException as e:
+        val = executor.create_value_for_output(interface=interface)
+        job.outputs.add(val)
+    except ComponentException as error:
         job.update_status(
             status=job.FAILURE,
-            error_message=str(e),
-            detailed_error_message=e.message_details,
+            error_message=str(error),
+            detailed_error_message=error.message_details,
         )
         return
     except Exception:
@@ -1145,8 +1153,6 @@ def parse_singular_job_output(
         )
         task_logger.error("Could not parse outputs", exc_info=True)
         return
-
-    job.outputs.add(*outputs)
 
     if remaining_interface_pks:
         parse_singular_job_output.execute_on_commit(
@@ -2067,9 +2073,9 @@ def parse_endpoint_invocation_outputs(
     orchestrator = invocation.orchestrator
 
     try:
-        outputs = orchestrator.get_outputs(
-            output_interfaces=invocation.algorithm_interface.outputs.all()
-        )
+        for interface in invocation.algorithm_interface.outputs.all():
+            val = orchestrator.create_value_for_output(interface=interface)
+            invocation.outputs.add(val)
     except ComponentException as error:
         invocation.update_status(
             status=invocation.StatusChoices.FAILURE,
@@ -2083,5 +2089,4 @@ def parse_endpoint_invocation_outputs(
         )
         task_logger.error("Could not parse invocation outputs", exc_info=True)
     else:
-        invocation.outputs.add(*outputs)
         invocation.update_status(status=invocation.StatusChoices.SUCCESS)

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1038,10 +1038,16 @@ def handle_event(*, event: dict, backend: str):
         task_logger.error(str(error), exc_info=True)
     else:
         job.update_status(
-            status=job.EXECUTED,
+            status=job.PARSING,
             **get_update_status_kwargs(executor=executor),
         )
-        parse_job_outputs.execute_on_commit(**job.task_kwargs)
+        interface_pks = list(
+            job.output_interfaces.order_by("pk").values_list("pk", flat=True)
+        )
+        parse_singular_job_output.execute_on_commit(
+            **job.task_kwargs,
+            interface_pks=interface_pks,
+        )
 
 
 @lambda_task(retry_on=(LockNotAcquiredException,))
@@ -1091,10 +1097,13 @@ def parse_singular_job_output(
     backend: str,
     interface_pks: list[int],
 ):
+    from grandchallenge.components.models import ComponentInterface
+
     if not interface_pks:
         raise RuntimeError("No output interfaces to parse")
 
     model = apps.get_model(app_label=job_app_label, model_name=job_model_name)
+
     with check_lock_acquired():
         job = model.objects.select_for_update(nowait=True).get(pk=job_pk)
 
@@ -1103,10 +1112,9 @@ def parse_singular_job_output(
 
     interface_pk, *remaining_interface_pks = interface_pks
 
-    interface_model = job.output_interfaces.model
     try:
-        interface = interface_model.objects.get(pk=interface_pk)
-    except interface_model.DoesNotExist:
+        interface = ComponentInterface.objects.get(pk=interface_pk)
+    except ComponentInterface.DoesNotExist:
         job.update_status(
             status=job.FAILURE,
             error_message=f"Output interface with pk={interface_pk} does not exist",

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1041,12 +1041,8 @@ def handle_event(*, event: dict, backend: str):
             status=job.PARSING,
             **get_update_status_kwargs(executor=executor),
         )
-        interface_pks = list(
-            job.output_interfaces.order_by("pk").values_list("pk", flat=True)
-        )
         parse_singular_job_output.execute_on_commit(
             **job.task_kwargs,
-            interface_pks=interface_pks,
         )
 
 
@@ -1070,19 +1066,7 @@ def parse_job_outputs(
         raise RuntimeError("Job already has outputs")
 
     job.update_status(status=job.PARSING)
-
-    interface_pks = list(
-        job.output_interfaces.order_by("pk").values_list("pk", flat=True)
-    )
-
-    # Kick off the parsing chain
-    parse_singular_job_output.execute_on_commit(
-        job_pk=job_pk,
-        job_app_label=job_app_label,
-        job_model_name=job_model_name,
-        backend=backend,
-        interface_pks=interface_pks,
-    )
+    parse_singular_job_output.execute_on_commit(**job.task_kwargs)
 
 
 @lambda_task(
@@ -1095,13 +1079,8 @@ def parse_singular_job_output(
     job_app_label: str,
     job_model_name: str,
     backend: str,
-    interface_pks: list[int],
+    interface_pks: list[int] = None,  # TODO remove
 ):
-    from grandchallenge.components.models import ComponentInterface
-
-    if not interface_pks:
-        raise RuntimeError("No output interfaces to parse")
-
     model = apps.get_model(app_label=job_app_label, model_name=job_model_name)
 
     with check_lock_acquired():
@@ -1110,60 +1089,44 @@ def parse_singular_job_output(
     if job.status != job.PARSING:
         raise RuntimeError("Job is not in parsing state")
 
-    interface_pk, *remaining_interface_pks = interface_pks
+    unparsed_interfaces = {*job.output_interfaces.all()}
+    parsed_interfaces = {output.interface for output in job.outputs.all()}
 
-    try:
-        interface = ComponentInterface.objects.get(pk=interface_pk)
-    except ComponentInterface.DoesNotExist:
-        job.update_status(
-            status=job.FAILURE,
-            error_message=SystemErrorMessages.UNEXPECTED_ERROR,
-        )
-        task_logger.error(
-            "Could not parse outputs - interface does not exist", exc_info=True
-        )
-        return
+    remaining_interfaces = unparsed_interfaces - parsed_interfaces
 
-    if job.outputs.filter(interface=interface_pk).exists():
-        job.update_status(
-            status=job.FAILURE,
-            error_message=SystemErrorMessages.UNEXPECTED_ERROR,
-        )
-        task_logger.error(
-            "Could not parse outputs - interface already parsed", exc_info=True
-        )
-        return
+    if remaining_interfaces:
+        parsed_interface = remaining_interfaces.pop()
+        executor = job.get_executor(backend=backend)
 
-    executor = job.get_executor(backend=backend)
+        try:
+            val = executor.create_value_for_output(interface=parsed_interface)
+            job.outputs.add(val)
+        except ComponentException as error:
+            job.update_status(
+                status=job.FAILURE,
+                error_message=str(error),
+                detailed_error_message=error.message_details,
+            )
+            return
+        except Exception:
+            job.update_status(
+                status=job.FAILURE,
+                error_message=SystemErrorMessages.UNEXPECTED_ERROR,
+            )
+            task_logger.error("Could not parse outputs", exc_info=True)
+            return
+    else:
+        parsed_interface = None
 
-    try:
-        val = executor.create_value_for_output(interface=interface)
-        job.outputs.add(val)
-    except ComponentException as error:
-        job.update_status(
-            status=job.FAILURE,
-            error_message=str(error),
-            detailed_error_message=error.message_details,
-        )
-        return
-    except Exception:
-        job.update_status(
-            status=job.FAILURE,
-            error_message=SystemErrorMessages.UNEXPECTED_ERROR,
-        )
-        task_logger.error("Could not parse outputs", exc_info=True)
-        return
-
-    if remaining_interface_pks:
-        parse_singular_job_output.execute_on_commit(
-            job_pk=job_pk,
-            job_app_label=job_app_label,
-            job_model_name=job_model_name,
-            backend=backend,
-            interface_pks=remaining_interface_pks,
-        )
+    if remaining_interfaces:
+        parse_singular_job_output.execute_on_commit(**job.task_kwargs)
     else:
         job.update_status(status=job.SUCCESS)
+
+    if parsed_interface:
+        return parsed_interface.slug
+    else:
+        return
 
 
 @lambda_task(retry_on=(RetryStep,))

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -1995,7 +1995,7 @@ def test_parse_endpoint_invocation_outputs_failure(mocker):
     )
     mocker.patch.object(
         EndpointOrchestrator,
-        "get_outputs",
+        "create_value_for_output",
         side_effect=Exception,
     )
 
@@ -2016,9 +2016,9 @@ def test_parse_endpoint_invocation_outputs_failure(mocker):
 @pytest.mark.django_db
 def test_parse_endpoint_invocation_outputs_wrong_state_raises(mocker, status):
     invocation = InvocationFactory(status=status)
-    mock_get_outputs = mocker.patch.object(
+    mock_create_value_for_output = mocker.patch.object(
         EndpointOrchestrator,
-        "get_outputs",
+        "create_value_for_output",
     )
 
     with pytest.raises(
@@ -2027,7 +2027,7 @@ def test_parse_endpoint_invocation_outputs_wrong_state_raises(mocker, status):
         parse_endpoint_invocation_outputs(**invocation.task_kwargs, event={})
     invocation.refresh_from_db()
 
-    mock_get_outputs.assert_not_called()
+    mock_create_value_for_output.assert_not_called()
     assert invocation.status == status
     assert invocation.outputs.count() == 0
 
@@ -2035,15 +2035,15 @@ def test_parse_endpoint_invocation_outputs_wrong_state_raises(mocker, status):
 @pytest.mark.django_db
 def test_parse_endpoint_invocation_outputs_cancelled_skipped(mocker):
     invocation = InvocationFactory(status=InvocationStatusChoices.CANCELLED)
-    mock_get_outputs = mocker.patch.object(
+    mock_create_value_for_output = mocker.patch.object(
         EndpointOrchestrator,
-        "get_outputs",
+        "create_value_for_output",
     )
 
     parse_endpoint_invocation_outputs(**invocation.task_kwargs, event={})
     invocation.refresh_from_db()
 
-    mock_get_outputs.assert_not_called()
+    mock_create_value_for_output.assert_not_called()
     assert invocation.status == InvocationStatusChoices.CANCELLED
     assert invocation.outputs.count() == 0
 
@@ -2080,6 +2080,23 @@ def test_invoke_endpoint_skips_keep_alive_for_reader_study_endpoint(mocker):
     spy_keep_alive.assert_not_called()
 
 
+class FixedOutputExecutor:
+    def create_value_for_output(self, *, interface):
+        return ComponentInterfaceValueFactory(interface=interface, value=42)
+
+
+class RaisedExceptionExecutor:
+    def create_value_for_output(self, *, interface):
+        raise Exception("Test exception that should not be passed to user")
+
+
+class RaisedComponentExceptionExecutor:
+    def create_value_for_output(self, *, interface):
+        raise ComponentException(
+            "Test exception that should be passed to user"
+        )
+
+
 @pytest.mark.django_db
 def test_parse_job_outputs(
     settings, django_capture_on_commit_callbacks, mocker
@@ -2109,16 +2126,9 @@ def test_parse_job_outputs(
         time_limit=60,
     )
 
-    class TestExecutor:
-        def get_outputs(self, output_interfaces):
-            return [
-                ComponentInterfaceValueFactory(interface=interface, value=42)
-                for interface in output_interfaces
-            ]
-
     mocker.patch(
         "grandchallenge.algorithms.models.Job.get_executor",
-        return_value=TestExecutor(),
+        return_value=FixedOutputExecutor(),
     )
 
     with django_capture_on_commit_callbacks(execute=True):
@@ -2159,16 +2169,9 @@ def test_parse_job_outputs_idempotent(
         time_limit=60,
     )
 
-    class TestExecutor:
-        def get_outputs(self, output_interfaces):
-            return [
-                ComponentInterfaceValueFactory(interface=interface, value=42)
-                for interface in output_interfaces
-            ]
-
     mocker.patch(
         "grandchallenge.algorithms.models.Job.get_executor",
-        return_value=TestExecutor(),
+        return_value=FixedOutputExecutor(),
     )
 
     ComponentInterfaceValue.objects.all().delete()
@@ -2254,16 +2257,9 @@ def test_parse_singular_job_output(
         time_limit=60,
     )
 
-    class TestExecutor:
-        def get_outputs(self, output_interfaces):
-            return [
-                ComponentInterfaceValueFactory(interface=interface, value=42)
-                for interface in output_interfaces
-            ]
-
     mocker.patch(
         "grandchallenge.algorithms.models.Job.get_executor",
-        return_value=TestExecutor(),
+        return_value=FixedOutputExecutor(),
     )
 
     with django_capture_on_commit_callbacks(execute=True):
@@ -2307,16 +2303,9 @@ def test_parse_singular_job_output_idempotent(
         time_limit=60,
     )
 
-    class TestExecutor:
-        def get_outputs(self, output_interfaces):
-            return [
-                ComponentInterfaceValueFactory(interface=interface, value=42)
-                for interface in output_interfaces
-            ]
-
     mocker.patch(
         "grandchallenge.algorithms.models.Job.get_executor",
-        return_value=TestExecutor(),
+        return_value=FixedOutputExecutor(),
     )
 
     ComponentInterfaceValue.objects.all().delete()
@@ -2393,7 +2382,7 @@ def test_parse_singular_job_output_nonexistent_interface(
 
     job.refresh_from_db()
     assert job.status == Job.FAILURE
-    assert job.error_message == "Output interface with pk=42 does not exist"
+    assert job.error_message == "An unexpected error occurred"
 
 
 @pytest.mark.django_db
@@ -2425,13 +2414,9 @@ def test_parse_singular_job_output_executor_exception(
         time_limit=60,
     )
 
-    class TestExecutor:
-        def get_outputs(self, *_, **__):
-            raise Exception("Test execution that should not be passed to user")
-
     mocker.patch(
         "grandchallenge.algorithms.models.Job.get_executor",
-        return_value=TestExecutor(),
+        return_value=RaisedExceptionExecutor(),
     )
 
     with django_capture_on_commit_callbacks(execute=True):
@@ -2473,15 +2458,9 @@ def test_parse_singular_job_output_executor_component_exception(
         time_limit=60,
     )
 
-    class TestExecutor:
-        def get_outputs(self, *_, **__):
-            raise ComponentException(
-                "Test execution that should be passed to user"
-            )
-
     mocker.patch(
         "grandchallenge.algorithms.models.Job.get_executor",
-        return_value=TestExecutor(),
+        return_value=RaisedComponentExceptionExecutor(),
     )
 
     with django_capture_on_commit_callbacks(execute=True):
@@ -2491,4 +2470,4 @@ def test_parse_singular_job_output_executor_component_exception(
 
     job.refresh_from_db()
     assert job.status == Job.FAILURE
-    assert job.error_message == "Test execution that should be passed to user"
+    assert job.error_message == "Test exception that should be passed to user"

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -2263,10 +2263,7 @@ def test_parse_singular_job_output(
     )
 
     with django_capture_on_commit_callbacks(execute=True):
-        parse_singular_job_output(
-            **job.task_kwargs,
-            interface_pks=[int_socket_1.pk, int_socket_2.pk, int_socket_3.pk],
-        )
+        parse_singular_job_output(**job.task_kwargs)
 
     job.refresh_from_db()
     assert job.error_message == ""
@@ -2312,23 +2309,13 @@ def test_parse_singular_job_output_idempotent(
     assert ComponentInterfaceValue.objects.count() == 0
 
     with django_capture_on_commit_callbacks(execute=True):
-        parse_singular_job_output(
-            **job.task_kwargs,
-            interface_pks=[int_socket_1.pk, int_socket_2.pk, int_socket_3.pk],
-        )
+        parse_singular_job_output(**job.task_kwargs)
 
     assert ComponentInterfaceValue.objects.count() == 3
 
     with pytest.raises(RuntimeError, match="Job is not in parsing state"):
         with django_capture_on_commit_callbacks(execute=True):
-            parse_singular_job_output(
-                **job.task_kwargs,
-                interface_pks=[
-                    int_socket_1.pk,
-                    int_socket_2.pk,
-                    int_socket_3.pk,
-                ],
-            )
+            parse_singular_job_output(**job.task_kwargs)
 
     assert (
         ComponentInterfaceValue.objects.count() == 3
@@ -2358,7 +2345,7 @@ def test_parse_singular_job_output_incorrect_state(
 
     with pytest.raises(RuntimeError, match="Job is not in parsing state"):
         with django_capture_on_commit_callbacks(execute=True):
-            parse_singular_job_output(**job.task_kwargs, interface_pks=[42])
+            parse_singular_job_output(**job.task_kwargs)
 
 
 @pytest.mark.django_db
@@ -2378,11 +2365,11 @@ def test_parse_singular_job_output_nonexistent_interface(
     )
 
     with django_capture_on_commit_callbacks(execute=True):
-        parse_singular_job_output(**job.task_kwargs, interface_pks=[42])
+        parse_singular_job_output(**job.task_kwargs)
 
     job.refresh_from_db()
     assert job.status == Job.FAILURE
-    assert job.error_message == "An unexpected error occurred"
+    assert job.error_message == "Output file 'interface-1' was not produced"
 
 
 @pytest.mark.django_db
@@ -2420,9 +2407,7 @@ def test_parse_singular_job_output_executor_exception(
     )
 
     with django_capture_on_commit_callbacks(execute=True):
-        parse_singular_job_output(
-            **job.task_kwargs, interface_pks=[int_socket_1.pk]
-        )
+        parse_singular_job_output(**job.task_kwargs)
 
     job.refresh_from_db()
     assert job.status == Job.FAILURE
@@ -2464,9 +2449,7 @@ def test_parse_singular_job_output_executor_component_exception(
     )
 
     with django_capture_on_commit_callbacks(execute=True):
-        parse_singular_job_output(
-            **job.task_kwargs, interface_pks=[int_socket_1.pk]
-        )
+        parse_singular_job_output(**job.task_kwargs)
 
     job.refresh_from_db()
     assert job.status == Job.FAILURE

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -2369,7 +2369,10 @@ def test_parse_singular_job_output_nonexistent_interface(
 
     job.refresh_from_db()
     assert job.status == Job.FAILURE
-    assert job.error_message == "Output file 'interface-1' was not produced"
+    assert (
+        job.error_message
+        == f"Output file '{job.output_interfaces.get().relative_path}' was not produced"
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This PR removes calling an intermediate lambda task. `parse_job_outputs` can then be removed from the codebase once deployed.

Also from looking at the code I saw that internal errors were being attached to the job objects which are then visible to the user, so these were changed to `SystemErrorMessages.UNEXPECTED_ERROR`. I also updated the internal API so that the caller is now responsible for iterating over the outputs, rather than sending a list with one entry.

See #4918