### PR TITLE
Expire sessions that have been stopped on ECS

### DIFF
--- a/app/grandchallenge/components/backends/amazon_ecs.py
+++ b/app/grandchallenge/components/backends/amazon_ecs.py
@@ -111,7 +111,7 @@ class ECSTaskOrchestrator:
         # so add a small delay here to save waiting for the longer Delay
         time.sleep(settings.COMPONENTS_SERVICE_WAITER_INITIAL_DELAY_SECONDS)
 
-        task_description = self._get_task_description(task_arn=task_arn)
+        task_description = self.get_task_description(task_arn=task_arn)
 
         if task_description["lastStatus"] == "RUNNING":
             return task_description
@@ -122,9 +122,9 @@ class ECSTaskOrchestrator:
                 tasks=[task_arn],
                 WaiterConfig={"Delay": 5, "MaxAttempts": 36},  # 3 minutes
             )
-            return self._get_task_description(task_arn=task_arn)
+            return self.get_task_description(task_arn=task_arn)
 
-    def _get_task_description(self, *, task_arn):
+    def get_task_description(self, *, task_arn):
         return get(
             self._ecs_client.describe_tasks(
                 cluster=settings.COMPONENTS_SERVICE_CLUSTER_NAME,
@@ -258,7 +258,7 @@ class ECSTaskOrchestrator:
     def stop(self, *, task_arn):
         # Fetch the task description before stopping so that we have
         # the task definition info as this gets deleted after some time
-        task_description = self._get_task_description(task_arn=task_arn)
+        task_description = self.get_task_description(task_arn=task_arn)
 
         self._ecs_client.stop_task(
             cluster=settings.COMPONENTS_SERVICE_CLUSTER_NAME, task=task_arn

--- a/app/grandchallenge/workstations/tasks.py
+++ b/app/grandchallenge/workstations/tasks.py
@@ -1,9 +1,11 @@
 from datetime import timedelta
 
 from django.conf import settings
-from django.db.models import Q
+from django.core.exceptions import ObjectDoesNotExist
 from django.utils.timezone import now
 from lambda_tasks.decorators import lambda_task
+
+from grandchallenge.components.backends.amazon_ecs import ECSTaskOrchestrator
 
 
 @lambda_task
@@ -18,26 +20,29 @@ def consolidate_unclaimed_sessions():
     if workstation_image is None:
         return {"n_sessions_stopped": 0, "n_sessions_started": 0}
 
-    sessions_to_stop = list(
+    unclaimed_sessions = (
         Session.objects.active()
         .select_for_update(skip_locked=True)
         .filter(claimed_at=None)
-        .filter(
-            Q(
-                created__lt=now()
-                - timedelta(
-                    hours=settings.WORKSTATIONS_MAXIMUM_UNCLAIMED_SESSION_HOURS
-                )
-            )
-            | ~Q(workstation_image=workstation_image)
-        )
     )
 
-    expiring_pks = {session.pk for session in sessions_to_stop}
+    expiring_pks = set()
 
-    for session in sessions_to_stop:
-        session.status = Session.EXPIRED
-        session.save()
+    for session in unclaimed_sessions:
+        task_expired = session.created < now() - timedelta(
+            hours=settings.WORKSTATIONS_MAXIMUM_UNCLAIMED_SESSION_HOURS
+        )
+
+        task_uses_old_image = session.workstation_image != workstation_image
+
+        if (
+            task_expired
+            or task_uses_old_image
+            or _is_session_stopped_on_ecs(session=session)
+        ):
+            expiring_pks.add(session.pk)
+            session.status = Session.EXPIRED
+            session.save()
 
     n_sessions_started = 0
 
@@ -78,6 +83,31 @@ def consolidate_unclaimed_sessions():
             n_sessions_started += 1
 
     return {
-        "n_sessions_stopped": len(sessions_to_stop),
+        "n_sessions_stopped": len(expiring_pks),
         "n_sessions_started": n_sessions_started,
     }
+
+
+def _is_session_stopped_on_ecs(*, session):
+    if session.task_arn:
+        orchestrator = ECSTaskOrchestrator(**session.orchestrator_kwargs)
+
+        try:
+            task_description = orchestrator.get_task_description(
+                task_arn=session.task_arn
+            )
+        except ObjectDoesNotExist:
+            # The task_arn was created but no longer exists, so must have stopped
+            return True
+
+        # Status options from https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-lifecycle-explanation.html
+        return task_description["lastStatus"] in {
+            "DEACTIVATING",
+            "STOPPING",
+            "DEPROVISIONING",
+            "STOPPED",
+            "DELETED",
+        }
+    else:
+        # No task_arn, so nothing could have stopped
+        return False

--- a/app/tests/workstations_tests/test_tasks.py
+++ b/app/tests/workstations_tests/test_tasks.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 import pytest
 from botocore.stub import Stubber
+from django.core.exceptions import ObjectDoesNotExist
 from django.utils.timezone import now
 
 from grandchallenge.components.backends.amazon_ecs import ECSTaskOrchestrator
@@ -694,3 +695,227 @@ class TestConsolidateUnclaimedSessions:
             .count()
             == 2
         )
+
+    def test_stops_session_when_ecs_task_is_stopped(
+        self,
+        settings,
+        default_workstation_image,
+        mocker,
+        django_capture_on_commit_callbacks,
+    ):
+        settings.COMPONENTS_SERVICE_CLUSTER_NAME = "test-cluster-name"
+
+        with django_capture_on_commit_callbacks():
+            session = Session.objects.create(
+                workstation_image=default_workstation_image,
+                region="eu-central-1",
+            )
+
+        Session.objects.filter(pk=session.pk).update(
+            task_arn="test-task-arn",
+        )
+
+        mocker.patch(
+            "grandchallenge.workstations.tasks.ECSTaskOrchestrator.get_task_description",
+            return_value={"lastStatus": "STOPPED"},
+        )
+
+        with django_capture_on_commit_callbacks() as callbacks:
+            result = consolidate_unclaimed_sessions()
+
+        assert result == {"n_sessions_stopped": 1, "n_sessions_started": 3}
+
+        session.refresh_from_db()
+        assert session.status == Session.EXPIRED
+
+        callback_reprs = [repr(c) for c in callbacks]
+        assert _stop_task_repr(pk=session.pk) in callback_reprs
+
+    def test_stops_session_when_ecs_task_no_longer_exists(
+        self,
+        settings,
+        default_workstation_image,
+        mocker,
+        django_capture_on_commit_callbacks,
+    ):
+        settings.COMPONENTS_SERVICE_CLUSTER_NAME = "test-cluster-name"
+
+        with django_capture_on_commit_callbacks():
+            session = Session.objects.create(
+                workstation_image=default_workstation_image,
+                region="eu-central-1",
+            )
+
+        Session.objects.filter(pk=session.pk).update(
+            task_arn="test-task-arn",
+        )
+
+        mocker.patch(
+            "grandchallenge.workstations.tasks.ECSTaskOrchestrator.get_task_description",
+            side_effect=ObjectDoesNotExist,
+        )
+
+        with django_capture_on_commit_callbacks() as callbacks:
+            result = consolidate_unclaimed_sessions()
+
+        assert result == {"n_sessions_stopped": 1, "n_sessions_started": 3}
+
+        session.refresh_from_db()
+        assert session.status == Session.EXPIRED
+
+        callback_reprs = [repr(c) for c in callbacks]
+        assert _stop_task_repr(pk=session.pk) in callback_reprs
+
+    def test_does_not_stop_session_when_ecs_task_is_running(
+        self,
+        settings,
+        default_workstation_image,
+        mocker,
+        django_capture_on_commit_callbacks,
+    ):
+        settings.COMPONENTS_SERVICE_CLUSTER_NAME = "test-cluster-name"
+        settings.WORKSTATIONS_NUMBER_UNCLAIMED_SESSIONS = 1
+
+        with django_capture_on_commit_callbacks():
+            session = Session.objects.create(
+                workstation_image=default_workstation_image,
+                region="eu-central-1",
+            )
+
+        Session.objects.filter(pk=session.pk).update(
+            task_arn="test-task-arn",
+        )
+
+        mocker.patch(
+            "grandchallenge.workstations.tasks.ECSTaskOrchestrator.get_task_description",
+            return_value={"lastStatus": "RUNNING"},
+        )
+
+        with django_capture_on_commit_callbacks() as callbacks:
+            result = consolidate_unclaimed_sessions()
+
+        assert result == {"n_sessions_stopped": 0, "n_sessions_started": 0}
+
+        session.refresh_from_db()
+        assert session.status == Session.QUEUED
+
+        callback_reprs = [repr(c) for c in callbacks]
+        assert _stop_task_repr(pk=session.pk) not in callback_reprs
+
+    def test_does_not_check_ecs_for_session_without_task_arn(
+        self,
+        settings,
+        default_workstation_image,
+        mocker,
+        django_capture_on_commit_callbacks,
+    ):
+        settings.WORKSTATIONS_NUMBER_UNCLAIMED_SESSIONS = 1
+
+        with django_capture_on_commit_callbacks():
+            session = Session.objects.create(
+                workstation_image=default_workstation_image,
+                region="eu-central-1",
+            )
+
+        mock_get_task_description = mocker.patch(
+            "grandchallenge.workstations.tasks.ECSTaskOrchestrator.get_task_description",
+        )
+
+        with django_capture_on_commit_callbacks() as callbacks:
+            result = consolidate_unclaimed_sessions()
+
+        assert result == {"n_sessions_stopped": 0, "n_sessions_started": 0}
+
+        session.refresh_from_db()
+        assert session.status == Session.QUEUED
+
+        mock_get_task_description.assert_not_called()
+        callback_reprs = [repr(c) for c in callbacks]
+        assert _stop_task_repr(pk=session.pk) not in callback_reprs
+
+    @pytest.mark.parametrize(
+        "last_status",
+        [
+            "DEACTIVATING",
+            "STOPPING",
+            "DEPROVISIONING",
+            "STOPPED",
+            "DELETED",
+        ],
+    )
+    def test_stops_session_for_all_terminal_ecs_statuses(
+        self,
+        settings,
+        default_workstation_image,
+        mocker,
+        django_capture_on_commit_callbacks,
+        last_status,
+    ):
+        settings.COMPONENTS_SERVICE_CLUSTER_NAME = "test-cluster-name"
+        settings.WORKSTATIONS_NUMBER_UNCLAIMED_SESSIONS = 0
+
+        with django_capture_on_commit_callbacks():
+            session = Session.objects.create(
+                workstation_image=default_workstation_image,
+                region="eu-central-1",
+            )
+
+        Session.objects.filter(pk=session.pk).update(
+            task_arn="test-task-arn",
+        )
+
+        mocker.patch(
+            "grandchallenge.workstations.tasks.ECSTaskOrchestrator.get_task_description",
+            return_value={"lastStatus": last_status},
+        )
+
+        with django_capture_on_commit_callbacks():
+            result = consolidate_unclaimed_sessions()
+
+        assert result == {"n_sessions_stopped": 1, "n_sessions_started": 0}
+
+        session.refresh_from_db()
+        assert session.status == Session.EXPIRED
+
+    @pytest.mark.parametrize(
+        "last_status",
+        [
+            "PROVISIONING",
+            "PENDING",
+            "ACTIVATING",
+            "RUNNING",
+        ],
+    )
+    def test_does_not_stop_session_for_active_ecs_statuses(
+        self,
+        settings,
+        default_workstation_image,
+        mocker,
+        django_capture_on_commit_callbacks,
+        last_status,
+    ):
+        settings.COMPONENTS_SERVICE_CLUSTER_NAME = "test-cluster-name"
+        settings.WORKSTATIONS_NUMBER_UNCLAIMED_SESSIONS = 1
+
+        with django_capture_on_commit_callbacks():
+            session = Session.objects.create(
+                workstation_image=default_workstation_image,
+                region="eu-central-1",
+            )
+
+        Session.objects.filter(pk=session.pk).update(
+            task_arn="test-task-arn",
+        )
+
+        mocker.patch(
+            "grandchallenge.workstations.tasks.ECSTaskOrchestrator.get_task_description",
+            return_value={"lastStatus": last_status},
+        )
+
+        with django_capture_on_commit_callbacks():
+            result = consolidate_unclaimed_sessions()
+
+        assert result == {"n_sessions_stopped": 0, "n_sessions_started": 0}
+
+        session.refresh_from_db()
+        assert session.status == Session.QUEUED

--- a/app/tests/workstations_tests/test_tasks.py
+++ b/app/tests/workstations_tests/test_tasks.py
@@ -696,41 +696,6 @@ class TestConsolidateUnclaimedSessions:
             == 2
         )
 
-    def test_stops_session_when_ecs_task_is_stopped(
-        self,
-        settings,
-        default_workstation_image,
-        mocker,
-        django_capture_on_commit_callbacks,
-    ):
-        settings.COMPONENTS_SERVICE_CLUSTER_NAME = "test-cluster-name"
-
-        with django_capture_on_commit_callbacks():
-            session = Session.objects.create(
-                workstation_image=default_workstation_image,
-                region="eu-central-1",
-            )
-
-        Session.objects.filter(pk=session.pk).update(
-            task_arn="test-task-arn",
-        )
-
-        mocker.patch(
-            "grandchallenge.workstations.tasks.ECSTaskOrchestrator.get_task_description",
-            return_value={"lastStatus": "STOPPED"},
-        )
-
-        with django_capture_on_commit_callbacks() as callbacks:
-            result = consolidate_unclaimed_sessions()
-
-        assert result == {"n_sessions_stopped": 1, "n_sessions_started": 3}
-
-        session.refresh_from_db()
-        assert session.status == Session.EXPIRED
-
-        callback_reprs = [repr(c) for c in callbacks]
-        assert _stop_task_repr(pk=session.pk) in callback_reprs
-
     def test_stops_session_when_ecs_task_no_longer_exists(
         self,
         settings,
@@ -765,42 +730,6 @@ class TestConsolidateUnclaimedSessions:
 
         callback_reprs = [repr(c) for c in callbacks]
         assert _stop_task_repr(pk=session.pk) in callback_reprs
-
-    def test_does_not_stop_session_when_ecs_task_is_running(
-        self,
-        settings,
-        default_workstation_image,
-        mocker,
-        django_capture_on_commit_callbacks,
-    ):
-        settings.COMPONENTS_SERVICE_CLUSTER_NAME = "test-cluster-name"
-        settings.WORKSTATIONS_NUMBER_UNCLAIMED_SESSIONS = 1
-
-        with django_capture_on_commit_callbacks():
-            session = Session.objects.create(
-                workstation_image=default_workstation_image,
-                region="eu-central-1",
-            )
-
-        Session.objects.filter(pk=session.pk).update(
-            task_arn="test-task-arn",
-        )
-
-        mocker.patch(
-            "grandchallenge.workstations.tasks.ECSTaskOrchestrator.get_task_description",
-            return_value={"lastStatus": "RUNNING"},
-        )
-
-        with django_capture_on_commit_callbacks() as callbacks:
-            result = consolidate_unclaimed_sessions()
-
-        assert result == {"n_sessions_stopped": 0, "n_sessions_started": 0}
-
-        session.refresh_from_db()
-        assert session.status == Session.QUEUED
-
-        callback_reprs = [repr(c) for c in callbacks]
-        assert _stop_task_repr(pk=session.pk) not in callback_reprs
 
     def test_does_not_check_ecs_for_session_without_task_arn(
         self,


### PR DESCRIPTION
If sessions on ECS are stopped then we need to update the status in Grand Challenge, this iterates over all of the active unclaimed sessions and marks them as expired if they have been stopped.

See https://github.com/DIAGNijmegen/rse-roadmap/issues/458