### PR TITLE
Parse outputs in parallel

### DIFF
--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1041,9 +1041,136 @@ def handle_event(*, event: dict, backend: str):
             status=job.PARSING,
             **get_update_status_kwargs(executor=executor),
         )
-        parse_singular_job_output.execute_on_commit(
+        for interface in job.output_interfaces.all():
+            parse_job_output.execute_on_commit(
+                **job.task_kwargs,
+                interface_slug=interface.slug,
+            )
+
+
+@lambda_task(
+    queue=LambdaTaskQueueChoices.MEM8G,
+)
+def parse_job_output(
+    *,
+    job_pk: str | UUID,
+    job_app_label: str,
+    job_model_name: str,
+    backend: str,
+    interface_slug: str,
+):
+    from grandchallenge.components.models import ComponentInterface
+
+    model = apps.get_model(app_label=job_app_label, model_name=job_model_name)
+
+    # This task should not lock the instance as it runs in parallel
+    job = model.objects.get(pk=job_pk)
+
+    if job.status != job.PARSING:
+        return {"status": "Job is not set for parsing"}
+
+    try:
+        interface = ComponentInterface.objects.get(slug=interface_slug)
+    except ComponentInterface.DoesNotExist:
+        mark_job_as_failed.execute_on_commit(
             **job.task_kwargs,
+            error_message=SystemErrorMessages.UNEXPECTED_ERROR,
         )
+        task_logger.error(
+            "Could not parse output: missing interface", exc_info=True
+        )
+        return {"status": f"Unexpected error: {interface_slug} does not exist"}
+    except ComponentInterface.MultipleObjectsReturned:
+        mark_job_as_failed.execute_on_commit(
+            **job.task_kwargs,
+            error_message=SystemErrorMessages.UNEXPECTED_ERROR,
+        )
+        task_logger.error(
+            "Could not parse output: interface slug not unique", exc_info=True
+        )
+        return {
+            "status": f"Unexpected error: Multiple interfaces with slug {interface_slug} exist"
+        }
+
+    if job.outputs.filter(interface=interface).exists():
+        task_logger.error("Interface already exists for job")
+        return {"status": f"{interface_slug} already exists for job"}
+
+    executor = job.get_executor(backend=backend)
+
+    try:
+        val = executor.create_value_for_output(interface=interface)
+        job.outputs.add(val)
+    except ComponentException as error:
+        mark_job_as_failed.execute_on_commit(
+            **job.task_kwargs,
+            error_message=str(error),
+            detailed_error_message=error.message_details,
+        )
+        return {"status": f"Handled exception: {error}"}
+    except Exception as error:
+        mark_job_as_failed.execute_on_commit(
+            **job.task_kwargs,
+            error_message=SystemErrorMessages.UNEXPECTED_ERROR,
+        )
+        task_logger.error(
+            "Could not parse output: unexpected error", exc_info=True
+        )
+        return {"status": f"Unexpected error: {error}"}
+
+    check_job_parsing_complete.execute_on_commit(**job.task_kwargs)
+
+    return {"status": f"Value created for {interface_slug}"}
+
+
+@lambda_task(retry_on=(LockNotAcquiredException,))
+def mark_job_as_failed(
+    *,
+    job_pk: str | UUID,
+    job_app_label: str,
+    job_model_name: str,
+    backend: str,  # Keep to be able to use **job.task_kwargs
+    error_message: str,
+    detailed_error_message: str | None = None,
+):
+    model = apps.get_model(app_label=job_app_label, model_name=job_model_name)
+
+    with check_lock_acquired():
+        job = model.objects.select_for_update(nowait=True).get(pk=job_pk)
+
+    job.update_status(
+        status=job.FAILURE,
+        error_message=error_message,
+        detailed_error_message=detailed_error_message,
+    )
+
+
+@lambda_task(retry_on=(LockNotAcquiredException,))
+def check_job_parsing_complete(
+    *,
+    job_pk: str | UUID,
+    job_app_label: str,
+    job_model_name: str,
+    backend: str,  # Keep to be able to use **job.task_kwargs
+):
+    model = apps.get_model(app_label=job_app_label, model_name=job_model_name)
+
+    with check_lock_acquired():
+        job = model.objects.select_for_update(nowait=True).get(pk=job_pk)
+
+    if job.status != job.PARSING:
+        return {"status": "Job is not set for parsing"}
+
+    expected_interfaces = {*job.output_interfaces.all()}
+    parsed_interfaces = {output.interface for output in job.outputs.all()}
+
+    remaining_interfaces = expected_interfaces - parsed_interfaces
+
+    if remaining_interfaces:
+        return {"status": f"{len(remaining_interfaces)} remaining interfaces"}
+    else:
+        job.update_status(status=job.SUCCESS)
+        return {"status": "Parsing complete"}
 
 
 @lambda_task(

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1063,7 +1063,9 @@ def parse_job_output(
 
     model = apps.get_model(app_label=job_app_label, model_name=job_model_name)
 
-    # This task should not lock the instance as it runs in parallel
+    # This task should not lock the instance as it runs in parallel,
+    # therefore the job must remain unmodified in this task. Use
+    # separate tasks for job updates.
     job = model.objects.get(pk=job_pk)
 
     if job.status != job.PARSING:

--- a/app/grandchallenge/components/tasks.py
+++ b/app/grandchallenge/components/tasks.py
@@ -1180,6 +1180,7 @@ def check_job_parsing_complete(
     retry_on=(LockNotAcquiredException,),
 )
 def parse_singular_job_output(
+    # TODO 4918 remove this task once deployed and queues cleared
     *,
     job_pk: str | UUID,
     job_app_label: str,

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -14,6 +14,7 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.files.base import ContentFile
 from django.utils.timezone import now
 from lambda_tasks.decorators import lambda_task
+from lambda_tasks.models import TaskRecord
 from requests import put
 
 from grandchallenge.algorithms.models import (
@@ -56,7 +57,7 @@ from grandchallenge.components.tasks import (
     handle_endpoint_status_event,
     invoke_endpoint,
     parse_endpoint_invocation_outputs,
-    parse_singular_job_output,
+    parse_job_output,
     preload_interactive_algorithms,
     remove_container_image_from_registry,
     remove_inactive_container_images,
@@ -2097,7 +2098,7 @@ class RaisedComponentExceptionExecutor:
 
 
 @pytest.mark.django_db
-def test_parse_singular_job_output(
+def test_parse_job_output(
     settings, django_capture_on_commit_callbacks, mocker
 ):
     settings.LAMBDA_TASKS_EAGER = True
@@ -2131,7 +2132,11 @@ def test_parse_singular_job_output(
     )
 
     with django_capture_on_commit_callbacks(execute=True):
-        parse_singular_job_output(**job.task_kwargs)
+        for interface in job.output_interfaces.all():
+            parse_job_output.execute_on_commit(
+                **job.task_kwargs,
+                interface_slug=interface.slug,
+            )
 
     job.refresh_from_db()
     assert job.error_message == ""
@@ -2140,7 +2145,7 @@ def test_parse_singular_job_output(
 
 
 @pytest.mark.django_db
-def test_parse_singular_job_output_idempotent(
+def test_parse_job_output_idempotent(
     settings, django_capture_on_commit_callbacks, mocker
 ):
     settings.LAMBDA_TASKS_EAGER = True
@@ -2177,13 +2182,30 @@ def test_parse_singular_job_output_idempotent(
     assert ComponentInterfaceValue.objects.count() == 0
 
     with django_capture_on_commit_callbacks(execute=True):
-        parse_singular_job_output(**job.task_kwargs)
+        for interface in job.output_interfaces.all():
+            parse_job_output.execute_on_commit(
+                **job.task_kwargs,
+                interface_slug=interface.slug,
+            )
+
+    for interface in job.output_interfaces.all():
+        assert TaskRecord.objects.filter(
+            kwargs__interface_slug=interface.slug
+        ).first().result == {"status": f"Value created for {interface.slug}"}
 
     assert ComponentInterfaceValue.objects.count() == 3
 
-    with pytest.raises(RuntimeError, match="Job is not in parsing state"):
-        with django_capture_on_commit_callbacks(execute=True):
-            parse_singular_job_output(**job.task_kwargs)
+    with django_capture_on_commit_callbacks(execute=True):
+        for interface in job.output_interfaces.all():
+            parse_job_output.execute_on_commit(
+                **job.task_kwargs,
+                interface_slug=interface.slug,
+            )
+
+    for interface in job.output_interfaces.all():
+        assert TaskRecord.objects.filter(
+            kwargs__interface_slug=interface.slug
+        ).first().result == {"status": "Job is not set for parsing"}
 
     assert (
         ComponentInterfaceValue.objects.count() == 3
@@ -2196,7 +2218,7 @@ def test_parse_singular_job_output_idempotent(
 
 
 @pytest.mark.django_db
-def test_parse_singular_job_output_incorrect_state(
+def test_parse_job_output_incorrect_state(
     settings, django_capture_on_commit_callbacks
 ):
     settings.LAMBDA_TASKS_EAGER = True
@@ -2211,13 +2233,21 @@ def test_parse_singular_job_output_incorrect_state(
         time_limit=60,
     )
 
-    with pytest.raises(RuntimeError, match="Job is not in parsing state"):
-        with django_capture_on_commit_callbacks(execute=True):
-            parse_singular_job_output(**job.task_kwargs)
+    with django_capture_on_commit_callbacks(execute=True):
+        for interface in job.output_interfaces.all():
+            parse_job_output.execute_on_commit(
+                **job.task_kwargs,
+                interface_slug=interface.slug,
+            )
+
+    for interface in job.output_interfaces.all():
+        assert TaskRecord.objects.get(
+            kwargs__interface_slug=interface.slug
+        ).result == {"status": "Job is not set for parsing"}
 
 
 @pytest.mark.django_db
-def test_parse_singular_job_output_nonexistent_interface(
+def test_parse_job_output_nonexistent_interface(
     settings, django_capture_on_commit_callbacks
 ):
     settings.LAMBDA_TASKS_EAGER = True
@@ -2233,7 +2263,11 @@ def test_parse_singular_job_output_nonexistent_interface(
     )
 
     with django_capture_on_commit_callbacks(execute=True):
-        parse_singular_job_output(**job.task_kwargs)
+        for interface in job.output_interfaces.all():
+            parse_job_output.execute_on_commit(
+                **job.task_kwargs,
+                interface_slug=interface.slug,
+            )
 
     job.refresh_from_db()
     assert job.status == Job.FAILURE
@@ -2244,7 +2278,7 @@ def test_parse_singular_job_output_nonexistent_interface(
 
 
 @pytest.mark.django_db
-def test_parse_singular_job_output_executor_exception(
+def test_parse_job_output_executor_exception(
     settings, django_capture_on_commit_callbacks, mocker
 ):
     settings.LAMBDA_TASKS_EAGER = True
@@ -2278,7 +2312,11 @@ def test_parse_singular_job_output_executor_exception(
     )
 
     with django_capture_on_commit_callbacks(execute=True):
-        parse_singular_job_output(**job.task_kwargs)
+        for interface in job.output_interfaces.all():
+            parse_job_output.execute_on_commit(
+                **job.task_kwargs,
+                interface_slug=interface.slug,
+            )
 
     job.refresh_from_db()
     assert job.status == Job.FAILURE
@@ -2286,7 +2324,7 @@ def test_parse_singular_job_output_executor_exception(
 
 
 @pytest.mark.django_db
-def test_parse_singular_job_output_executor_component_exception(
+def test_parse_job_output_executor_component_exception(
     settings, django_capture_on_commit_callbacks, mocker
 ):
     settings.LAMBDA_TASKS_EAGER = True
@@ -2320,7 +2358,11 @@ def test_parse_singular_job_output_executor_component_exception(
     )
 
     with django_capture_on_commit_callbacks(execute=True):
-        parse_singular_job_output(**job.task_kwargs)
+        for interface in job.output_interfaces.all():
+            parse_job_output.execute_on_commit(
+                **job.task_kwargs,
+                interface_slug=interface.slug,
+            )
 
     job.refresh_from_db()
     assert job.status == Job.FAILURE

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -2271,10 +2271,10 @@ def test_parse_job_output_nonexistent_interface(
 
     job.refresh_from_db()
     assert job.status == Job.FAILURE
-    assert (
-        job.error_message
-        == f"Output file '{job.output_interfaces.get().relative_path}' was not produced"
-    )
+    assert job.error_message in {
+        f"Output file '{job.output_interfaces.get().relative_path}' was not produced",
+        f"Output directory '{job.output_interfaces.get().relative_path}' is empty",
+    }
 
 
 @pytest.mark.django_db

--- a/app/tests/components_tests/test_tasks.py
+++ b/app/tests/components_tests/test_tasks.py
@@ -2218,6 +2218,77 @@ def test_parse_job_output_idempotent(
 
 
 @pytest.mark.django_db
+def test_parse_job_output_idempotent_still_processing(
+    settings, django_capture_on_commit_callbacks, mocker
+):
+    settings.LAMBDA_TASKS_EAGER = True
+
+    ai = AlgorithmImageFactory(
+        is_manifest_valid=True, is_in_registry=True, is_desired_version=True
+    )
+
+    int_socket_0, int_socket_1, int_socket_2 = (
+        ComponentInterfaceFactory.create_batch(
+            3, kind=InterfaceKindChoices.INTEGER
+        )
+    )
+
+    interface = AlgorithmInterfaceFactory(
+        inputs=[int_socket_0],
+        outputs=[int_socket_1, int_socket_2],
+    )
+    ai.algorithm.interfaces.add(interface)
+
+    job = AlgorithmJobFactory(
+        algorithm_image=ai,
+        algorithm_interface=interface,
+        status=Job.PARSING,
+        time_limit=60,
+    )
+
+    mocker.patch(
+        "grandchallenge.algorithms.models.Job.get_executor",
+        return_value=FixedOutputExecutor(),
+    )
+
+    ComponentInterfaceValue.objects.all().delete()
+    assert ComponentInterfaceValue.objects.count() == 0
+
+    interface = job.output_interfaces.first()
+
+    with django_capture_on_commit_callbacks(execute=True):
+        parse_job_output.execute_on_commit(
+            **job.task_kwargs,
+            interface_slug=interface.slug,
+        )
+
+    assert TaskRecord.objects.filter(
+        kwargs__interface_slug=interface.slug
+    ).first().result == {"status": f"Value created for {interface.slug}"}
+
+    assert ComponentInterfaceValue.objects.count() == 1
+
+    with django_capture_on_commit_callbacks(execute=True):
+        parse_job_output.execute_on_commit(
+            **job.task_kwargs,
+            interface_slug=interface.slug,
+        )
+
+    assert TaskRecord.objects.filter(
+        kwargs__interface_slug=interface.slug
+    ).first().result == {"status": f"{interface.slug} already exists for job"}
+
+    assert (
+        ComponentInterfaceValue.objects.count() == 1
+    )  # Still only created 1 outputs
+
+    job.refresh_from_db()
+    assert job.error_message == ""
+    assert job.status == Job.PARSING
+    assert job.outputs.count() == 1
+
+
+@pytest.mark.django_db
 def test_parse_job_output_incorrect_state(
     settings, django_capture_on_commit_callbacks
 ):


### PR DESCRIPTION
Uses the same pattern as input validation for output parsing.

See #4918