### PR TITLE
Fix phase admin slowness

### DIFF
--- a/app/grandchallenge/evaluation/admin.py
+++ b/app/grandchallenge/evaluation/admin.py
@@ -56,6 +56,7 @@ class PhaseAdminForm(ModelForm):
 
 class EvaluationSocketInline(admin.TabularInline):
     extra = 1
+    autocomplete_fields = ("socket",)
 
     def get_formset(self, request, obj=None, **kwargs):
         # Enable form validation
@@ -99,7 +100,12 @@ class PhaseAdmin(admin.ModelAdmin):
         "external_evaluation",
         "challenge__short_name",
     )
-    autocomplete_fields = ("archive",)
+    autocomplete_fields = (
+        "archive",
+        "optional_hanging_protocols",
+        "workstation",
+        "workstation_config",
+    )
     readonly_fields = (
         "give_algorithm_editors_job_view_permissions",
         "algorithm_interfaces",

--- a/app/grandchallenge/hanging_protocols/admin.py
+++ b/app/grandchallenge/hanging_protocols/admin.py
@@ -15,6 +15,7 @@ from grandchallenge.hanging_protocols.models import (
 @admin.register(HangingProtocol)
 class HangingProtocolAdmin(ModelAdmin):
     readonly_fields = ("creator",)
+    search_fields = ("title", "slug")
 
 
 admin.site.register(

--- a/app/grandchallenge/workstation_configs/admin.py
+++ b/app/grandchallenge/workstation_configs/admin.py
@@ -16,6 +16,7 @@ from grandchallenge.workstation_configs.models import (
 @admin.register(WorkstationConfig)
 class WorkstationConfigAdmin(admin.ModelAdmin):
     readonly_fields = ("creator",)
+    search_fields = ("title", "slug")
 
 
 admin.site.register(

--- a/app/grandchallenge/workstations/admin.py
+++ b/app/grandchallenge/workstations/admin.py
@@ -168,7 +168,11 @@ class WorkstationImageAdmin(ComponentImageAdmin):
     )
 
 
-admin.site.register(Workstation)
+@admin.register(Workstation)
+class WorkstationAdmin(admin.ModelAdmin):
+    search_fields = ("title", "slug")
+
+
 admin.site.register(WorkstationUserObjectPermission, UserObjectPermissionAdmin)
 admin.site.register(
     WorkstationGroupObjectPermission, GroupObjectPermissionAdmin


### PR DESCRIPTION
Adds search fields to the related models so that they can be used as autocomplete fields so that they are only loaded on demand.

Closes https://github.com/DIAGNijmegen/rse-grand-challenge-admin/issues/783